### PR TITLE
[EFIP-10] Whitelisted Delegate calls for EtherFiNode/EigenPod

### DIFF
--- a/proposals/EFIP-10.md
+++ b/proposals/EFIP-10.md
@@ -1,0 +1,34 @@
+# [EFIP-10] Whitelisted Delegate calls for EtherFiNode/EigenPod
+
+
+**Author**: dave (dave@ether.fi), syko (seongyun@ether.fi)
+
+**Date**: 2024-07-22
+
+## Summary
+
+This EFIP proposes the introduction of a whitelist mechanism on the delegate call into the EtherFiNode/EigenPod contracts. This change aims to enhance security by restricting call forwarding and function execution to a predefined list of delegates, ensuring that only authorized operations can be performed.
+
+## Motivation
+
+Currently, we use the blacklisting to restrict blacklisted functions from being executed. However, the blacklisting approach is not robust and can be bypassed by malicious actors by upgrade. Introducing the whitelisting will mitigate these risks by ensuring only allowed operations can be executed.
+
+## Proposal
+
+The proposal introduces changes to the EtherFiNode and EtherFiNodesManager contracts to implement the whitelist mechanism:
+
+1. **Whitelist Management**:
+    - Addition of functions to manage the whitelist for `eigenPodCall` and `externalCall`
+    - Implementation of checks to ensure only whitelisted operations ca be performed.
+
+2. **Call Forwarding Restrictions**:
+    - Ensuring that only the whitelisted operations can be performed.
+
+
+## References
+
+- [Pull Request #100](https://github.com/etherfi-protocol/smart-contracts/pull/100)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -66,7 +66,12 @@ contract EtherFiNodesManager is
 
     IDelegationManager public delegationManager;
 
-    mapping(address => bool) public eigenLayerOperatingAdmin;
+    mapping(address => bool) public operatingAdmin;
+
+    // function -> allowed
+    mapping(bytes4 => bool) public allowedForwardedEigenpodCalls;
+    // function -> target_address -> allowed
+    mapping(bytes4 => mapping(address => bool)) public allowedForwardedExternalCalls;
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
@@ -82,6 +87,9 @@ contract EtherFiNodesManager is
     event FullWithdrawal(uint256 indexed _validatorId, address indexed etherFiNode, uint256 toOperator, uint256 toTnft, uint256 toBnft, uint256 toTreasury);
     event QueuedRestakingWithdrawal(uint256 indexed _validatorId, address indexed etherFiNode, bytes32[] withdrawalRoots);
 
+    event AllowedForwardedExternalCallsUpdated(bytes4 indexed selector, address indexed _target, bool _allowed);
+    event AllowedForwardedEigenpodCallsUpdated(bytes4 indexed selector, bool _allowed);
+
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
     //--------------------------------------------------------------------------------------
@@ -95,6 +103,8 @@ contract EtherFiNodesManager is
 
     error InvalidParams();
     error NonZeroAddress();
+    error ForwardedCallNotAllowed();
+    error InvalidForwardedCall();
 
     /// @dev Sets the revenue splits on deployment
     /// @dev AuctionManager, treasury and deposit contracts must be deployed first
@@ -189,7 +199,7 @@ contract EtherFiNodesManager is
         }
     }
 
-    function completeQueuedWithdrawals(uint256[] calldata _validatorIds, IDelegationManager.Withdrawal[] memory withdrawals, uint256[] calldata middlewareTimesIndexes, bool _receiveAsTokens) external onlyEigenLayerOperatingAdmin {
+    function completeQueuedWithdrawals(uint256[] calldata _validatorIds, IDelegationManager.Withdrawal[] memory withdrawals, uint256[] calldata middlewareTimesIndexes, bool _receiveAsTokens) external onlyOperatingAdmin {
         for (uint256 i = 0; i < _validatorIds.length; i++) {
             address etherfiNode = etherfiNodeAddress[_validatorIds[i]];
             IEtherFiNode(etherfiNode).completeQueuedWithdrawal(withdrawals[i], middlewareTimesIndexes[i], _receiveAsTokens);
@@ -367,66 +377,62 @@ contract EtherFiNodesManager is
         _unRegisterValidator(_validatorId);
     }
 
-    // https://github.com/Layr-Labs/eigenlayer-contracts/blob/dev/src/contracts/pods/EigenPod.sol
-    /// @notice Call the eigenPod contract
-    /// @param data to call eigenPod contract
-    // - withdrawBeforeRestaking
-    // - activateRestaking
-    // - verifyWithdrawalCredentials
-    // - recoverTokens
-    // - withdrawNonBeaconChainETHBalanceWei
-    // - 
-    // - verifyBalanceUpdates
-    // - verifyAndProcessWithdrawals
-    function callEigenPod(uint256[] calldata _validatorIds, bytes[] calldata data) external nonReentrant whenNotPaused onlyEigenLayerOperatingAdmin returns (bytes[] memory returnData) {
+    //--------------------------------------------------------------------------------------
+    //-------------------------------- CALL FORWARDING  ------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    /// @notice Update the whitelist for external calls that can be executed by an EtherfiNode
+    /// @param _selector method selector
+    /// @param _target call target for forwarded call
+    /// @param _allowed enable or disable the call
+    function updateAllowedForwardedExternalCalls(bytes4 _selector, address _target, bool _allowed) external onlyAdmin {
+        allowedForwardedExternalCalls[_selector][_target] = _allowed;
+        emit AllowedForwardedExternalCallsUpdated(_selector, _target, _allowed);
+    }
+
+    /// @notice Update the whitelist for external calls that can be executed against the corresponding eigenpod
+    /// @param _selector method selector
+    /// @param _allowed enable or disable the call
+    function updateAllowedForwardedEigenpodCalls(bytes4 _selector, bool _allowed) external onlyAdmin {
+        allowedForwardedEigenpodCalls[_selector] = _allowed;
+        emit AllowedForwardedEigenpodCallsUpdated(_selector, _allowed);
+    }
+
+    function forwardEigenpodCall(uint256[] calldata _validatorIds, bytes[] calldata _data) external nonReentrant whenNotPaused onlyOperatingAdmin returns (bytes[] memory returnData) {
         returnData = new bytes[](_validatorIds.length);
         for (uint256 i = 0; i < _validatorIds.length; i++) {
-            returnData[i] = IEtherFiNode(etherfiNodeAddress[_validatorIds[i]]).callEigenPod(data[i]);
+            _verifyForwardedEigenpodCall(_data[i], _validatorIds[i]);
+            returnData[i] = IEtherFiNode(etherfiNodeAddress[_validatorIds[i]]).callEigenPod(_data[i]);
         }
     }
 
-    // https://github.com/Layr-Labs/eigenlayer-contracts/blob/dev/src/contracts/core/DelegationManager.sol
-    /// @notice Call the Eigenlayer delegation Manager contract
-    /// @param data to call eigenPod contract
-    // - delegateTo(address operator, SignatureWithExpiry memory approverSignatureAndExpiry, bytes32 approverSalt)
-    // - undelegate(address staker)
-    // - completeQueuedWithdrawal
-    // - queueWithdrawals
-    function callDelegationManager(uint256[] calldata _validatorIds, bytes[] calldata data) external nonReentrant whenNotPaused onlyEigenLayerOperatingAdmin returns (bytes[] memory returnData) {
-        address to = address(delegationManager);
+    function forwardExternalCall(uint256[] calldata _validatorIds, bytes[] calldata _data, address _target) external nonReentrant whenNotPaused onlyOperatingAdmin returns (bytes[] memory returnData) {
         returnData = new bytes[](_validatorIds.length);
         for (uint256 i = 0; i < _validatorIds.length; i++) {
-            returnData[i] = IEtherFiNode(etherfiNodeAddress[_validatorIds[i]]).forwardCall(to, data[i]);
+            _verifyForwardedExternalCall(_target, _data[i], _validatorIds[i]);
+            returnData[i] = IEtherFiNode(etherfiNodeAddress[_validatorIds[i]]).forwardCall(_target, _data[i]);
         }
     }
 
-    // https://github.com/Layr-Labs/eigenlayer-contracts/blob/dev/src/contracts/pods/EigenPodManager.sol
-    /// @notice Call the Eigenlayer EigenPod Manager contract
-    /// @param data to call contract
-    // - recordBeaconChainETHBalanceUpdate
-    function callEigenPodManager(uint256[] calldata _validatorIds, bytes[] calldata data) external nonReentrant whenNotPaused onlyEigenLayerOperatingAdmin returns (bytes[] memory returnData) {
-        address to = address(eigenPodManager);
-        returnData = new bytes[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            returnData[i] = IEtherFiNode(etherfiNodeAddress[_validatorIds[i]]).forwardCall(to, data[i]);
+    function _verifyForwardedEigenpodCall(bytes calldata _data, uint256 _validatorId) internal view {
+        if (_data.length < 4) revert InvalidForwardedCall();
+        bytes4 selector = bytes4(_data[:4]);
+        if (!allowedForwardedEigenpodCalls[selector]) revert ForwardedCallNotAllowed();
+
+        // withdrawNonBeaconChainETHBalanceWei
+        if (selector == IEigenPod.withdrawNonBeaconChainETHBalanceWei.selector) {
+            require(_data.length == 68, "INVALID_DATA_LENGTH");
+            address recipient = address(bytes20(_data[16:36]));
+
+            // No withdrawal to any other address than the safe
+            require (recipient == etherfiNodeAddress[_validatorId], "INCORRECT_RECIPIENT");
         }
     }
 
-    function callDelayedWithdrawalRouter(uint256[] calldata _validatorIds, bytes[] calldata data) external nonReentrant whenNotPaused onlyEigenLayerOperatingAdmin returns (bytes[] memory returnData) {
-        address to = address(delayedWithdrawalRouter);
-        returnData = new bytes[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            returnData[i] = IEtherFiNode(etherfiNodeAddress[_validatorIds[i]]).forwardCall(to, data[i]);
-        }
-    }
-
-    // the etherfi node contract can interact with the external contracts. This feature is strictly controlled by the operating admin
-    // note that the `forwardCall.forwardCall` does not allow to put any value.
-    function callExternal(address to, uint256[] calldata _validatorIds, bytes[] calldata data) external nonReentrant whenNotPaused onlyEigenLayerOperatingAdmin returns (bytes[] memory returnData) {
-        returnData = new bytes[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            returnData[i] = IEtherFiNode(etherfiNodeAddress[_validatorIds[i]]).forwardCall(to, data[i]);
-        }
+    function _verifyForwardedExternalCall(address _to, bytes calldata _data, uint256 _validatorId) internal view {
+        if (_data.length < 4) revert InvalidForwardedCall();
+        bytes4 selector = bytes4(_data[:4]);
+        if (!allowedForwardedExternalCalls[selector][_to]) revert ForwardedCallNotAllowed();
     }
 
     //--------------------------------------------------------------------------------------
@@ -487,7 +493,7 @@ contract EtherFiNodesManager is
     }
 
     function updateEigenLayerOperatingAdmin(address _address, bool _isAdmin) external onlyOwner {
-        eigenLayerOperatingAdmin[_address] = _isAdmin;
+        operatingAdmin[_address] = _isAdmin;
     }
 
     // Pauses the contract
@@ -742,8 +748,8 @@ contract EtherFiNodesManager is
         if (msg.sender != stakingManagerContract) revert NotStakingManager();
     }
 
-    function _eigenLayerOperatingAdmin() internal view virtual {
-        if (!eigenLayerOperatingAdmin[msg.sender] && !admins[msg.sender] && msg.sender != owner()) revert NotAdmin();
+    function _operatingAdmin() internal view virtual {
+        if (!operatingAdmin[msg.sender] && !admins[msg.sender] && msg.sender != owner()) revert NotAdmin();
     }
 
     //--------------------------------------------------------------------------------------
@@ -760,8 +766,8 @@ contract EtherFiNodesManager is
         _;
     }
 
-    modifier onlyEigenLayerOperatingAdmin() {
-        _eigenLayerOperatingAdmin();
+    modifier onlyOperatingAdmin() {
+        _operatingAdmin();
         _;
     }
 }

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -420,6 +420,15 @@ contract EtherFiNodesManager is
         }
     }
 
+    // the etherfi node contract can interact with the external contracts. This feature is strictly controlled by the operating admin
+    // note that the `forwardCall.forwardCall` does not allow to put any value.
+    function callExternal(address to, uint256[] calldata _validatorIds, bytes[] calldata data) external nonReentrant whenNotPaused onlyEigenLayerOperatingAdmin returns (bytes[] memory returnData) {
+        returnData = new bytes[](_validatorIds.length);
+        for (uint256 i = 0; i < _validatorIds.length; i++) {
+            returnData[i] = IEtherFiNode(etherfiNodeAddress[_validatorIds[i]]).forwardCall(to, data[i]);
+        }
+    }
+
     //--------------------------------------------------------------------------------------
     //-------------------------------------  SETTER   --------------------------------------
     //--------------------------------------------------------------------------------------

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -48,7 +48,7 @@ interface IEtherFiNodesManager {
     function maxEigenlayerWithdrawals() external view returns (uint8);
 
     function admins(address _address) external view returns (bool);
-    function eigenLayerOperatingAdmin(address _address) external view returns (bool);
+    function operatingAdmin(address _address) external view returns (bool);
 
     // Non-VIEW functions    
     function updateEtherFiNode(uint256 _validatorId) external;

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -418,7 +418,7 @@ contract EtherFiNodeTest is TestSetup {
         data[0] = abi.encodeWithSelector(selector, safe, address(eigenPod).balance);
 
         vm.prank(owner);
-        managerInstance.callEigenPod(validatorIds, data);
+        managerInstance.forwardEigenpodCall(validatorIds, data);
     }
 
     function test_restakedAttackerCantBlockWithdraw() public {
@@ -1986,7 +1986,7 @@ contract EtherFiNodeTest is TestSetup {
         // FAIL, the forward call is not allowed for `completeQueuedWithdrawal`
         vm.expectRevert("NOT_ALLOWED");
         vm.prank(owner);
-        managerInstance.callDelegationManager(validatorIds, data);
+        managerInstance.forwardExternalCall(validatorIds, data, address(managerInstance.delegationManager()));
 
         // FAIL, if the `minWithdrawalDelayBlocks` is not passed
         vm.prank(owner);

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -412,7 +412,7 @@ contract EtherFiNodesManagerTest is TestSetup {
         // Chad becomes an admin
         vm.prank(owner);
         managerInstance.updateEigenLayerOperatingAdmin(chad, true);
-        assertTrue(managerInstance.eigenLayerOperatingAdmin(chad));
+        assertTrue(managerInstance.operatingAdmin(chad));
 
         // it works now
         {


### PR DESCRIPTION
(made from @solipsis 's work merged to staging-2.5 for mainnet)

Currently, we use the blacklisting to restrict blacklisted functions from being executed. However, the blacklisting approach is not robust and can be bypassed by malicious actors by upgrade. Introducing the whitelisting will mitigate these risks by ensuring only allowed operations can be executed.

This proposes the introduction of a whitelist mechanism on the delegate call into the EtherFiNode/EigenPod contracts. This change aims to enhance security by restricting call forwarding and function execution to a predefined list of delegates, ensuring that only authorized operations can be performed.