### PR TITLE
[Certora][H-02] NFT Withdrawal Price Finalization

### DIFF
--- a/script/upgrades/WithdrawRequestNFTUpgradeScript.s.sol
+++ b/script/upgrades/WithdrawRequestNFTUpgradeScript.s.sol
@@ -15,7 +15,7 @@ contract WithdrawRequestNFTUpgrade is Script {
         address addressProviderAddress = vm.envAddress("CONTRACT_REGISTRY");
         addressProvider = AddressProvider(addressProviderAddress);
 
-        address proxyAddress = addressProvider.getContractAddress("WithdrawRequestNFT");
+        address payable proxyAddress = payable(addressProvider.getContractAddress("WithdrawRequestNFT"));
 
         vm.startBroadcast(deployerPrivateKey);
 

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -248,7 +248,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         for (uint256 i = 0; i < _report.withdrawalRequestsToInvalidate.length; i++) {
             withdrawRequestNft.invalidateRequest(_report.withdrawalRequestsToInvalidate[i]);
         }
-        withdrawRequestNft.finalizeRequests(_report.lastFinalizedWithdrawalRequestId);
+        withdrawRequestNft.finalizeRequests(_report.lastFinalizedWithdrawalRequestId, _report.finalizedWithdrawalAmount);
    }
 
     function slotForNextReportToProcess() public view returns (uint32) {

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -248,7 +248,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         for (uint256 i = 0; i < _report.withdrawalRequestsToInvalidate.length; i++) {
             withdrawRequestNft.invalidateRequest(_report.withdrawalRequestsToInvalidate[i]);
         }
-        withdrawRequestNft.finalizeRequests(_report.lastFinalizedWithdrawalRequestId, _report.finalizedWithdrawalAmount);
+        withdrawRequestNft.finalizeRequests(_report.lastFinalizedWithdrawalRequestId);
    }
 
     function slotForNextReportToProcess() public view returns (uint32) {

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -195,13 +195,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
     function withdraw(address _recipient, uint256 _amount) external whenNotPaused returns (uint256) {
         uint256 share = sharesForWithdrawalAmount(_amount);
         require(msg.sender == address(withdrawRequestNFT) || msg.sender == address(membershipManager) || msg.sender == address(liquifier), "Incorrect Caller");
-        if (totalValueInLp < _amount || (msg.sender == address(withdrawRequestNFT) && ethAmountLockedForWithdrawal < _amount) || eETH.balanceOf(msg.sender) < _amount) revert InsufficientLiquidity();
+        if (totalValueInLp < _amount || eETH.balanceOf(msg.sender) < _amount) revert InsufficientLiquidity();
         if (_amount > type(uint128).max || _amount == 0 || share == 0) revert InvalidAmount();
 
         totalValueInLp -= uint128(_amount);
-        if (msg.sender == address(withdrawRequestNFT)) {
-            ethAmountLockedForWithdrawal -= uint128(_amount);
-        }
+        // if (msg.sender == address(withdrawRequestNFT)) {
+        //     ethAmountLockedForWithdrawal -= uint128(_amount);
+        // }
 
         eETH.burnShares(msg.sender, share);
 
@@ -224,7 +224,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         // transfer shares to WithdrawRequestNFT contract from this contract
         eETH.transferFrom(msg.sender, address(withdrawRequestNFT), amount);
 
-        uint256 requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient, 0);
+        uint256 requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient);
        
         emit Withdraw(msg.sender, recipient, amount, SourceOfFunds.EETH);
 
@@ -260,7 +260,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         // transfer shares to WithdrawRequestNFT contract
         eETH.transferFrom(msg.sender, address(withdrawRequestNFT), amount);
 
-        uint256 requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient, fee);
+        uint256 requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient);
 
         emit Withdraw(msg.sender, recipient, amount, SourceOfFunds.ETHER_FAN);
 

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -423,6 +423,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
 
         emit Rebase(getTotalPooledEther(), eETH.totalShares());
     }
+    
     /// @notice pay protocol fees including 5% to treaury, 5% to node operator and ethfund bnft holders
     /// @param _protocolFees The amount of protocol fees to pay in ether
     function payProtocolFees(uint128 _protocolFees) external {

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -25,12 +25,14 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     uint32 public lastFinalizedRequestId;
     uint96 public accumulatedDustEEthShares; // to be burned or used to cover the validator churn cost
 
+    FinalizationCheckpoint[] public finalizationCheckpoints;
+
     RoleRegistry public roleRegistry;
 
     bytes32 public constant WITHDRAW_NFT_ADMIN_ROLE = keccak256("WITHDRAW_NFT_ADMIN_ROLE");
 
     event WithdrawRequestCreated(uint32 indexed requestId, uint256 amountOfEEth, uint256 shareOfEEth, address owner, uint256 fee);
-    event WithdrawRequestClaimed(uint32 indexed requestId, uint256 amountOfEEth, uint256 burntShareOfEEth, address owner, uint256 fee);
+    event WithdrawRequestClaimed(uint32 indexed requestId, uint256 amountOfEEth, uint256 DEPRECATED_burntShareOfEEth, address owner, uint256 fee);
     event WithdrawRequestInvalidated(uint32 indexed requestId);
     event WithdrawRequestValidated(uint32 indexed requestId);
     event WithdrawRequestSeized(uint32 indexed requestId);
@@ -61,6 +63,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
         // TODO: compile list of values in DEPRECATED_admins to clear out
         roleRegistry = RoleRegistry(_roleRegistry);
+
+        // to avoid having to deal with the finalizationCheckpoints[index - 1] edgecase where the index is 0, we add a dummy checkpoint
+        finalizationCheckpoints.push(FinalizationCheckpoint(0, 0));
     }
 
     /// @notice creates a withdraw request and issues an associated NFT to the recipient
@@ -71,7 +76,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @param fee fee to be subtracted from amount when recipient calls claimWithdraw
     /// @return uint256 id of the withdraw request
     function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient, uint256 fee) external payable onlyLiquidtyPool returns (uint256) {
-        uint256 requestId = nextRequestId++;
+        uint256 requestId = nextRequestId++; 
         uint32 feeGwei = uint32(fee / 1 gwei);
 
         _requests[requestId] = IWithdrawRequestNFT.WithdrawRequest(amountOfEEth, shareOfEEth, true, feeGwei);
@@ -81,16 +86,30 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         return requestId;
     }
 
-    function getClaimableAmount(uint256 tokenId) public view returns (uint256) {
-        require(tokenId < nextRequestId, "Request does not exist");
+    function getClaimableAmount(uint256 tokenId, uint256 checkpointIndex) public view returns (uint256) {
         require(tokenId <= lastFinalizedRequestId, "Request is not finalized");
+        require(tokenId < nextRequestId, "Request does not exist");
         require(ownerOf(tokenId) != address(0), "Already Claimed");
 
+        require(
+            checkpointIndex != 0 &&
+            checkpointIndex < finalizationCheckpoints.length, 
+            "Invalid checkpoint index"
+        );
+        FinalizationCheckpoint memory lowerBoundCheckpoint = finalizationCheckpoints[checkpointIndex - 1];
+        FinalizationCheckpoint memory checkpoint = finalizationCheckpoints[checkpointIndex];
+        require(
+            lowerBoundCheckpoint.lastFinalizedRequestId < tokenId && 
+            tokenId <= checkpoint.lastFinalizedRequestId, 
+            "Invalid checkpoint"
+        );
         IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
 
-        // send the lesser value of the originally requested amount of eEth or the current eEth value of the shares
-        uint256 amountForShares = liquidityPool.amountForShare(request.shareOfEEth);
-        uint256 amountToTransfer = (request.amountOfEEth < amountForShares) ? request.amountOfEEth : amountForShares;
+        // send the lesser ether ETH value of the originally requested amount of eEth or the eEth value at the last `cachedSharePrice` update
+        uint256 cachedSharePrice = checkpoint.cachedShareValue;
+        uint256 amountForSharesCached = request.shareOfEEth * cachedSharePrice / 1 ether;
+        uint256 amountToTransfer = _min(request.amountOfEEth, amountForSharesCached);
+        
         uint256 fee = uint256(request.feeGwei) * 1 gwei;
 
         return amountToTransfer - fee;
@@ -99,40 +118,35 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @notice called by the NFT owner to claim their ETH
     /// @dev burns the NFT and transfers ETH from the liquidity pool to the owner minus any fee, withdraw request must be valid and finalized
     /// @param tokenId the id of the withdraw request and associated NFT
-    function claimWithdraw(uint256 tokenId) external {
-        return _claimWithdraw(tokenId, ownerOf(tokenId));
+    function claimWithdraw(uint256 tokenId, uint256 checkpointIndex) external {
+        return _claimWithdraw(tokenId, ownerOf(tokenId), checkpointIndex);
     }
     
-    function _claimWithdraw(uint256 tokenId, address recipient) internal {
+    function _claimWithdraw(uint256 tokenId, address recipient, uint256 checkpointIndex) internal {
+
         require(ownerOf(tokenId) == msg.sender, "Not the owner of the NFT");
         IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
         require(request.isValid, "Request is not valid");
 
         uint256 fee = uint256(request.feeGwei) * 1 gwei;
-        uint256 amountToWithdraw = getClaimableAmount(tokenId);
+        uint256 amountToWithdraw = getClaimableAmount(tokenId, checkpointIndex);
 
         // transfer eth to recipient
         _burn(tokenId);
         delete _requests[tokenId];
 
-        uint256 amountBurnedShare = 0;
         if (fee > 0) {
             // send fee to membership manager
-            amountBurnedShare += liquidityPool.withdraw(address(membershipManager), fee);
+            _sendFund(address(membershipManager), fee);
         }
-        amountBurnedShare += liquidityPool.withdraw(recipient, amountToWithdraw);
+        _sendFund(recipient, amountToWithdraw);
 
-        uint256 amountUnBurnedShare = request.shareOfEEth - amountBurnedShare;
-        if (amountUnBurnedShare > 0) {
-            accumulatedDustEEthShares += uint96(amountUnBurnedShare);
-        }
-
-        emit WithdrawRequestClaimed(uint32(tokenId), amountToWithdraw + fee, amountBurnedShare, recipient, fee);
+        emit WithdrawRequestClaimed(uint32(tokenId), amountToWithdraw + fee, 0, recipient, fee);
     }
 
-    function batchClaimWithdraw(uint256[] calldata tokenIds) external {
+    function batchClaimWithdraw(uint256[] calldata tokenIds, uint256[] calldata checkpointIndices) external {
         for (uint256 i = 0; i < tokenIds.length; i++) {
-            _claimWithdraw(tokenIds[i], ownerOf(tokenIds[i]));
+            _claimWithdraw(tokenIds[i], ownerOf(tokenIds[i]), checkpointIndices[i]);
         }
     }
 
@@ -155,7 +169,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     // Given an invalidated withdrawal request NFT of ID `requestId`:,
     // - burn the NFT
     // - withdraw its ETH to the `recipient`
-    function seizeInvalidRequest(uint256 requestId, address recipient) external onlyOwner {
+    function seizeInvalidRequest(uint256 requestId, address recipient, uint256 checkpointIndex) external onlyOwner {
         require(!_requests[requestId].isValid, "Request is valid");
         require(ownerOf(requestId) != address(0), "Already Claimed");
 
@@ -165,14 +179,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         // Undo its invalidation to claim
         _requests[requestId].isValid = true;
 
-        // its ETH amount is not locked
-        // - if it was finalized when being invalidated, we revoked it via `reduceEthAmountLockedForWithdrawal`
-        // - if it was not finalized when being invalidated, it was not locked
-        uint256 ethAmount = getClaimableAmount(requestId);
-        liquidityPool.addEthAmountLockedForWithdrawal(uint128(ethAmount));
-
         // withdraw the ETH to the recipient
-        _claimWithdraw(requestId, recipient);
+        // TODO: fix this
+        _claimWithdraw(requestId, recipient, checkpointIndex);
 
         emit WithdrawRequestSeized(uint32(requestId));
     }
@@ -193,11 +202,11 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     function calculateTotalPendingAmount(uint256 lastRequestId) public view returns (uint256) {
         uint256 totalAmount = 0;
         for (uint256 i = lastFinalizedRequestId + 1; i <= lastRequestId; i++) {
-            if (!isValid(i)) continue;
 
             IWithdrawRequestNFT.WithdrawRequest memory request = _requests[i];
             uint256 amountForShares = liquidityPool.amountForShare(request.shareOfEEth);
-            uint256 amount = (request.amountOfEEth < amountForShares) ? request.amountOfEEth : amountForShares;
+
+            uint256 amount = _min(request.amountOfEEth, amountForShares);
 
             totalAmount += amount;
         }
@@ -208,25 +217,29 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
 
         uint128 totalAmount = uint128(calculateTotalPendingAmount(lastRequestId));
-        _finalizeRequests(lastRequestId, totalAmount);
+        uint256 cachedSharePrice = liquidityPool.amountForShare(1 ether);
+
+        finalizationCheckpoints.push(FinalizationCheckpoint(uint32(lastRequestId), cachedSharePrice));
+        
+        // TODO: We can probably deprecate this variable and use the last element of the finalizationCheckpoints array
+        lastFinalizedRequestId = uint32(lastRequestId);
+
+        liquidityPool.withdraw(address(this), totalAmount);
+        emit UpdateFinalizedRequestId(uint32(lastRequestId), totalAmount);
     }
 
+    // Maybe deprecated ? I should try to fix any accounting errors and delete this function
     // It can be used to correct the total amount of pending withdrawals. There are some accounting erros as of now
     function finalizeRequests(uint256 lastRequestId, uint128 totalAmount) external {
         if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
 
-        _finalizeRequests(lastRequestId, totalAmount);
+        return;
     }
 
     function invalidateRequest(uint256 requestId) external {
         if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
 
         require(isValid(requestId), "Request is not valid");
-
-        if (isFinalized(requestId)) {
-            uint256 ethAmount = getClaimableAmount(requestId);
-            liquidityPool.reduceEthAmountLockedForWithdrawal(uint128(ethAmount));
-        }
 
         _requests[requestId].isValid = false;
 
@@ -252,18 +265,75 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
-    function _finalizeRequests(uint256 lastRequestId, uint128 totalAmount) internal {
-        emit UpdateFinalizedRequestId(uint32(lastRequestId), totalAmount);
-        lastFinalizedRequestId = uint32(lastRequestId);
-        liquidityPool.addEthAmountLockedForWithdrawal(totalAmount);
-    }
-
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
+
+    function _sendFund(address _recipient, uint256 _amount) internal {
+        uint256 balanace = address(this).balance;
+        (bool sent, ) = _recipient.call{value: _amount}("");
+        require(sent && address(this).balance == balanace - _amount, "SendFail");
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    // This contract only accepts ETH sent from the liquidity pool
+    receive() external payable onlyLiquidtyPool() { }
 
     modifier onlyLiquidtyPool() {
         require(msg.sender == address(liquidityPool), "Caller is not the liquidity pool");
         _;
     }
+
+
+    function getFinalizationCheckpoint(uint256 checkpointId) external view returns (FinalizationCheckpoint memory) {
+        return finalizationCheckpoints[checkpointId];
+    }
+
+    /// @dev View function to find a finalization checkpoint to use in `claimWithdraw()` 
+    ///  Search will be performed in the range of `[_start, _end]` over the `finalizationCheckpoints` array
+    ///
+    /// @param _requestId request id to search the checkpoint for
+    /// @param _start index of the left boundary of the search range
+    /// @param _end index of the right boundary of the search range, should be less than or equal to `finalizationCheckpoints.length`
+    ///
+    /// @return index into `finalizationCheckpoints` that the `_requestId` belongs to. 
+    function findCheckpointIndex(uint256 _requestId, uint256 _start, uint256 _end) public view returns (uint256) {
+        require(_requestId <= lastFinalizedRequestId, "Request is not finalized");
+        require(_start <= _end, "Invalid range");
+        require(_end < finalizationCheckpoints.length, "End index out of bounds of finalizationCheckpoints");
+
+        // Binary search
+        uint256 min = _start;
+        uint256 max = _end;
+
+        while (max > min) {
+            uint256 mid = (max + min + 1) / 2;
+            if (finalizationCheckpoints[mid].lastFinalizedRequestId < _requestId) {
+
+                // if mid index in the array is less than the request id, we need to move up the array, as the index we are looking for has 
+                // a `finalizationCheckpoints[mid].lastFinalizedRequestId` greater than the request id
+
+
+                min = mid;
+            } else {
+                // by getting here, we have a `finalizationCheckpoints[mid].lastFinalizedRequestId` greater than the request id
+                // to know we have found the right index, finalizationCheckpoints[mid - 1].lastFinalizedRequestId` must be less than the request id
+
+                if (finalizationCheckpoints[mid - 1].lastFinalizedRequestId < _requestId) {
+                    return mid;
+                }
+
+                max = mid - 1; // there are values to the left of mid that are greater than the request id
+            }
+        }
+    }
+
+    // Add a getter function for the length of the array
+    function getFinalizationCheckpointsLength() public view returns (uint256) {
+        return finalizationCheckpoints.length;
+    }
+
 }

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -13,6 +13,9 @@ import "./RoleRegistry.sol";
 
 
 contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IWithdrawRequestNFT {
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
 
     ILiquidityPool public liquidityPool;
     IeETH public eETH; 
@@ -29,16 +32,28 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     RoleRegistry public roleRegistry;
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ROLES  ----------------------------------------
+    //--------------------------------------------------------------------------------------
+
     bytes32 public constant WITHDRAW_NFT_ADMIN_ROLE = keccak256("WITHDRAW_NFT_ADMIN_ROLE");
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     event WithdrawRequestCreated(uint32 indexed requestId, uint256 amountOfEEth, uint256 shareOfEEth, address owner);
     event WithdrawRequestClaimed(uint32 indexed requestId, uint256 amountOfEEth, uint256 DEPRECATED_burntShareOfEEth, address owner);
     event WithdrawRequestInvalidated(uint32 indexed requestId);
     event WithdrawRequestValidated(uint32 indexed requestId);
     event WithdrawRequestSeized(uint32 indexed requestId);
-    event UpdateFinalizedRequestId(uint32 indexed requestId, uint128 finalizedAmount);
+    event UpdateFinalizedRequestId(uint32 indexed requestId, uint256 finalizedAmount);
 
     error IncorrectRole();
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -62,12 +77,10 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         require(address(roleRegistry) == address(0x00), "already initialized");
 
         // TODO: compile list of values in DEPRECATED_admins to clear out
-        roleRegistry = RoleRegistry(_roleRegistry);
-
-        // to avoid having to deal with the finalizationCheckpoints[index - 1] edgecase where the index is 0, we add a dummy checkpoint
-        finalizationCheckpoints.push(FinalizationCheckpoint(0, 0));
-
         DEPRECATED_accumulatedDustEEthShares = 0;
+
+        roleRegistry = RoleRegistry(_roleRegistry);
+        finalizationCheckpoints.push(FinalizationCheckpoint(0, 0));
     }
 
     /// @notice creates a withdraw request and issues an associated NFT to the recipient
@@ -76,8 +89,8 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @param shareOfEEth share of eETH requested for withdrawal
     /// @param recipient address to recieve with WithdrawRequestNFT
     /// @return uint256 id of the withdraw request
-    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient) external payable onlyLiquidtyPool returns (uint256) {
-        uint256 requestId = nextRequestId++; 
+    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient) external payable onlyLiquidityPool returns (uint32) {
+        uint32 requestId = nextRequestId++; 
 
         _requests[requestId] = IWithdrawRequestNFT.WithdrawRequest(amountOfEEth, shareOfEEth, true, 0);
         _safeMint(recipient, requestId);
@@ -86,73 +99,32 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         return requestId;
     }
 
-    /// @notice returns the value of a request after finalization. The value of a request can be:
-    ///  - nominal (when the amount of eth locked for this request are equal to the request's eETH)
-    ///  - discounted (when the amount of eth will be lower, because the protocol share rate dropped
-    ///   before request is finalized, so it will be equal to `request's shares` * `protocol share rate`)
-    /// @param tokenId the id of the withdraw request NFT
+    /// @notice called by the NFT owner of a finalized request to claim their ETH
+    /// @dev `checkpointIndex` can be found using `findCheckpointIndex` function
+    /// @param requestId the id of the withdraw request and associated NFT
     /// @param checkpointIndex the index of the `finalizationCheckpoints` that the request belongs to.
-    /// `checkpointIndex` can be found using `findCheckpointIndex` function
-    /// @return uint256 the amount of ETH that can be claimed by the owner of the NFT
-    function getClaimableAmount(uint256 tokenId, uint256 checkpointIndex) public view returns (uint256) {
-        require(tokenId <= lastFinalizedRequestId, "Request is not finalized");
-        require(tokenId < nextRequestId, "Request does not exist");
-        require(ownerOf(tokenId) != address(0), "Already Claimed");
-
-        require(
-            checkpointIndex != 0 &&
-            checkpointIndex < finalizationCheckpoints.length, 
-            "Invalid checkpoint index"
-        );
-        FinalizationCheckpoint memory lowerBoundCheckpoint = finalizationCheckpoints[checkpointIndex - 1];
-        FinalizationCheckpoint memory checkpoint = finalizationCheckpoints[checkpointIndex];
-        require(
-            lowerBoundCheckpoint.lastFinalizedRequestId < tokenId && 
-            tokenId <= checkpoint.lastFinalizedRequestId, 
-            "Invalid checkpoint"
-        );
-        IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
-
-        uint256 amountForSharesCached = request.shareOfEEth * checkpoint.cachedShareValue / 1 ether;
-        uint256 amountToTransfer = _min(request.amountOfEEth, amountForSharesCached);
-
-        return amountToTransfer;
+    function claimWithdraw(uint32 requestId, uint32 checkpointIndex) external {
+        return _claimWithdraw(requestId, ownerOf(requestId), checkpointIndex);
     }
 
-    /// @notice called by the NFT owner to claim their ETH
-    /// @dev burns the NFT and transfers ETH from the liquidity pool to the owner minus any fee, withdraw request must be valid and finalized
-    /// @param tokenId the id of the withdraw request and associated NFT
-    function claimWithdraw(uint256 tokenId, uint256 checkpointIndex) external {
-        return _claimWithdraw(tokenId, ownerOf(tokenId), checkpointIndex);
-    }
-    
-    function _claimWithdraw(uint256 tokenId, address recipient, uint256 checkpointIndex) internal {
-
-        require(ownerOf(tokenId) == msg.sender, "Not the owner of the NFT");
-        IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
-        require(request.isValid, "Request is not valid");
-
-        uint256 amountToWithdraw = getClaimableAmount(tokenId, checkpointIndex);
-
-        // transfer eth to recipient
-        _burn(tokenId);
-        delete _requests[tokenId];
-
-        _sendFund(recipient, amountToWithdraw);
-
-        emit WithdrawRequestClaimed(uint32(tokenId), amountToWithdraw, 0, recipient);
-    }
-
-    function batchClaimWithdraw(uint256[] calldata tokenIds, uint256[] calldata checkpointIndices) external {
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            _claimWithdraw(tokenIds[i], ownerOf(tokenIds[i]), checkpointIndices[i]);
+    /// @notice Batch version of `claimWithdraw`
+    function batchClaimWithdraw(uint32[] calldata requestIds, uint32[] calldata checkpointIndices) external {
+        for (uint32 i = 0; i < requestIds.length; i++) {
+            _claimWithdraw(requestIds[i], ownerOf(requestIds[i]), checkpointIndices[i]);
         }
     }
 
-    // Given an invalidated withdrawal request NFT of ID `requestId`:,
-    // - burn the NFT
-    // - withdraw its ETH to the `recipient`
-    function seizeInvalidRequest(uint256 requestId, address recipient, uint256 checkpointIndex) external onlyOwner {
+    /// @notice allows the admin to withdraw the accumulated dust eETH
+    function withdrawAccumulatedDustEEth(address _recipient) external {
+        if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+
+        uint256 dust = getAccumulatedDustEEthAmount();
+
+        // the dust amount is monotonically increasing, so we can just transfer the whole amount
+        eETH.transfer(_recipient, dust);
+    }
+
+    function seizeInvalidRequest(uint32 requestId, address recipient, uint32 checkpointIndex) external onlyOwner {
         require(!_requests[requestId].isValid, "Request is valid");
         require(ownerOf(requestId) != address(0), "Already Claimed");
 
@@ -162,117 +134,81 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         // Undo its invalidation to claim
         _requests[requestId].isValid = true;
 
-        // withdraw the ETH to the recipient
-        // TODO: fix this
         _claimWithdraw(requestId, recipient, checkpointIndex);
 
-        emit WithdrawRequestSeized(uint32(requestId));
+        emit WithdrawRequestSeized(requestId);
     }
 
-    function getRequest(uint256 requestId) external view returns (IWithdrawRequestNFT.WithdrawRequest memory) {
-        return _requests[requestId];
-    }
-
-    function isFinalized(uint256 requestId) public view returns (bool) {
-        return requestId <= lastFinalizedRequestId;
-    }
-
-    function isValid(uint256 requestId) public view returns (bool) {
-        require(_exists(requestId), "Request does not exist");
-        return _requests[requestId].isValid;
-    }
-
-    function calculateTotalPendingAmount(uint256 lastRequestId) public view returns (uint256) {
-        uint256 totalAmount = 0;
-        for (uint256 i = lastFinalizedRequestId + 1; i <= lastRequestId; i++) {
-
-            IWithdrawRequestNFT.WithdrawRequest memory request = _requests[i];
-            uint256 amountForShares = liquidityPool.amountForShare(request.shareOfEEth);
-
-            uint256 amount = _min(request.amountOfEEth, amountForShares);
-
-            totalAmount += amount;
-        }
-        return totalAmount;
-    }
-
-    function finalizeRequests(uint256 lastRequestId) external {
+    function finalizeRequests(uint32 lastRequestId) external {
         if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
 
-        uint128 totalAmount = uint128(calculateTotalPendingAmount(lastRequestId));
+        uint256 totalAmount = uint256(calculateTotalPendingAmount(lastRequestId));
         uint256 cachedSharePrice = liquidityPool.amountForShare(1 ether);
 
         finalizationCheckpoints.push(FinalizationCheckpoint(uint32(lastRequestId), cachedSharePrice));
         
-        // TODO: We can probably deprecate this variable and use the last element of the finalizationCheckpoints array
-        lastFinalizedRequestId = uint32(lastRequestId);
+        lastFinalizedRequestId = lastRequestId;
 
-        liquidityPool.withdraw(address(this), totalAmount);
-        emit UpdateFinalizedRequestId(uint32(lastRequestId), totalAmount);
+        if (totalAmount > 0) {
+            liquidityPool.withdraw(address(this), totalAmount);
+        }
+
+        emit UpdateFinalizedRequestId(lastRequestId, totalAmount);
     }
 
-    // Maybe deprecated ? I should try to fix any accounting errors and delete this function
-    // It can be used to correct the total amount of pending withdrawals. There are some accounting erros as of now
-    function finalizeRequests(uint256 lastRequestId, uint128 totalAmount) external {
+    function invalidateRequest(uint32 requestId) external {
         if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
-
-        return;
-    }
-
-    function invalidateRequest(uint256 requestId) external {
-        if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
-
         require(isValid(requestId), "Request is not valid");
 
         _requests[requestId].isValid = false;
 
-        emit WithdrawRequestInvalidated(uint32(requestId));
+        emit WithdrawRequestInvalidated(requestId);
     }
 
-    function validateRequest(uint256 requestId) external {
+    function validateRequest(uint32 requestId) external {
         if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
-
         require(!_requests[requestId].isValid, "Request is valid");
+        
         _requests[requestId].isValid = true;
 
-        emit WithdrawRequestValidated(uint32(requestId));
+        emit WithdrawRequestValidated(requestId);
     }
 
-    // invalid NFTs is non-transferable except for the case they are being burnt by the owner via `seizeInvalidRequest`
-    function _beforeTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) internal override {
-        for (uint256 i = 0; i < batchSize; i++) {
-            uint256 tokenId = firstTokenId + i;
-            require(_requests[tokenId].isValid || msg.sender == owner(), "INVALID_REQUEST");
-        }
-    }
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  VIEW FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+    /// @notice returns the value of a request after finalization. The value of a request can be:
+    ///  - nominal (when the amount of eth locked for this request are equal to the request's eETH)
+    ///  - discounted (when the amount of eth will be lower, because the protocol share rate dropped
+    ///   before request is finalized, so it will be equal to `request's shares` * `protocol share rate`)
+    /// @param requestId the id of the withdraw request NFT
+    /// @param checkpointIndex the index of the `finalizationCheckpoints` that the request belongs to.
+    /// `checkpointIndex` can be found using `findCheckpointIndex` function
+    /// @return uint256 the amount of ETH that can be claimed by the owner of the NFT
+    function getClaimableAmount(uint32 requestId, uint32 checkpointIndex) public view returns (uint256) {
+        require(requestId <= lastFinalizedRequestId, "Request is not finalized");
+        require(requestId < nextRequestId, "Request does not exist");
+        require(ownerOf(requestId) != address(0), "Already claimed");
 
-    function getImplementation() external view returns (address) {
-        return _getImplementation();
-    }
+        require(
+            checkpointIndex != 0 &&
+            checkpointIndex < finalizationCheckpoints.length, 
+            "Invalid checkpoint index"
+        );
+        FinalizationCheckpoint memory lowerBoundCheckpoint = finalizationCheckpoints[checkpointIndex - 1];
+        FinalizationCheckpoint memory checkpoint = finalizationCheckpoints[checkpointIndex];
+        require(
+            lowerBoundCheckpoint.lastFinalizedRequestId < requestId && 
+            requestId <= checkpoint.lastFinalizedRequestId, 
+            "Checkpoint does not contain the request"
+        );
 
-    function _sendFund(address _recipient, uint256 _amount) internal {
-        uint256 balanace = address(this).balance;
-        (bool sent, ) = _recipient.call{value: _amount}("");
-        require(sent && address(this).balance == balanace - _amount, "SendFail");
-    }
+        IWithdrawRequestNFT.WithdrawRequest memory request = _requests[requestId];
+        uint256 amountForSharesCached = request.shareOfEEth * checkpoint.cachedShareValue / 1 ether;
+        uint256 amountToTransfer = _min(request.amountOfEEth, amountForSharesCached);
 
-    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a < b ? a : b;
-    }
-
-    // This contract only accepts ETH sent from the liquidity pool
-    receive() external payable onlyLiquidtyPool() { }
-
-    modifier onlyLiquidtyPool() {
-        require(msg.sender == address(liquidityPool), "Caller is not the liquidity pool");
-        _;
-    }
-
-
-    function getFinalizationCheckpoint(uint256 checkpointId) external view returns (FinalizationCheckpoint memory) {
-        return finalizationCheckpoints[checkpointId];
+        return amountToTransfer;
     }
 
     /// @dev View function to find a finalization checkpoint to use in `claimWithdraw()` 
@@ -283,23 +219,21 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @param _end index of the right boundary of the search range, should be less than or equal to `finalizationCheckpoints.length`
     ///
     /// @return index into `finalizationCheckpoints` that the `_requestId` belongs to. 
-    function findCheckpointIndex(uint256 _requestId, uint256 _start, uint256 _end) public view returns (uint256) {
+    function findCheckpointIndex(uint32 _requestId, uint32 _start, uint32 _end) public view returns (uint32) {
         require(_requestId <= lastFinalizedRequestId, "Request is not finalized");
         require(_start <= _end, "Invalid range");
         require(_end < finalizationCheckpoints.length, "End index out of bounds of finalizationCheckpoints");
 
         // Binary search
-        uint256 min = _start;
-        uint256 max = _end;
+        uint32 min = _start;
+        uint32 max = _end;
 
         while (max > min) {
-            uint256 mid = (max + min + 1) / 2;
+            uint32 mid = (max + min + 1) / 2;
             if (finalizationCheckpoints[mid].lastFinalizedRequestId < _requestId) {
 
                 // if mid index in the array is less than the request id, we need to move up the array, as the index we are looking for has 
                 // a `finalizationCheckpoints[mid].lastFinalizedRequestId` greater than the request id
-
-
                 min = mid;
             } else {
                 // by getting here, we have a `finalizationCheckpoints[mid].lastFinalizedRequestId` greater than the request id
@@ -314,11 +248,12 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         }
     }
 
-    // Add a getter function for the length of the array
-    function getFinalizationCheckpointsLength() public view returns (uint256) {
-        return finalizationCheckpoints.length;
-    }
-
+    /// @notice The excess eETH balance of this contract beyond what is needed to fulfill withdrawal requests.
+    /// This excess accumulates due to:
+    /// - eETH requested for withdrawal accruing staking rewards until the withdrawal is finalized. 
+    ///   Any remaining positive rebase rewards stay in the contract after finalization
+    /// - eETH balance calculation includes integer division, and there is a common case when the whole eETH 
+    /// balance can't be transferred from the account while leaving the last 1-2 wei on the sender's account
     function getAccumulatedDustEEthAmount() public view returns (uint256) {
         uint256 amountRequestedWithdraw = calculateTotalPendingAmount(nextRequestId - 1);
 
@@ -327,12 +262,96 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         return contractEEthBalance - amountRequestedWithdraw;
     }
 
-    function withdrawAccumulatedDustEEth(address _recipient) external {
-        if (!roleRegistry.hasRole(WITHDRAW_NFT_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+    /// @notice The amount of eETH that needed to fulfill the pending withdrawal requests up to and including `lastRequestId`
+    function calculateTotalPendingAmount(uint32 lastRequestId) public view returns (uint256) {
+        uint256 totalAmount = 0;
+        for (uint32 i = lastFinalizedRequestId + 1; i <= lastRequestId; i++) {
 
-        uint256 dust = getAccumulatedDustEEthAmount();
+            IWithdrawRequestNFT.WithdrawRequest memory request = _requests[i];
+            uint256 amountForShares = liquidityPool.amountForShare(request.shareOfEEth);
+            uint256 amount = _min(request.amountOfEEth, amountForShares);
 
-        // the dust amount is monotonically increasing, so we can just transfer the whole amount
-        eETH.transfer(_recipient, dust);
+            totalAmount += amount;
+        }
+        return totalAmount;
+    }
+
+    function getFinalizationCheckpoint(uint32 checkpointId) external view returns (FinalizationCheckpoint memory) {
+        return finalizationCheckpoints[checkpointId];
+    }
+
+    function getFinalizationCheckpointsLength() public view returns (uint32) {
+        return uint32(finalizationCheckpoints.length);
+    }
+
+    function getRequest(uint32 requestId) external view returns (IWithdrawRequestNFT.WithdrawRequest memory) {
+        return _requests[requestId];
+    }
+
+
+    function isFinalized(uint32 requestId) public view returns (bool) {
+        return requestId <= lastFinalizedRequestId;
+    }
+
+    function isValid(uint32 requestId) public view returns (bool) {
+        require(_exists(requestId), "Request does not exist");
+        return _requests[requestId].isValid;
+    }
+
+    function getImplementation() external view returns (address) {
+        return _getImplementation();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
+    //--------------------------------------------------------------------------------------
+
+    function _claimWithdraw(uint32 requestId, address recipient, uint32 checkpointIndex) internal {
+
+        require(ownerOf(requestId) == msg.sender, "Not the owner of the NFT");
+        IWithdrawRequestNFT.WithdrawRequest memory request = _requests[requestId];
+        require(request.isValid, "Request is not valid");
+
+        uint256 amountToWithdraw = getClaimableAmount(requestId, checkpointIndex);
+
+        // transfer eth to recipient
+        _burn(requestId);
+        delete _requests[requestId];
+
+        _sendFund(recipient, amountToWithdraw);
+
+        emit WithdrawRequestClaimed(requestId, amountToWithdraw, 0, recipient);
+    }
+
+    // invalid NFTs is non-transferable except for the case they are being burnt by the owner via `seizeInvalidRequest`
+    function _beforeTokenTransfer(address /*from*/, address /*to*/, uint256 firstTokenId, uint256 batchSize) internal view override {
+        for (uint256 i = 0; i < batchSize; i++) {
+            uint256 tokenId = firstTokenId + i;
+            require(_requests[tokenId].isValid || msg.sender == owner(), "INVALID_REQUEST");
+        }
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    function _sendFund(address _recipient, uint256 _amount) internal {
+        uint256 balanace = address(this).balance;
+        (bool sent, ) = _recipient.call{value: _amount}("");
+        require(sent && address(this).balance == balanace - _amount, "SendFail");
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  MODIFIERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    // This contract only accepts ETH sent from the liquidity pool
+    receive() external payable onlyLiquidityPool() { }
+
+    modifier onlyLiquidityPool() {
+        require(msg.sender == address(liquidityPool), "Caller is not the liquidity pool");
+        _;
     }
 }

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -199,7 +199,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// `checkpointIndex` can be found using `findCheckpointIndex()` function
     /// @return uint256 the amount of ETH that can be claimed by the owner of the NFT
     function getClaimableAmount(uint32 requestId, uint32 checkpointIndex) public view returns (uint256) {
-        require(requestId <= lastFinalizedRequestId, "Request is not finalized");
+        require(isFinalized(tokenId), "Request is not finalized");
         require(requestId < nextRequestId, "Request does not exist");
         require(ownerOf(requestId) != address(0), "Already claimed");
 

--- a/src/interfaces/IEtherFiOracle.sol
+++ b/src/interfaces/IEtherFiOracle.sol
@@ -15,7 +15,7 @@ interface IEtherFiOracle {
         uint256[] exitedValidators;
         uint32[]  exitedValidatorsExitTimestamps;
         uint256[] slashedValidators;
-        uint256[] withdrawalRequestsToInvalidate;
+        uint32[] withdrawalRequestsToInvalidate;
         uint32 lastFinalizedWithdrawalRequestId;
         uint32 eEthTargetAllocationWeight;
         uint32 etherFanTargetAllocationWeight;

--- a/src/interfaces/ILiquidityPool.sol
+++ b/src/interfaces/ILiquidityPool.sol
@@ -56,8 +56,8 @@ interface ILiquidityPool {
     function deposit(address _user, address _referral) external payable returns (uint256);
     function depositToRecipient(address _recipient, uint256 _amount, address _referral) external returns (uint256);
     function withdraw(address _recipient, uint256 _amount) external returns (uint256);
-    function requestWithdraw(address recipient, uint256 amount) external returns (uint256);
-    function requestWithdrawWithPermit(address _owner, uint256 _amount, PermitInput calldata _permit) external returns (uint256);
+    function requestWithdraw(address recipient, uint256 amount) external returns (uint32);
+    function requestWithdrawWithPermit(address _owner, uint256 _amount, PermitInput calldata _permit) external returns (uint32);
     function requestMembershipNFTWithdraw(address recipient, uint256 amount, uint256 fee) external returns (uint256);
 
     function batchDeposit(uint256[] calldata _candidateBidIds, uint256 _numberOfValidators) external payable returns (uint256[] memory);
@@ -69,6 +69,4 @@ interface ILiquidityPool {
 
     function rebase(int128 _accruedRewards) external;
     function payProtocolFees(uint128 _protocolFees) external;
-    function addEthAmountLockedForWithdrawal(uint128 _amount) external;
-    function reduceEthAmountLockedForWithdrawal(uint128 _amount) external;    
 }

--- a/src/interfaces/IWithdrawRequestNFT.sol
+++ b/src/interfaces/IWithdrawRequestNFT.sol
@@ -23,4 +23,5 @@ interface IWithdrawRequestNFT {
 
     function invalidateRequest(uint32 requestId) external;
     function finalizeRequests(uint32 lastRequestId) external;
+    function finalizeRequests(uint256 lastRequestId, uint256 totalAmount) external;
 }

--- a/src/interfaces/IWithdrawRequestNFT.sol
+++ b/src/interfaces/IWithdrawRequestNFT.sol
@@ -15,13 +15,12 @@ interface IWithdrawRequestNFT {
     }
 
     function initialize(address _liquidityPoolAddress, address _eEthAddress, address _membershipManager) external;
-    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester) external payable returns (uint256);
-    function claimWithdraw(uint256 requestId, uint256 checkpointIndex) external;
+    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester) external payable returns (uint32);
+    function claimWithdraw(uint32 requestId, uint32 checkpointIndex) external;
 
-    function getRequest(uint256 requestId) external view returns (WithdrawRequest memory);
-    function isFinalized(uint256 requestId) external view returns (bool);
+    function getRequest(uint32 requestId) external view returns (WithdrawRequest memory);
+    function isFinalized(uint32 requestId) external view returns (bool);
 
-    function invalidateRequest(uint256 requestId) external;
-    function finalizeRequests(uint256 upperBound) external;
-    function finalizeRequests(uint256 lastRequestId, uint128 totalAmount) external;
+    function invalidateRequest(uint32 requestId) external;
+    function finalizeRequests(uint32 lastRequestId) external;
 }

--- a/src/interfaces/IWithdrawRequestNFT.sol
+++ b/src/interfaces/IWithdrawRequestNFT.sol
@@ -9,9 +9,14 @@ interface IWithdrawRequestNFT {
         uint32  feeGwei;
     }
 
+    struct FinalizationCheckpoint {
+        uint256 lastFinalizedRequestId;
+        uint256 cachedShareValue;
+    }
+
     function initialize(address _liquidityPoolAddress, address _eEthAddress, address _membershipManager) external;
     function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester, uint256 fee) external payable returns (uint256);
-    function claimWithdraw(uint256 requestId) external;
+    function claimWithdraw(uint256 requestId, uint256 checkpointIndex) external;
 
     function getRequest(uint256 requestId) external view returns (WithdrawRequest memory);
     function isFinalized(uint256 requestId) external view returns (bool);

--- a/src/interfaces/IWithdrawRequestNFT.sol
+++ b/src/interfaces/IWithdrawRequestNFT.sol
@@ -15,7 +15,7 @@ interface IWithdrawRequestNFT {
     }
 
     function initialize(address _liquidityPoolAddress, address _eEthAddress, address _membershipManager) external;
-    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester, uint256 fee) external payable returns (uint256);
+    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester) external payable returns (uint256);
     function claimWithdraw(uint256 requestId, uint256 checkpointIndex) external;
 
     function getRequest(uint256 requestId) external view returns (WithdrawRequest memory);

--- a/test/EtherFiAdminUpgrade.t.sol
+++ b/test/EtherFiAdminUpgrade.t.sol
@@ -74,7 +74,7 @@ contract EtherFiAdminUpgradeTest is TestSetup {
                 exitedValidators: new uint256[](0),
                 exitedValidatorsExitTimestamps: new uint32[](0),
                 slashedValidators: new uint256[](0),
-                withdrawalRequestsToInvalidate: new uint256[](0),
+                withdrawalRequestsToInvalidate: new uint32[](0),
                 lastFinalizedWithdrawalRequestId: 21696,
                 eEthTargetAllocationWeight: 0,
                 etherFanTargetAllocationWeight: 0,
@@ -230,7 +230,7 @@ contract EtherFiAdminUpgradeTest is TestSetup {
         uint256 postTotalPooledEth = liquidityPoolInstance.getTotalPooledEther();
         uint256 boost = membershipManagerV1Instance.fanBoostThresholdEthAmount();
 
-        assert(preTotalPooledEth + accruedRewards + boost == postTotalPooledEth);
+        assertEq(preTotalPooledEth + accruedRewards + boost, postTotalPooledEth + report.finalizedWithdrawalAmount);
     }
 
     //0xab30d861d075d595fdff4dc100568722047230ceea4916e4d7eceff3804c50c4 admin

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -144,7 +144,7 @@ contract LiquidityPoolTest is TestSetup {
         _finalizeWithdrawalRequest(aliceReqId);
         
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(aliceReqId);
+        withdrawRequestNFTInstance.claimWithdraw(aliceReqId, 1);
         assertEq(eETHInstance.balanceOf(alice), 1 ether);
         assertEq(alice.balance, 2 ether);
         vm.stopPrank();
@@ -159,7 +159,7 @@ contract LiquidityPoolTest is TestSetup {
         _finalizeWithdrawalRequest(bobReqId);
 
         vm.startPrank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(bobReqId);
+        withdrawRequestNFTInstance.claimWithdraw(bobReqId, 1);
         assertEq(eETHInstance.balanceOf(bob), 0);
         assertEq(bob.balance, 3 ether);
         vm.stopPrank();
@@ -757,7 +757,7 @@ contract LiquidityPoolTest is TestSetup {
         _finalizeWithdrawalRequest(bobRequestId);
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(bobRequestId);
+        withdrawRequestNFTInstance.claimWithdraw(bobRequestId, 1);
 
         assertEq(address(liquidityPoolInstance).balance, 0);
         assertEq(eETHInstance.totalSupply(), 0);

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -159,7 +159,7 @@ contract LiquidityPoolTest is TestSetup {
         _finalizeWithdrawalRequest(bobReqId);
 
         vm.startPrank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(bobReqId, 1);
+        withdrawRequestNFTInstance.claimWithdraw(bobReqId, 2);
         assertEq(eETHInstance.balanceOf(bob), 0);
         assertEq(bob.balance, 3 ether);
         vm.stopPrank();

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -138,7 +138,7 @@ contract LiquidityPoolTest is TestSetup {
         uint256 aliceNonce = eETHInstance.nonces(alice);
         // alice priv key = 2
         ILiquidityPool.PermitInput memory permitInputAlice = createPermitInput(2, address(liquidityPoolInstance), 2 ether, aliceNonce, 2**256 - 1, eETHInstance.DOMAIN_SEPARATOR());
-        uint256 aliceReqId = liquidityPoolInstance.requestWithdrawWithPermit(alice, 2 ether, permitInputAlice);
+        uint32 aliceReqId = liquidityPoolInstance.requestWithdrawWithPermit(alice, 2 ether, permitInputAlice);
         vm.stopPrank();
         
         _finalizeWithdrawalRequest(aliceReqId);
@@ -153,7 +153,7 @@ contract LiquidityPoolTest is TestSetup {
         uint256 bobNonce = eETHInstance.nonces(bob);
         // bob priv key = 3
         ILiquidityPool.PermitInput memory permitInputBob = createPermitInput(3, address(liquidityPoolInstance), 2 ether, bobNonce, 2**256 - 1, eETHInstance.DOMAIN_SEPARATOR());
-        uint256 bobReqId = liquidityPoolInstance.requestWithdrawWithPermit(bob, 2 ether, permitInputBob);
+        uint32 bobReqId = liquidityPoolInstance.requestWithdrawWithPermit(bob, 2 ether, permitInputBob);
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(bobReqId);
@@ -751,7 +751,7 @@ contract LiquidityPoolTest is TestSetup {
 
         vm.startPrank(bob);
         eETHInstance.approve(address(liquidityPoolInstance), eEthTVL);
-        uint256 bobRequestId = liquidityPoolInstance.requestWithdraw(bob, eEthTVL);
+        uint32 bobRequestId = liquidityPoolInstance.requestWithdraw(bob, eEthTVL);
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(bobRequestId);

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -457,8 +457,8 @@ contract LiquifierTest is TestSetup {
         uint256 afterTVL = liquidityPoolInstance.getTotalPooledEther();
         uint256 afterLiquifierTotalPooledEther = liquifierInstance.getTotalPooledEther();
 
-        assertApproxEqAbs(afterTVL, beforeTVL, 1);
-        assertApproxEqAbs(beforeLiquifierTotalPooledEther, afterLiquifierTotalPooledEther, 1);
+        assertApproxEqAbs(afterTVL, beforeTVL, 2);
+        assertApproxEqAbs(beforeLiquifierTotalPooledEther, afterLiquifierTotalPooledEther, 2);
     }
 
     function test_withdrawEEth() public {

--- a/test/MembershipManager.t.sol
+++ b/test/MembershipManager.t.sol
@@ -65,10 +65,10 @@ contract MembershipManagerTest is TestSetup {
         membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken);
 
         // Bob burns the NFT extracting remaining value
-        uint256 bobTokenId = membershipManagerV1Instance.requestWithdrawAndBurn(bobToken);
+        uint32 bobTokenId = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(bobToken));
         vm.stopPrank();
 
-        _finalizeWithdrawalRequest(bobTokenId);
+        _finalizeWithdrawalRequest(uint32(bobTokenId));
 
         vm.prank(bob);
         withdrawRequestNFTInstance.claimWithdraw(bobTokenId, 1);
@@ -90,18 +90,18 @@ contract MembershipManagerTest is TestSetup {
         uint256 bobToken1 = membershipManagerV1Instance.wrapEth{value: 10 ether}(10 ether, 0);
         uint256 bobToken2 = membershipManagerV1Instance.wrapEth{value: 10 ether}(10 ether, 0);
 
-        uint256 requestId1 = membershipManagerV1Instance.requestWithdrawAndBurn(bobToken1);
-        uint256 requestId2 = membershipManagerV1Instance.requestWithdrawAndBurn(bobToken2);
+        uint32 requestId1 = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(bobToken1));
+        uint32 requestId2 = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(bobToken2));
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(requestId1);
         _finalizeWithdrawalRequest(requestId2);
 
         vm.startPrank(bob);
-        uint256[] memory requestIds = new uint256[](2);
+        uint32[] memory requestIds = new uint32[](2);
         requestIds[0] = requestId1;
         requestIds[1] = requestId2;
-        uint256[] memory requestIdCheckpoints = new uint256[](2);
+        uint32[] memory requestIdCheckpoints = new uint32[](2);
         requestIdCheckpoints[0] = 1;
         requestIdCheckpoints[1] = 2;
         withdrawRequestNFTInstance.batchClaimWithdraw(requestIds, requestIdCheckpoints);
@@ -138,7 +138,7 @@ contract MembershipManagerTest is TestSetup {
         assertEq(membershipNftInstance.tierPointsOf(tokenId), 24);
 
         // Alice's NFT unwraps 1 membership points to 1 ETH
-        uint256 aliceRequestId1 = membershipManagerV1Instance.requestWithdraw(tokenId, 1 ether);
+        uint32 aliceRequestId1 = uint32(membershipManagerV1Instance.requestWithdraw(tokenId, 1 ether));
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(aliceRequestId1);
@@ -160,7 +160,7 @@ contract MembershipManagerTest is TestSetup {
         assertEq(membershipNftInstance.tierPointsOf(tokenId), 24 * 2);
 
         // Alice's NFT unwraps all her remaining membership points, burning the NFT
-        uint256 aliceRequestId2 = membershipManagerV1Instance.requestWithdrawAndBurn(tokenId);
+        uint32 aliceRequestId2 = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(tokenId));
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(aliceRequestId2);
@@ -531,7 +531,7 @@ contract MembershipManagerTest is TestSetup {
         assertEq(membershipNftInstance.valueOf(aliceToken), 2 ether);
 
         // Alice burns membership points directly for ETH
-        uint256 requestId = membershipManagerV1Instance.requestWithdraw(aliceToken, 1 ether);
+        uint32 requestId = uint32(membershipManagerV1Instance.requestWithdraw(aliceToken, 1 ether));
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(requestId);
@@ -1017,12 +1017,12 @@ contract MembershipManagerTest is TestSetup {
                     counts[2]++;
                 }
                 if (random % 3 == 0 && i % 4 != 0) {
-                    uint256 requestId = membershipManagerV1Instance.requestWithdraw(token, withdrawalAmount);
+                    uint32 requestId = uint32(membershipManagerV1Instance.requestWithdraw(token, withdrawalAmount));
                     vm.stopPrank();
 
                     _finalizeWithdrawalRequest(requestId);
 
-                    uint256 requestCheckpointIndex = withdrawRequestNFTInstance.findCheckpointIndex(requestId, 0, withdrawRequestNFTInstance.getFinalizationCheckpointsLength() - 1);
+                    uint32 requestCheckpointIndex = withdrawRequestNFTInstance.findCheckpointIndex(requestId, 0, withdrawRequestNFTInstance.getFinalizationCheckpointsLength() - 1);
                     vm.startPrank(actor);
                     withdrawRequestNFTInstance.claimWithdraw(requestId, requestCheckpointIndex);
                     counts[3]++;
@@ -1041,11 +1041,11 @@ contract MembershipManagerTest is TestSetup {
             uint256 expectedBalanceAfterWithdrawal = address(actor).balance + tokenValue;
 
             vm.prank(actor);
-            uint256 requestId = membershipManagerV1Instance.requestWithdrawAndBurn(token);
+            uint32 requestId = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(token));
 
             _finalizeWithdrawalRequest(requestId);
             
-            uint256 requestCheckpointIndex = withdrawRequestNFTInstance.findCheckpointIndex(requestId, 0, withdrawRequestNFTInstance.getFinalizationCheckpointsLength() - 1);
+            uint32 requestCheckpointIndex = withdrawRequestNFTInstance.findCheckpointIndex(requestId, 0, withdrawRequestNFTInstance.getFinalizationCheckpointsLength() - 1);
             vm.prank(actor);
             withdrawRequestNFTInstance.claimWithdraw(requestId, requestCheckpointIndex);
 
@@ -1340,14 +1340,14 @@ contract MembershipManagerTest is TestSetup {
 
         // Alice burns one NFT paying for the burn fee
         assertEq(membershipManagerV1Instance.hasMetBurnFeeWaiverPeriod(aliceToken1), false);
-        uint256 reqId1 = membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken1);
+        uint32 reqId1 = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken1));
 
         // 16 days passed
         vm.warp(block.timestamp + uint256(16 * 24 * 60 * 60));
 
         // Alice burns the other NFT not paying for the burn fee since the stkaing period passed 30 days
         assertEq(membershipManagerV1Instance.hasMetBurnFeeWaiverPeriod(aliceToken2), true);
-        uint256 reqId2 = membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken2);
+        uint32 reqId2 = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken2));
 
         assertEq(withdrawRequestNFTInstance.getRequest(reqId1).amountOfEEth, 1 ether);
         // burn fees are deprecated
@@ -1368,7 +1368,7 @@ contract MembershipManagerTest is TestSetup {
         assertEq(eETHInstance.balanceOf(alice), 0 ether);
 
         // Alice mints an NFT with 1 ETH
-        uint256 aliceToken = membershipManagerV1Instance.wrapEth{value: 1 ether}(1 ether, 0 ether);
+        uint32 aliceToken = uint32(membershipManagerV1Instance.wrapEth{value: 1 ether}(1 ether, 0 ether));
 
         assertEq(alice.balance, 0 ether);
         assertEq(address(liquidityPoolInstance).balance, 1 ether);

--- a/test/MembershipManager.t.sol
+++ b/test/MembershipManager.t.sol
@@ -1022,7 +1022,7 @@ contract MembershipManagerTest is TestSetup {
 
                     _finalizeWithdrawalRequest(requestId);
 
-                    uint32 requestCheckpointIndex = withdrawRequestNFTInstance.findCheckpointIndex(requestId, 0, withdrawRequestNFTInstance.getFinalizationCheckpointsLength() - 1);
+                    uint32 requestCheckpointIndex = withdrawRequestNFTInstance.findCheckpointIndex(requestId, 1, withdrawRequestNFTInstance.getLastCheckpointIndex());
                     vm.startPrank(actor);
                     withdrawRequestNFTInstance.claimWithdraw(requestId, requestCheckpointIndex);
                     counts[3]++;
@@ -1045,7 +1045,7 @@ contract MembershipManagerTest is TestSetup {
 
             _finalizeWithdrawalRequest(requestId);
             
-            uint32 requestCheckpointIndex = withdrawRequestNFTInstance.findCheckpointIndex(requestId, 0, withdrawRequestNFTInstance.getFinalizationCheckpointsLength() - 1);
+            uint32 requestCheckpointIndex = withdrawRequestNFTInstance.findCheckpointIndex(requestId, 1, withdrawRequestNFTInstance.getLastCheckpointIndex());
             vm.prank(actor);
             withdrawRequestNFTInstance.claimWithdraw(requestId, requestCheckpointIndex);
 

--- a/test/MembershipManager.t.sol
+++ b/test/MembershipManager.t.sol
@@ -71,7 +71,7 @@ contract MembershipManagerTest is TestSetup {
         _finalizeWithdrawalRequest(bobTokenId);
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(bobTokenId);
+        withdrawRequestNFTInstance.claimWithdraw(bobTokenId, 1);
 
         assertEq(bob.balance, 100 ether, "Bob should have 100 ether");
         assertEq(membershipNftInstance.balanceOf(bob, bobToken), 0);
@@ -101,7 +101,10 @@ contract MembershipManagerTest is TestSetup {
         uint256[] memory requestIds = new uint256[](2);
         requestIds[0] = requestId1;
         requestIds[1] = requestId2;
-        withdrawRequestNFTInstance.batchClaimWithdraw(requestIds);
+        uint256[] memory requestIdCheckpoints = new uint256[](2);
+        requestIdCheckpoints[0] = 1;
+        requestIdCheckpoints[1] = 2;
+        withdrawRequestNFTInstance.batchClaimWithdraw(requestIds, requestIdCheckpoints);
         vm.stopPrank();
 
         assertEq(address(membershipManagerV1Instance).balance, 2 * 0.5 ether);
@@ -140,7 +143,7 @@ contract MembershipManagerTest is TestSetup {
         _finalizeWithdrawalRequest(aliceRequestId1);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId1);
+        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId1, 1);
         assertEq(membershipNftInstance.loyaltyPointsOf(tokenId), 2 * kwei);
         assertEq(membershipNftInstance.tierPointsOf(tokenId), 0);
         assertEq(membershipNftInstance.valueOf(tokenId), 1 ether);
@@ -162,7 +165,7 @@ contract MembershipManagerTest is TestSetup {
         _finalizeWithdrawalRequest(aliceRequestId2);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId2);
+        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId2, 1);
         assertEq(membershipNftInstance.balanceOf(alice, tokenId), 0); 
         assertEq(alice.balance, 2 ether);
         vm.stopPrank();
@@ -533,7 +536,7 @@ contract MembershipManagerTest is TestSetup {
         _finalizeWithdrawalRequest(requestId);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
         assertEq(eETHInstance.balanceOf(alice), 0 ether);
         assertEq(membershipNftInstance.valueOf(aliceToken), 1 ether);
         assertEq(alice.balance, 1 ether);
@@ -1019,7 +1022,7 @@ contract MembershipManagerTest is TestSetup {
                     _finalizeWithdrawalRequest(requestId);
 
                     vm.startPrank(actor);
-                    withdrawRequestNFTInstance.claimWithdraw(requestId);
+                    withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
                     counts[3]++;
                 }
 
@@ -1041,7 +1044,7 @@ contract MembershipManagerTest is TestSetup {
             _finalizeWithdrawalRequest(requestId);
             
             vm.prank(actor);
-            withdrawRequestNFTInstance.claimWithdraw(requestId);
+            withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
 
             assertLe(address(actor).balance, expectedBalanceAfterWithdrawal);
             assertGe(address(actor).balance, expectedBalanceAfterWithdrawal - 3); // rounding errors

--- a/test/MembershipManagerV0.t.sol
+++ b/test/MembershipManagerV0.t.sol
@@ -75,7 +75,7 @@ contract MembershipManagerV0Test is TestSetup {
         membershipManagerInstance.requestWithdrawAndBurn(aliceToken);
 
         // Bob burns the NFT extracting remaining value
-        uint256 bobTokenId = membershipManagerInstance.requestWithdrawAndBurn(bobToken);
+        uint32 bobTokenId = uint32(membershipManagerInstance.requestWithdrawAndBurn(bobToken));
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(bobTokenId);
@@ -111,7 +111,7 @@ contract MembershipManagerV0Test is TestSetup {
         assertEq(membershipNftInstance.tierPointsOf(tokenId), 24);
 
         // Alice's NFT unwraps 1 membership points to 1 ETH
-        uint256 aliceRequestId1 = membershipManagerInstance.requestWithdraw(tokenId, 1 ether);
+        uint32 aliceRequestId1 = uint32(membershipManagerInstance.requestWithdraw(tokenId, 1 ether));
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(aliceRequestId1);
@@ -133,7 +133,7 @@ contract MembershipManagerV0Test is TestSetup {
         assertEq(membershipNftInstance.tierPointsOf(tokenId), 24 * 2);
 
         // Alice's NFT unwraps all her remaining membership points, burning the NFT
-        uint256 aliceRequestId2 = membershipManagerInstance.requestWithdrawAndBurn(tokenId);
+        uint32 aliceRequestId2 = uint32(membershipManagerInstance.requestWithdrawAndBurn(tokenId));
         vm.stopPrank();
 
         _finalizeWithdrawalRequest(aliceRequestId2);
@@ -868,7 +868,7 @@ contract MembershipManagerV0Test is TestSetup {
         vm.startPrank(alice);
         uint256 aliceToken1 = membershipManagerInstance.wrapEth{value: 50 ether}(50 ether, 0 ether);
         uint256 aliceToken2 = membershipManagerInstance.wrapEth{value: 50 ether}(50 ether, 0 ether);
-        uint256 reqId;
+        uint32 reqId;
 
         skip(1 days);
 
@@ -919,7 +919,7 @@ contract MembershipManagerV0Test is TestSetup {
 
         vm.startPrank(alice);
         // Alice requests to withdraw 10 ETH 
-        reqId = membershipManagerV1Instance.requestWithdraw(aliceToken1, 10 ether);
+        reqId = uint32(membershipManagerV1Instance.requestWithdraw(aliceToken1, 10 ether));
         assertEq(membershipNftInstance.valueOf(aliceToken1), 190 ether);
         assertEq(membershipNftInstance.loyaltyPointsOf(aliceToken1), 50 * kwei);
         assertEq(membershipNftInstance.tierPointsOf(aliceToken1), 0);
@@ -931,7 +931,7 @@ contract MembershipManagerV0Test is TestSetup {
         withdrawRequestNFTInstance.claimWithdraw(reqId, 1);
         assertEq(address(alice).balance, 10 ether);
 
-        reqId = membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken1);
+        reqId = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken1));
         assertEq(membershipNftInstance.valueOf(aliceToken1), 0 ether);
         vm.stopPrank();
 
@@ -941,7 +941,7 @@ contract MembershipManagerV0Test is TestSetup {
         withdrawRequestNFTInstance.claimWithdraw(reqId, 2);
         assertEq(address(alice).balance, 200 ether);
 
-        reqId = membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken2);
+        reqId = uint32(membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken2));
         assertEq(membershipNftInstance.valueOf(aliceToken2), 0 ether);
         vm.stopPrank();
 

--- a/test/MembershipManagerV0.t.sol
+++ b/test/MembershipManagerV0.t.sol
@@ -81,7 +81,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(bobTokenId);
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(bobTokenId);
+        withdrawRequestNFTInstance.claimWithdraw(bobTokenId, 1);
 
         assertEq(bob.balance, 100 ether, "Bob should have 100 ether");
         assertEq(membershipNftInstance.balanceOf(bob, bobToken), 0);
@@ -117,7 +117,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(aliceRequestId1);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId1);
+        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId1, 1);
         assertEq(membershipNftInstance.loyaltyPointsOf(tokenId), 2 * kwei);
         assertEq(membershipNftInstance.tierPointsOf(tokenId), 0);
         assertEq(membershipNftInstance.valueOf(tokenId), 1 ether);
@@ -139,7 +139,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(aliceRequestId2);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId2);
+        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId2, 1);
         assertEq(membershipNftInstance.balanceOf(alice, tokenId), 0); 
         assertEq(alice.balance, 2 ether);
         vm.stopPrank();
@@ -928,7 +928,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(reqId);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(reqId);
+        withdrawRequestNFTInstance.claimWithdraw(reqId, 1);
         assertEq(address(alice).balance, 10 ether);
 
         reqId = membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken1);
@@ -938,7 +938,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(reqId);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(reqId);
+        withdrawRequestNFTInstance.claimWithdraw(reqId, 1);
         assertEq(address(alice).balance, 200 ether);
 
         reqId = membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken2);
@@ -948,7 +948,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(reqId);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(reqId);
+        withdrawRequestNFTInstance.claimWithdraw(reqId, 1);
         assertEq(address(alice).balance, 400 ether);
 
         vm.stopPrank();

--- a/test/MembershipManagerV0.t.sol
+++ b/test/MembershipManagerV0.t.sol
@@ -139,7 +139,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(aliceRequestId2);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId2, 1);
+        withdrawRequestNFTInstance.claimWithdraw(aliceRequestId2, 2);
         assertEq(membershipNftInstance.balanceOf(alice, tokenId), 0); 
         assertEq(alice.balance, 2 ether);
         vm.stopPrank();
@@ -861,7 +861,7 @@ contract MembershipManagerV0Test is TestSetup {
         assertEq(membershipNftInstance.valueOf(tokens[4]), 1 ether + 1 ether * uint256(30) / uint256(100));
     }
 
-    function test_token_vault_migratino() public {
+    function test_token_vault_migration() public {
         vm.deal(alice, 100 ether);
 
         // Alice mints two NFTs with 50 ETH for each
@@ -938,7 +938,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(reqId);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(reqId, 1);
+        withdrawRequestNFTInstance.claimWithdraw(reqId, 2);
         assertEq(address(alice).balance, 200 ether);
 
         reqId = membershipManagerV1Instance.requestWithdrawAndBurn(aliceToken2);
@@ -948,7 +948,7 @@ contract MembershipManagerV0Test is TestSetup {
         _finalizeWithdrawalRequest(reqId);
 
         vm.startPrank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(reqId, 1);
+        withdrawRequestNFTInstance.claimWithdraw(reqId, 3);
         assertEq(address(alice).balance, 400 ether);
 
         vm.stopPrank();

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -387,7 +387,7 @@ contract TestSetup is Test {
         nodeOperatorManagerInstance = NodeOperatorManager(addressProviderInstance.getContractAddress("NodeOperatorManager"));
         node = EtherFiNode(payable(addressProviderInstance.getContractAddress("EtherFiNode")));
         earlyAdopterPoolInstance = EarlyAdopterPool(payable(addressProviderInstance.getContractAddress("EarlyAdopterPool")));
-        withdrawRequestNFTInstance = WithdrawRequestNFT(addressProviderInstance.getContractAddress("WithdrawRequestNFT"));
+        withdrawRequestNFTInstance = WithdrawRequestNFT(payable(addressProviderInstance.getContractAddress("WithdrawRequestNFT")));
         liquifierInstance = Liquifier(payable(addressProviderInstance.getContractAddress("Liquifier")));
         etherFiTimelockInstance = EtherFiTimelock(payable(addressProviderInstance.getContractAddress("EtherFiTimelock")));
         etherFiAdminInstance = EtherFiAdmin(payable(addressProviderInstance.getContractAddress("EtherFiAdmin")));

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -258,7 +258,6 @@ contract TestSetup is Test {
         uint256 delay;
     }
 
-
     // initialize a fork in which fresh contracts are deployed
     // and initialized to the same state as the unit tests.
     function initializeTestingFork(uint8 forkEnum) public {

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -814,7 +814,7 @@ contract TestSetup is Test {
         uint256[] memory exitedValidators = new uint256[](0);
         uint32[] memory  exitTimestamps = new uint32[](0);
         uint256[] memory slashedValidators = new uint256[](0);
-        uint256[] memory withdrawalRequestsToInvalidate = new uint256[](0);
+        uint32[] memory withdrawalRequestsToInvalidate = new uint32[](0);
         reportAtPeriod2A = IEtherFiOracle.OracleReport(1, 0, 1024 - 1, 0, 1024 - 1, 1, 0,validatorsToApprove, validatorsToExit, exitedValidators, exitTimestamps, slashedValidators, withdrawalRequestsToInvalidate, 1, 80, 20, 0, 0);
         reportAtPeriod2B = IEtherFiOracle.OracleReport(1, 0, 1024 - 1, 0, 1024 - 1, 1, 0,validatorsToApprove, validatorsToExit, exitedValidators, exitTimestamps, slashedValidators, withdrawalRequestsToInvalidate, 1, 81, 19, 0, 0);
         reportAtPeriod2C = IEtherFiOracle.OracleReport(2, 0, 1024 - 1, 0, 1024 - 1, 1, 0, validatorsToApprove, validatorsToExit, exitedValidators, exitTimestamps, slashedValidators, withdrawalRequestsToInvalidate, 1, 79, 21, 0, 0);
@@ -1019,7 +1019,7 @@ contract TestSetup is Test {
         uint256[] memory emptyVals = new uint256[](0);
         uint32[] memory emptyVals32 = new uint32[](0);
         uint32 consensusVersion = etherFiOracleInstance.consensusVersion();
-        report = IEtherFiOracle.OracleReport(consensusVersion, 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, emptyVals, emptyVals32, emptyVals, emptyVals, 0, 0, 0, 0, 0);
+        report = IEtherFiOracle.OracleReport(consensusVersion, 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, emptyVals, emptyVals32, emptyVals, emptyVals32, 0, 0, 0, 0, 0);
     }
 
     function calculatePermitDigest(address _owner, address spender, uint256 value, uint256 nonce, uint256 deadline, bytes32 domainSeparator) public pure returns (bytes32) {
@@ -1231,7 +1231,7 @@ contract TestSetup is Test {
         return newValidators;
     }
 
-    function _finalizeWithdrawalRequest(uint256 _requestId) internal {
+    function _finalizeWithdrawalRequest(uint32 _requestId) internal {
         vm.startPrank(alice);
         withdrawRequestNFTInstance.finalizeRequests(_requestId);
         uint128 amount = withdrawRequestNFTInstance.getRequest(_requestId).amountOfEEth;

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -31,7 +31,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), amountOfEEth);
 
         vm.prank(bob);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
 
         WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
 
@@ -53,7 +53,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), amountOfEEth);
 
         vm.prank(bob);
-        uint256 requestId1 = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
+        uint32 requestId1 = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
 
         assertEq(requestId1, 1, "Request id should be 1");
 
@@ -61,7 +61,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), amountOfEEth);
 
         vm.prank(bob);
-        uint256 requestId2 = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
+        uint32 requestId2 = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
 
         assertEq(requestId2, 2, "Request id should be 2");
     }
@@ -79,7 +79,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), amountOfEEth);
 
         vm.prank(bob);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
 
         bool earlyRequestIsFinalized = withdrawRequestNFTInstance.isFinalized(requestId);
         assertFalse(earlyRequestIsFinalized, "Request should not be Finalized");
@@ -106,7 +106,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), amountOfEEth);
 
         vm.prank(bob);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
 
         bool requestIsFinalized = withdrawRequestNFTInstance.isFinalized(requestId);
         assertFalse(requestIsFinalized, "Request should not be finalized");
@@ -130,7 +130,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), amountOfEEth);
 
         vm.prank(bob);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
 
         bool requestIsFinalized = withdrawRequestNFTInstance.isFinalized(requestId);
         assertFalse(requestIsFinalized, "Request should not be finalized");
@@ -153,7 +153,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), amountOfEEth);
 
         vm.prank(bob);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, amountOfEEth);
 
         vm.expectRevert("Not the owner of the NFT");
         vm.prank(alice);
@@ -177,7 +177,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
 
         vm.prank(bob);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
         assertEq(withdrawRequestNFTInstance.getAccumulatedDustEEthAmount(), 0, "Accumulated dust should be 0");
         assertEq(eETHInstance.balanceOf(bob), 9 ether);
@@ -228,7 +228,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
 
         vm.prank(bob);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
         vm.prank(address(membershipManagerInstance));
         liquidityPoolInstance.rebase(-35 ether);
@@ -255,7 +255,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // bob requests withdrawal
         vm.prank(bob);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 60 ether);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, 60 ether);
 
         // Somehow, LP gets some ETH
         // For example, alice deposits 100 ETH :D
@@ -295,7 +295,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.prank(bob);
         // Withdraw request for 9 wei eETH amount (= 8.82 wei eETH share)
         // 8 wei eETH share is transfered to `withdrawRequestNFT` contract
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 9);
+        uint32 requestId = liquidityPoolInstance.requestWithdraw(bob, 9);
         assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), 8);
         // Within `LP.requestWithdraw`
         // - `share` is calculated by `sharesForAmount` as (9 * 98) / 100 = 8.82 ---> (rounded down to) 8
@@ -327,7 +327,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
     // It depicts the scenario where bob's WithdrawalRequest NFT is stolen by alice.
     // The owner invalidates the request 
-    function test_InvalidatedRequestNft_after_finalization() public returns (uint256 requestId) {
+    function test_InvalidatedRequestNft_after_finalization() public returns (uint32 requestId) {
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 10 ether}();
         vm.stopPrank();
@@ -353,7 +353,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         withdrawRequestNFTInstance.invalidateRequest(requestId);
     }
 
-    function test_InvalidatedRequestNft_before_finalization() public returns (uint256 requestId) {
+    function test_InvalidatedRequestNft_before_finalization() public returns (uint32 requestId) {
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 10 ether}();
         vm.stopPrank();
@@ -378,7 +378,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     function test_InvalidatedRequestNft_NonTransferrable() public {
-        uint256 requestId = test_InvalidatedRequestNft_after_finalization();
+        uint32 requestId = test_InvalidatedRequestNft_after_finalization();
 
         vm.prank(alice);
         vm.expectRevert("INVALID_REQUEST");
@@ -386,7 +386,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     function test_seizeInvalidAndMintNew_revert_if_not_owner() public {
-        uint256 requestId = test_InvalidatedRequestNft_after_finalization();
+        uint32 requestId = test_InvalidatedRequestNft_after_finalization();
         uint256 claimableAmount = withdrawRequestNFTInstance.getRequest(requestId).amountOfEEth;
 
         // REVERT if not owner
@@ -396,26 +396,24 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     function test_InvalidatedRequestNft_seizeInvalidAndMintNew_1() public {
-        uint256 requestId = test_InvalidatedRequestNft_after_finalization();
+        uint32 requestId = test_InvalidatedRequestNft_after_finalization();
         uint256 claimableAmount = withdrawRequestNFTInstance.getRequest(requestId).amountOfEEth;
         uint256 chadBalance = address(chad).balance;
 
         vm.prank(owner);
         withdrawRequestNFTInstance.seizeInvalidRequest(requestId, chad, 1);
 
-        assertEq(liquidityPoolInstance.ethAmountLockedForWithdrawal(), 0, "Must be withdrawn");
         assertEq(address(chad).balance, chadBalance + claimableAmount, "Chad should receive the claimable amount");
     }
 
     function test_InvalidatedRequestNft_seizeInvalidAndMintNew_2() public {
-        uint256 requestId = test_InvalidatedRequestNft_before_finalization();
+        uint32 requestId = test_InvalidatedRequestNft_before_finalization();
         uint256 claimableAmount = withdrawRequestNFTInstance.getRequest(requestId).amountOfEEth;
         uint256 chadBalance = address(chad).balance;
 
         vm.prank(owner);
         withdrawRequestNFTInstance.seizeInvalidRequest(requestId, chad, 1);
 
-        assertEq(liquidityPoolInstance.ethAmountLockedForWithdrawal(), 0, "Must be withdrawn");
         assertEq(address(chad).balance, chadBalance + claimableAmount, "Chad should receive the claimable amount");
     }
 }

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -179,7 +179,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.prank(bob);
         uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
-        assertEq(withdrawRequestNFTInstance.accumulatedDustEEthShares(), 0, "Accumulated dust should be 0");
+        assertEq(withdrawRequestNFTInstance.getAccumulatedDustEEthAmount(), 0, "Accumulated dust should be 0");
         assertEq(eETHInstance.balanceOf(bob), 9 ether);
         assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), 1 ether, "eETH balance should be 1 ether");
 
@@ -202,10 +202,10 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         assertEq(bobsEndingBalance, bobsStartingBalance + 1 ether, "Bobs balance should be 1 ether higher");
         assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), 1 ether, "eETH balance should be 1 ether");
-        assertEq(liquidityPoolInstance.amountForShare(withdrawRequestNFTInstance.accumulatedDustEEthShares()), 1 ether);
+        assertEq(withdrawRequestNFTInstance.getAccumulatedDustEEthAmount(), 1 ether);
 
         vm.prank(alice);
-        withdrawRequestNFTInstance.withdrawAccumulatedDustEEthShares(bob);
+        withdrawRequestNFTInstance.withdrawAccumulatedDustEEth(bob);
         assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), 0 ether, "eETH balance should be 0 ether");
         assertEq(eETHInstance.balanceOf(bob), 18 ether + 1 ether); // 1 ether eETH in `withdrawRequestNFT` contract is sent to Bob
     }

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -137,7 +137,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         vm.expectRevert("Request is not finalized");
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
     }
 
     function test_ClaimWithdrawOfOthers() public {
@@ -157,7 +157,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         vm.expectRevert("Not the owner of the NFT");
         vm.prank(alice);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
     }
 
     function test_ValidClaimWithdraw1() public {
@@ -196,7 +196,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         _finalizeWithdrawalRequest(requestId);
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
 
         uint256 bobsEndingBalance = address(bob).balance;
 
@@ -239,7 +239,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         _finalizeWithdrawalRequest(requestId);
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
 
         uint256 bobsEndingBalance = address(bob).balance;
 
@@ -268,7 +268,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 bobsStartingBalance = address(bob).balance;
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
 
         uint256 bobsEndingBalance = address(bob).balance;
 
@@ -305,7 +305,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        withdrawRequestNFTInstance.claimWithdraw(requestId, 1);
         // Within `claimWithdraw`,
         // - `request.amountOfEEth` is 9
         // - `amountForShares` is (8 * 100) / 98 = 8.16 ---> (rounded down to) 8
@@ -392,7 +392,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         // REVERT if not owner
         vm.prank(alice);
         vm.expectRevert("Ownable: caller is not the owner");
-        withdrawRequestNFTInstance.seizeInvalidRequest(requestId, chad);
+        withdrawRequestNFTInstance.seizeInvalidRequest(requestId, chad, 1);
     }
 
     function test_InvalidatedRequestNft_seizeInvalidAndMintNew_1() public {
@@ -401,7 +401,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 chadBalance = address(chad).balance;
 
         vm.prank(owner);
-        withdrawRequestNFTInstance.seizeInvalidRequest(requestId, chad);
+        withdrawRequestNFTInstance.seizeInvalidRequest(requestId, chad, 1);
 
         assertEq(liquidityPoolInstance.ethAmountLockedForWithdrawal(), 0, "Must be withdrawn");
         assertEq(address(chad).balance, chadBalance + claimableAmount, "Chad should receive the claimable amount");
@@ -413,7 +413,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 chadBalance = address(chad).balance;
 
         vm.prank(owner);
-        withdrawRequestNFTInstance.seizeInvalidRequest(requestId, chad);
+        withdrawRequestNFTInstance.seizeInvalidRequest(requestId, chad, 1);
 
         assertEq(liquidityPoolInstance.ethAmountLockedForWithdrawal(), 0, "Must be withdrawn");
         assertEq(address(chad).balance, chadBalance + claimableAmount, "Chad should receive the claimable amount");

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -429,15 +429,11 @@ contract WithdrawRequestNFTTest is TestSetup {
         assertEq(address(chad).balance, chadBalance + claimableAmount, "Chad should receive the claimable amount");
     }
 
-    function test_updated_checkpoint_logic() public payable {
-        for (uint256 i = 0; i < 100; i++) {
+    function test_updated_checkpoint_logic() public {
+        for (uint256 i = 0; i < 50; i++) {
             address user = vm.addr(i + 1);
             users.push(user);
             vm.deal(user, 15 ether);
-        }
-
-        // first 50 users deposit
-        for (uint256 i = 0; i < 50; i++) {
             vm.prank(users[i]);
             liquidityPoolInstance.deposit{value: 1 ether}();
         }

--- a/test/eethPayoutUpgrade.t.sol
+++ b/test/eethPayoutUpgrade.t.sol
@@ -54,7 +54,7 @@ contract eethPayoutUpgradeTest is TestSetup {
             exitedValidators: new uint256[](0),
             exitedValidatorsExitTimestamps: new uint32[](0),
             slashedValidators: new uint256[](0),
-            withdrawalRequestsToInvalidate: new uint256[](0),
+            withdrawalRequestsToInvalidate: new uint32[](0),
             lastFinalizedWithdrawalRequestId: 30403,
             eEthTargetAllocationWeight: 0,
             etherFanTargetAllocationWeight: 0,


### PR DESCRIPTION
### Motivation
This pr addresses the concerns with the withdrawal flow raised by the certora team during the audit:
- The withdrawal requests claim process is unfair as users are exposed to the ramifications of a negative rebase after their request is finalized
- eETH requested for withdrawal still accrue staking rewards after requests are made. These positive rebase rewards remain in this contract after users claim their withdrawal, but there is currently no accounting or method to withdraw these funds as revenue

### Features
- A new mechanism to finalize the value of request when its corresponding batch of withdrawals is processed by the oracle. Note that users are still exposed to negative rebases that occur *before*  finalization
- Logic to query and claim the excess staking rewards mentioned above
- Removal of unnecessary accounting like `EthAmountLockedForWithdrawal` in the new flow
- Refactor the codebase to consistently use uint32 for withdrawal NFT id values  

### Migration
- To make the existing unclaimed finalized withdrawals work with the new system, `lastFinalizedRequestId` will be reset to 0 and the oracle will re-finalize all withdrawals with the new logic. It will be much to expensive to call `calculateTotalPendingAmount` on 30,000ish withdrawals. We will have to calculate the amount needed to re-finalized all the withdrawals off-chain and pass it on-chain with `finalizeRequests(uint256 lastRequestId, uint256 totalAmount)`. The ability to withdrawal will be temporary paused to maintain correct accounting 