### PR TITLE
Pepe partial withdrawals

### DIFF
--- a/script/deploys/DeployEtherFISuite.s.sol
+++ b/script/deploys/DeployEtherFISuite.s.sol
@@ -153,7 +153,7 @@ contract DeployEtherFiSuiteScript is Script {
         regulationsManagerInstance = RegulationsManager(address(regulationsManagerProxy));
         regulationsManagerInstance.initialize();
 
-        EtherFiNode etherFiNode = new EtherFiNode();
+        EtherFiNode etherFiNode = new EtherFiNode(address(liquidityPoolProxy));
 
         // Mainnet Addresses
         // address private immutable rETH = 0xae78736Cd615f374D3085123A210448E74Fc6393;

--- a/script/deploys/DeployPhaseOne.s.sol
+++ b/script/deploys/DeployPhaseOne.s.sol
@@ -44,6 +44,8 @@ contract DeployPhaseOne is Script {
     EtherFiNodesManager public etherFiNodesManagerImplementation;
     EtherFiNodesManager public etherFiNodesManager;
 
+    address liquidityPool;
+
     struct suiteAddresses {
         address treasury;
         address nodeOperatorManager;
@@ -115,7 +117,8 @@ contract DeployPhaseOne is Script {
             address(0)
         );
 
-        EtherFiNode etherFiNode = new EtherFiNode();
+        require(liquidityPool != address(0x0), "must set liquidityPool");
+        EtherFiNode etherFiNode = new EtherFiNode(liquidityPool);
 
         // Setup dependencies
         nodeOperatorManager.setAuctionContractAddress(address(auctionManager));

--- a/script/upgrades/EtherFiNodeScript.s.sol
+++ b/script/upgrades/EtherFiNodeScript.s.sol
@@ -9,12 +9,14 @@ import "../../src/helpers/AddressProvider.sol";
 contract EtherFiNodeUpgrade is Script {
 
     AddressProvider public addressProvider;
+    address liquidityPool;
 
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
 
         address addressProviderAddress = vm.envAddress("CONTRACT_REGISTRY");
         addressProvider = AddressProvider(addressProviderAddress);
+        require(liquidityPool != address(0x0), "must set liquidityPool");
 
         address stakingManagerProxyAddress = addressProvider.getContractAddress("StakingManager");
 
@@ -22,7 +24,8 @@ contract EtherFiNodeUpgrade is Script {
 
         vm.startBroadcast(deployerPrivateKey);
 
-        EtherFiNode etherFiNode = new EtherFiNode();
+        EtherFiNode etherFiNode = new EtherFiNode(liquidityPool);
+
         stakingManager.upgradeEtherFiNode(address(etherFiNode));
 
         vm.stopBroadcast();

--- a/script/upgrades/MultipleValidatorsPerSafe.s.sol
+++ b/script/upgrades/MultipleValidatorsPerSafe.s.sol
@@ -56,7 +56,7 @@ contract MultipleValidatorsPerSafe is Script {
         StakingManager StakingManagerNewImpl = new StakingManager();
         TNFT TNFTNewImpl = new TNFT();
         EtherFiNodesManager EtherFiNodesManagerNewImpl = new EtherFiNodesManager();
-        EtherFiNode EtherFiNodeNewImpl = new EtherFiNode();
+        EtherFiNode EtherFiNodeNewImpl = new EtherFiNode(address(liquidityPool));
 
         address el_delegationManager;
         if (block.chainid == 1) {

--- a/script/upgrades/UpgradeForEigenLayerM2.s.sol
+++ b/script/upgrades/UpgradeForEigenLayerM2.s.sol
@@ -21,10 +21,12 @@ contract UpgradeForEigenLayerM2 is Script {
     AddressProvider public addressProvider;
 
     address addressProviderAddress;
+    address liquidityPool;
 
     StakingManager stakingManager;
     EtherFiNodesManager nodesManager;
     Liquifier liquifier;
+    
 
     EtherFiTimelock timelock;
 
@@ -46,13 +48,15 @@ contract UpgradeForEigenLayerM2 is Script {
         addressProviderAddress = vm.envAddress("CONTRACT_REGISTRY");
         addressProvider = AddressProvider(addressProviderAddress);
 
+        require(liquidityPool != address(0x0), "must set liquidityPool");
+
         retrieve_contract_addresses();
-        
+
         vm.startBroadcast(deployerPrivateKey);
 
         // Liquifier LiquifierNewImpl = new Liquifier();
         EtherFiNodesManager EtherFiNodesManagerNewImpl = new EtherFiNodesManager();
-        EtherFiNode EtherFiNodeNewImpl = new EtherFiNode();
+        EtherFiNode EtherFiNodeNewImpl = new EtherFiNode(liquidityPool);
 
         address el_delegationManager;
         address pancakeRouter;

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -486,7 +486,6 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
             uint256 principal = (withdrawableBalanceInExecutionLayer() >= 32 ether) ? 32 ether : withdrawableBalanceInExecutionLayer();
             (payouts[2], payouts[1]) = _calculatePrincipals(principal);
             (payouts[0], payouts[1], payouts[2], payouts[3]) = _applyNonExitPenalty(_info, payouts[0], payouts[1], payouts[2], payouts[3]);
-
             return (payouts[0], payouts[1], payouts[2], payouts[3]);
         } else {
             require(false, "WRONG_VERSION");

--- a/src/interfaces/IEtherFiNode.sol
+++ b/src/interfaces/IEtherFiNode.sol
@@ -83,6 +83,8 @@ interface IEtherFiNode {
     function withdrawableBalanceInExecutionLayer() external view returns (uint256);
     function updateNumExitRequests(uint16 _up, uint16 _down) external;
     function migrateVersion(uint256 _validatorId, IEtherFiNodesManager.ValidatorInfo memory _info) external;
+    function queueEigenlayerPartialWithdrawal(uint256 _amount) external returns (bytes32);
+    function completeEigenlayerPartialWithdrawal(IDelegationManager.Withdrawal memory _withdrawal, uint256 _middlewareTimesIndex) external;
 
     function startCheckpoint(bool _revertIfNoBalance) external;
     function setProofSubmitter(address _newProofSubmitter) external;

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -56,12 +56,10 @@ interface IEtherFiNodesManager {
     function batchQueueRestakedWithdrawal(uint256[] calldata _validatorIds) external;
     function batchSendExitRequest(uint256[] calldata _validatorIds) external;
     function batchFullWithdraw(uint256[] calldata _validatorIds) external;
-    function batchPartialWithdraw(uint256[] calldata _validatorIds) external;
     function fullWithdraw(uint256 _validatorId) external;
     function getUnusedWithdrawalSafesLength() external view returns (uint256);
     function incrementNumberOfValidators(uint64 _count) external;
     function markBeingSlashed(uint256[] calldata _validatorIds) external;
-    function partialWithdraw(uint256 _validatorId) external;
     function processNodeExit(uint256[] calldata _validatorIds, uint32[] calldata _exitTimestamp) external;
     function allocateEtherFiNode(bool _enableRestaking) external returns (address);
     function registerValidator(uint256 _validatorId, bool _enableRestaking, address _withdrawalSafeAddress) external;

--- a/test/EigenLayerIntegration.t.sol
+++ b/test/EigenLayerIntegration.t.sol
@@ -71,7 +71,7 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
         vm.stopPrank();
 
         EtherFiNodesManager newManagerImpl = new EtherFiNodesManager();
-        EtherFiNode newNodeImpl = new EtherFiNode();
+        EtherFiNode newNodeImpl = new EtherFiNode(address(liquidityPool));
 
         vm.startPrank(managerInstance.owner());
         managerInstance.upgradeTo(address(newManagerImpl));

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -544,7 +544,7 @@ contract EtherFiNodeTest is TestSetup {
         managerInstance.markBeingSlashed(validatorIds);
         info = managerInstance.getValidatorInfo(validatorIds[0]);
         assertTrue(info.phase == IEtherFiNode.VALIDATOR_PHASE.BEING_SLASHED);
-        
+
         hoax(alice);
         managerInstance.processNodeExit(validatorIds, exitTimestamps);
         info = managerInstance.getValidatorInfo(validatorIds[0]);
@@ -552,68 +552,6 @@ contract EtherFiNodeTest is TestSetup {
         assertTrue(info.exitTimestamp > 0);
     }
 
-    /*
-    function test_partialWithdrawRewardsDistribution() public {
-        address nodeOperator = 0xCd5EBC2dD4Cb3dc52ac66CEEcc72c838B40A5931;
-        address staker = 0x9154a74AAfF2F586FB0a884AeAb7A64521c64bCf;
-        address etherfiNode = managerInstance.etherfiNodeAddress(bidId[0]);
-
-        // Transfer the T-NFT to 'dan'
-        hoax(staker);
-        TNFTInstance.transferFrom(staker, dan, bidId[0]);
-
-        uint256 nodeOperatorBalance = address(nodeOperator).balance;
-        uint256 treasuryBalance = address(treasuryInstance).balance;
-        uint256 danBalance = address(dan).balance;
-        uint256 bnftStakerBalance = address(staker).balance;
-
-        // Simulate the rewards distribution from the beacon chain
-        vm.deal(etherfiNode, address(etherfiNode).balance + 1 ether);
-
-        // Withdraw the {staking, protocol} rewards
-        // - bid amount = 0 ether (Auction revenue no longer distributed to nodes)
-        //   - 50 % ether is vested for the stakers
-        //   - 50 % ether is shared across all validators
-        //     - 25 % to treasury, 25% to node operator, the rest to the stakers
-        // - staking rewards amount = 1 ether
-        hoax(owner);
-        managerInstance.partialWithdraw(bidId[0]);
-        assertEq(
-            address(nodeOperator).balance,
-            nodeOperatorBalance + (1 ether * 5) / 100
-        );
-        assertEq(
-            address(treasuryInstance).balance,
-            treasuryBalance + (1 ether * 5 ) / 100
-        );
-        assertEq(address(dan).balance, danBalance + 0.815625000000000000 ether);
-        assertEq(address(staker).balance, bnftStakerBalance + 0.084375000000000000 ether);
-
-        vm.deal(etherfiNode, 16.0 ether);
-        vm.expectRevert("MUST_EXIT");
-        vm.prank(owner);
-        managerInstance.partialWithdraw(bidId[0]);
-    }
-    */
-
-    /*
-    function test_partialWithdrawFails() public {
-        address etherfiNode = managerInstance.etherfiNodeAddress(bidId[0]);
-
-        vm.deal(etherfiNode, 4 ether);
-
-        vm.expectRevert(EtherFiNodesManager.NotAdmin.selector);
-        vm.prank(bob);
-        managerInstance.markBeingSlashed(bidId);
-
-        hoax(alice);
-        managerInstance.markBeingSlashed(bidId);
-
-        vm.prank(managerInstance.owner());
-        vm.expectRevert("NOT_LIVE");
-        managerInstance.partialWithdraw(bidId[0]);
-    }
-    */
 
     function test_markBeingSlashedFails() public {
         uint256[] memory validatorIds = new uint256[](1);

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -579,25 +579,6 @@ contract EtherFiNodeTest is TestSetup {
         assertTrue(managerInstance.phase(bidId[0]) == IEtherFiNode.VALIDATOR_PHASE.BEING_SLASHED);
     }
 
-    /*
-    function test_partialWithdrawAfterExitRequest() public {
-        address nodeOperator = 0xCd5EBC2dD4Cb3dc52ac66CEEcc72c838B40A5931;
-        address staker = 0x9154a74AAfF2F586FB0a884AeAb7A64521c64bCf;
-        address etherfiNode = managerInstance.etherfiNodeAddress(bidId[0]);
-
-        // Simulate the rewards distribution from the beacon chain
-        vm.deal(etherfiNode, address(etherfiNode).balance + 1 ether);
-
-        // Send Exit Request
-        hoax(TNFTInstance.ownerOf(bidId[0]));
-        managerInstance.batchSendExitRequest(_to_uint256_array(bidId[0]));
-
-        vm.prank(managerInstance.owner());
-        vm.expectRevert("PENDING_EXIT_REQUEST");
-        managerInstance.partialWithdraw(bidId[0]);
-    }
-    */
-
     function test_getFullWithdrawalPayoutsFails() public {
 
         uint256[] memory validatorIds = new uint256[](1);
@@ -724,36 +705,6 @@ contract EtherFiNodeTest is TestSetup {
         (toNodeOperator, toTnft, toBnft, toTreasury) = managerInstance
             .getFullWithdrawalPayouts(validatorIds[0]);
     }
-
-    /*
-    function test_partialWithdrawAfterExitFails() public {
-        address nodeOperator = 0xCd5EBC2dD4Cb3dc52ac66CEEcc72c838B40A5931;
-        address staker = 0x9154a74AAfF2F586FB0a884AeAb7A64521c64bCf;
-
-        uint256[] memory validatorIds = new uint256[](1);
-        validatorIds[0] = bidId[0];
-        uint32[] memory exitTimestamps = new uint32[](1);
-        exitTimestamps[0] = 1;
-        address etherfiNode = managerInstance.etherfiNodeAddress(validatorIds[0]);
-
-        // 8. balance < 4 ether
-        vm.deal(etherfiNode, 4 ether);
-
-        startHoax(alice);
-        assertEq(managerInstance.numberOfValidators(), 1);
-        managerInstance.processNodeExit(validatorIds, exitTimestamps);
-        assertEq(managerInstance.numberOfValidators(), 0);
-        vm.stopPrank();
-
-        // Transfer the T-NFT to 'dan'
-        hoax(staker);
-        TNFTInstance.transferFrom(staker, dan, validatorIds[0]);
-
-        hoax(owner);
-        vm.expectRevert("NOT_LIVE");
-        managerInstance.partialWithdraw(validatorIds[0]);
-    }
-    */
 
     function test_getFullWithdrawalPayoutsAuditFix3() public {
         uint256[] memory validatorIds = new uint256[](1);
@@ -2091,39 +2042,6 @@ contract EtherFiNodeTest is TestSetup {
         uint256[] memory newValidatorIds = liquidityPoolInstance.batchDepositAsBnftHolder{value: 2 ether}(bidIds, 1, validatorId);
     }
 
-    /*
-    function test_PartialWithdrawalOfPrincipalFails() public {
-        uint256[] memory validatorIds = launch_validator(1, 0, false);
-        uint256 validatorId = validatorIds[0];
-        address etherfiNode = managerInstance.etherfiNodeAddress(validatorId);
-
-        assertTrue(managerInstance.phase(validatorIds[0]) == IEtherFiNode.VALIDATOR_PHASE.LIVE);
-        assertEq(IEtherFiNode(etherfiNode).numAssociatedValidators(), 1);
-
-        // launch 3 more validators
-        uint256[] memory newValidatorIds = launch_validator(3, validatorId, false);
-        assertEq(IEtherFiNode(etherfiNode).numAssociatedValidators(), 4);
-
-        uint256[] memory validatorIdsToExit = new uint256[](1);
-        uint32[] memory exitTimestamps = new uint32[](1);
-        exitTimestamps[0] = uint32(block.timestamp);
-
-        // Exit 1 among 4
-        validatorIdsToExit[0] = newValidatorIds[0];
-        _transferTo(etherfiNode, 16 ether);
-
-        // Someone triggers paritalWithrdaw
-        // Before the Oracle marks it as EXITED
-        vm.prank(managerInstance.owner());
-        vm.expectRevert("MUST_EXIT");
-        managerInstance.partialWithdraw(validatorId);
-
-        hoax(managerInstance.owner());
-        managerInstance.processNodeExit(validatorIdsToExit, exitTimestamps);
-
-        managerInstance.fullWithdraw(validatorIdsToExit[0]);
-    }
-    */
 
     function test_TnftTransferFailsWithMultipleValidators_Fails() public {
         uint256[] memory validatorIds = launch_validator(1, 0, false);

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -552,6 +552,7 @@ contract EtherFiNodeTest is TestSetup {
         assertTrue(info.exitTimestamp > 0);
     }
 
+    /*
     function test_partialWithdrawRewardsDistribution() public {
         address nodeOperator = 0xCd5EBC2dD4Cb3dc52ac66CEEcc72c838B40A5931;
         address staker = 0x9154a74AAfF2F586FB0a884AeAb7A64521c64bCf;
@@ -593,7 +594,9 @@ contract EtherFiNodeTest is TestSetup {
         vm.prank(owner);
         managerInstance.partialWithdraw(bidId[0]);
     }
+    */
 
+    /*
     function test_partialWithdrawFails() public {
         address etherfiNode = managerInstance.etherfiNodeAddress(bidId[0]);
 
@@ -610,6 +613,7 @@ contract EtherFiNodeTest is TestSetup {
         vm.expectRevert("NOT_LIVE");
         managerInstance.partialWithdraw(bidId[0]);
     }
+    */
 
     function test_markBeingSlashedFails() public {
         uint256[] memory validatorIds = new uint256[](1);
@@ -637,6 +641,7 @@ contract EtherFiNodeTest is TestSetup {
         assertTrue(managerInstance.phase(bidId[0]) == IEtherFiNode.VALIDATOR_PHASE.BEING_SLASHED);
     }
 
+    /*
     function test_partialWithdrawAfterExitRequest() public {
         address nodeOperator = 0xCd5EBC2dD4Cb3dc52ac66CEEcc72c838B40A5931;
         address staker = 0x9154a74AAfF2F586FB0a884AeAb7A64521c64bCf;
@@ -653,6 +658,7 @@ contract EtherFiNodeTest is TestSetup {
         vm.expectRevert("PENDING_EXIT_REQUEST");
         managerInstance.partialWithdraw(bidId[0]);
     }
+    */
 
     function test_getFullWithdrawalPayoutsFails() public {
 
@@ -781,6 +787,7 @@ contract EtherFiNodeTest is TestSetup {
             .getFullWithdrawalPayouts(validatorIds[0]);
     }
 
+    /*
     function test_partialWithdrawAfterExitFails() public {
         address nodeOperator = 0xCd5EBC2dD4Cb3dc52ac66CEEcc72c838B40A5931;
         address staker = 0x9154a74AAfF2F586FB0a884AeAb7A64521c64bCf;
@@ -808,6 +815,7 @@ contract EtherFiNodeTest is TestSetup {
         vm.expectRevert("NOT_LIVE");
         managerInstance.partialWithdraw(validatorIds[0]);
     }
+    */
 
     function test_getFullWithdrawalPayoutsAuditFix3() public {
         uint256[] memory validatorIds = new uint256[](1);
@@ -1955,39 +1963,6 @@ contract EtherFiNodeTest is TestSetup {
         assertEq(uint8(managerInstance.phase(newValidatorIds[0])), uint8(IEtherFiNode.VALIDATOR_PHASE.WAITING_FOR_APPROVAL));
     }
 
-    function test_mainnet_partialWithdraw_after_upgrade() public {
-        initializeRealisticFork(MAINNET_FORK);
-        _upgrade_etherfi_node_contract();   
-        _upgrade_etherfi_nodes_manager_contract(); 
-
-        uint256 validatorId = 2285;
-        uint256[] memory validatorIds = new uint256[](1);
-        validatorIds[0] = validatorId;
-        address nodeAddress = managerInstance.etherfiNodeAddress(validatorId);
-
-        _transferTo(nodeAddress, 1 ether);
-
-        vm.prank(owner);
-        managerInstance.batchQueueRestakedWithdrawal(validatorIds);
-        _moveClock(7 * 7200);
-
-        // Success
-        vm.prank(managerInstance.owner());
-        managerInstance.partialWithdraw(validatorId);
-
-        _transferTo(nodeAddress, 1 ether);
-        vm.prank(owner); // alice is admin
-        managerInstance.batchQueueRestakedWithdrawal(validatorIds);
-
-        hoax(TNFTInstance.ownerOf(validatorId));
-        managerInstance.batchSendExitRequest(validatorIds);
-
-        // `partialWithdraw` Fail, if there is any pending exit request
-        vm.prank(managerInstance.owner());
-        vm.expectRevert("PENDING_EXIT_REQUEST");
-        managerInstance.partialWithdraw(validatorId);
-    }
-
     function test_mainnet_launch_validator_with_reserved_version1_safe() public {
         initializeRealisticFork(MAINNET_FORK);
         _upgrade_etherfi_node_contract();   
@@ -2142,28 +2117,6 @@ contract EtherFiNodeTest is TestSetup {
         }
     }
 
-    function test_ForcedPartialWithdrawal_succeeds() public {
-        uint256[] memory validatorIds = launch_validator(1, 0, false);
-        uint256 validatorId = validatorIds[0];
-        address etherfiNode = managerInstance.etherfiNodeAddress(validatorId);
-
-        assertTrue(managerInstance.phase(validatorIds[0]) == IEtherFiNode.VALIDATOR_PHASE.LIVE);
-        assertEq(IEtherFiNode(etherfiNode).numAssociatedValidators(), 1);
-
-        // launch 3 more validators
-        uint256[] memory newValidatorIds = launch_validator(3, validatorId, false);
-        assertEq(IEtherFiNode(etherfiNode).numAssociatedValidators(), 4);
-
-        // Earned >= 16 ether
-        _transferTo(etherfiNode, 16 ether);
-
-        vm.expectRevert(EtherFiNodesManager.NotAdmin.selector);
-        managerInstance.partialWithdraw(validatorId);
-
-        vm.prank(alice);
-        managerInstance.partialWithdraw(validatorId);
-    }
-
     function test_lp_as_bnft_holders_cant_mix_up_1() public {
         uint256[] memory validatorIds = launch_validator(1, 0, false);
         uint256 validatorId = validatorIds[0];
@@ -2200,6 +2153,7 @@ contract EtherFiNodeTest is TestSetup {
         uint256[] memory newValidatorIds = liquidityPoolInstance.batchDepositAsBnftHolder{value: 2 ether}(bidIds, 1, validatorId);
     }
 
+    /*
     function test_PartialWithdrawalOfPrincipalFails() public {
         uint256[] memory validatorIds = launch_validator(1, 0, false);
         uint256 validatorId = validatorIds[0];
@@ -2231,6 +2185,7 @@ contract EtherFiNodeTest is TestSetup {
 
         managerInstance.fullWithdraw(validatorIdsToExit[0]);
     }
+    */
 
     function test_TnftTransferFailsWithMultipleValidators_Fails() public {
         uint256[] memory validatorIds = launch_validator(1, 0, false);

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -358,14 +358,6 @@ contract EtherFiNodesManagerTest is TestSetup {
 
         hoax(alice);
         vm.expectRevert("Pausable: paused");
-        managerInstance.partialWithdraw(0);
-
-        hoax(alice);
-        vm.expectRevert("Pausable: paused");
-        managerInstance.batchPartialWithdraw(ids);
-
-        hoax(alice);
-        vm.expectRevert("Pausable: paused");
         managerInstance.fullWithdraw(0);
 
         hoax(alice);

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -562,13 +562,6 @@ contract LiquidityPoolTest is TestSetup {
 
         liquidityPoolInstance.batchApproveRegistration(validatorIds, pubKey, sig);
         assertEq(liquidityPoolInstance.numPendingDeposits(), 0);
-
-        address etherfiNode = managerInstance.etherfiNodeAddress(validatorIds[0]);
-        vm.deal(address(etherfiNode), 1 ether);
-        managerInstance.batchPartialWithdraw(validatorIds);
-
-        // The liquidity pool receives the rewards as B-NFT holder and T-NFT holder
-        assertEq((address(liquidityPoolInstance).balance), 1 * 0.9 ether);
     }
 
     function test_batchPartialWithdrawOptimized() internal {

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -461,7 +461,7 @@ contract TestSetup is Test {
         regulationsManagerInstance.initialize();
         regulationsManagerInstance.updateAdmin(alice, true);
 
-        node = new EtherFiNode();
+        node = new EtherFiNode(address(liquidityPool));
 
         rETH = new TestERC20("Rocket Pool ETH", "rETH");
         rETH.mint(alice, 10e18);
@@ -1287,7 +1287,7 @@ contract TestSetup is Test {
     }
 
     function _upgrade_etherfi_node_contract() internal {
-        EtherFiNode etherFiNode = new EtherFiNode();
+        EtherFiNode etherFiNode = new EtherFiNode(address(liquidityPool));
         address newImpl = address(etherFiNode);
         vm.prank(stakingManagerInstance.owner());
         stakingManagerInstance.upgradeEtherFiNode(newImpl);

--- a/test/Upgradable.t.sol
+++ b/test/Upgradable.t.sol
@@ -66,6 +66,7 @@ contract EtherFiNodeV2 is EtherFiNode {
     function isUpgraded() public pure returns(bool){
         return true;
     }
+    constructor() EtherFiNode(address(0x0)) {}
 }
 
 contract NodeOperatorManagerV2 is NodeOperatorManager {


### PR DESCRIPTION
Implement post PEPE partial withdrawal support

Tried to find the smallest secure option that will enable partial withdrawals but not get in the way of the ongoing audit

* All changes 100% orthogonal to existing code and no changes to existing code + Only touches EtherFiNode contract
* Funds can only flow to liquidity pool, and only if all validators in a pod are in an active state (not withdrawn from beacon)
  * see `isFullWithdrawalInProgress()` for related logic. This should work for all cases with the new checkpoint proofs
* operates directly at pod level instead of validator level to better match with PEPE semantics