### PR TITLE
Oracle Report must be based on the block after the last admin execution block

### DIFF
--- a/release/abis/EtherFiAdmin.json
+++ b/release/abis/EtherFiAdmin.json
@@ -1,589 +1,852 @@
 [
   {
+    "type": "constructor",
     "inputs": [],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
+    "stateMutability": "nonpayable"
   },
   {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "previousAdmin",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
-      }
-    ],
-    "name": "AdminChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "_address",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "_reportHash",
-        "type": "bytes32"
-      }
-    ],
-    "name": "AdminOperationsExecuted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "_address",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "_isAdmin",
-        "type": "bool"
-      }
-    ],
-    "name": "AdminUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "beacon",
-        "type": "address"
-      }
-    ],
-    "name": "BeaconUpgraded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "version",
-        "type": "uint8"
-      }
-    ],
-    "name": "Initialized",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "implementation",
-        "type": "address"
-      }
-    ],
-    "name": "Upgraded",
-    "type": "event"
-  },
-  {
-    "inputs": [],
+    "type": "function",
     "name": "acceptableRebaseAprInBps",
+    "inputs": [],
     "outputs": [
       {
-        "internalType": "int32",
         "name": "",
-        "type": "int32"
+        "type": "int32",
+        "internalType": "int32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "type": "function",
     "name": "admins",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "auctionManager",
-    "outputs": [
-      {
-        "internalType": "contract IAuctionManager",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "blockForNextReportToProcess",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "etherFiNodesManager",
-    "outputs": [
-      {
-        "internalType": "contract IEtherFiNodesManager",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "etherFiOracle",
-    "outputs": [
-      {
-        "internalType": "contract IEtherFiOracle",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "auctionManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IAuctionManager"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "blockForNextReportToProcess",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "canExecuteTasks",
+    "inputs": [
+      {
+        "name": "_report",
+        "type": "tuple",
+        "internalType": "struct IEtherFiOracle.OracleReport",
         "components": [
           {
-            "internalType": "uint32",
             "name": "consensusVersion",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "internalType": "uint32",
             "name": "refSlotFrom",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "internalType": "uint32",
             "name": "refSlotTo",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "internalType": "uint32",
             "name": "refBlockFrom",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "internalType": "uint32",
             "name": "refBlockTo",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "internalType": "int128",
             "name": "accruedRewards",
-            "type": "int128"
+            "type": "int128",
+            "internalType": "int128"
           },
           {
-            "internalType": "uint256[]",
             "name": "validatorsToApprove",
-            "type": "uint256[]"
+            "type": "uint256[]",
+            "internalType": "uint256[]"
           },
           {
-            "internalType": "uint256[]",
             "name": "liquidityPoolValidatorsToExit",
-            "type": "uint256[]"
+            "type": "uint256[]",
+            "internalType": "uint256[]"
           },
           {
-            "internalType": "uint256[]",
             "name": "exitedValidators",
-            "type": "uint256[]"
+            "type": "uint256[]",
+            "internalType": "uint256[]"
           },
           {
-            "internalType": "uint32[]",
             "name": "exitedValidatorsExitTimestamps",
-            "type": "uint32[]"
+            "type": "uint32[]",
+            "internalType": "uint32[]"
           },
           {
-            "internalType": "uint256[]",
             "name": "slashedValidators",
-            "type": "uint256[]"
+            "type": "uint256[]",
+            "internalType": "uint256[]"
           },
           {
-            "internalType": "uint256[]",
             "name": "withdrawalRequestsToInvalidate",
-            "type": "uint256[]"
+            "type": "uint256[]",
+            "internalType": "uint256[]"
           },
           {
-            "internalType": "uint32",
             "name": "lastFinalizedWithdrawalRequestId",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "internalType": "uint32",
             "name": "eEthTargetAllocationWeight",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "internalType": "uint32",
             "name": "etherFanTargetAllocationWeight",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "internalType": "uint128",
             "name": "finalizedWithdrawalAmount",
-            "type": "uint128"
+            "type": "uint128",
+            "internalType": "uint128"
           },
           {
-            "internalType": "uint32",
             "name": "numValidatorsToSpinUp",
-            "type": "uint32"
+            "type": "uint32",
+            "internalType": "uint32"
           }
-        ],
-        "internalType": "struct IEtherFiOracle.OracleReport",
-        "name": "_report",
-        "type": "tuple"
-      },
-      {
-        "internalType": "bytes[]",
-        "name": "_pubKey",
-        "type": "bytes[]"
-      },
-      {
-        "internalType": "bytes[]",
-        "name": "_signature",
-        "type": "bytes[]"
+        ]
       }
     ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "etherFiNodesManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IEtherFiNodesManager"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "etherFiOracle",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IEtherFiOracle"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "executeTasks",
+    "inputs": [
+      {
+        "name": "_report",
+        "type": "tuple",
+        "internalType": "struct IEtherFiOracle.OracleReport",
+        "components": [
+          {
+            "name": "consensusVersion",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refSlotFrom",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refSlotTo",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refBlockFrom",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refBlockTo",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "accruedRewards",
+            "type": "int128",
+            "internalType": "int128"
+          },
+          {
+            "name": "validatorsToApprove",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "liquidityPoolValidatorsToExit",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "exitedValidators",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "exitedValidatorsExitTimestamps",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "slashedValidators",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "withdrawalRequestsToInvalidate",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "lastFinalizedWithdrawalRequestId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "eEthTargetAllocationWeight",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "etherFanTargetAllocationWeight",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "finalizedWithdrawalAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "numValidatorsToSpinUp",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      },
+      {
+        "name": "_pubKey",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "_signature",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
     "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    "stateMutability": "nonpayable"
   },
   {
-    "inputs": [],
+    "type": "function",
     "name": "getImplementation",
+    "inputs": [],
     "outputs": [
       {
-        "internalType": "address",
         "name": "",
-        "type": "address"
+        "type": "address",
+        "internalType": "address"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_etherFiOracle",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_stakingManager",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_auctionManager",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_etherFiNodesManager",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_liquidityPool",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_membershipManager",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_withdrawRequestNft",
-        "type": "address"
-      },
-      {
-        "internalType": "int32",
-        "name": "_acceptableRebaseAprInBps",
-        "type": "int32"
-      }
-    ],
+    "type": "function",
     "name": "initialize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "lastHandledReportRefBlock",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "lastHandledReportRefSlot",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "liquidityPool",
-    "outputs": [
-      {
-        "internalType": "contract ILiquidityPool",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "membershipManager",
-    "outputs": [
-      {
-        "internalType": "contract IMembershipManager",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "numValidatorsToSpinUp",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "proxiableUUID",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "slotForNextReportToProcess",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "stakingManager",
-    "outputs": [
-      {
-        "internalType": "contract IStakingManager",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
+        "name": "_etherFiOracle",
+        "type": "address",
+        "internalType": "address"
+      },
       {
-        "internalType": "int32",
+        "name": "_stakingManager",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_auctionManager",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_etherFiNodesManager",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_liquidityPool",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_membershipManager",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_withdrawRequestNft",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
         "name": "_acceptableRebaseAprInBps",
-        "type": "int32"
-      }
-    ],
-    "name": "updateAcceptableRebaseApr",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_address",
-        "type": "address"
+        "type": "int32",
+        "internalType": "int32"
       },
       {
-        "internalType": "bool",
-        "name": "_isAdmin",
-        "type": "bool"
+        "name": "_postReportWaitTimeInSlots",
+        "type": "uint16",
+        "internalType": "uint16"
       }
     ],
-    "name": "updateAdmin",
     "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    "stateMutability": "nonpayable"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newImplementation",
-        "type": "address"
-      }
-    ],
-    "name": "upgradeTo",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newImplementation",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "upgradeToAndCall",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
+    "type": "function",
+    "name": "lastAdminExecutionBlock",
     "inputs": [],
-    "name": "withdrawRequestNft",
     "outputs": [
       {
-        "internalType": "contract IWithdrawRequestNFT",
         "name": "",
-        "type": "address"
+        "type": "uint32",
+        "internalType": "uint32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lastHandledReportRefBlock",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lastHandledReportRefSlot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "liquidityPool",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract ILiquidityPool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "membershipManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IMembershipManager"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "numValidatorsToSpinUp",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [
+      {
+        "name": "_etherFiOracle",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_stakingManager",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_auctionManager",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_etherFiNodesManager",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_liquidityPool",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_membershipManager",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pausers",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "postReportWaitTimeInSlots",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "slotForNextReportToProcess",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stakingManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IStakingManager"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unPause",
+    "inputs": [
+      {
+        "name": "_etherFiOracle",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_stakingManager",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_auctionManager",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_etherFiNodesManager",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_liquidityPool",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "_membershipManager",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAcceptableRebaseApr",
+    "inputs": [
+      {
+        "name": "_acceptableRebaseAprInBps",
+        "type": "int32",
+        "internalType": "int32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAdmin",
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_isAdmin",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauser",
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_isPauser",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePostReportWaitTimeInSlots",
+    "inputs": [
+      {
+        "name": "_postReportWaitTimeInSlots",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeTo",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawRequestNft",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IWithdrawRequestNFT"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "AdminChanged",
+    "inputs": [
+      {
+        "name": "previousAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AdminOperationsExecuted",
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "_reportHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AdminUpdated",
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "_isAdmin",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BeaconUpgraded",
+    "inputs": [
+      {
+        "name": "beacon",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
   }
 ]

--- a/release/abis/EtherFiOracle.json
+++ b/release/abis/EtherFiOracle.json
@@ -1,1117 +1,1254 @@
 [
   {
+    "type": "constructor",
     "inputs": [],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
+    "stateMutability": "nonpayable"
   },
   {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "previousAdmin",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
-      }
-    ],
-    "name": "AdminChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "beacon",
-        "type": "address"
-      }
-    ],
-    "name": "BeaconUpgraded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "member",
-        "type": "address"
-      }
-    ],
-    "name": "CommitteeMemberAdded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "member",
-        "type": "address"
-      }
-    ],
-    "name": "CommitteeMemberRemoved",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "member",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "enabled",
-        "type": "bool"
-      }
-    ],
-    "name": "CommitteeMemberUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "newConsensusVersion",
-        "type": "uint32"
-      }
-    ],
-    "name": "ConsensusVersionUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "version",
-        "type": "uint8"
-      }
-    ],
-    "name": "Initialized",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "newOracleReportPeriod",
-        "type": "uint32"
-      }
-    ],
-    "name": "OracleReportPeriodUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "Paused",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "newQuorumSize",
-        "type": "uint32"
-      }
-    ],
-    "name": "QuorumUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "consensusVersion",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "refSlotFrom",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "refSlotTo",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "refBlockFrom",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "refBlockTo",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "hash",
-        "type": "bytes32"
-      }
-    ],
-    "name": "ReportPublished",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "reportStartSlot",
-        "type": "uint32"
-      }
-    ],
-    "name": "ReportStartSlotUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "consensusVersion",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "refSlotFrom",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "refSlotTo",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "refBlockFrom",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "refBlockTo",
-        "type": "uint32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "hash",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "committeeMember",
-        "type": "address"
-      }
-    ],
-    "name": "ReportSubmitted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "Unpaused",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "implementation",
-        "type": "address"
-      }
-    ],
-    "name": "Upgraded",
-    "type": "event"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_address",
-        "type": "address"
-      }
-    ],
+    "type": "function",
     "name": "addCommitteeMember",
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    "stateMutability": "nonpayable"
   },
   {
+    "type": "function",
+    "name": "admins",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "beaconGenesisTimestamp",
     "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "blockStampForNextReport",
+    "inputs": [],
     "outputs": [
       {
-        "internalType": "uint32",
         "name": "slotFrom",
-        "type": "uint32"
+        "type": "uint32",
+        "internalType": "uint32"
       },
       {
-        "internalType": "uint32",
         "name": "slotTo",
-        "type": "uint32"
+        "type": "uint32",
+        "internalType": "uint32"
       },
       {
-        "internalType": "uint32",
         "name": "blockFrom",
-        "type": "uint32"
+        "type": "uint32",
+        "internalType": "uint32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "type": "function",
     "name": "committeeMemberStates",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "outputs": [
       {
-        "internalType": "bool",
         "name": "registered",
-        "type": "bool"
+        "type": "bool",
+        "internalType": "bool"
       },
       {
-        "internalType": "bool",
         "name": "enabled",
-        "type": "bool"
+        "type": "bool",
+        "internalType": "bool"
       },
       {
-        "internalType": "uint32",
         "name": "lastReportRefSlot",
-        "type": "uint32"
+        "type": "uint32",
+        "internalType": "uint32"
       },
       {
-        "internalType": "uint32",
         "name": "numReports",
-        "type": "uint32"
+        "type": "uint32",
+        "internalType": "uint32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "timestamp",
-        "type": "uint256"
-      }
-    ],
+    "type": "function",
     "name": "computeSlotAtTimestamp",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "consensusStates",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
     "outputs": [
       {
-        "internalType": "uint32",
         "name": "support",
-        "type": "uint32"
+        "type": "uint32",
+        "internalType": "uint32"
       },
       {
-        "internalType": "bool",
         "name": "consensusReached",
-        "type": "bool"
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "consensusTimestamp",
+        "type": "uint32",
+        "internalType": "uint32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [],
+    "type": "function",
     "name": "consensusVersion",
+    "inputs": [],
     "outputs": [
       {
-        "internalType": "uint32",
         "name": "",
-        "type": "uint32"
+        "type": "uint32",
+        "internalType": "uint32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint32",
-            "name": "consensusVersion",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refSlotFrom",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refSlotTo",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refBlockFrom",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refBlockTo",
-            "type": "uint32"
-          },
-          {
-            "internalType": "int128",
-            "name": "accruedRewards",
-            "type": "int128"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "validatorsToApprove",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "liquidityPoolValidatorsToExit",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "exitedValidators",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint32[]",
-            "name": "exitedValidatorsExitTimestamps",
-            "type": "uint32[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "slashedValidators",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "withdrawalRequestsToInvalidate",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint32",
-            "name": "lastFinalizedWithdrawalRequestId",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "eEthTargetAllocationWeight",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "etherFanTargetAllocationWeight",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint128",
-            "name": "finalizedWithdrawalAmount",
-            "type": "uint128"
-          },
-          {
-            "internalType": "uint32",
-            "name": "numValidatorsToSpinUp",
-            "type": "uint32"
-          }
-        ],
-        "internalType": "struct IEtherFiOracle.OracleReport",
-        "name": "_report",
-        "type": "tuple"
-      }
-    ],
+    "type": "function",
     "name": "generateReportHash",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getImplementation",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
-        "internalType": "uint32",
-        "name": "_quorumSize",
-        "type": "uint32"
-      },
-      {
-        "internalType": "uint32",
-        "name": "_reportPeriodSlot",
-        "type": "uint32"
-      },
-      {
-        "internalType": "uint32",
-        "name": "_reportStartSlot",
-        "type": "uint32"
-      },
-      {
-        "internalType": "uint32",
-        "name": "_slotsPerEpoch",
-        "type": "uint32"
-      },
-      {
-        "internalType": "uint32",
-        "name": "_secondsPerSlot",
-        "type": "uint32"
-      },
-      {
-        "internalType": "uint32",
-        "name": "_genesisTime",
-        "type": "uint32"
+        "name": "_report",
+        "type": "tuple",
+        "internalType": "struct IEtherFiOracle.OracleReport",
+        "components": [
+          {
+            "name": "consensusVersion",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refSlotFrom",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refSlotTo",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refBlockFrom",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refBlockTo",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "accruedRewards",
+            "type": "int128",
+            "internalType": "int128"
+          },
+          {
+            "name": "validatorsToApprove",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "liquidityPoolValidatorsToExit",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "exitedValidators",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "exitedValidatorsExitTimestamps",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "slashedValidators",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "withdrawalRequestsToInvalidate",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "lastFinalizedWithdrawalRequestId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "eEthTargetAllocationWeight",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "etherFanTargetAllocationWeight",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "finalizedWithdrawalAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "numValidatorsToSpinUp",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
       }
     ],
-    "name": "initialize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
   },
   {
+    "type": "function",
+    "name": "getConsensusSlot",
     "inputs": [
       {
-        "internalType": "bytes32",
         "name": "_hash",
-        "type": "bytes32"
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
-    "name": "isConsensusReached",
     "outputs": [
       {
-        "internalType": "bool",
         "name": "",
-        "type": "bool"
+        "type": "uint32",
+        "internalType": "uint32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [],
-    "name": "lastPublishedReportRefBlock",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "lastPublishedReportRefSlot",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
+    "type": "function",
+    "name": "getConsensusTimestamp",
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_address",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_enabled",
-        "type": "bool"
+        "name": "_hash",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
-    "name": "manageCommitteeMember",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "numActiveCommitteeMembers",
     "outputs": [
       {
-        "internalType": "uint32",
         "name": "",
-        "type": "uint32"
+        "type": "uint32",
+        "internalType": "uint32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
+    "type": "function",
+    "name": "getImplementation",
     "inputs": [],
-    "name": "numCommitteeMembers",
     "outputs": [
       {
-        "internalType": "uint32",
         "name": "",
-        "type": "uint32"
+        "type": "address",
+        "internalType": "address"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "pauseContract",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "paused",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "proxiableUUID",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "quorumSize",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
+    "type": "function",
+    "name": "initialize",
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_address",
-        "type": "address"
-      }
-    ],
-    "name": "removeCommitteeMember",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "reportPeriodSlot",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "reportStartSlot",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint32",
-        "name": "_consensusVersion",
-        "type": "uint32"
-      }
-    ],
-    "name": "setConsensusVersion",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint32",
-        "name": "_reportPeriodSlot",
-        "type": "uint32"
-      }
-    ],
-    "name": "setOracleReportPeriod",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint32",
         "name": "_quorumSize",
-        "type": "uint32"
-      }
-    ],
-    "name": "setQuorumSize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint32",
-        "name": "_reportStartSlot",
-        "type": "uint32"
-      }
-    ],
-    "name": "setReportStartSlot",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_member",
-        "type": "address"
-      }
-    ],
-    "name": "shouldSubmitReport",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "slotForNextReport",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint32",
-            "name": "consensusVersion",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refSlotFrom",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refSlotTo",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refBlockFrom",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refBlockTo",
-            "type": "uint32"
-          },
-          {
-            "internalType": "int128",
-            "name": "accruedRewards",
-            "type": "int128"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "validatorsToApprove",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "liquidityPoolValidatorsToExit",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "exitedValidators",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint32[]",
-            "name": "exitedValidatorsExitTimestamps",
-            "type": "uint32[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "slashedValidators",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "withdrawalRequestsToInvalidate",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint32",
-            "name": "lastFinalizedWithdrawalRequestId",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "eEthTargetAllocationWeight",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "etherFanTargetAllocationWeight",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint128",
-            "name": "finalizedWithdrawalAmount",
-            "type": "uint128"
-          },
-          {
-            "internalType": "uint32",
-            "name": "numValidatorsToSpinUp",
-            "type": "uint32"
-          }
-        ],
-        "internalType": "struct IEtherFiOracle.OracleReport",
-        "name": "_report",
-        "type": "tuple"
-      }
-    ],
-    "name": "submitReport",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "unPauseContract",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newImplementation",
-        "type": "address"
-      }
-    ],
-    "name": "upgradeTo",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newImplementation",
-        "type": "address"
+        "type": "uint32",
+        "internalType": "uint32"
       },
       {
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
+        "name": "_reportPeriodSlot",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "_reportStartSlot",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "_slotsPerEpoch",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "_secondsPerSlot",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "_genesisTime",
+        "type": "uint32",
+        "internalType": "uint32"
       }
     ],
-    "name": "upgradeToAndCall",
     "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
+    "stateMutability": "nonpayable"
   },
   {
+    "type": "function",
+    "name": "isConsensusReached",
     "inputs": [
       {
-        "components": [
-          {
-            "internalType": "uint32",
-            "name": "consensusVersion",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refSlotFrom",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refSlotTo",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refBlockFrom",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "refBlockTo",
-            "type": "uint32"
-          },
-          {
-            "internalType": "int128",
-            "name": "accruedRewards",
-            "type": "int128"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "validatorsToApprove",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "liquidityPoolValidatorsToExit",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "exitedValidators",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint32[]",
-            "name": "exitedValidatorsExitTimestamps",
-            "type": "uint32[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "slashedValidators",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint256[]",
-            "name": "withdrawalRequestsToInvalidate",
-            "type": "uint256[]"
-          },
-          {
-            "internalType": "uint32",
-            "name": "lastFinalizedWithdrawalRequestId",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "eEthTargetAllocationWeight",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "etherFanTargetAllocationWeight",
-            "type": "uint32"
-          },
-          {
-            "internalType": "uint128",
-            "name": "finalizedWithdrawalAmount",
-            "type": "uint128"
-          },
-          {
-            "internalType": "uint32",
-            "name": "numValidatorsToSpinUp",
-            "type": "uint32"
-          }
-        ],
-        "internalType": "struct IEtherFiOracle.OracleReport",
-        "name": "_report",
-        "type": "tuple"
+        "name": "_hash",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
-    "name": "verifyReport",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lastPublishedReportRefBlock",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lastPublishedReportRefSlot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "manageCommitteeMember",
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
     "outputs": [],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "numActiveCommitteeMembers",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "numCommitteeMembers",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pauseContract",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quorumSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "removeCommitteeMember",
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "reportPeriodSlot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "reportStartSlot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setConsensusVersion",
+    "inputs": [
+      {
+        "name": "_consensusVersion",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setEtherFiAdmin",
+    "inputs": [
+      {
+        "name": "_etherFiAdminAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setOracleReportPeriod",
+    "inputs": [
+      {
+        "name": "_reportPeriodSlot",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setQuorumSize",
+    "inputs": [
+      {
+        "name": "_quorumSize",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setReportStartSlot",
+    "inputs": [
+      {
+        "name": "_reportStartSlot",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "shouldSubmitReport",
+    "inputs": [
+      {
+        "name": "_member",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "slotForNextReport",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "submitReport",
+    "inputs": [
+      {
+        "name": "_report",
+        "type": "tuple",
+        "internalType": "struct IEtherFiOracle.OracleReport",
+        "components": [
+          {
+            "name": "consensusVersion",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refSlotFrom",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refSlotTo",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refBlockFrom",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refBlockTo",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "accruedRewards",
+            "type": "int128",
+            "internalType": "int128"
+          },
+          {
+            "name": "validatorsToApprove",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "liquidityPoolValidatorsToExit",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "exitedValidators",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "exitedValidatorsExitTimestamps",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "slashedValidators",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "withdrawalRequestsToInvalidate",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "lastFinalizedWithdrawalRequestId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "eEthTargetAllocationWeight",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "etherFanTargetAllocationWeight",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "finalizedWithdrawalAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "numValidatorsToSpinUp",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unPauseContract",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpublishReport",
+    "inputs": [
+      {
+        "name": "_hash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAdmin",
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_isAdmin",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateLastPublishedBlockStamps",
+    "inputs": [
+      {
+        "name": "_lastPublishedReportRefSlot",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "_lastPublishedReportRefBlock",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeTo",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "verifyReport",
+    "inputs": [
+      {
+        "name": "_report",
+        "type": "tuple",
+        "internalType": "struct IEtherFiOracle.OracleReport",
+        "components": [
+          {
+            "name": "consensusVersion",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refSlotFrom",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refSlotTo",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refBlockFrom",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "refBlockTo",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "accruedRewards",
+            "type": "int128",
+            "internalType": "int128"
+          },
+          {
+            "name": "validatorsToApprove",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "liquidityPoolValidatorsToExit",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "exitedValidators",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "exitedValidatorsExitTimestamps",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "slashedValidators",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "withdrawalRequestsToInvalidate",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "lastFinalizedWithdrawalRequestId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "eEthTargetAllocationWeight",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "etherFanTargetAllocationWeight",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "finalizedWithdrawalAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "numValidatorsToSpinUp",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "AdminChanged",
+    "inputs": [
+      {
+        "name": "previousAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BeaconUpgraded",
+    "inputs": [
+      {
+        "name": "beacon",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CommitteeMemberAdded",
+    "inputs": [
+      {
+        "name": "member",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CommitteeMemberRemoved",
+    "inputs": [
+      {
+        "name": "member",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CommitteeMemberUpdated",
+    "inputs": [
+      {
+        "name": "member",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ConsensusVersionUpdated",
+    "inputs": [
+      {
+        "name": "newConsensusVersion",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OracleReportPeriodUpdated",
+    "inputs": [
+      {
+        "name": "newOracleReportPeriod",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "QuorumUpdated",
+    "inputs": [
+      {
+        "name": "newQuorumSize",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ReportPublished",
+    "inputs": [
+      {
+        "name": "consensusVersion",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "refSlotFrom",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "refSlotTo",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "refBlockFrom",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "refBlockTo",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "hash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ReportStartSlotUpdated",
+    "inputs": [
+      {
+        "name": "reportStartSlot",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ReportSubmitted",
+    "inputs": [
+      {
+        "name": "consensusVersion",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "refSlotFrom",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "refSlotTo",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "refBlockFrom",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "refBlockTo",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "hash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "committeeMember",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
   }
 ]

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -15,6 +15,10 @@ import "./interfaces/IWithdrawRequestNFT.sol";
 
 import "forge-std/console.sol";
 
+interface IEtherFiPausable {
+    function paused() external view returns (bool);
+}
+
 contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     IEtherFiOracle public etherFiOracle;
@@ -34,6 +38,9 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     int32 public acceptableRebaseAprInBps;
 
     uint16 public postReportWaitTimeInSlots;
+    uint32 public lastAdminExecutionBlock;
+
+    mapping(address => bool) public pausers;
 
     event AdminUpdated(address _address, bool _isAdmin);
     event AdminOperationsExecuted(address indexed _address, bytes32 indexed _reportHash);
@@ -72,35 +79,54 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     // based on the boolean flags
     // if true, pause,
     // else, unpuase
-    function pause(bool _etherFiOracle, bool _stakingManager, bool _auctionManager, bool _etherFiNodesManager, bool _liquidityPool, bool _membershipManager) external isAdmin() {
-        if (_etherFiOracle) {
+    function pause(bool _etherFiOracle, bool _stakingManager, bool _auctionManager, bool _etherFiNodesManager, bool _liquidityPool, bool _membershipManager) external isPauser() {
+        if (_etherFiOracle && !IEtherFiPausable(address(etherFiOracle)).paused()) {
             etherFiOracle.pauseContract();
-        } else {
+        }
+
+        if (_stakingManager && !IEtherFiPausable(address(stakingManager)).paused()) {
+            stakingManager.pauseContract();
+        }
+
+        if (_auctionManager && !IEtherFiPausable(address(auctionManager)).paused()) {
+            auctionManager.pauseContract();
+        }
+
+        if (_etherFiNodesManager && !IEtherFiPausable(address(etherFiNodesManager)).paused()) {
+            etherFiNodesManager.pauseContract();
+        }
+
+        if (_liquidityPool && !IEtherFiPausable(address(liquidityPool)).paused()) {
+            liquidityPool.pauseContract();
+        }
+
+        if (_membershipManager && !IEtherFiPausable(address(membershipManager)).paused()) {
+            membershipManager.pauseContract();
+        }
+    }
+
+    function unPause(bool _etherFiOracle, bool _stakingManager, bool _auctionManager, bool _etherFiNodesManager, bool _liquidityPool, bool _membershipManager) external onlyOwner {
+        if (_etherFiOracle && IEtherFiPausable(address(etherFiOracle)).paused()) {
             etherFiOracle.unPauseContract();
         }
-        if (_stakingManager) {
-            stakingManager.pauseContract();
-        } else {
+
+        if (_stakingManager && IEtherFiPausable(address(stakingManager)).paused()) {
             stakingManager.unPauseContract();
         }
-        if (_auctionManager) {
-            auctionManager.pauseContract();
-        } else {
+
+        if (_auctionManager && IEtherFiPausable(address(auctionManager)).paused()) {
             auctionManager.unPauseContract();
         }
-        if (_etherFiNodesManager) {
-            etherFiNodesManager.pauseContract();
-        } else {
+
+        if (_etherFiNodesManager && IEtherFiPausable(address(etherFiNodesManager)).paused()) {
             etherFiNodesManager.unPauseContract();
         }
-        if (_liquidityPool) {
-            liquidityPool.pauseContract();
-        } else {
+
+        if (_liquidityPool && IEtherFiPausable(address(liquidityPool)).paused()) {
             liquidityPool.unPauseContract();
         }
-        if (_membershipManager) {
-            membershipManager.pauseContract();
-        } else {
+
+        if (_membershipManager && IEtherFiPausable(address(membershipManager)).paused()) {
             membershipManager.unPauseContract();
         }
     }
@@ -113,7 +139,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         if (slotForNextReportToProcess() != _report.refSlotFrom) return false;
         if (blockForNextReportToProcess() != _report.refBlockFrom) return false;
         if (current_slot < postReportWaitTimeInSlots + etherFiOracle.getConsensusSlot(reportHash)) return false;
-        if (current_slot >= _report.refSlotTo + 1 + etherFiOracle.reportPeriodSlot()) return false;
         return true;
     }
 
@@ -124,7 +149,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         require(slotForNextReportToProcess() == _report.refSlotFrom, "EtherFiAdmin: report has wrong `refSlotFrom`");
         require(blockForNextReportToProcess() == _report.refBlockFrom, "EtherFiAdmin: report has wrong `refBlockFrom`");
         require(current_slot >= postReportWaitTimeInSlots + etherFiOracle.getConsensusSlot(reportHash), "EtherFiAdmin: report is too fresh");
-        require(current_slot < _report.refSlotTo + 1 + etherFiOracle.reportPeriodSlot(), "EtherFiAdmin: report is too old");
 
         numValidatorsToSpinUp = _report.numValidatorsToSpinUp;
 
@@ -135,6 +159,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
         lastHandledReportRefSlot = _report.refSlotTo;
         lastHandledReportRefBlock = _report.refBlockTo;
+        lastAdminExecutionBlock = uint32(block.number);
 
         emit AdminOperationsExecuted(msg.sender, reportHash);
     }
@@ -217,11 +242,15 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         emit AdminUpdated(_address, _isAdmin);
     }
 
+    function updatePauser(address _address, bool _isPauser) external onlyOwner {
+        pausers[_address] = _isPauser;
+    }
+
     function updateAcceptableRebaseApr(int32 _acceptableRebaseAprInBps) external onlyOwner {
         acceptableRebaseAprInBps = _acceptableRebaseAprInBps;
     }
 
-    function updatePostReportWaitTimeInSlots(uint16 _postReportWaitTimeInSlots) external onlyOwner {
+    function updatePostReportWaitTimeInSlots(uint16 _postReportWaitTimeInSlots) external isAdmin {
         postReportWaitTimeInSlots = _postReportWaitTimeInSlots;
     }
 
@@ -233,7 +262,12 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
 
     modifier isAdmin() {
-        require(admins[msg.sender], "EtherFiAdmin: not an admin");
+        require(admins[msg.sender] || msg.sender == owner(), "EtherFiAdmin: not an admio");
+        _;
+    }
+
+    modifier isPauser() {
+        require(pausers[msg.sender] || msg.sender == owner(), "EtherFiAdmin: not a pauser");
         _;
     }
 }

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -10,7 +10,6 @@ import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 import "./interfaces/IEtherFiOracle.sol";
 import "./interfaces/IEtherFiAdmin.sol";
 
-import "forge-std/console.sol";
 
 contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable, UUPSUpgradeable, IEtherFiOracle {
 
@@ -123,6 +122,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         require(_isFinalized(slot), "Report Epoch is not finalized yet");
         require(computeSlotAtTimestamp(block.timestamp) >= reportStartSlot, "Report Slot has not started yet");
         require(lastPublishedReportRefSlot == etherFiAdmin.lastHandledReportRefSlot(), "Last published report is not handled yet");
+
         return slot > committeeMemberStates[_member].lastReportRefSlot;
     }
 
@@ -134,6 +134,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         require(_report.refSlotTo == slotTo, "Report is for wrong slotTo");
         require(_report.refBlockFrom == blockFrom, "Report is for wrong blockFrom");
         require(_report.refBlockTo < block.number, "Report is for wrong blockTo");
+        require(_report.refBlockTo > etherFiAdmin.lastAdminExecutionBlock(), "Report must be based on the block after the last admin execution block");
 
         // If two epochs in a row are justified, the current_epoch - 2 is considered finalized
         // Put 1 epoch more as a safe buffer

--- a/src/interfaces/IEtherFiAdmin.sol
+++ b/src/interfaces/IEtherFiAdmin.sol
@@ -4,5 +4,6 @@ pragma solidity 0.8.13;
 interface IEtherFiAdmin {
     function lastHandledReportRefSlot() external view returns (uint32);
     function lastHandledReportRefBlock() external view returns (uint32);
+    function lastAdminExecutionBlock() external view returns (uint32);
     function numValidatorsToSpinUp() external view returns (uint32);
 }

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -570,4 +570,49 @@ contract EtherFiOracleTest is TestSetup {
         etherFiAdminInstance.unPause(true, true, true, true, true, true);
         vm.stopPrank();
     }
+
+    function test_report_earlier_than_last_admin_execution_fails() public {
+        vm.prank(owner);
+        bytes[] memory emptyBytes = new bytes[](0);
+        etherFiOracleInstance.setQuorumSize(1);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        _moveClock(1024 + 2 * 32);
+
+        (uint32 slotFrom, uint32 slotTo, uint32 blockFrom) = etherFiOracleInstance.blockStampForNextReport();
+        assertEq(slotFrom, 0);
+        assertEq(slotTo, 1024-1);
+        assertEq(blockFrom, 0);
+
+        report.refSlotFrom = 0;
+        report.refSlotTo = 1024-1;
+        report.refBlockFrom = 0;
+        report.refBlockTo = 1024-1;
+
+        vm.startPrank(alice);
+        etherFiOracleInstance.submitReport(report);
+        _moveClock(1 * 1024); // The oracle bot failed to submit the report for admin task execution... which can happen in real life
+        etherFiAdminInstance.executeTasks(report, emptyBytes, emptyBytes);
+
+        report.refSlotFrom = 1024;
+        report.refSlotTo = 2 * 1024 - 1;
+        report.refBlockFrom = 1024;
+        report.refBlockTo = 2 * 1024 - 1;
+
+        vm.expectRevert("Report must be based on the block after the last admin execution block");
+        etherFiOracleInstance.submitReport(report);
+
+        // After a period, the oracle bot submits the new report such that the report's 'refBlockTo' > 'lastAdminExecutionBlock'
+        // which succeeds
+        _moveClock(1024);
+        report.refSlotFrom = 1024;
+        report.refSlotTo = 3 * 1024 - 1;
+        report.refBlockFrom = 1024;
+        report.refBlockTo = 3 * 1024 - 1;
+
+        etherFiOracleInstance.submitReport(report);
+        etherFiAdminInstance.executeTasks(report, emptyBytes, emptyBytes);
+
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
An oracle report with its `refBlockTo` = `x` is generated refferring to the SC states at the block = `x`.

Say the report with `refBlockTo` = `x` is published and next report with `refBlockTo` = `x + T` will follow later (T is the oracle report generation period).
Assume that the Oracle bot failed to trigger the admin task execution for the report with `refBlockTo` = `x` until the block = `x + T` and it did after the block `x + T`. Now, the next report with `refBlockTo` = `x + T` is in trouble because while it is based on the SC states at block = `x + T`, the SC states has changed by the admin task execution AFTER block = `x + T`. That is, the new report could be generated based on the past states.

The solution is to reject the Oracle report with `refBlockTo` is earlier than the last admin task execution block.


Note that the state variable `lastAdminExecutionBlock` is put before `pausers` since the EtherFiAdmin contract is never updated yet.