### PR TITLE
Remove hasRestaked() from critical paths

### DIFF
--- a/script/deploys/DeployEtherFiViewer.s.sol
+++ b/script/deploys/DeployEtherFiViewer.s.sol
@@ -33,7 +33,5 @@ contract DeployEtherFiViewer is Script {
         assert(etherFiNodeAddresses[1] == 0xC3D3662A44c0d80080D3AF0eea752369c504724e);
 
         viewer.EigenPod_mostRecentWithdrawalTimestamp(validatorIds);
-        viewer.EigenPod_hasRestaked(validatorIds);
-        
     }
 }

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -28,7 +28,6 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
     address public eigenPod;
 
     /// @dev Is this withdrawal safe is configured for restaking within the etherfi protocol.
-    ///      Independent of whether the associated eigenpod has toggled its hasRestaked flag.
     bool public isRestakingEnabled;
 
     uint16 public version;
@@ -618,13 +617,6 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
         emit EigenPodCreated(address(this), eigenPod);
     }
 
-    function queuePhase1PartialWithdrawal() public {
-        if (!isRestakingEnabled || IEigenPod(eigenPod).hasRestaked()) return;
-
-        // EigenPod has never been truly re-staked.
-        IEigenPod(eigenPod).withdrawBeforeRestaking();
-    }
-
     // returns the withdrawal roots for the queued full-withdrawals
     // the {NonBeaconChainEthWithdrawal, partial withdraw}'s queued withdrawals can be retrieved (indexed) on DelayedWithdrawalRouter
     function queueEigenpodFullWithdrawal() public onlyEtherFiNodeManagerContract returns (bytes32[] memory fullWithdrawalRoots) {
@@ -634,33 +626,9 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
     function _queueEigenpodFullWithdrawal() private returns (bytes32[] memory fullWithdrawalRoots) {
         if (!isRestakingEnabled) return fullWithdrawalRoots;
 
-        if (!IEigenPod(eigenPod).hasRestaked()) {
-            // EigenPod has never re-staked. Then, just withdraw the funds to the withdrawal safe
-            IEigenPod(eigenPod).withdrawBeforeRestaking();
-        } else {
-            // There are three flows of withdrawals from EL: {NonBeaconChainEthWithdrawal, partial withdraw, full withdrawal}
-            // All flows are subject to the DelayedWithdrawal put by the EL's DelayedWithdrawalRouter
-            // - In the NonBeaconChainEthWithdrawal, the verification is not required and the withdrawal is queued upon the call to `withdrawNonBeaconChainETHBalanceWei`
-            // - In the partial withdrawal, the verified withdrawal is immeidately queued 
-            // https://github.com/Layr-Labs/eigenlayer-contracts/tree/90a0f6aee79b4a38e1b63b32f9627f21b1162fbb/src/contracts/pods/EigenPod.sol#L717
-            // - In the full withdrawal, the verified withdrawal amount is kept in the EigenPod until we call `DelegationManager.queueWithdrawals`
-            // https://github.com/Layr-Labs/eigenlayer-contracts/tree/90a0f6aee79b4a38e1b63b32f9627f21b1162fbb/src/contracts/pods/EigenPod.sol#L685
-            // 
-            // Therefore, here we only need to queue {NonBeaconChainEthWithdrawal, full withdrawal}
-            _queueNonBeaconChainEthWithdrawal();
-            fullWithdrawalRoots = _queueRestakedFullWithdrawal();
-        }
-
-    }
-
-    function _queueNonBeaconChainEthWithdrawal() internal {
-        uint256 amountToWithdraw = IEigenPod(eigenPod).nonBeaconChainETHBalanceWei();
-        if (amountToWithdraw > 0) IEigenPod(eigenPod).withdrawNonBeaconChainETHBalanceWei(address(this), amountToWithdraw);
-    }
-
-    // Once the `EigenPod.activeValidatorCount()` is available. We can make it permission-less
-    function _queueRestakedFullWithdrawal() internal returns (bytes32[] memory fullWithdrawalRoots) {
-        if (!IEigenPod(eigenPod).hasRestaked()) return fullWithdrawalRoots;
+        // Withdrawals from Eigenlayer are queued through either the DelayedWithdrawalRouter (DEPRECATED) or the DelegationManager.
+        // pre-PEPE update, nonBeaconChainEth and partial withdrawals are queued through the DelayedWithdrawalRouter.
+        // post-PEPE update, all withdrawals are queued through the DelegationManager
 
         // calculate the pending amount. The withdrawal proof verification will update the EigenPod's `withdrawableRestakedExecutionLayerGwei` value
         uint256 unclaimedFullWithdrawalAmountInGwei = IEigenPod(eigenPod).withdrawableRestakedExecutionLayerGwei() - pendingWithdrawalFromRestakingInGwei;
@@ -677,14 +645,14 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
         // That is why we use two variables for accounting
         pendingWithdrawalFromRestakingInGwei += uint64(32 ether / 1 gwei);
 
-        IDelegationManager mgr = IEtherFiNodesManager(etherFiNodesManager).delegationManager();
+        IDelegationManager delegationManager = IEtherFiNodesManager(etherFiNodesManager).delegationManager();
 
         // Queue the withdrawal for whatever amount is available
         IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
         IStrategy[] memory strategies = new IStrategy[](1);
         uint256[] memory shares = new uint256[](1);
 
-        strategies[0] = mgr.beaconChainETHStrategy();
+        strategies[0] = delegationManager.beaconChainETHStrategy();
         shares[0] = 32 ether;
         params[0] = IDelegationManager.QueuedWithdrawalParams({
             strategies: strategies,
@@ -692,9 +660,9 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
             withdrawer: address(this)
         });
 
-        fullWithdrawalRoots = mgr.queueWithdrawals(params);
+        // each withdrawal root is hash of the withdrawal object, "keccak256(abi.encode(withdrawal))"
+        return delegationManager.queueWithdrawals(params);
     }
-
 
     /// @notice claim queued withdrawals (eigenlayer phase1 + phase2 partial withdrawals) from the EigenPod to this withdrawal safe.
     /// @param maxNumWithdrawals maximum number of queued withdrawals to claim in this tx.

--- a/src/helpers/EtherFiViewer.sol
+++ b/src/helpers/EtherFiViewer.sol
@@ -42,20 +42,6 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         return IEigenPod(_getEtherFiNode(_validatorId).eigenPod());
     }
 
-    function EigenPod_hasRestaked(uint256[] memory _validatorIds) external view returns (bool[] memory _hasRestaked) {
-        _hasRestaked = new bool[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            _hasRestaked[i] = _getEigenPod(_validatorIds[i]).hasRestaked();
-        }
-    }
-
-    function EigenPod_withdrawableRestakedExecutionLayerGwei(uint256[] memory _validatorIds) external view returns (uint256[] memory _withdrawableRestakedExecutionLayerGwei) {
-        _withdrawableRestakedExecutionLayerGwei = new uint256[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            _withdrawableRestakedExecutionLayerGwei[i] = _getEigenPod(_validatorIds[i]).withdrawableRestakedExecutionLayerGwei();
-        }
-    }
-
     function EigenPod_nonBeaconChainETHBalanceWei(uint256[] memory _validatorIds) external view returns (uint256[] memory _nonBeaconChainETHBalanceWei) {
         _nonBeaconChainETHBalanceWei = new uint256[](_validatorIds.length);
         for (uint256 i = 0; i < _validatorIds.length; i++) {

--- a/src/interfaces/IEtherFiNode.sol
+++ b/src/interfaces/IEtherFiNode.sol
@@ -72,7 +72,6 @@ interface IEtherFiNode {
     function processNodeExit(uint256 _validatorId) external returns (bytes32[] memory withdrawalRoots);
     function processFullWithdraw(uint256 _validatorId) external;
     function queueEigenpodFullWithdrawal() external returns (bytes32[] memory withdrawalRoots);
-    function queuePhase1PartialWithdrawal() external;
     function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory withdrawals, uint256[] calldata middlewareTimesIndexes, bool _receiveAsTokens) external;
     function completeQueuedWithdrawal(IDelegationManager.Withdrawal memory withdrawals, uint256 middlewareTimesIndexes, bool _receiveAsTokens) external;
     function updateNumberOfAssociatedValidators(uint16 _up, uint16 _down) external;

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -71,34 +71,6 @@ contract EtherFiNodeTest is TestSetup {
 
     }
 
-    function test_claimMixedSafeAndPodFunds() public {
-        initializeTestingFork(MAINNET_FORK);
-
-        uint256 bidId = depositAndRegisterValidator(true);
-        safeInstance = EtherFiNode(payable(managerInstance.etherfiNodeAddress(bidId)));
-
-        // simulate 1 eth of already claimed staking rewards and 1 eth of unclaimed restaked rewards
-        _transferTo(address(safeInstance.eigenPod()), 1 ether);
-        _transferTo(address(safeInstance), 1 ether);
-
-        assertEq(address(safeInstance).balance, 1 ether);
-        assertEq(address(safeInstance.eigenPod()).balance, 1 ether);
-
-        // claim the restaked rewards
-        // safeInstance.queueRestakedWithdrawal();
-        uint256[] memory validatorIds = new uint256[](1);
-        validatorIds[0] = bidId;
-        vm.prank(alice); // alice is admin
-        managerInstance.batchQueueRestakedWithdrawal(validatorIds);
-
-        vm.roll(block.number + (50400) + 1);
-
-        safeInstance.claimDelayedWithdrawalRouterWithdrawals(1, false, validatorIds[0]);
-
-        assertEq(address(safeInstance).balance, 2 ether);
-        assertEq(address(safeInstance.eigenPod()).balance, 0 ether);
-    }
-
     function test_splitBalanceInExecutionLayer() public {
 
         initializeTestingFork(MAINNET_FORK);

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -1840,24 +1840,12 @@ contract EtherFiNodeTest is TestSetup {
             vm.roll(block.number + minDelayBlock);
         }
 
-        // - Check if a random transfer to EigenPod blocks the fullWithdrawal
-        // The later `fullWithdraw` should succeed even though there are still some unclaimed withdrawals
-        // this is because we only enforce that all withdrawals before the observed exit of the node have completed
-        _transferTo(address(managerInstance.getEigenPod(validatorId)), 0.0001 ether);
-        IEtherFiNode(nodeAddress).queuePhase1PartialWithdrawal();
-
-        uint256 prevEtherFiNodeAddress = address(nodeAddress).balance;
-
-        // FAIL, call by a rando
-        vm.expectRevert("DelegationManager._completeQueuedWithdrawal: only withdrawer can complete action");
-        mgr.completeQueuedWithdrawal(withdrawal, tokens, 0, true);
-
-        assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), 32 ether / 1 gwei);
+        uint256 prevEtherfiNodeBalance = address(nodeAddress).balance;
 
         // 2. DelegationManager.completeQueuedWithdrawal            
         managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
 
-        assertEq(address(nodeAddress).balance, prevEtherFiNodeAddress + 32 ether);
+        assertEq(address(nodeAddress).balance, prevEtherfiNodeBalance + 32 ether);
         assertEq(eigenPodManager.podOwnerShares(nodeAddress), 0);
         assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), 0);
     }


### PR DESCRIPTION
The upcoming Eigenlayer PEPE update removes the `hasRestaked()` function that our protocol uses in several locations. With the release of PEPE there will never be a state where previously hasRestaked would have been false, so we can safely remove those codepaths. 