### PR TITLE
Simplify StakingManager <> LiquidityPool interaction, bug fixes, Fix broken unit tests

### DIFF
--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -293,7 +293,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         require(msg.value == _numberOfValidators * spawnerDepositAmountPerValidator, "Not Enough Deposit");
         require(totalValueInLp + msg.value >= 32 ether * _numberOfValidators, "Not enough balance");
 
-        uint256[] memory newValidators = stakingManager.batchDepositWithBidIds(_candidateBidIds, _numberOfValidators, msg.sender, tnftHolder, bnftHolder, restakeBnftDeposits, _validatorIdToShareSafeWith);
+        uint256[] memory newValidators = stakingManager.batchDepositWithBidIds(_candidateBidIds, _numberOfValidators, tnftHolder, bnftHolder, restakeBnftDeposits, _validatorIdToShareSafeWith);
         numPendingDeposits += uint32(newValidators.length);
         
         // In the case when some bids are already taken, we refund 2 ETH for each
@@ -327,7 +327,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         uint256 outboundEthAmountFromLp = isLpBnftHolder ? 1 ether * _validatorIds.length : 0;
         _accountForEthSentOut(outboundEthAmountFromLp);
 
-        stakingManager.batchRegisterValidators{value: 1 ether * _validatorIds.length}(_validatorIds, _bnftRecipient, address(this), _registerValidatorDepositData, msg.sender);
+        stakingManager.batchRegisterValidators{value: 1 ether * _validatorIds.length}(_validatorIds, _bnftRecipient, address(this), _registerValidatorDepositData);
         
         for(uint256 i; i < _validatorIds.length; i++) {
             depositDataRootForApprovalDeposits[_validatorIds[i]] = _depositDataRootApproval[i];

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -448,6 +448,7 @@ contract StakingManager is
         return address(upgradableBeacon);
     }
 
+    // staker == BNFT holder for the validator of id = 'id'
     function bidIdToStaker(uint256 id) external view returns (address) {
         return bidIdToStakerInfo[id].staker;
     }

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -120,18 +120,17 @@ contract StakingManager is
     /// @notice Allows depositing multiple stakes at once
     /// @dev Function gets called from the liquidity pool as part of the BNFT staker flow
     /// @param _candidateBidIds IDs of the bids to be matched with each stake
-    /// @param _validatorSpawner the address of the validator spawner
     /// @param _enableRestaking Eigen layer integration check to identify if restaking is possible
     /// @param _validatorIdToShareWithdrawalSafe the validator ID to use for the withdrawal safe
     /// @return Array of the bid IDs that were processed and assigned
-    function batchDepositWithBidIds(uint256[] calldata _candidateBidIds, uint256 _numberOfValidators, address _validatorSpawner, address _tnftHolder, address _bnftHolder, bool _enableRestaking, uint256 _validatorIdToShareWithdrawalSafe)
+    function batchDepositWithBidIds(uint256[] calldata _candidateBidIds, uint256 _numberOfValidators, address _tnftHolder, address _bnftHolder, bool _enableRestaking, uint256 _validatorIdToShareWithdrawalSafe)
         public whenNotPaused nonReentrant returns (uint256[] memory)
     {
         require(msg.sender == liquidityPoolContract, "Incorrect Caller");
         require(_candidateBidIds.length >= _numberOfValidators && _numberOfValidators <= maxBatchDepositSize, "WRONG_PARAMS");
         require(auctionManager.numberOfActiveBids() >= _numberOfValidators, "NOT_ENOUGH_BIDS");
 
-        return _processDeposits(_candidateBidIds, _numberOfValidators, _validatorSpawner, _tnftHolder, _bnftHolder, _enableRestaking, _validatorIdToShareWithdrawalSafe);
+        return _processDeposits(_candidateBidIds, _numberOfValidators, _tnftHolder, _bnftHolder, _enableRestaking, _validatorIdToShareWithdrawalSafe);
     }
 
     /// @notice Creates validator object, mints NFTs, sets NB variables and deposits 1 ETH into beacon chain
@@ -140,20 +139,18 @@ contract StakingManager is
     /// @param _bNftRecipient Array of BNFT recipients
     /// @param _tNftRecipient Array of TNFT recipients
     /// @param _depositData Array of data structures to hold all data needed for depositing to the beacon chain
-    /// @param _validatorSpawner the address of the validator spawner
     function batchRegisterValidators(
         uint256[] calldata _validatorId,
         address _bNftRecipient,
         address _tNftRecipient,
-        DepositData[] calldata _depositData,
-        address _validatorSpawner
+        DepositData[] calldata _depositData
     ) public payable whenNotPaused nonReentrant {
         require(msg.sender == liquidityPoolContract, "INCORRECT_CALLER");
         require(_validatorId.length <= maxBatchDepositSize && _validatorId.length == _depositData.length, "WRONG_PARAMS");
         require(msg.value == _validatorId.length * 1 ether, "DEPOSIT_AMOUNT_MISMATCH");
 
         for (uint256 x; x < _validatorId.length; ++x) {
-            _registerValidator(_validatorId[x], _bNftRecipient, _tNftRecipient, _depositData[x], _validatorSpawner, 1 ether);
+            _registerValidator(_validatorId[x], _bNftRecipient, _tNftRecipient, _depositData[x], 1 ether);
         }
     }
 
@@ -188,8 +185,8 @@ contract StakingManager is
     ///         already gone through the 'registered' phase will lose 1 ETH which is stuck in the beacon chain and will serve as a penalty for
     ///         cancelling late. We need to update the number of validators each source has spun up to keep the target weight calculation correct.
     /// @param _validatorIds validators to cancel
-    /// @param _caller address of the bNFT holder who initiated the transaction. Used for verification
-    function batchCancelDeposit(uint256[] calldata _validatorIds, address _caller) public whenNotPaused nonReentrant {
+    /// @param _bnftHolder address of the bNFT holder who initiated the transaction. Used for verification
+    function batchCancelDeposit(uint256[] calldata _validatorIds, address _bnftHolder) public whenNotPaused nonReentrant {
         require(msg.sender == liquidityPoolContract, "INCORRECT_CALLER");
 
         for (uint256 x; x < _validatorIds.length; ++x) { 
@@ -198,7 +195,7 @@ contract StakingManager is
                 TNFTInterfaceInstance.burnFromCancelBNftFlow(nftTokenId);
                 BNFTInterfaceInstance.burnFromCancelBNftFlow(nftTokenId);
             }
-            _cancelDeposit(_validatorIds[x], _caller);
+            _cancelDeposit(_validatorIds[x], _bnftHolder);
         }
     }
 
@@ -300,7 +297,6 @@ contract StakingManager is
     function _processDeposits(
         uint256[] calldata _candidateBidIds, 
         uint256 _numberOfDeposits,
-        address _validatorSpawner,
         address _tnftHolder,
         address _bnftHolder,
         bool _enableRestaking,
@@ -321,7 +317,7 @@ contract StakingManager is
                 auctionManager.updateSelectedBidInformation(bidId);
                 processedBidIds[processedBidIdsCount] = bidId;
                 processedBidIdsCount++;
-                _processDeposit(bidId, _validatorSpawner, _tnftHolder, _bnftHolder, _enableRestaking, _validatorIdToShareWithdrawalSafe);
+                _processDeposit(bidId, _tnftHolder, _bnftHolder, _enableRestaking, _validatorIdToShareWithdrawalSafe);
             }
         }
 
@@ -338,7 +334,6 @@ contract StakingManager is
     /// @param _bNftRecipient The address to receive the minted B-NFT
     /// @param _tNftRecipient The address to receive the minted T-NFT
     /// @param _depositData Data structure to hold all data needed for depositing to the beacon chain
-    /// @param _validatorSpawner User who has begun the registration chain of transactions
     /// however, instead of the validator key, it will include the IPFS hash
     /// containing the validator key encrypted by the corresponding node operator's public key
     function _registerValidator(
@@ -346,15 +341,14 @@ contract StakingManager is
         address _bNftRecipient, 
         address _tNftRecipient, 
         DepositData calldata _depositData, 
-        address _validatorSpawner,
         uint256 _depositAmount
     ) internal {
-        require(bidIdToStakerInfo[_validatorId].staker == _validatorSpawner, "INCORRECT_CALLER");
+        require(bidIdToStakerInfo[_validatorId].staker == _bNftRecipient, "INCORRECT_BNFT_RECIPIENT");
         bytes memory withdrawalCredentials = nodesManager.getWithdrawalCredentials(_validatorId);
         bytes32 depositDataRoot = depositRootGenerator.generateDepositRoot(_depositData.publicKey, _depositData.signature, withdrawalCredentials, _depositAmount);
         require(depositDataRoot == _depositData.depositDataRoot, "WRONG_ROOT");
 
-        bytes32 fullHash = keccak256(abi.encode(_validatorId, _validatorSpawner, _tNftRecipient, _bNftRecipient));
+        bytes32 fullHash = keccak256(abi.encode(_validatorId, msg.sender, _tNftRecipient, _bNftRecipient));
         bytes10 truncatedHash = bytes10(fullHash);
         require(truncatedHash == bidIdToStakerInfo[_validatorId].hash, "INCORRECT_HASH");
 
@@ -389,12 +383,12 @@ contract StakingManager is
 
     /// @notice Update the state of the contract now that a deposit has been made
     /// @param _bidId The bid that won the right to the deposit
-    function _processDeposit(uint256 _bidId, address _validatorSpawner, address _tnftHolder, address _bnftHolder, bool _enableRestaking, uint256 _validatorIdToShareWithdrawalSafe) internal {
+    function _processDeposit(uint256 _bidId, address _tnftHolder, address _bnftHolder, bool _enableRestaking, uint256 _validatorIdToShareWithdrawalSafe) internal {
         // Compute the keccak256 hash of the input data
-        bytes32 fullHash = keccak256(abi.encode(_bidId, _validatorSpawner, _tnftHolder, _bnftHolder));
+        bytes32 fullHash = keccak256(abi.encode(_bidId, msg.sender, _tnftHolder, _bnftHolder));
         bytes10 truncatedHash = bytes10(fullHash);
         
-        bidIdToStakerInfo[_bidId] = StakerInfo(_validatorSpawner, 0, truncatedHash);
+        bidIdToStakerInfo[_bidId] = StakerInfo(_bnftHolder, 0, truncatedHash);
         uint256 validatorId = _bidId;
 
         // register a withdrawalSafe for this bid/validator, creating a new one if necessary
@@ -410,14 +404,14 @@ contract StakingManager is
         }
         nodesManager.registerValidator(validatorId, _enableRestaking, etherfiNode);
 
-        emit StakeDeposit(_validatorSpawner, _bidId, etherfiNode, _enableRestaking);
+        emit StakeDeposit(msg.sender, _bidId, etherfiNode, _enableRestaking);
     }
 
     /// @notice Cancels a users stake
     /// @param _validatorId the ID of the validator deposit to cancel
-    function _cancelDeposit(uint256 _validatorId, address _caller) internal {
+    function _cancelDeposit(uint256 _validatorId, address _bnftHolder) internal {
         require(bidIdToStakerInfo[_validatorId].staker != address(0), "NO_DEPOSIT_EXIST");
-        require(bidIdToStakerInfo[_validatorId].staker == _caller, "INCORRECT_CALLER");
+        require(bidIdToStakerInfo[_validatorId].staker == _bnftHolder, "INCORRECT_BNFT_HOLDER");
 
         bidIdToStakerInfo[_validatorId].staker = address(0);
         nodesManager.unregisterValidator(_validatorId);

--- a/src/interfaces/IStakingManager.sol
+++ b/src/interfaces/IStakingManager.sol
@@ -25,10 +25,10 @@ interface IStakingManager {
     function setEtherFiNodesManagerAddress(address _managerAddress) external;
     function setLiquidityPoolAddress(address _liquidityPoolAddress) external;
     
-    function batchDepositWithBidIds(uint256[] calldata _candidateBidIds, uint256 _numberOfValidators, address _staker, address _tnftHolder, address _bnftHolder, bool _enableRestaking, uint256 _validatorIdToCoUseWithdrawalSafe) external returns (uint256[] memory);
-    function batchRegisterValidators(uint256[] calldata _validatorId, address _bNftRecipient, address _tNftRecipient, DepositData[] calldata _depositData, address _user) external payable;
+    function batchDepositWithBidIds(uint256[] calldata _candidateBidIds, uint256 _numberOfValidators, address _tnftHolder, address _bnftHolder, bool _enableRestaking, uint256 _validatorIdToCoUseWithdrawalSafe) external returns (uint256[] memory);
+    function batchRegisterValidators(uint256[] calldata _validatorId, address _bNftRecipient, address _tNftRecipient, DepositData[] calldata _depositData) external payable;
     function batchApproveRegistration(uint256[] memory _validatorId, bytes[] calldata _pubKey, bytes[] calldata _signature, bytes32[] calldata _depositDataRootApproval) external payable;
-    function batchCancelDeposit(uint256[] calldata _validatorIds, address _caller) external;
+    function batchCancelDeposit(uint256[] calldata _validatorIds, address _bnftHolder) external;
 
     function instantiateEtherFiNode(bool _createEigenPod) external returns (address);
 }

--- a/test/AddressProvider.t.sol
+++ b/test/AddressProvider.t.sol
@@ -126,9 +126,8 @@ contract AddressProviderTest is TestSetup {
             "RegulationsManager"
         );
 
-        assertEq(addressProviderInstance.getImplementationAddress("LiquidityPool"), address(liquidityPoolImplementation));
-        assertEq(addressProviderInstance.getImplementationAddress("RegulationsManager"), address(regulationsManagerImplementation));
-        assertEq(addressProviderInstance.getImplementationAddress("AuctionManager"), address(auctionImplementation));
+        assertEq(addressProviderInstance.getImplementationAddress("LiquidityPool"), address(liquidityPoolInstance.getImplementation()));
+        assertEq(addressProviderInstance.getImplementationAddress("AuctionManager"), address(auctionInstance.getImplementation()));
 
         AuctionManagerV2Test auctionManagerV2Implementation = new AuctionManagerV2Test();
         auctionInstance.upgradeTo(address(auctionManagerV2Implementation));

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -931,8 +931,13 @@ contract EtherFiNodeTest is TestSetup {
         assertEq(nonExitPenalty, 0 ether);
     }
 
-    function test_ImplementationContract() public {
-        assertEq(safeInstance.implementation(), address(node));
+    function test_upgradeEtherFiNode() public {
+        EtherFiNode etherFiNode = new EtherFiNode();
+        address newImpl = address(etherFiNode);
+        vm.prank(stakingManagerInstance.owner());
+        stakingManagerInstance.upgradeEtherFiNode(newImpl);
+
+        assertEq(safeInstance.implementation(), address(newImpl));
     }
 
     function test_trackingTVL() public {

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -136,7 +136,7 @@ contract EtherFiNodesManagerTest is TestSetup {
 
         // deposit
         vm.prank(address(liquidityPoolInstance));
-        uint256[] memory processedBids = stakingManagerInstance.batchDepositWithBidIds(bidId, 1, alice, bob, henry, false, 0);
+        uint256[] memory processedBids = stakingManagerInstance.batchDepositWithBidIds(bidId, 1, bob, henry, false, 0);
 
         // assigned safe should be the premade one
         address node = managerInstance.etherfiNodeAddress(processedBids[0]);
@@ -149,7 +149,7 @@ contract EtherFiNodesManagerTest is TestSetup {
 
         // recycle the first safe
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchCancelDeposit(processedBids, alice);
+        stakingManagerInstance.batchCancelDeposit(processedBids, henry);
         assertEq(managerInstance.getUnusedWithdrawalSafesLength(), 2);
 
         // original premade safe should be on top of the stack after being recycled

--- a/test/EtherFiTimelock.sol
+++ b/test/EtherFiTimelock.sol
@@ -38,7 +38,7 @@ contract TimelockTest is TestSetup {
         managerInstance.renounceOwnership();
 
         // encoded data for EtherFiNodesManager.setStakingRewardsSplit()
-        bytes memory data = abi.encodeWithSelector(EtherFiNodesManager.setStakingRewardsSplit.selector, 1, 0, 0, 0);
+        bytes memory data = abi.encodeWithSelector(EtherFiNodesManager.setStakingRewardsSplit.selector, 1_000_000, 0, 0, 0);
 
         // attempt to directly execute with timelock. Not allowed to do tx before queuing it
         vm.prank(owner);
@@ -131,11 +131,11 @@ contract TimelockTest is TestSetup {
         // values should be updated
 
         (uint64 treasurySplit,,,) = managerInstance.stakingRewardsSplit();
-        assertEq(treasurySplit, 1);
+        assertEq(treasurySplit, 1_000_000);
 
 
         // queue and execute a tx to undo that change
-        bytes memory undoData = abi.encodeWithSelector(EtherFiNodesManager.setStakingRewardsSplit.selector, 5, 0, 0, 0);
+        bytes memory undoData = abi.encodeWithSelector(EtherFiNodesManager.setStakingRewardsSplit.selector, 0, 1_000_000, 0, 0);
         vm.prank(admin);
         tl.schedule(
             address(managerInstance), // target
@@ -155,7 +155,7 @@ contract TimelockTest is TestSetup {
             0                         // optional salt
         );
         (treasurySplit,,,) = managerInstance.stakingRewardsSplit();
-        assertEq(treasurySplit, 5);
+        assertEq(treasurySplit, 0);
 
         // non-proposer should not be able to schedule tx
         address rando = vm.addr(0x987654321);

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -885,7 +885,7 @@ contract LiquidityPoolTest is TestSetup {
         liquidityPoolInstance.batchDeposit{value: 8 ether}(bidIds, 4);
         vm.stopPrank();
 
-        vm.startPrank(owner);
+        vm.startPrank(alice);
         //Owner de registers themselves
         liquidityPoolInstance.deRegisterBnftHolder(owner);
         vm.stopPrank();
@@ -928,7 +928,7 @@ contract LiquidityPoolTest is TestSetup {
 
     function test_RestakedDepositFromBNFTHolder() public {
         initializeRealisticFork(MAINNET_FORK);
-        _upgrade_liquidity_pool_contract();
+        setupRoleRegistry();
 
         _initBid();
 

--- a/test/StakingManager.t.sol
+++ b/test/StakingManager.t.sol
@@ -184,7 +184,7 @@ contract StakingManagerTest is TestSetup {
         uint256[] memory bidId = test_CreateOneBid();
 
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchDepositWithBidIds(bidId, 1, alice, bob, henry, false, 0);
+        stakingManagerInstance.batchDepositWithBidIds(bidId, 1, bob, henry, false, 0);
     
         return bidId;
     }
@@ -196,35 +196,31 @@ contract StakingManagerTest is TestSetup {
 
         vm.expectRevert("DEPOSIT_AMOUNT_MISMATCH");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators(validatorId, alice, bob, depositDataArray, henry);
+        stakingManagerInstance.batchRegisterValidators(validatorId, alice, bob, depositDataArray);
 
         vm.deal(address(liquidityPoolInstance), 100 ether);
 
         vm.expectRevert("INCORRECT_CALLER");
         vm.prank(alice);
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray);
 
         address randomAddress = vm.addr(121232);
-        vm.expectRevert("INCORRECT_HASH");
+        vm.expectRevert("INCORRECT_BNFT_RECIPIENT");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, randomAddress, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, randomAddress, bob, depositDataArray);
 
         vm.expectRevert("INCORRECT_HASH");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, randomAddress, depositDataArray, alice);
-
-        vm.expectRevert("INCORRECT_CALLER");
-        vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray, randomAddress);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, randomAddress, depositDataArray);
 
         vm.expectEmit(true, true, true, true);
         emit ValidatorRegistered(alice, henry, bob, validatorId[0], hex"8f9c0aab19ee7586d3d470f132842396af606947a0589382483308fdffdaf544078c3be24210677a9c471ce70b3b4c2c", "test_ipfs");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray);
     
         vm.expectRevert("INVALID_PHASE_TRANSITION");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray);
     }
 
     function test_BatchDepositWithBidIdsFailsIfNotEnoughActiveBids() public {
@@ -236,7 +232,7 @@ contract StakingManagerTest is TestSetup {
  
         vm.expectRevert("NOT_ENOUGH_BIDS");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 2, alice, bob, henry, false, 0);
+        stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 2, bob, henry, false, 0);
     }
 
     function test_BatchDepositWithBidIdsFailsIfNoIdsProvided() public {
@@ -246,7 +242,7 @@ contract StakingManagerTest is TestSetup {
         uint256[] memory bidIdArray = new uint256[](0);
         vm.expectRevert("WRONG_PARAMS");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 1, alice, bob, henry, false, 0);
+        stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 1, bob, henry, false, 0);
     }
 
     function test_BatchDepositWithBidIdsFailsIfPaused() public {
@@ -257,7 +253,7 @@ contract StakingManagerTest is TestSetup {
 
         vm.expectRevert("Pausable: paused");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchDepositWithBidIds(bidId, 1, alice, bob, henry, false, 0);
+        stakingManagerInstance.batchDepositWithBidIds(bidId, 1, bob, henry, false, 0);
     }
 
     function test_BatchDepositWithIdsSimpleWorksCorrectly() public {
@@ -276,7 +272,7 @@ contract StakingManagerTest is TestSetup {
         bidIdArray[9] = 20;
 
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 1, alice, bob, henry, false, 0);
+        stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 1, bob, henry, false, 0);
 
         assertEq(auctionInstance.numberOfActiveBids(), 19);
 
@@ -309,7 +305,7 @@ contract StakingManagerTest is TestSetup {
 
         vm.expectRevert("Pausable: paused");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray);
     }
 
     function test_BatchRegisterValidatorWorksCorrectly() public {
@@ -328,14 +324,14 @@ contract StakingManagerTest is TestSetup {
         bidIdArray[9] = 20;
 
         vm.prank(address(liquidityPoolInstance));
-        uint256[] memory validatorIds = stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 4, alice, bob, henry, false, 0);
+        uint256[] memory validatorIds = stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 4, bob, henry, false, 0);
 
         assertEq(address(auctionInstance).balance, 3 ether, "Auction balance should be 3");
 
         (IStakingManager.DepositData[] memory depositDataArray,,,) = _prepareForValidatorRegistration(validatorIds);
         vm.deal(address(liquidityPoolInstance), 100 ether);
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 4 ether}(validatorIds, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 4 ether}(validatorIds, henry, bob, depositDataArray);
 
         assertEq(managerInstance.numberOfValidators(), 4);
         assertEq(auctionInstance.accumulatedRevenue(), 0.4 ether, "Auction accumulated revenue should be 0.4");
@@ -357,7 +353,7 @@ contract StakingManagerTest is TestSetup {
         bidIdArray[2] = 6;
 
         vm.prank(address(liquidityPoolInstance));
-        uint256[] memory validatorIds = stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 3, alice, bob, henry, false, 0);
+        uint256[] memory validatorIds = stakingManagerInstance.batchDepositWithBidIds(bidIdArray, 3, bob, henry, false, 0);
 
         (IStakingManager.DepositData[] memory depositDataArray,,,) = _prepareForValidatorRegistration(validatorIds);
         vm.deal(address(liquidityPoolInstance), 100 ether);
@@ -366,7 +362,7 @@ contract StakingManagerTest is TestSetup {
 
         vm.expectRevert("WRONG_PARAMS");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 4 ether}(newWrongValidatorIds, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 4 ether}(newWrongValidatorIds, henry, bob, depositDataArray);
     }
 
     function test_BatchFailsIfMoreThanMax() public {
@@ -377,17 +373,17 @@ contract StakingManagerTest is TestSetup {
 
         vm.expectRevert("WRONG_PARAMS");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchDepositWithBidIds(bidIds, 2, alice, bob, henry, false, 0);
+        stakingManagerInstance.batchDepositWithBidIds(bidIds, 2, bob, henry, false, 0);
 
         uint256[] memory validatorIds = new uint256[](2);
 
         // '1' works though
         vm.prank(address(liquidityPoolInstance));
-        uint256[] memory tmp = stakingManagerInstance.batchDepositWithBidIds(bidIds, 1, alice, bob, henry, false, 0);
+        uint256[] memory tmp = stakingManagerInstance.batchDepositWithBidIds(bidIds, 1, bob, henry, false, 0);
         validatorIds[0] = tmp[0];
 
         vm.prank(address(liquidityPoolInstance));
-        tmp = stakingManagerInstance.batchDepositWithBidIds(bidIds, 1, alice, bob, henry, false, 0);
+        tmp = stakingManagerInstance.batchDepositWithBidIds(bidIds, 1, bob, henry, false, 0);
         validatorIds[1] = tmp[0];
 
         (IStakingManager.DepositData[] memory depositDataArray,,,) = _prepareForValidatorRegistration(validatorIds);
@@ -395,32 +391,31 @@ contract StakingManagerTest is TestSetup {
 
         vm.expectRevert("WRONG_PARAMS");
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether * validatorIds.length}(validatorIds, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether * validatorIds.length}(validatorIds, henry, bob, depositDataArray);
 
 
         (depositDataArray,,,) = _prepareForValidatorRegistration(tmp);
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether * tmp.length}(tmp, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether * tmp.length}(tmp, henry, bob, depositDataArray);
     }
 
-    function test_cancelDeposit() public {
-        //  stakingManagerInstance.batchDepositWithBidIds(bidId, 1, alice, bob, henry, false, 0);
+    function test_cancelDeposit_1() public {
         uint256[] memory validatorId = test_DepositOneWorksCorrectly();
 
         vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("INCORRECT_CALLER");
+        vm.expectRevert("INCORRECT_BNFT_HOLDER");
         stakingManagerInstance.batchCancelDeposit(validatorId, bob);
 
-        vm.prank(address(liquidityPoolInstance));
+        vm.prank(address(alice));
         vm.expectRevert("INCORRECT_CALLER");
         stakingManagerInstance.batchCancelDeposit(validatorId, henry);
 
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchCancelDeposit(validatorId, alice);
+        stakingManagerInstance.batchCancelDeposit(validatorId, henry);
 
         vm.prank(address(liquidityPoolInstance));
         vm.expectRevert("NO_DEPOSIT_EXIST");
-        stakingManagerInstance.batchCancelDeposit(validatorId, alice);
+        stakingManagerInstance.batchCancelDeposit(validatorId, henry);
     }
 
     function test_cancelDepositFailsIfIncorrectPhase() public {
@@ -429,11 +424,11 @@ contract StakingManagerTest is TestSetup {
         (IStakingManager.DepositData[] memory depositDataArray,,,) = _prepareForValidatorRegistration(validatorId);
         vm.deal(address(liquidityPoolInstance), 100 ether);
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray, alice);
+        stakingManagerInstance.batchRegisterValidators{value: 1 ether}(validatorId, henry, bob, depositDataArray);
 
         vm.prank(address(liquidityPoolInstance));
         vm.expectRevert("INVALID_PHASE_TRANSITION");
-        stakingManagerInstance.batchCancelDeposit(validatorId, alice);
+        stakingManagerInstance.batchCancelDeposit(validatorId, henry);
     }
 
     function test_cancelDepositFailsIfContractPaused() public {
@@ -451,10 +446,10 @@ contract StakingManagerTest is TestSetup {
         uint256[] memory validatorId = test_DepositOneWorksCorrectly();
 
         uint256 selectedBidId = validatorId[0];
-        address staker = stakingManagerInstance.bidIdToStaker(validatorId[0]);
+        address bnftStaker = stakingManagerInstance.bidIdToStaker(validatorId[0]);
         address etherFiNode = managerInstance.etherfiNodeAddress(validatorId[0]);
 
-        assertEq(staker, alice);
+        assertEq(bnftStaker, henry);
         assertEq(selectedBidId, validatorId[0]);
         assertTrue(managerInstance.phase(validatorId[0]) == IEtherFiNode.VALIDATOR_PHASE.STAKE_DEPOSITED);
 
@@ -470,7 +465,7 @@ contract StakingManagerTest is TestSetup {
         vm.expectEmit(true, false, false, true);
         emit DepositCancelled(validatorId[0]);
         vm.prank(address(liquidityPoolInstance));
-        stakingManagerInstance.batchCancelDeposit(validatorId, alice);
+        stakingManagerInstance.batchCancelDeposit(validatorId, henry);
 
         assertEq(managerInstance.etherfiNodeAddress(validatorId[0]), address(0));
         assertEq(stakingManagerInstance.bidIdToStaker(validatorId[0]), address(0));

--- a/test/Upgradable.t.sol
+++ b/test/Upgradable.t.sol
@@ -32,6 +32,12 @@ contract StakingManagerV2Syko is StakingManager {
     }
 }
 
+contract StakingManagerV2 is StakingManager {
+    function isUpgraded() public pure returns(bool){
+        return true;
+    }
+}
+
 contract AuctionManagerV2Test is AuctionManager {
     function isUpgraded() public pure returns(bool){
         return true;
@@ -82,7 +88,7 @@ contract UpgradeTest is TestSetup {
     TNFTV2 public TNFTV2Instance;
     EtherFiNodesManagerV2 public etherFiNodesManagerV2Instance;
     ProtocolRevenueManagerV2 public protocolRevenueManagerV2Instance;
-    StakingManager public stakingManagerV2Instance;
+    StakingManagerV2 public stakingManagerV2Instance;
     NodeOperatorManagerV2 public nodeOperatorManagerV2Instance;
 
     uint256[] public slippageArray;
@@ -103,7 +109,6 @@ contract UpgradeTest is TestSetup {
         auctionInstance.createBid{value: 0.1 ether}(1, 0.1 ether);
 
         assertEq(auctionInstance.numberOfActiveBids(), 1);
-        assertEq(auctionInstance.getImplementation(), address(auctionImplementation));
 
         AuctionManagerV2Test auctionManagerV2Implementation = new AuctionManagerV2Test();
 
@@ -124,8 +129,6 @@ contract UpgradeTest is TestSetup {
     }
 
     function test_CanUpgradeBNFT() public {
-        assertEq(BNFTInstance.getImplementation(), address(BNFTImplementation));
-
         BNFTV2 BNFTV2Implementation = new BNFTV2();
 
         vm.prank(owner);
@@ -142,8 +145,6 @@ contract UpgradeTest is TestSetup {
     }
 
     function test_CanUpgradeTNFT() public {
-        assertEq(TNFTInstance.getImplementation(), address(TNFTImplementation));
-
         TNFTV2 TNFTV2Implementation = new TNFTV2();
 
         vm.prank(owner);
@@ -160,8 +161,6 @@ contract UpgradeTest is TestSetup {
     }
 
     function test_CanUpgradeEtherFiNodesManager() public {
-        assertEq(managerInstance.getImplementation(), address(managerImplementation));
-
         vm.prank(alice);
         managerInstance.setStakingRewardsSplit(uint64(100000), uint64(100000), uint64(400000), uint64(400000));
 
@@ -201,8 +200,6 @@ contract UpgradeTest is TestSetup {
     }
 
     function test_CanUpgradeProtocolRevenueManager() public {
-        assertEq(protocolRevenueManagerInstance.getImplementation(), address(protocolRevenueManagerImplementation));
-
         vm.prank(alice);
 
         ProtocolRevenueManagerV2 protocolRevenueManagerV2Implementation = new ProtocolRevenueManagerV2();
@@ -236,12 +233,10 @@ contract UpgradeTest is TestSetup {
 
         vm.stopPrank();
 
-        assertEq(stakingManagerInstance.getImplementation(), address(stakingManagerImplementation));
-
         vm.prank(alice);
         stakingManagerInstance.setMaxBatchDepositSize(uint128(25));
 
-        StakingManager stakingManagerV2Implementation = new StakingManager();
+        StakingManagerV2 stakingManagerV2Implementation = new StakingManagerV2();
 
         vm.expectRevert("Initializable: contract is already initialized");
         vm.prank(owner);
@@ -255,14 +250,14 @@ contract UpgradeTest is TestSetup {
         vm.prank(owner);
         stakingManagerInstance.upgradeTo(address(stakingManagerV2Implementation));
 
-        stakingManagerV2Instance = StakingManager(address(stakingManagerProxy));
+        stakingManagerV2Instance = StakingManagerV2(address(stakingManagerProxy));
 
         vm.expectRevert("Initializable: contract is already initialized");
         vm.prank(owner);
         stakingManagerV2Instance.initialize(address(auctionInstance), address(depositContractEth2));
 
         assertEq(stakingManagerV2Instance.getImplementation(), address(stakingManagerV2Implementation));
-        // assertEq(stakingManagerV2Instance.isUpgraded(), true);
+        assertEq(stakingManagerV2Instance.isUpgraded(), true);
         
         // State is maintained
         assertEq(stakingManagerV2Instance.maxBatchDepositSize(), 25);
@@ -286,12 +281,9 @@ contract UpgradeTest is TestSetup {
     }
 
     function test_CanUpgradeNodeOperatorManager() public {
-
         vm.prank(alice);
         nodeOperatorManagerInstance.registerNodeOperator(_ipfsHash, 5);
         
-        assertEq(nodeOperatorManagerInstance.getImplementation(), address(nodeOperatorManagerImplementation));
-
         NodeOperatorManagerV2 nodeOperatorManagerV2Implementation = new NodeOperatorManagerV2();
 
         vm.expectRevert("Initializable: contract is already initialized");


### PR DESCRIPTION
- Previously, we had a use case for delegate staking where a user can own a validator by staking 32 ETH. We are going to deprecate it and will keep only the Liquid Staking.
- Fix broken unit tests