### PR TITLE
Fix missed vm.startPrank in tests

### DIFF
--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -660,7 +660,8 @@ contract TestSetup is Test {
         _approveNodeOperators();
         _setUpNodeOperatorWhitelist();
         vm.stopPrank();
-
+        
+        vm.startPrank(owner);
         nodeOperatorManagerInstance.setAuctionContractAddress(address(auctionInstance));
 
         auctionInstance.setStakingManagerContractAddress(address(stakingManagerInstance));


### PR DESCRIPTION
Hello team! During tests execution I encountered the following error in `setUpTests` of the `TestSetup.sol` file:

<img width="1277" alt="image" src="https://github.com/etherfi-protocol/smart-contracts/assets/16706712/e10bd4c2-ec79-41d0-885a-a790d903ec45">

Seems that on the [line](https://github.com/etherfi-protocol/smart-contracts/blob/4160ada6203f83e7cf776cc94eb3bb8eeccf0076/test/TestSetup.sol#L663) the `vm.startPrank(owner);` call missed to use the same owner, which deployed the contracts. This PR adds the line