### PR TITLE
reduced the size of StakingManager contract, improved the deploy script

### DIFF
--- a/test/StakingManager.t.sol
+++ b/test/StakingManager.t.sol
@@ -260,7 +260,7 @@ contract StakingManagerTest is TestSetup {
 
         uint256[] memory bidIdArray = new uint256[](0);
 
-        vm.expectRevert("Incorrect bids or numVals");
+        vm.expectRevert("WRONG_PARAMS");
         stakingManagerInstance.batchDepositWithBidIds{value: 32 ether}(
             bidIdArray,
             false
@@ -1295,21 +1295,21 @@ contract StakingManagerTest is TestSetup {
 
     function test_CanOnlySetAddressesOnce() public {
         vm.startPrank(owner);
-        vm.expectRevert("ALREADY_SET");
+        vm.expectRevert(StakingManager.ALREADY_SET.selector);
         stakingManagerInstance.registerEtherFiNodeImplementationContract(
             address(0)
         );
 
-        vm.expectRevert("ALREADY_SET");
+        vm.expectRevert(StakingManager.ALREADY_SET.selector);
         stakingManagerInstance.registerTNFTContract(address(0));
 
-        vm.expectRevert("ALREADY_SET");
+        vm.expectRevert(StakingManager.ALREADY_SET.selector);
         stakingManagerInstance.registerBNFTContract(address(0));
 
-        vm.expectRevert("ALREADY_SET");
+        vm.expectRevert(StakingManager.ALREADY_SET.selector);
         stakingManagerInstance.setLiquidityPoolAddress(address(0));
 
-        vm.expectRevert("ALREADY_SET");
+        vm.expectRevert(StakingManager.ALREADY_SET.selector);
         stakingManagerInstance.setEtherFiNodesManagerAddress(address(0));
     }
 


### PR DESCRIPTION
Generate the correct timelock txn data from script

````
    ├─ [0] VM::startBroadcast(<pk>)
    │   └─ ← ()
    ├─ [4397838] → new LiquidityPool@0xF48dDB2b39071C8838c16c61B5017F2fE1094043
    │   ├─ emit Initialized(version: 255)
    │   └─ ← 22134 bytes of code
    ├─ [4914753] → new StakingManager@0x9f4c278A83928494bDAea44be5aFC99015076776
    │   ├─ emit Initialized(version: 255)
    │   └─ ← 24715 bytes of code
    ├─ [2267375] → new TNFT@0xd27a57BB8f9B7ec7862dF87f5143146C161f5a8B
    │   ├─ emit Initialized(version: 255)
    │   └─ ← 11495 bytes of code
    ├─ [4925971] → new EtherFiNodesManager@0xB27d4e7b8fF1EF21751b50F3821D99719Ad5868f
    │   ├─ emit Initialized(version: 255)
    │   └─ ← 24771 bytes of code
    ├─ [3179715] → new EtherFiNode@0xafb82ce44fd8a3431a64742bCD3547EEDA1AFea7
    │   └─ ← 15913 bytes of code
    ├─ [2402] EtherFiTimelock::getMinDelay() [staticcall]
    │   └─ ← 259200 [2.592e5]
    ├─ emit TimelockTransaction(target: 0x308861A430be4cce5502d0A12724771Fc6DaF216, value: 0, data: 0x3659cfe6000000000000000000000000f48ddb2b39071c8838c16c61b5017f2fe1094043, predecessor: 0x0000000000000000000000000000000000000000000000000000000000000000, salt: 0x0000000000000000000000000000000000000000000000000000000000000000, delay: 259200 [2.592e5])
    ├─ emit TimelockTransaction(target: 0x25e821b7197B146F7713C3b89B6A4D83516B912d, value: 0, data: 0x3659cfe60000000000000000000000009f4c278a83928494bdaea44be5afc99015076776, predecessor: 0x0000000000000000000000000000000000000000000000000000000000000000, salt: 0x0000000000000000000000000000000000000000000000000000000000000000, delay: 259200 [2.592e5])
    ├─ emit TimelockTransaction(target: 0x7B5ae07E2AF1C861BcC4736D23f5f66A61E0cA5e, value: 0, data: 0x3659cfe6000000000000000000000000d27a57bb8f9b7ec7862df87f5143146c161f5a8b, predecessor: 0x0000000000000000000000000000000000000000000000000000000000000000, salt: 0x0000000000000000000000000000000000000000000000000000000000000000, delay: 259200 [2.592e5])
    ├─ emit TimelockTransaction(target: 0x8B71140AD2e5d1E7018d2a7f8a288BD3CD38916F, value: 0, data: 0x3659cfe6000000000000000000000000b27d4e7b8ff1ef21751b50f3821d99719ad5868f, predecessor: 0x0000000000000000000000000000000000000000000000000000000000000000, salt: 0x0000000000000000000000000000000000000000000000000000000000000000, delay: 259200 [2.592e5])
    ├─ emit TimelockTransaction(target: 0x25e821b7197B146F7713C3b89B6A4D83516B912d, value: 0, data: 0x49370974000000000000000000000000afb82ce44fd8a3431a64742bcd3547eeda1afea7, predecessor: 0x0000000000000000000000000000000000000000000000000000000000000000, salt: 0x0000000000000000000000000000000000000000000000000000000000000000, delay: 259200 [2.592e5])
    ├─ emit TimelockTransaction(target: 0x8B71140AD2e5d1E7018d2a7f8a288BD3CD38916F, value: 0, data: 0xde5faecc00000000000000000000000039053d51b77dc0d36036fc1fcc8cb819df8ef37a, predecessor: 0x0000000000000000000000000000000000000000000000000000000000000000, salt: 0x0000000000000000000000000000000000000000000000000000000000000000, delay: 259200 [2.592e5])
    ├─ [0] VM::stopBroadcast()
    │   └─ ← ()
    └─ ← ()
````