### PR TITLE
fix recycling condition

### DIFF
--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -27,13 +27,12 @@ contract EtherFiNode is IEtherFiNode {
     bool public isRestakingEnabled;
 
     uint16 public version;
-    uint16 private _numAssociatedValidators;
+    uint16 private _numAssociatedValidators; // num validators in {LIVE, BEING_SLASHED, EXITED} phase
     uint16 public numExitRequestsByTnft;
     uint16 public numExitedValidators; // EXITED & but not FULLY_WITHDRAWN
 
-    // TODO: see if we really need to maintain the validator Ids on-chain
     mapping(uint256 => uint256) public associatedValidatorIndices;
-    uint256[] public associatedValidatorIds;
+    uint256[] public associatedValidatorIds; // validators in {STAKE_DEPOSITED, WAITING_FOR_APPROVAL, LIVE, BEING_SLASHED, EXITED} phase
 
     // Track the amount of pending/completed withdrawals;
     uint64 public pendingWithdrawalFromRestakingInGwei; // incremented when the delayed withdrawal (from EigenPod to EtherFiNode) is queued, decremented when it is completed
@@ -103,6 +102,7 @@ contract EtherFiNode is IEtherFiNode {
 
     // At version 0, an EtherFiNode contract is associated with only one validator
     // After version 1, it can be associated with multiple validators having the same (B-nft, T-nft, node operator) 
+    // returns the number of the validators in {LIVE, BEING_SLASHED, EXITED} phase associated with this safe
     function numAssociatedValidators() public view returns (uint256) {
         if (version == 0) {
             // For the safe at version 0, `phase` variable is still valid and can be used to check if the validator is still active 
@@ -119,7 +119,6 @@ contract EtherFiNode is IEtherFiNode {
     function registerValidator(uint256 _validatorId, bool _enableRestaking) public onlyEtherFiNodeManagerContract ensureLatestVersion {
         require(numAssociatedValidators() == 0 || isRestakingEnabled == _enableRestaking, "restaking status mismatch");
 
-        // TODO: see if we really need to maintain the validator Ids on-chain
         {
             uint256 index = associatedValidatorIds.length;
             associatedValidatorIds.push(_validatorId);
@@ -150,7 +149,6 @@ contract EtherFiNode is IEtherFiNode {
             numExitRequestsByTnft -= 1;
         }
 
-        // TODO: see if we really need to maintain the validator Ids on-chain
         {
             uint256 index = associatedValidatorIndices[_validatorId];        
             uint256 endIndex = associatedValidatorIds.length - 1;
@@ -163,7 +161,8 @@ contract EtherFiNode is IEtherFiNode {
             delete associatedValidatorIndices[_validatorId];
         }
         
-        if (numAssociatedValidators() == 0) {
+        if (associatedValidatorIds.length == 0) {
+            require(numAssociatedValidators() == 0, "INVALID_STATE");
             restakingObservedExitBlock = 0;
             isRestakingEnabled = false;
             return true;

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -15,6 +15,7 @@ import "./interfaces/IProtocolRevenueManager.sol";
 import "./interfaces/IStakingManager.sol";
 import "./TNFT.sol";
 import "./BNFT.sol";
+import "forge-std/console.sol";
 
 
 contract EtherFiNodesManager is
@@ -520,12 +521,12 @@ contract EtherFiNodesManager is
         address safeAddress = etherfiNodeAddress[_validatorId];
         if (safeAddress == address(0)) revert NotInstalled();
 
-        IEtherFiNode(safeAddress).unRegisterValidator(_validatorId, validatorInfos[_validatorId]);
+        bool doRecycle = IEtherFiNode(safeAddress).unRegisterValidator(_validatorId, validatorInfos[_validatorId]);
 
         delete etherfiNodeAddress[_validatorId];
         // delete validatorInfos[_validatorId];
 
-        if (IEtherFiNode(safeAddress).numAssociatedValidators() == 0) {
+        if (doRecycle) {
             unusedWithdrawalSafes.push(safeAddress);
         }
     }

--- a/src/interfaces/IEtherFiNode.sol
+++ b/src/interfaces/IEtherFiNode.sol
@@ -57,6 +57,7 @@ interface IEtherFiNode {
     function getRewardsPayouts(uint32 _exitRequestTimestamp, IEtherFiNodesManager.RewardsSplit memory _splits) external view returns (uint256, uint256, uint256, uint256);
     function getFullWithdrawalPayouts(IEtherFiNodesManager.ValidatorInfo memory _info, IEtherFiNodesManager.RewardsSplit memory _SRsplits) external view returns (uint256, uint256, uint256, uint256);
     function associatedValidatorIds(uint256 _index) external view returns (uint256);
+    function associatedValidatorIndices(uint256 _validatorId) external view returns (uint256);
     function validatePhaseTransition(VALIDATOR_PHASE _currentPhase, VALIDATOR_PHASE _newPhase) external pure returns (bool);
 
     function DEPRECATED_exitRequestTimestamp() external view returns (uint32);

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1381,12 +1381,11 @@ contract TestSetup is Test {
         bytes[] memory pubKey = new bytes[](_validatorIds.length);
 
         for (uint256 i = 0; i < _validatorIds.length; i++) {
-            address etherFiNode = managerInstance.etherfiNodeAddress(_validatorIds[i]);
             pubKey[i] = hex"8f9c0aab19ee7586d3d470f132842396af606947a0589382483308fdffdaf544078c3be24210677a9c471ce70b3b4c2c";
             bytes32 root = depGen.generateDepositRoot(
                 pubKey[i],
                 hex"877bee8d83cac8bf46c89ce50215da0b5e370d282bb6c8599aabdbc780c33833687df5e1f5b5c2de8a6cd20b6572c8b0130b1744310a998e1079e3286ff03e18e4f94de8cdebecf3aaac3277b742adb8b0eea074e619c20d13a1dda6cba6e3df",
-                managerInstance.generateWithdrawalCredentials(etherFiNode),
+                managerInstance.getWithdrawalCredentials(_validatorIds[i]),
                 1 ether
             );
             depositDataArray[i] = IStakingManager.DepositData({
@@ -1399,7 +1398,7 @@ contract TestSetup is Test {
             depositDataRootsForApproval[i] = depGen.generateDepositRoot(
                 pubKey[i],
                 hex"ad899d85dcfcc2506a8749020752f81353dd87e623b2982b7bbfbbdd7964790eab4e06e226917cba1253f063d64a7e5407d8542776631b96c4cea78e0968833b36d4e0ae0b94de46718f905ca6d9b8279e1044a41875640f8cb34dc3f6e4de65",
-                managerInstance.generateWithdrawalCredentials(etherFiNode),
+                managerInstance.getWithdrawalCredentials(_validatorIds[i]),
                 31 ether
             );
 


### PR DESCRIPTION
The `EtherFiNode.numAssociatedValidators()` tracks the number of active validators associated with the safe. However, a safe can be locked for a certain validator before it gets fully active; i.e., while they are in  {STAKE_DEPOSITED, WAITING_FOR_APPROVA} phases.

So, in order to check if the contract is eligible for recycling, we need to check `associatedValidatorIds.length == 0` which includes the validators in {STAKE_DEPOSITED, WAITING_FOR_APPROVA} phases.