### PR TITLE
[HotFix] Enable partial redemption of stETH 

### DIFF
--- a/proposals/references/NM-0217-partial-redemption-of-stETH.md
+++ b/proposals/references/NM-0217-partial-redemption-of-stETH.md
@@ -1,0 +1,13 @@
+# [HotFix] Enable partial redemption of stETH
+
+**PR**: https://github.com/etherfi-protocol/smart-contracts/pull/137
+
+### Summary
+
+This PR attemps to solve an issue that did not allow to trigger partial redemption requests for stETH.
+
+---
+
+### Findings
+
+There are no current findings related to this change.

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -178,7 +178,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
     /// it returns the amount of shares burned
     function withdraw(address _recipient, uint256 _amount) external whenNotPaused returns (uint256) {
         uint256 share = sharesForWithdrawalAmount(_amount);
-        require(msg.sender == address(withdrawRequestNFT) || msg.sender == address(membershipManager), "Incorrect Caller");
+        require(msg.sender == address(withdrawRequestNFT) || msg.sender == address(membershipManager) || msg.sender == address(liquifier), "Incorrect Caller");
         if (totalValueInLp < _amount || (msg.sender == address(withdrawRequestNFT) && ethAmountLockedForWithdrawal < _amount) || eETH.balanceOf(msg.sender) < _amount) revert InsufficientLiquidity();
         if (_amount > type(uint128).max || _amount == 0 || share == 0) revert InvalidAmount();
 

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -97,6 +97,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     error NotSupportedToken();
     error EthTransferFailed();
     error NotEnoughBalance();
+    error IncorrectAmount();
     error AlreadyRegistered();
     error NotRegistered();
     error WrongOutput();
@@ -227,7 +228,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
 
     function stEthRequestWithdrawal(uint256 _amount) public onlyAdmin returns (uint256[] memory) {
-        if (_amount < lidoWithdrawalQueue.MIN_STETH_WITHDRAWAL_AMOUNT() || _amount < lido.balanceOf(address(this))) revert NotEnoughBalance();
+        if (_amount < lidoWithdrawalQueue.MIN_STETH_WITHDRAWAL_AMOUNT() || _amount > lido.balanceOf(address(this))) revert IncorrectAmount();
 
         tokenInfos[address(lido)].ethAmountPendingForWithdrawals += uint128(_amount);
 

--- a/src/interfaces/ILiquidityPool.sol
+++ b/src/interfaces/ILiquidityPool.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "./IStakingManager.sol";
+import "./IeETH.sol";
 
 interface ILiquidityPool {
 
@@ -50,6 +51,8 @@ interface ILiquidityPool {
     function sharesForAmount(uint256 _amount) external view returns (uint256);
     function sharesForWithdrawalAmount(uint256 _amount) external view returns (uint256);
     function amountForShare(uint256 _share) external view returns (uint256);
+
+    function eETH() external view returns (IeETH);
 
     function deposit() external payable returns (uint256);
     function deposit(address _referral) external payable returns (uint256);

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -217,6 +217,16 @@ contract LiquifierTest is TestSetup {
 
     }
 
+    function test_stEthRequestWithdrawal() public {
+        test_deposit_stEth();
+
+        vm.startPrank(alice);        
+        liquifierInstance.stEthRequestWithdrawal(1 ether);
+        liquifierInstance.stEthRequestWithdrawal(5 ether);
+        liquifierInstance.stEthRequestWithdrawal();
+        vm.stopPrank();
+    }
+
     function test_withdrawal_of_restaked_wBETH_succeeds() internal {
         _setUp(MAINNET_FORK);
 

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -218,9 +218,10 @@ contract LiquifierTest is TestSetup {
     }
 
     function test_stEthRequestWithdrawal() public {
-        test_deposit_stEth();
-
-        vm.startPrank(alice);        
+        initializeRealisticFork(MAINNET_FORK);
+        _upgrade_liquifier();
+        
+        vm.startPrank(admin);        
         liquifierInstance.stEthRequestWithdrawal(1 ether);
         liquifierInstance.stEthRequestWithdrawal(5 ether);
         liquifierInstance.stEthRequestWithdrawal();
@@ -683,5 +684,49 @@ contract LiquifierTest is TestSetup {
 
         liquidityPoolInstance.getTotalPooledEther();
         liquifierInstance.getTotalPooledEther();
+    }
+
+    function test_swapEEthForStEth_mainnet() public {
+        initializeRealisticFork(MAINNET_FORK);
+        setUpLiquifier(MAINNET_FORK);
+
+        vm.prank(liquifierInstance.owner());
+        liquifierInstance.unPauseContract();
+
+
+        vm.deal(alice, 100 ether);
+        vm.startPrank(alice);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+
+        eETHInstance.approve(address(liquifierInstance), 50 ether);
+
+        uint256 beforeTVL = liquidityPoolInstance.getTotalPooledEther();
+        uint256 beforeLiquifierTotalPooledEther = liquifierInstance.getTotalPooledEther();
+
+        liquifierInstance.swapEEthForStEth(50 ether);
+        vm.stopPrank();
+
+        uint256 afterTVL = liquidityPoolInstance.getTotalPooledEther();
+        uint256 afterLiquifierTotalPooledEther = liquifierInstance.getTotalPooledEther();
+
+        assertEq(afterTVL, beforeTVL);
+        assertEq(beforeLiquifierTotalPooledEther, afterLiquifierTotalPooledEther);
+    }
+
+    function test_withdrawEEth() public {
+        test_swapEEthForStEth_mainnet();
+
+        _upgrade_liquidity_pool_contract();
+
+        uint256 beforeTVL = liquidityPoolInstance.getTotalPooledEther();
+        uint256 beforeLiquifierTotalPooledEther = liquifierInstance.getTotalPooledEther();
+
+        vm.prank(admin);
+        liquifierInstance.withdrawEEth(10 ether);
+
+        uint256 afterTVL = liquidityPoolInstance.getTotalPooledEther();
+        uint256 afterLiquifierTotalPooledEther = liquifierInstance.getTotalPooledEther();
+
+        assertApproxEqAbs(int256(afterTVL) - int256(beforeTVL), int256(afterLiquifierTotalPooledEther) - int256(beforeLiquifierTotalPooledEther), 1);
     }
 }


### PR DESCRIPTION
Due to the wrong branch expression in `Liquifier.stEthRequestWithdrawal(uint256 amount)`, we were not able to trigger the partial redemption request for stETH. This PR fixes it