### PR TITLE
[Certora] [M-10] + [M-11] Manual tracking of EETH shares owned by membership manager

### DIFF
--- a/test/MembershipManager.t.sol
+++ b/test/MembershipManager.t.sol
@@ -20,6 +20,9 @@ contract MembershipManagerTest is TestSetup {
 
 
         _upgradeMembershipManagerFromV0ToV1();
+
+        vm.prank(membershipManagerV1Instance.owner());
+        membershipManagerV1Instance.initializeV2dot5();
     }
 
     function test_withdrawalPenalty() public {
@@ -1037,7 +1040,7 @@ contract MembershipManagerTest is TestSetup {
             uint256 requestId = membershipManagerV1Instance.requestWithdrawAndBurn(token);
 
             _finalizeWithdrawalRequest(requestId);
-            
+
             vm.prank(actor);
             withdrawRequestNFTInstance.claimWithdraw(requestId);
 
@@ -1059,6 +1062,10 @@ contract MembershipManagerTest is TestSetup {
         // console.log("resting Rewards", liquidityPoolInstance.amountForShare(membershipManagerV1Instance.sharesReservedForRewards()));
         assertEq(totalActorsBalance + address(liquidityPoolInstance).balance, totalMoneySupply);
         // assertLe(membershipManagerV1Instance.sharesReservedForRewards(), eETHInstance.shares(address(membershipManagerV1Instance)));
+
+        // ensure after all operations that shares should be very close to zero minus rounding and slippage
+        uint256 roundingThreshold = 1 gwei;
+        assert(roundingThreshold - membershipManagerV1Instance.membershipShares() > 0);
     }
 
     function test_eap_migration() public {

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -721,6 +721,7 @@ contract TestSetup is Test {
         whitelist[0] = address(weEthInstance);
         whitelist[1] = address(liquidityPoolInstance);
         eETHInstance.setWhitelistedSpender(whitelist, true);
+
     }
 
     function setupRoleRegistry() public {


### PR DESCRIPTION
This PR reintroduces changes from [PR #180](https://github.com/etherfi-protocol/smart-contracts/pull/180), which was reverted from staging-2.5. 

The changes were reverted because:
1. We plan to deprecate the membership manager in a future update
2. These changes bring substantial implementation risk that require additional testing and time to review

I am reopening this PR as a reference in case we decide to include these changes in the current upgrade