### PR TITLE
[Certora] [M-10] + [M-11] Manual tracking of EETH shares owned by membership manager

### DIFF
--- a/test/MembershipManager.t.sol
+++ b/test/MembershipManager.t.sol
@@ -20,6 +20,9 @@ contract MembershipManagerTest is TestSetup {
 
 
         _upgradeMembershipManagerFromV0ToV1();
+
+        vm.prank(membershipManagerV1Instance.owner());
+        membershipManagerV1Instance.initializeV2dot5();
     }
 
     function test_withdrawalPenalty() public {
@@ -1039,7 +1042,7 @@ contract MembershipManagerTest is TestSetup {
             uint256 requestId = membershipManagerV1Instance.requestWithdrawAndBurn(token);
 
             _finalizeWithdrawalRequest(requestId);
-            
+
             vm.prank(actor);
             withdrawRequestNFTInstance.claimWithdraw(requestId);
 
@@ -1061,6 +1064,10 @@ contract MembershipManagerTest is TestSetup {
         // console.log("resting Rewards", liquidityPoolInstance.amountForShare(membershipManagerV1Instance.sharesReservedForRewards()));
         assertEq(totalActorsBalance + address(liquidityPoolInstance).balance, totalMoneySupply);
         // assertLe(membershipManagerV1Instance.sharesReservedForRewards(), eETHInstance.shares(address(membershipManagerV1Instance)));
+
+        // ensure after all operations that shares should be very close to zero minus rounding and slippage
+        uint256 roundingThreshold = 1 gwei;
+        assert(roundingThreshold - membershipManagerV1Instance.membershipShares() > 0);
     }
 
     function test_eap_migration() public {

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -723,6 +723,7 @@ contract TestSetup is Test {
         whitelist[0] = address(weEthInstance);
         whitelist[1] = address(liquidityPoolInstance);
         eETHInstance.setWhitelistedSpender(whitelist, true);
+
     }
 
     function setupRoleRegistry() public {


### PR DESCRIPTION
This PR adds a manual tracking for the number of EETH shares owned by the membership manager. This prevents anyone from being able to impact rebasing operations via donating eETH shares to the membership manager

Primary testing provided by the existing `test_bring_random_monkeys()` function. At the conclusion of this function with thousands of deposit / rebase / withdrawal operations, shares are within 5000 shares of the target amount which is just dust.