### PR TITLE
[EFIP-5] Security Improvements for eETH/weETH

### DIFF
--- a/proposals/EFIP-5.md
+++ b/proposals/EFIP-5.md
@@ -49,7 +49,7 @@ contract EETH {
 
 ### Blacklist on `transfer`
 
-It introduces a blacklist mechanism on `transfer`. It will prevent the transfer of tokens to the blacklisted addresses. This will help to prevent the funds from being sent to the malicious contracts or addresses.
+It introduces a blacklist mechanism on `transfer`. It will prevent the transfer of tokens to and from blacklisted addresses. This will help to prevent the funds from being sent to the malicious contracts or addresses.
 
 Note that [USDCv2](https://etherscan.io/address/0x43506849d7c04f9138d1a2050bbf3a0c054402dd#code) by Circle implements the blacklist.
 

--- a/proposals/EFIP-5.md
+++ b/proposals/EFIP-5.md
@@ -22,7 +22,7 @@ The below are PoC implementations. The actual implementation may vary.
 
 ### Whitelist on `spender` of `permit`
 
-It introduces a whitelist mechanism on `spender` of `permit`. It will only allow the permit to be signed only for the whitelisted addresses to be the `spender` such as the well-known DEXes or lending protocols.
+It introduces a whitelist mechanism on `spender` of `permit`. It will only allow whitelisted addresses to be the `spender` such as the well-known DEXes or lending protocols.
 
 ```
 contract EETH {

--- a/proposals/EFIP-5.md
+++ b/proposals/EFIP-5.md
@@ -60,7 +60,7 @@ contract EETH {
     mapping(address => bool) public blacklisted;
 
     function _transfer(address _sender, address _recipient, uint256 _amount) internal {
-        require(!blacklisted[_sender] || !blacklisted[_recipient], "EETH: blacklisted address");
+        require(!blacklisted[_sender] && !blacklisted[_recipient], "EETH: blacklisted address");
 
         ...
     }

--- a/proposals/EFIP-5.md
+++ b/proposals/EFIP-5.md
@@ -1,4 +1,4 @@
-# [EFIP-5] Security Improvements for eETH/weETH: Whitelist on `spender` of `permit`, blacklist on `transfer`, and rescue mechanism
+# [EFIP-5] Security Improvements for eETH/weETH: Whitelist on `spender` of `permit` and Blacklist on `transfer`
 
 **Author**: syko (seongyun@ether.fi)
 

--- a/proposals/EFIP-5.md
+++ b/proposals/EFIP-5.md
@@ -11,7 +11,7 @@ This EFIP aims to improve the security of ether.fi eETH/weETH by introducing a w
 
 ## Motivation
 
-While ERC20's extension on `Permit` brings convenience by using off-chain signatures for authorization, it also introduces risks. We have been seeing growing incidents of phishing attacks, where users are tricked into signing a permit for a malicious contract.
+While ERC20's extension on `Permit` brings convenience by using off-chain signatures for authorization, it is a well-known vulnerability that can lead to [phishing attacks](https://cointelegraph.com/magazine/phishing-crypto-erc-20-bait-scammers/). We have also been seeing growing incidents of incidents, where eETH/weETH users are tricked into signing a permit for a malicious contract or address.
 
 In addition, the funds can be sent to the malicious contracts or addresses by the owner or the malicious contracts can lock the funds by transferring them to the blacklisted addresses. This can lead to the loss of funds or the funds being locked forever.
 
@@ -87,8 +87,8 @@ contract EETH {
 
 ## References
 
-A list of relevant links like for this proposal e.g.
-- USDCv2 https://etherscan.io/address/0x43506849d7c04f9138d1a2050bbf3a0c054402dd#code
+- Ethereum’s ERC-20 design flaws are a crypto scammer’s best friend [link](https://cointelegraph.com/magazine/phishing-crypto-erc-20-bait-scammers/)
+- USDCv2 [link](https://etherscan.io/address/0x43506849d7c04f9138d1a2050bbf3a0c054402dd)
 
 ## Copyright
 

--- a/proposals/EFIP-5.md
+++ b/proposals/EFIP-5.md
@@ -1,0 +1,96 @@
+# [EFIP-5] Security Improvements for eETH/weETH: Whitelist on `spender` of `permit`, blacklist on `transfer`, and rescue mechanism
+
+**Author**: syko (seongyun@ether.fi)
+
+**Date**: 2024-06-28
+
+## Summary
+
+This EFIP aims to improve the security of ether.fi eETH/weETH by introducing a whitelist mechanism on `spender` of `permit`, a blacklist mechanism on `transfer`, and a rescue mechanism for the blacklisted or locked funds.
+
+
+## Motivation
+
+While ERC20's extension on `Permit` brings convenience by using off-chain signatures for authorization, it also introduces risks. We have been seeing growing incidents of phishing attacks, where users are tricked into signing a permit for a malicious contract.
+
+In addition, the funds can be sent to the malicious contracts or addresses by the owner or the malicious contracts can lock the funds by transferring them to the blacklisted addresses. This can lead to the loss of funds or the funds being locked forever.
+
+Note that [USDCv2](https://etherscan.io/address/0x43506849d7c04f9138d1a2050bbf3a0c054402dd#code) by Circle implements the blacklist and rescue mechanisms.
+
+## Proposal
+
+The below are PoC implementation for each feature. Note that the actual implementation may vary.
+
+### Whitelist on `spender` of `permit`
+
+It introduces a whitelist mechanism on `spender` of `permit`. It will only allow the permit to be signed only for the whitelisted addresses to be the `spender` such as the well-known DEXes or lending protocols.
+
+```
+contract EETH {
+    ...
+
+    mapping(address => bool) public whitelistedSpender;
+
+    function permit(
+            address owner,
+            address spender,
+            uint256 value,
+            uint256 deadline,
+            uint8 v,
+            bytes32 r,
+            bytes32 s
+    ) public virtual override(IeETH, IERC20PermitUpgradeable) {
+        require(whitelistedSpender[spender], "EETH: spender not whitelisted"); 
+
+        ...
+    }
+}
+```
+
+
+### Blacklist on `transfer`
+
+It introduces a blacklist mechanism on `transfer`. It will prevent the transfer of tokens to the blacklisted addresses. This will help to prevent the funds from being sent to the malicious contracts or addresses.
+
+```
+contract EETH {
+    ...
+    
+    mapping(address => bool) public blacklisted;
+
+    function _transfer(address _sender, address _recipient, uint256 _amount) internal {
+        require(!blacklisted[_sender] || !blacklisted[_recipient], "EETH: blacklisted address");
+
+        ...
+    }
+}
+```
+
+### Rescue
+
+It introduces a rescue mechanism for the blacklisted or locked funds. It will allow the owner to rescue the funds from the blacklisted or locked addresses. This will help to recover the funds in case of any accidental or malicious transfers.
+
+```
+contract EETH {
+    ...
+    
+    mapping(address => bool) public blacklisted;
+
+    function _transfer(address _sender, address _recipient, uint256 _amount) internal {
+        require(!blacklisted[_sender] || !blacklisted[_recipient], "EETH: blacklisted address");
+        
+        ...
+    }
+}
+```
+
+
+## References
+
+A list of relevant links like for this proposal e.g.
+- USDCv2 https://etherscan.io/address/0x43506849d7c04f9138d1a2050bbf3a0c054402dd#code
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+

--- a/proposals/EFIP-5.md
+++ b/proposals/EFIP-5.md
@@ -6,20 +6,19 @@
 
 ## Summary
 
-This EFIP aims to improve the security of ether.fi eETH/weETH by introducing a whitelist mechanism on `spender` of `permit`, a blacklist mechanism on `transfer`, and a rescue mechanism for the blacklisted or locked funds.
+This EFIP aims to improve the security of ether.fi eETH/weETH by introducing a whitelist on `spender` of `permit` and a blacklist on `transfer`.
 
 
 ## Motivation
 
 While ERC20's extension on `Permit` brings convenience by using off-chain signatures for authorization, it is a well-known vulnerability that can lead to [phishing attacks](https://cointelegraph.com/magazine/phishing-crypto-erc-20-bait-scammers/). We have also been seeing growing incidents of incidents, where eETH/weETH users are tricked into signing a permit for a malicious contract or address.
 
-In addition, the funds can be sent to the malicious contracts or addresses by the owner or the malicious contracts can lock the funds by transferring them to the blacklisted addresses. This can lead to the loss of funds or the funds being locked forever.
+In addition, the funds can be sent to the malicious contracts or addresses by the owner or the malicious contracts can lock the funds by transferring them to the malicious addresses. This can lead to the loss of funds or the funds being locked forever.
 
-Note that [USDCv2](https://etherscan.io/address/0x43506849d7c04f9138d1a2050bbf3a0c054402dd#code) by Circle implements the blacklist and rescue mechanisms.
 
 ## Proposal
 
-The below are PoC implementation for each feature. Note that the actual implementation may vary.
+The below are PoC implementations. The actual implementation may vary.
 
 ### Whitelist on `spender` of `permit`
 
@@ -52,6 +51,8 @@ contract EETH {
 
 It introduces a blacklist mechanism on `transfer`. It will prevent the transfer of tokens to the blacklisted addresses. This will help to prevent the funds from being sent to the malicious contracts or addresses.
 
+Note that [USDCv2](https://etherscan.io/address/0x43506849d7c04f9138d1a2050bbf3a0c054402dd#code) by Circle implements the blacklist.
+
 ```
 contract EETH {
     ...
@@ -65,25 +66,6 @@ contract EETH {
     }
 }
 ```
-
-### Rescue
-
-It introduces a rescue mechanism for the blacklisted or locked funds. It will allow the owner to rescue the funds from the blacklisted or locked addresses. This will help to recover the funds in case of any accidental or malicious transfers.
-
-```
-contract EETH {
-    ...
-    
-    mapping(address => bool) public blacklisted;
-
-    function _transfer(address _sender, address _recipient, uint256 _amount) internal {
-        require(!blacklisted[_sender] || !blacklisted[_recipient], "EETH: blacklisted address");
-        
-        ...
-    }
-}
-```
-
 
 ## References
 


### PR DESCRIPTION
## Summary

This EFIP aims to improve the security of ether.fi eETH/weETH by introducing a whitelist on `spender` of `permit` and a blacklist on `transfer`.


## Motivation

While ERC20's extension on `Permit` brings convenience by using off-chain signatures for authorization, it is a well-known vulnerability that can lead to [phishing attacks](https://cointelegraph.com/magazine/phishing-crypto-erc-20-bait-scammers/). We have also been seeing growing incidents of incidents, where eETH/weETH users are tricked into signing a permit for a malicious contract or address.

In addition, the funds can be sent to the malicious contracts or addresses by the owner or the malicious contracts can lock the funds by transferring them to the malicious addresses. This can lead to the loss of funds or the funds being locked forever.