### PR TITLE
Avs refactor

### DIFF
--- a/src/EtherFiAvsOperator.sol
+++ b/src/EtherFiAvsOperator.sol
@@ -159,6 +159,11 @@ contract EtherFiAvsOperator is IERC1271Upgradeable, IBeacon {
         return verifyBlsKeyAgainstHash(pubkeyRegistrationMessageHash, params);
     }
 
+    function getAvsInfo(address _avsRegistryCoordinator) external view returns (AvsInfo memory) {
+        return avsInfos[_avsRegistryCoordinator];
+    }
+
+
     modifier managerOnly() {
         require(msg.sender == avsOperatorsManager, "NOT_MANAGER");
         _;

--- a/src/EtherFiAvsOperator.sol
+++ b/src/EtherFiAvsOperator.sol
@@ -13,18 +13,18 @@ import "./eigenlayer-interfaces/IDelegationManager.sol";
 
 contract EtherFiAvsOperator is IERC1271Upgradeable, IBeacon {
 
-    struct AvsInfo {
-        bool isWhitelisted;
-        bytes quorumNumbers;
-        string socket;
-        IBLSApkRegistry.PubkeyRegistrationParams params;
-        bool isRegistered;
-    }
 
     address public avsOperatorsManager;
     address public ecdsaSigner;   // ECDSA signer that ether.fi owns
     address public avsNodeRunner; // Staking Company such as DSRV, Pier Two, Nethermind, ...
 
+    struct AvsInfo {
+        bool isWhitelisted;
+        bytes UNUSED_quorumNumbers;
+        string UNUSED_socket;
+        IBLSApkRegistry.PubkeyRegistrationParams UNUSED_params;
+        bool UNUSED_isRegistered;
+    }
     mapping(address => AvsInfo) public avsInfos;
 
     function initialize(address _avsOperatorsManager) external {
@@ -32,6 +32,7 @@ contract EtherFiAvsOperator is IERC1271Upgradeable, IBeacon {
         avsOperatorsManager = _avsOperatorsManager;
     }
 
+    // register this contract as a valid operator that can be delegated funds within eigenlayer core contracts
     function registerAsOperator(IDelegationManager _delegationManager, IDelegationManager.OperatorDetails calldata _detail, string calldata _metaDataURI) external managerOnly {
         _delegationManager.registerAsOperator(_detail, _metaDataURI);
     }
@@ -44,71 +45,49 @@ contract EtherFiAvsOperator is IERC1271Upgradeable, IBeacon {
         _delegationManager.updateOperatorMetadataURI(_metadataURI);
     }
 
-    function updateSocket(address _avsRegistryCoordinator, string memory _socket) external {
-        require(isAvsWhitelisted(_avsRegistryCoordinator), "AVS_NOT_WHITELISTED");
-        require(isAvsRegistered(_avsRegistryCoordinator), "AVS_NOT_REGISTERED");
-
-        IRegistryCoordinator(_avsRegistryCoordinator).updateSocket(_socket);
-        avsInfos[_avsRegistryCoordinator].socket = _socket;
-    }
-
-    function registerBlsKeyAsDelegatedNodeOperator(
-        address _avsRegistryCoordinator, 
+    function registerEigenDALikeOperator(
+        address _avsRegistryCoordinator,
         bytes calldata _quorumNumbers,
         string calldata _socket,
-        IBLSApkRegistry.PubkeyRegistrationParams calldata _params
-    ) external managerOnly {
-        require(isAvsWhitelisted(_avsRegistryCoordinator), "AVS_NOT_WHITELISTED");
-        require(!isAvsRegistered(_avsRegistryCoordinator), "AVS_ALREADY_REGISTERED");
-        require(verifyBlsKey(_avsRegistryCoordinator, _params), "BLSApkRegistry.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match");
-
-        avsInfos[_avsRegistryCoordinator].quorumNumbers = _quorumNumbers;
-        avsInfos[_avsRegistryCoordinator].socket = _socket;
-        avsInfos[_avsRegistryCoordinator].params = _params;
-    }
-
-    function registerOperator(
-        address _avsRegistryCoordinator,
+        IBLSApkRegistry.PubkeyRegistrationParams calldata _params,
         ISignatureUtils.SignatureWithSaltAndExpiry memory _operatorSignature
     ) external managerOnly {
         require(isAvsWhitelisted(_avsRegistryCoordinator), "AVS_NOT_WHITELISTED");
-        require(!isAvsRegistered(_avsRegistryCoordinator), "AVS_ALREADY_REGISTERED");
 
-        avsInfos[_avsRegistryCoordinator].isRegistered = true;
-
-        IRegistryCoordinator(_avsRegistryCoordinator).registerOperator(avsInfos[_avsRegistryCoordinator].quorumNumbers, avsInfos[_avsRegistryCoordinator].socket, avsInfos[_avsRegistryCoordinator].params, _operatorSignature);
+        IRegistryCoordinator(_avsRegistryCoordinator).registerOperator(_quorumNumbers, _socket, _params, _operatorSignature);
     }
 
-    function registerOperatorWithChurn(
+    function registerEigenDALikeOperatorWithChurn(
         address _avsRegistryCoordinator,
+        bytes calldata _quorumNumbers,
+        string calldata _socket,
+        IBLSApkRegistry.PubkeyRegistrationParams calldata _params,
         IRegistryCoordinator.OperatorKickParam[] calldata _operatorKickParams,
         ISignatureUtils.SignatureWithSaltAndExpiry memory _churnApproverSignature,
         ISignatureUtils.SignatureWithSaltAndExpiry memory _operatorSignature
     ) external managerOnly {
         require(isAvsWhitelisted(_avsRegistryCoordinator), "AVS_NOT_WHITELISTED");
-        require(!isAvsRegistered(_avsRegistryCoordinator), "AVS_ALREADY_REGISTERED");
 
-        IRegistryCoordinator(_avsRegistryCoordinator).registerOperatorWithChurn(avsInfos[_avsRegistryCoordinator].quorumNumbers, avsInfos[_avsRegistryCoordinator].socket, avsInfos[_avsRegistryCoordinator].params, _operatorKickParams, _churnApproverSignature, _operatorSignature);
+        IRegistryCoordinator(_avsRegistryCoordinator).registerOperatorWithChurn(
+            _quorumNumbers,
+            _socket,
+            _params,
+            _operatorKickParams,
+            _churnApproverSignature,
+            _operatorSignature
+        );
     }
 
-    function deregisterOperator(
+    function deregisterEigenDALikeOperator(
         address _avsRegistryCoordinator,
-        bytes calldata quorumNumbers
+        bytes calldata _quorumNumbers
     ) external managerOnly {
         delete avsInfos[_avsRegistryCoordinator];
 
-        IRegistryCoordinator(_avsRegistryCoordinator).deregisterOperator(quorumNumbers);
+        IRegistryCoordinator(_avsRegistryCoordinator).deregisterOperator(_quorumNumbers);
     }
 
-    function runnerForwardCall(
-        address _target, 
-        bytes4 _selector, 
-        bytes calldata _remainingCalldata) 
-    external managerOnly returns (bytes memory) {
-        require(isValidOperatorCall(_target, _selector, _remainingCalldata), "INVALID_OPERATOR_CALL");
-        return Address.functionCall(_target, abi.encodePacked(_selector, _remainingCalldata));
-    }
-
+    // forwards a whitelisted call from the manager contract to an arbitrary target
     function forwardCall(address to, bytes calldata data) external managerOnly returns (bytes memory) {
         return Address.functionCall(to, data);
     }
@@ -125,13 +104,6 @@ contract EtherFiAvsOperator is IERC1271Upgradeable, IBeacon {
         ecdsaSigner = _ecdsaSigner;
     }
 
-
-    // VIEW functions
-
-    function getAvsInfo(address _avsRegistryCoordinator) external view returns (AvsInfo memory) {
-        return avsInfos[_avsRegistryCoordinator];
-    }
-
     /**
      * @dev Should return whether the signature provided is valid for the provided data
      * @param _digestHash   Hash of the data to be signed
@@ -144,36 +116,6 @@ contract EtherFiAvsOperator is IERC1271Upgradeable, IBeacon {
 
     function isAvsWhitelisted(address _avsRegistryCoordinator) public view returns (bool) {
         return avsInfos[_avsRegistryCoordinator].isWhitelisted;
-    }
-
-    function isAvsRegistered(address _avsRegistryCoordinator) public view returns (bool) {
-        return avsInfos[_avsRegistryCoordinator].isRegistered;
-    }
-
-    function isValidOperatorCall(address _avsRegistryCoordinator, bytes4 _selector, bytes calldata _remainingCalldata) public view returns (bool) {
-        if (!isAvsWhitelisted(_avsRegistryCoordinator)) return false;
-
-        if (_selector == hex"11d2c708") {
-            // Witness Chain
-            // OperatorRegistry.registerWatchtowerAsOperator(address watchtower, uint256 expiry, bytes memory signedMessage)
-            // - https://github.com/witnesschain-com/diligencewatchtower-contracts/blob/main/src/core/OperatorRegistry.sol#L158
-            return true;
-        }
-        
-        return false;
-    }
-
-    function isRegisteredBlsKey(
-        address _avsRegistryCoordinator,
-        bytes calldata _quorumNumbers,
-        string calldata _socket,
-        IBLSApkRegistry.PubkeyRegistrationParams calldata _params
-    ) public view returns (bool) {
-        AvsInfo memory avsInfo = avsInfos[_avsRegistryCoordinator];
-        bytes32 digestHash1 = keccak256(abi.encode(_avsRegistryCoordinator, _quorumNumbers, _socket, _params));
-        bytes32 digestHash2 = keccak256(abi.encode(_avsRegistryCoordinator, avsInfo.quorumNumbers, avsInfo.socket, avsInfo.params));
-
-        return digestHash1 == digestHash2;
     }
 
     /// @dev implementation address for beacon proxy.
@@ -192,16 +134,16 @@ contract EtherFiAvsOperator is IERC1271Upgradeable, IBeacon {
     function verifyBlsKeyAgainstHash(BN254.G1Point memory pubkeyRegistrationMessageHash, IBLSApkRegistry.PubkeyRegistrationParams memory params) public view returns (bool) {
         // gamma = h(sigma, P, P', H(m))
         uint256 gamma = uint256(keccak256(abi.encodePacked(
-            params.pubkeyRegistrationSignature.X, 
-            params.pubkeyRegistrationSignature.Y, 
-            params.pubkeyG1.X, 
-            params.pubkeyG1.Y, 
-            params.pubkeyG2.X, 
-            params.pubkeyG2.Y, 
-            pubkeyRegistrationMessageHash.X, 
+            params.pubkeyRegistrationSignature.X,
+            params.pubkeyRegistrationSignature.Y,
+            params.pubkeyG1.X,
+            params.pubkeyG1.Y,
+            params.pubkeyG2.X,
+            params.pubkeyG2.Y,
+            pubkeyRegistrationMessageHash.X,
             pubkeyRegistrationMessageHash.Y
         ))) % BN254.FR_MODULUS;
-        
+
         // e(sigma + P * gamma, [-1]_2) = e(H(m) + [1]_1 * gamma, P') 
         return BN254.pairing(
                 BN254.plus(params.pubkeyRegistrationSignature, BN254.scalar_mul(params.pubkeyG1, gamma)),

--- a/src/EtherFiAvsOperatorsManager.sol
+++ b/src/EtherFiAvsOperatorsManager.sol
@@ -35,7 +35,6 @@ contract EtherFiAvsOperatorsManager is
     // Operator -> AvsServiceManager -> whitelisted
     // This structure mirrors how Eigenlayers AvsDirectory tracks operator data
     mapping(address => mapping(address => bool)) public operatorAvsWhitelist;
-    //mapping(address => mapping(address => IBLSApkRegistry.PubkeyRegistrationParams)) public operatorBLSKeys;
 
     // operator -> targetAddress -> selector -> allowed
     // allowed calls that AvsRunner can trigger from operator contract
@@ -219,6 +218,10 @@ contract EtherFiAvsOperatorsManager is
 
     function updateAdmin(address _address, bool _isAdmin) external onlyOwner {
         admins[_address] = _isAdmin;
+    }
+
+    function updateAllowedOperatorCalls(uint256 _operatorId, address _target, bytes4 _selector, bool _allowed) external onlyAdmin {
+        allowedOperatorCalls[_operatorId][_target][_selector] = _allowed;
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}

--- a/test/EtherFiAvsOperatorsManager.t.sol
+++ b/test/EtherFiAvsOperatorsManager.t.sol
@@ -114,6 +114,7 @@ contract EtherFiAvsOperatorsManagerTest is TestSetup {
         assertEq(stored_details.stakerOptOutWindowBlocks, details.stakerOptOutWindowBlocks);
     }
 
+    /*
     function test_registerBlsKeyAsDelegatedNodeOperator() public {
         test_registerAsOperator();
 
@@ -141,11 +142,11 @@ contract EtherFiAvsOperatorsManagerTest is TestSetup {
         vm.prank(avsNodeRunner);
         avsOperatorsManager.registerBlsKeyAsDelegatedNodeOperator(id, eigenDA_registryCoordinator, quorumNumbers, socket, params);
     }
+    */
 
     function test_update_operator_info() public {
         test_registerAsOperator();
-    
-        string memory new_socket = "new_socket";
+
         IBLSApkRegistry.PubkeyRegistrationParams memory new_params = IBLSApkRegistry.PubkeyRegistrationParams({
             pubkeyRegistrationSignature: BN254.G1Point(2, 2),
             pubkeyG1: BN254.G1Point(2, 2),
@@ -157,11 +158,6 @@ contract EtherFiAvsOperatorsManagerTest is TestSetup {
             stakerOptOutWindowBlocks: 2
         });
         string memory new_metadata_uri = "new_metadata_uri";
-
-
-        vm.prank(alice);
-        vm.expectRevert("INCORRECT_CALLER");
-        avsOperatorsManager.updateSocket(id, eigenDA_registryCoordinator, new_socket);
 
         vm.prank(avsNodeRunner);
         vm.expectRevert("Ownable: caller is not the owner");
@@ -182,7 +178,6 @@ contract EtherFiAvsOperatorsManagerTest is TestSetup {
         address nethermind = 0x57b6FdEF3A23B81547df68F44e5524b987755c99;
 
         assertTrue(avsDirectory.avsOperatorStatus(eigenDA_servicemanager, nethermind) == IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED);
-        assertTrue(avsOperatorsManager.avsOperatorStatus(1, eigenDA_servicemanager) == IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED);
         assertTrue(
             avsOperatorsManager.calculateOperatorAVSRegistrationDigestHash(id, eigenDA_servicemanager, bytes32(abi.encode(1)), 1) ==
             avsDirectory.calculateOperatorAVSRegistrationDigestHash(address(avsOperatorsManager.avsOperators(id)), eigenDA_servicemanager, bytes32(abi.encode(1)), 1)


### PR DESCRIPTION
A bunch of updates for smooth long term onboarding of AVS now that we know more.

1. All of our assumptions were wrong. Not every AVS follows the EigenDA template. Some don't even have some of the middleware contracts like `registryCoordinator`. `Socket` is only relevant for eigenDA. Some protocols use multiple BLS keys. We can't track registered status on our end become some AVS will automatically deregister users in churn situations where our contract would then be out of sync

Long term I think the sustainable option is to treat the operator as a simple forwarding contract and do all the heavy lifting in the CLI + backend tooling. We will need to invest the time to make these tools helpful for us and good at tracking what has occured on chain, since it will be slightly obscured. Also other possible routes where we make adapter contracts for every AVS.

I left in the existing functions for interacting with contracts that have the same setup as eigenDA

I think a flow like this might work
1. Get things working with forwarding calls. This lets us get to market fast
2. Once we have a good handle on the AVS, create adapter contracts/functions that make future operations easier