### PR TITLE
(Contest) Optimize the gas spendings for auction manager

### DIFF
--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -174,7 +174,7 @@ contract AuctionManager is
             });
 
             // The Bid with its bid Id `x` can be accessed
-            // - if x < bidIdsBeforeGasOptimization, then bids[x] is the bid
+            // - if x <= bidIdsBeforeGasOptimization, then bids[x] is the bid
             // - otherwise, then batchedBids[x / 10] is all needed to construct the bid info
             //   - isAcitve = (batchedBids[x / 10].isActiveBits >> (x % 10)) & 1
             //   - bidderPubKeyIndex = batchedBids[x / 10].bidderPubKeyStartIndex + (x % 10)

--- a/src/NodeOperatorManager.sol
+++ b/src/NodeOperatorManager.sol
@@ -126,6 +126,22 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
         return ipfsIndex;
     }
 
+    function batchFetchNextKeyIndex(
+        address _user,
+        uint256 _size
+    ) external onlyAuctionManagerContract returns (uint64) {
+        KeyData storage keyData = addressToOperatorData[_user];
+        uint64 totalKeys = keyData.totalKeys;
+        require(
+            keyData.keysUsed + _size < totalKeys,
+            "Insufficient public keys"
+        );
+
+        uint64 ipfsIndex = keyData.keysUsed;
+        keyData.keysUsed += _size;
+        return ipfsIndex;
+    }
+
     /// @notice Approves or un approves an operator to run validators from a specific source of funds
     /// @dev To allow a permissioned system, we will approve node operators to run validators only for a specific source of funds (EETH / ETHER_FAN)
     ///         Some operators can be approved for both sources and some for only one. Being approved means that when a BNFT player deposits,

--- a/src/interfaces/IAuctionManager.sol
+++ b/src/interfaces/IAuctionManager.sol
@@ -9,6 +9,14 @@ interface IAuctionManager {
         bool isActive;
     }
 
+    struct BatchedBid {
+        uint16 numBids;
+        uint16 isActiveBits;
+        uint32 amountPerBidInGwei;
+        uint32 bidderPubKeyStartIndex;
+        address bidderAddress;
+    }
+
     function initialize(address _nodeOperatorManagerContract) external;
 
     function getBidOwner(uint256 _bidId) external view returns (address);

--- a/src/interfaces/INodeOperatorManager.sol
+++ b/src/interfaces/INodeOperatorManager.sol
@@ -41,6 +41,7 @@ interface INodeOperatorManager {
     ) external;
 
     function fetchNextKeyIndex(address _user) external returns (uint64);
+    function batchFetchNextKeyIndex(address _user, uint256 _size) external returns (uint64);
 
     function isEligibleToRunValidatorsForSourceOfFund(address _operator, LiquidityPool.SourceOfFunds _source) external view returns (bool approved);
 


### PR DESCRIPTION
# Why
Our node operators are going to bankrupt due to the gas cost they are spending to make bids.
In the current version, the AuctionManager allocates 2 slots (= 2 * 32 bytes) in storage per bid, see `IAuctionManager.Bid`, while those multiple bids have redundant & repeated data with rooms for improvement.

# What
The goal is to reduce the gas spendings to create bids by an order of magnitude at least.
The idea is to create a batched bid object (`IAuctionManager.BatchedBid`) that contains all the required info to re-construct the individual bid info so that the solution is also backward-compatible.

# How
As the initiative, I made code changes in this PR. Plz check the diffs to see the idea and leave any questions :)
It uses the batch size 10 as hard-coded number. You may change it to a constant variable.
With batch size = 10, the gas cost will be reduced to 1/20.

````
// The Bid with its bid Id `x` can be accessed
// - if x <= bidIdsBeforeGasOptimization, then bids[x] is the bid
// - otherwise, then batchedBids[x / 10] is all needed to construct the bid info
//   - isAcitve = (batchedBids[x / 10].isActiveBits >> (x % 10)) & 1
//   - bidderPubKeyIndex = batchedBids[x / 10].bidderPubKeyStartIndex + (x % 10)
````

# TODO
Fix all related parts of code so that the unit test run successfully