### PR TITLE
EtherFiStaking with delegation/voting

### DIFF
--- a/script/deploys/EtherFiStaking.s.sol
+++ b/script/deploys/EtherFiStaking.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+
+import "../../src/EtherFiStaking.sol";
+import "../../src/UUPSProxy.sol";
+
+
+contract Deploy is Script {
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        address ethfiToken = 0xFe0c30065B384F05761f15d0CC899D4F9F9Cc0eB;
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        EtherFiStaking impl = new EtherFiStaking();
+        UUPSProxy proxy = new UUPSProxy(
+            address(impl), 
+            abi.encodeWithSelector(EtherFiStaking.initialize.selector, address(ethfiToken))
+        );
+
+        EtherFiStaking etherfiStaking = EtherFiStaking(address(proxy));
+
+        vm.stopBroadcast();
+    }
+
+}

--- a/src/EtherFiStaking.sol
+++ b/src/EtherFiStaking.sol
@@ -1,0 +1,200 @@
+
+
+/// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+
+import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
+
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title EtherFi Staking Contract
+ * @notice This contract allows users to stake ETHFI tokens, earn votes through delegation, and withdraw their staked tokens. 
+ * Users can delegate their votes to another address or self-delegate if no delegation is specified. The contract uses 
+ * OpenZeppelin upgradeable libraries for security and upgradability, including Ownable, Pausable, and ReentrancyGuard. 
+ * It ensures safe ERC20 token transfers and maintains mappings for user balances, delegations, and vote counts. 
+ * Key functionalities include deposit, withdraw, balance checking, and vote delegation management.
+ */
+
+contract EtherFiStaking is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, ReentrancyGuardUpgradeable {
+    using SafeERC20 for IERC20;
+
+    IERC20 public ethfiToken;
+
+    mapping(address => uint256) private _balances; // from user address to their staked balance
+    mapping(address => address) private _delegation; // from user address to their delegatee
+    mapping(address => uint256) private _votes; // from delegatee address to their total votes
+
+    event Deposited(address indexed user, uint256 amount);
+    event Withdrawn(address indexed user, uint256 amount);
+    event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
+    event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address _ethfiToken) initializer external {
+        __Pausable_init();
+        __Ownable_init();
+        __UUPSUpgradeable_init();
+        __ReentrancyGuard_init();
+
+        ethfiToken = IERC20(_ethfiToken);
+    }
+
+    /// @notice deposit ETHFI tokens to stake
+    /// @param amount The amount of ETHFI tokens to deposit
+    /// @param delegatee The address to delegate the votes to
+    // - If the user is already delegating, undelegate and move the whole votes to the new delegatee
+    function deposit(uint256 amount, address delegatee) external whenNotPaused nonReentrant checkDepositInvariant(amount, delegatee) {
+        require(amount > 0, "Deposit amount must be greater than zero");
+        require(delegatee != address(0), "Delegatee cannot be zero address");
+
+        // If the user is not delegating to the delegatee, undelegate
+        if (delegates(msg.sender) != delegatee) {
+            _undelegate(msg.sender);
+        }
+
+        assert(delegates(msg.sender) == address(0) || delegates(msg.sender) == delegatee);
+
+        // Update the user's staked balance
+        _balances[msg.sender] += amount;
+
+        if (delegates(msg.sender) == address(0)) {
+            // If the user is not delegating to anyone, delegate to themself
+            _delegate(msg.sender, delegatee);
+        } else {
+            // If the user is already delegating, move the `amount` votes to the delegatee
+            _moveDelegateVotes(address(0), delegates(msg.sender), amount);
+        }
+
+        // Transfer the tokens to the contract
+        ethfiToken.safeTransferFrom(msg.sender, address(this), amount);
+
+        emit Deposited(msg.sender, amount);
+    }
+
+    /// @notice unstake and withdraw ETHFI tokens
+    /// @param amount The amount of ETHFI tokens to withdraw
+    function withdraw(uint256 amount) external whenNotPaused nonReentrant checkWithdrawInvariant(amount) {
+        require(amount > 0, "Withdrawal amount must be greater than zero");
+        require(_balances[msg.sender] >= amount, "Insufficient balance for withdrawal");
+
+        // Update the user's staked balance
+        _balances[msg.sender] -= amount;
+
+        // Reduce the delegatee's votes
+        _moveDelegateVotes(delegates(msg.sender), address(0), amount);
+
+        // Transfer the tokens to the user
+        ethfiToken.safeTransfer(msg.sender, amount);
+
+        emit Withdrawn(msg.sender, amount);
+    }
+
+    /// @notice delegate votes to a delegatee
+    /// @param delegatee The address to delegate the votes to
+    // If the `msg.sender` is already delegating, it will move the votes to the new delegatee
+    function delegate(address delegatee) external whenNotPaused {
+        _delegate(msg.sender, delegatee);
+    }
+
+    /// @notice staked balance of a user
+    /// @param user The address of the user
+    function balanceOf(address user) external view returns (uint256) {
+        return _balances[user];
+    }
+
+    /**
+     * @dev Returns the current amount of votes that `account` has.
+     */
+    function getVotes(address account) public view virtual returns (uint256) {
+        return _votes[account];
+    }
+
+    /**
+     * @dev Returns the delegate that `account` has chosen.
+     */
+    function delegates(address account) public view virtual returns (address) {
+        return _delegation[account];
+    }
+
+    function _moveDelegateVotes(
+        address from,
+        address to,
+        uint256 amount
+    ) private {
+        if (from != to && amount > 0) {
+            if (from != address(0)) {
+                uint256 oldValue = _votes[from];
+                uint256 newValue = oldValue - amount;
+                _votes[from] = newValue;
+                emit DelegateVotesChanged(from, oldValue, newValue);
+            }
+            if (to != address(0)) {
+                uint256 oldValue = _votes[to];
+                uint256 newValue = oldValue + amount;
+                _votes[to] = newValue;
+                emit DelegateVotesChanged(to, oldValue, newValue);
+            }
+        }
+    }
+    
+    /**
+     * @dev Delegate all of `account`'s voting units to `delegatee`.
+     *
+     * Emits events {IVotes-DelegateChanged} and {IVotes-DelegateVotesChanged}.
+     */
+    function _delegate(address account, address delegatee) internal virtual {
+        address oldDelegate = delegates(account);
+        _delegation[account] = delegatee;
+
+        emit DelegateChanged(account, oldDelegate, delegatee);
+        _moveDelegateVotes(oldDelegate, delegatee, _getVotingUnits(account));
+    }
+
+    // undelegate and get the votes back to `account`
+    function _undelegate(address account) internal virtual {
+        address oldDelegate = delegates(account);
+        _delegation[account] = address(0);
+
+        emit DelegateChanged(account, oldDelegate, address(0));
+        _moveDelegateVotes(oldDelegate, address(0), _getVotingUnits(account));
+    }
+
+    function _getVotingUnits(address account) internal view virtual returns (uint256) {
+        return _balances[account];
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    /// @dev Modifier to check the invariant after deposit
+    modifier checkDepositInvariant(uint256 amount, address delegatee) {
+        uint256 contractTokenBalance = ethfiToken.balanceOf(address(this));
+        _;
+        require(ethfiToken.balanceOf(address(this)) == contractTokenBalance + amount, "Invariant check failed after deposit");
+        require(delegates(msg.sender) == delegatee, "Invariant check failed after deposit");
+    }
+
+    /// @dev Modifier to check the invariant after withdraw
+    modifier checkWithdrawInvariant(uint256 amount) {
+        uint256 contractTokenBalance = ethfiToken.balanceOf(address(this));
+        _;
+        require(ethfiToken.balanceOf(address(this)) == contractTokenBalance - amount, "Invariant check failed after withdrawal");
+    }
+}   

--- a/test/EtherFiStaking.t.sol
+++ b/test/EtherFiStaking.t.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "./TestSetup.sol";
+import "forge-std/Test.sol";
+
+
+import "../src/EtherFiStaking.sol";
+import "../src/UUPSProxy.sol";
+
+import "./eigenlayer-mocks/ERC20Mock.sol";
+
+contract EtherFiStakingTest is TestSetup {
+// contract EtherFiStakingTest is Test {
+    // address alice = vm.addr(2);
+
+    address public token;
+
+    EtherFiStaking public etherfiStaking;
+
+    function setUp() public {
+        initializeRealisticFork(MAINNET_FORK);
+        token = address(ethfiToken);
+
+        // token = address(new ERC20Mock());
+
+        _deploy_EtherFiStaking();
+
+        address ethfi_foundation = 0x7A6A41F353B3002751d94118aA7f4935dA39bB53;
+        vm.prank(ethfi_foundation);
+        IERC20(token).transfer(alice, 1000 ether);
+    }
+
+    function _deploy_EtherFiStaking() public {
+        EtherFiStaking impl = new EtherFiStaking();
+        UUPSProxy proxy = new UUPSProxy(
+            address(impl), 
+            abi.encodeWithSelector(EtherFiStaking.initialize.selector, address(token))
+        );
+
+        etherfiStaking = EtherFiStaking(address(proxy));
+    }
+
+
+    function test_deposit_with_zeroaddress_delegatee_fail() public {
+        vm.startPrank(alice);
+        IERC20(token).approve(address(etherfiStaking), 100 ether);
+        vm.expectRevert("Delegatee cannot be zero address");
+        etherfiStaking.deposit(100 ether, address(0));
+        vm.stopPrank();
+    }
+
+
+    function test_deposit_success() public {
+        assertEq(etherfiStaking.balanceOf(alice), 0 ether);
+        assertEq(etherfiStaking.getVotes(alice), 0 ether);
+
+        vm.startPrank(alice);
+        IERC20(token).approve(address(etherfiStaking), 100 ether);
+        etherfiStaking.deposit(100 ether, alice);
+        vm.stopPrank();
+
+        assertEq(etherfiStaking.balanceOf(alice), 100 ether);
+        assertEq(etherfiStaking.getVotes(alice), 100 ether);
+    }
+
+    function test_withdraw_success() public {
+        test_deposit_success();
+
+        vm.prank(alice);
+        etherfiStaking.withdraw(50 ether);
+        assertEq(etherfiStaking.balanceOf(alice), 50 ether);
+        assertEq(etherfiStaking.getVotes(alice), 50 ether);
+
+        vm.prank(alice);
+        etherfiStaking.withdraw(25 ether);
+        assertEq(etherfiStaking.balanceOf(alice), 25 ether);
+        assertEq(etherfiStaking.getVotes(alice), 25 ether);
+
+        vm.prank(alice);
+        etherfiStaking.withdraw(25 ether);
+        assertEq(etherfiStaking.balanceOf(alice), 0 ether);
+        assertEq(etherfiStaking.getVotes(alice), 0 ether);
+
+        test_deposit_success();
+
+        vm.prank(alice);
+        etherfiStaking.withdraw(50 ether);
+        assertEq(etherfiStaking.balanceOf(alice), 50 ether);
+        assertEq(etherfiStaking.getVotes(alice), 50 ether);
+    }
+
+    function test_withdraw_beyond_balance_fails() public {
+        test_deposit_success();
+
+        vm.prank(alice);
+        vm.expectRevert("Insufficient balance for withdrawal");
+        etherfiStaking.withdraw(1000 ether);
+    }
+
+    function test_delegate() public {
+        test_deposit_success();
+
+        vm.prank(alice);
+        etherfiStaking.delegate(bob);
+
+        assertEq(etherfiStaking.balanceOf(alice), 100 ether);
+        assertEq(etherfiStaking.balanceOf(bob), 0 ether);
+        assertEq(etherfiStaking.getVotes(alice), 0 ether);
+        assertEq(etherfiStaking.getVotes(bob), 100 ether);
+    }
+
+}

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -47,6 +47,7 @@ import "../src/EtherFiOracle.sol";
 import "../src/EtherFiAdmin.sol";
 import "../src/EtherFiTimelock.sol";
 
+
 contract TestSetup is Test {
 
     event Schedule(address target, uint256 value, bytes data, bytes32 predecessor, bytes32 salt, uint256 delay);
@@ -168,6 +169,8 @@ contract TestSetup is Test {
 
     EtherFiNode public node;
     Treasury public treasuryInstance;
+
+    IERC20 public ethfiToken;
 
     Attacker public attacker;
     RevertAttacker public revertAttacker;
@@ -321,6 +324,8 @@ contract TestSetup is Test {
             eigenLayerEigenPodManager = IEigenPodManager(0x91E677b07F7AF907ec9a428aafA9fc14a0d3A338);
             eigenLayerDelegationManager = IDelegationManager(0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A);
             eigenLayerTimelock = ITimelock(0xA6Db1A8C5a981d1536266D2a393c5F8dDb210EAF);
+
+            ethfiToken = IERC20(0xFe0c30065B384F05761f15d0CC899D4F9F9Cc0eB);
 
         } else if (forkEnum == TESTNET_FORK) {
             vm.selectFork(vm.createFork(vm.envString("TESTNET_RPC_URL")));


### PR DESCRIPTION
A simple ETHFI staking contract :)

- support delegation of voting via {`deposit`, `delegate`}. the delegation can happen during the staking together.
- support voting via Snapshot.org