### PR TITLE
[EigenLayer Slashing] EtherFiNodesManager & EtherFiNode

### DIFF
--- a/script/deploys/DeployEtherFiViewer.s.sol
+++ b/script/deploys/DeployEtherFiViewer.s.sol
@@ -32,8 +32,7 @@ contract DeployEtherFiViewer is Script {
         assert(etherFiNodeAddresses[0] == 0x31db9021ec8E1065e1f55553c69e1B1ea9d20533);
         assert(etherFiNodeAddresses[1] == 0xC3D3662A44c0d80080D3AF0eea752369c504724e);
 
-        viewer.EigenPod_mostRecentWithdrawalTimestamp(validatorIds);
         viewer.EigenPod_hasRestaked(validatorIds);
-        
+
     }
 }

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -38,14 +38,8 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
     mapping(uint256 => uint256) public associatedValidatorIndices;
     uint256[] public associatedValidatorIds; // validators in {STAKE_DEPOSITED, WAITING_FOR_APPROVAL, LIVE, BEING_SLASHED, EXITED} phase
 
-    // Track the amount of pending/completed withdrawals;
-    uint64 public pendingWithdrawalFromRestakingInGwei; // incremented when the delayed withdrawal (from EigenPod to EtherFiNode) is queued, decremented when it is completed
-    uint64 public completedWithdrawalFromRestakingInGwei; // incremented when the delayed withdarwal is completed, decremented when the fund is withdrawan (from EtherFiNode to the externals via fullWithdraw call)
-
-    // eigenLayer phase 1 bookeeping
-    // we need to mark a block from which we know all beaconchain eth has been moved to the eigenPod
-    // so that we can properly calculate exit payouts and ensure queued withdrawals have been resolved
-    // (eigenLayer withdrawals are tied to blocknumber instead of timestamp)
+    uint64 public DEPRECATED_pendingWithdrawalFromRestakingInGwei;
+    uint64 public DEPRECATED_completedWithdrawalFromRestakingInGwei;
     mapping(uint256 => uint32) DEPRECATED_restakingObservedExitBlocks;
 
     error CallFailed(bytes data);
@@ -213,61 +207,32 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
 
     function processFullWithdraw(uint256 _validatorId) external onlyEtherFiNodeManagerContract ensureLatestVersion {
         updateNumberOfAssociatedValidators(0, 1);
-
-        if (isRestakingEnabled) {
-            // TODO: revisit for the case of slashing
-            require(completedWithdrawalFromRestakingInGwei >= 32 ether / 1 gwei, "INSUFFICIENT_BALANCE");
-            completedWithdrawalFromRestakingInGwei -= uint64(32 ether / 1 gwei);
-        }
     }
 
-    function completeQueuedWithdrawal(IDelegationManager.Withdrawal memory withdrawals, uint256 middlewareTimesIndexes, bool _receiveAsTokens) external onlyEtherFiNodeManagerContract {
+    function completeQueuedWithdrawal(IDelegationManager.Withdrawal memory withdrawals, bool _receiveAsTokens) external onlyEtherFiNodeManagerContract {
         IDelegationManager.Withdrawal[] memory _withdrawals = new IDelegationManager.Withdrawal[](1);
         _withdrawals[0] = withdrawals;
-        uint256[] memory _middlewareTimesIndexes = new uint256[](1);
-        _middlewareTimesIndexes[0] = middlewareTimesIndexes;
-        return _completeQueuedWithdrawals(_withdrawals, _middlewareTimesIndexes, _receiveAsTokens);
+        return _completeQueuedWithdrawals(_withdrawals, _receiveAsTokens);
     }
 
-    function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory withdrawals, uint256[] memory middlewareTimesIndexes, bool _receiveAsTokens) external onlyEtherFiNodeManagerContract {
-        return _completeQueuedWithdrawals(withdrawals, middlewareTimesIndexes, _receiveAsTokens);
+    function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory withdrawals, bool _receiveAsTokens) external onlyEtherFiNodeManagerContract {
+        return _completeQueuedWithdrawals(withdrawals, _receiveAsTokens);
     }
 
     // `DelegationManager.completeQueuedWithdrawals` is used to complete the withdrawals:
-    // (1) by `EtherFiNode._queueRestakedFullWithdrawal`. It is used to process the full withdraw
-    // (2) by `DelegationManager.undelegate`
-    // While `_receiveAsTokens == True` for (1), `_receiveAsTokens == False` for (2)
-    // (Note that this is a simplication based on the use cases)
-    function _completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory withdrawals, uint256[] memory middlewareTimesIndexes, bool _receiveAsTokens) internal {
-        uint256 totalAmount = 0;
-
+    // if `_receiveAsTokens` is true, the ETH in EigenPod will be withdrawn to EtherFiNode via EigenPodManager.withdrawSharesAsTokens(...) call
+    // if `_receiveAsTokens` is false, the ETH in EigenPod will be delegated to the current operator
+    function _completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory withdrawals, bool _receiveAsTokens) internal {
         bool[] memory receiveAsTokens = new bool[](withdrawals.length);
-        IERC20[][] memory tokens = new IERC20[][](withdrawals.length);
+        IERC20[][] memory tokens = new IERC20[][](withdrawals.length); // redundant for BeaconETH strategy
         for (uint256 i = 0; i < withdrawals.length; i++) {
             require(withdrawals[i].withdrawer == address(this) && withdrawals[i].staker == address(this), "INVALID");
-
             receiveAsTokens[i] = _receiveAsTokens;
             tokens[i] = new IERC20[](withdrawals[i].strategies.length);
-            for (uint256 j = 0; j < withdrawals[i].shares.length; j++) {
-                totalAmount += withdrawals[i].shares[j];
-            }
-        }
-
-        if (_receiveAsTokens) {
-            // the queued withdrawal is for (1) full withdraw, so the pendingWithdrawalFromRestakingInGwei should be at least 32 ether
-            require(pendingWithdrawalFromRestakingInGwei >= uint64(totalAmount / 1 gwei), "NO_PENDING_WITHDRAWAL");
-            pendingWithdrawalFromRestakingInGwei -= uint64(totalAmount / 1 gwei);
-            completedWithdrawalFromRestakingInGwei += uint64(totalAmount / 1 gwei);
-        } else {
-            // the queued withdrawal is for (2) undelegate, we put a guard `pendingWithdrawalFromRestakingInGwei` == 0
-            // If it is non-zero, that means there is at least one validator of which delayed withdrawal is in the queue.
-            // Complete that first.
-            /// @dev this is not the most optimal way to handle these two use cases, but we ack that it's a temporary solution
-            require(pendingWithdrawalFromRestakingInGwei == 0, "PENDING_WITHDRAWAL_NOT_ZERO");
         }
 
         IDelegationManager mgr = IEtherFiNodesManager(etherFiNodesManager).delegationManager();
-        mgr.completeQueuedWithdrawals(withdrawals, tokens, middlewareTimesIndexes, receiveAsTokens);
+        mgr.completeQueuedWithdrawals(withdrawals, tokens, receiveAsTokens);
     }
 
     /// @dev transfer funds from the withdrawal safe to the 4 associated parties (bNFT, tNFT, treasury, nodeOperator)
@@ -347,43 +312,42 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
     /// @notice total balance (in the execution layer) of this withdrawal safe split into its component parts.
     ///   1. the withdrawal safe balance
     ///   2. the EigenPod balance
-    ///   3. the withdrawals pending in DelayedWithdrawalRouter
-    function splitBalanceInExecutionLayer() public view returns (uint256 _withdrawalSafe, uint256 _eigenPod, uint256 _delayedWithdrawalRouter) {
+    ///   3. the withdrawals pending in the DelegationManager
+    function splitBalanceInExecutionLayer() public view returns (uint256 _withdrawalSafe, uint256 _eigenPod, uint256 _withdrawal_queue) {
         _withdrawalSafe = address(this).balance;
 
         if (isRestakingEnabled) {
-            _eigenPod = eigenPod.balance;
+            IDelegationManager delegationManager = IEtherFiNodesManager(etherFiNodesManager).delegationManager();
 
-            IDelayedWithdrawalRouter delayedWithdrawalRouter = IDelayedWithdrawalRouter(IEtherFiNodesManager(etherFiNodesManager).delayedWithdrawalRouter());
-            IDelayedWithdrawalRouter.DelayedWithdrawal[] memory delayedWithdrawals = delayedWithdrawalRouter.getUserDelayedWithdrawals(address(this));
-            for (uint256 x = 0; x < delayedWithdrawals.length; x++) {
-                _delayedWithdrawalRouter += delayedWithdrawals[x].amount;
+            // get the shares locked in the EigenPod
+            // - `withdrawableShares` reflects the slashing on 'depositShares'
+            (uint256[] memory withdrawableShares, uint256[] memory depositShares) = delegationManager.getWithdrawableShares(address(this), getStrategies());
+            _eigenPod = withdrawableShares[0];
+
+            // get the shares locked in the DelegationManager
+            // - `shares` reflects the slashing. but it can change over time while in the queue until the slashing completion
+            (IDelegationManager.Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(address(this));
+            for (uint256 i = 0; i < withdrawals.length; i++) {
+                assert (withdrawals[i].strategies.length == 1); // only BeaconETH strategy is used
+                for (uint256 j = 0; j < shares[i].length; j++) {
+                    _withdrawal_queue += shares[i][j];
+                }
             }
         }
-        return (_withdrawalSafe, _eigenPod, _delayedWithdrawalRouter);
+        return (_withdrawalSafe, _eigenPod, _withdrawal_queue);
     }
-
 
     /// @notice total balance (wei) of this safe currently in the execution layer.
     function totalBalanceInExecutionLayer() public view returns (uint256) {
-        (uint256 _safe, uint256 _pod, uint256 _router) = splitBalanceInExecutionLayer();
-        return _safe + _pod + _router;
+        (uint256 _safe, uint256 _pod, uint256 _withdrawal_queue) = splitBalanceInExecutionLayer();
+        return _safe + _pod + _withdrawal_queue;
     }
 
-    /// @notice balance (wei) of this safe that could be immediately withdrawn.
-    ///         This only differs from the balance in the safe in the case of restaked validators
-    ///         because some funds might not be withdrawable yet due to eigenlayer's queued withdrawal system
+    /// @notice balance (wei) of this safe that could be immediately withdrawn
+    // This withdrawable balance amount is updated after completion of the queued withdarawal with `receiveAsToken = True`
     function withdrawableBalanceInExecutionLayer() public view returns (uint256) {
         uint256 safeBalance = address(this).balance;
-        uint256 claimableBalance = 0;
-        if (isRestakingEnabled) {
-            IDelayedWithdrawalRouter delayedWithdrawalRouter = IDelayedWithdrawalRouter(IEtherFiNodesManager(etherFiNodesManager).delayedWithdrawalRouter());
-            IDelayedWithdrawalRouter.DelayedWithdrawal[] memory claimableWithdrawals = delayedWithdrawalRouter.getClaimableUserDelayedWithdrawals(address(this));
-            for (uint256 x = 0; x < claimableWithdrawals.length; x++) {
-                claimableBalance += claimableWithdrawals[x].amount;
-            }
-        }
-        return safeBalance + claimableBalance;
+        return safeBalance;
     }
 
     function moveFundsToManager(uint256 _amount) external onlyEtherFiNodeManagerContract {
@@ -620,8 +584,11 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
         emit EigenPodCreated(address(this), eigenPod);
     }
 
+    // per Validator, queue the withdrawal of native ETH from EigenPod to EtherFiNode
+    // Pre-Requisite:
+    // - the ETH was withdrawn from the beacon chain to the EigenPod
+    // - the PEPE proofs were submitted and verified
     // returns the withdrawal roots for the queued full-withdrawals
-    // the {NonBeaconChainEthWithdrawal, partial withdraw}'s queued withdrawals can be retrieved (indexed) on DelayedWithdrawalRouter
     function queueEigenpodFullWithdrawal() public onlyEtherFiNodeManagerContract returns (bytes32[] memory fullWithdrawalRoots) {
         return _queueEigenpodFullWithdrawal();
     }
@@ -629,56 +596,40 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
     function _queueEigenpodFullWithdrawal() private returns (bytes32[] memory fullWithdrawalRoots) {
         if (!isRestakingEnabled) return fullWithdrawalRoots;
 
-        // Withdrawals from Eigenlayer are queued through either the DelayedWithdrawalRouter (DEPRECATED) or the DelegationManager.
-        // pre-PEPE update, nonBeaconChainEth and partial withdrawals are queued through the DelayedWithdrawalRouter.
-        // post-PEPE update, all withdrawals are queued through the DelegationManager
-
-        // calculate the pending amount. The withdrawal proof verification will update the EigenPod's `withdrawableRestakedExecutionLayerGwei` value
-        uint256 unclaimedFullWithdrawalAmountInGwei = IEigenPod(eigenPod).withdrawableRestakedExecutionLayerGwei() - pendingWithdrawalFromRestakingInGwei;
-        if (unclaimedFullWithdrawalAmountInGwei == 0) return fullWithdrawalRoots;
-
-        // TODO: revisit for the case of slashing
-        // we will need to re-visit this logic once the EigenLayer's slashing mechanism is implemented
-        // + we need to consider the slashing amount in the full withdrawal from the beacon layer as well
-        require(unclaimedFullWithdrawalAmountInGwei >= 32 ether / 1 gwei, "SLASHED");
-
-        // Update the pending withdrawal amount
-        // Note that the call to `DelegationManager.queueWithdrawals(...)` won't update the EigenPod's `withdrawableRestakedExecutionLayerGwei`
-        // It is updated only when the withdrawal is completed by the `DelegationManager.completeQueuedWithdrawals(...)`
-        // That is why we use two variables for accounting
-        pendingWithdrawalFromRestakingInGwei += uint64(32 ether / 1 gwei);
-
+        // Withdrawals from Eigenlayer are queued through the DelegationManager
         IDelegationManager delegationManager = IEtherFiNodesManager(etherFiNodesManager).delegationManager();
 
-        // Queue the withdrawal for whatever amount is available
-        IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
-        IStrategy[] memory strategies = new IStrategy[](1);
+        // get the withdrawable amount        
+        IStrategy[] memory strategies = getStrategies();
+        (uint256[] memory withdrawableShares, uint256[] memory depositShares) = delegationManager.getWithdrawableShares(address(this), strategies);
+
+        // calculate the amount to withdraw
+        // as this is per validator withdrawal, we cap the withdrawal amount to 32 ether
+        // in the case of slashing, the withdrawals for the last few validators might have less than 32 ether
+        // TODO: revisit for Pectra where a validator can have more than 32 ether
+        uint256 depositSharesToWithdraw = Math.min(depositShares[0], 32 ether);
+
+        // Queue the withdrawal
+        // Note that the actual withdarwal amount can change if the slashing happens
+        IDelegationManagerTypes.QueuedWithdrawalParams[] memory params = new IDelegationManagerTypes.QueuedWithdrawalParams[](1);
         uint256[] memory shares = new uint256[](1);
 
         strategies[0] = delegationManager.beaconChainETHStrategy();
-        shares[0] = 32 ether;
-        params[0] = IDelegationManager.QueuedWithdrawalParams({
+        shares[0] = depositSharesToWithdraw;
+        params[0] = IDelegationManagerTypes.QueuedWithdrawalParams({
             strategies: strategies,
-            shares: shares,
+            depositShares: shares,
             withdrawer: address(this)
         });
 
-        // each withdrawal root is hash of the withdrawal object, "keccak256(abi.encode(withdrawal))"
         return delegationManager.queueWithdrawals(params);
     }
 
-    /// @dev as of eigenlayer's PEPE upgrade the delayedWithdrawalRouter is deprecated.
-    ///         once all outstanding funds have been claimed we can delete this functionality
-    function DEPRECATED_claimDelayedWithdrawalRouterWithdrawals() public {
-        if (!isRestakingEnabled) return;
-
-        uint256 maxWithdrawals = 10; // maximum number of withdrawals to process in 1 tx
-
-        // only claim if we have active unclaimed withdrawals
-        IDelayedWithdrawalRouter delayedWithdrawalRouter = IDelayedWithdrawalRouter(IEtherFiNodesManager(etherFiNodesManager).delayedWithdrawalRouter());
-        if (delayedWithdrawalRouter.getUserDelayedWithdrawals(address(this)).length > 0) {
-            delayedWithdrawalRouter.claimDelayedWithdrawals(address(this), maxWithdrawals);
-        }
+    function getStrategies() public view returns (IStrategy[] memory) {
+        IDelegationManager delegationManager = IEtherFiNodesManager(etherFiNodesManager).delegationManager();
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = delegationManager.beaconChainETHStrategy();
+        return strategies;
     }
 
     function validatePhaseTransition(VALIDATOR_PHASE _currentPhase, VALIDATOR_PHASE _newPhase) public pure returns (bool) {

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -217,10 +217,10 @@ contract EtherFiNodesManager is
         }
     }
 
-    function completeQueuedWithdrawals(uint256[] calldata _validatorIds, IDelegationManager.Withdrawal[] memory withdrawals, uint256[] calldata middlewareTimesIndexes, bool _receiveAsTokens) external onlyOperatingAdmin {
+    function completeQueuedWithdrawals(uint256[] calldata _validatorIds, IDelegationManager.Withdrawal[] memory withdrawals, bool _receiveAsTokens) external onlyOperatingAdmin {
         for (uint256 i = 0; i < _validatorIds.length; i++) {
             address etherfiNode = etherfiNodeAddress[_validatorIds[i]];
-            IEtherFiNode(etherfiNode).completeQueuedWithdrawal(withdrawals[i], middlewareTimesIndexes[i], _receiveAsTokens);
+            IEtherFiNode(etherfiNode).completeQueuedWithdrawal(withdrawals[i], _receiveAsTokens);
         }
     }
 

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -15,6 +15,7 @@ import "./LiquidityPool.sol";
 
 import "./eigenlayer-interfaces/IStrategyManager.sol";
 import "./eigenlayer-interfaces/IDelegationManager.sol";
+import "./eigenlayer-interfaces/IRewardsCoordinator.sol";
 
 contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     using SafeERC20 for IERC20;
@@ -25,6 +26,8 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         IStrategy elStrategy;
         uint256 elSharesInPendingForWithdrawals;
     }
+
+    IRewardsCoordinator public immutable rewardsCoordinator;
 
     LiquidityPool public liquidityPool;
     Liquifier public liquifier;
@@ -39,7 +42,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     mapping(address => TokenInfo) public tokenInfos;
     
     EnumerableSet.Bytes32Set private withdrawalRootsSet;
-    mapping(bytes32 => IDelegationManager.Withdrawal) public withdrawalRootToWithdrawal;
+    mapping(bytes32 => IDelegationManager.Withdrawal) public DEPRECATED_withdrawalRootToWithdrawal;
 
 
     event QueuedStEthWithdrawals(uint256[] _reqIds);
@@ -56,7 +59,8 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     error IncorrectCaller();
 
      /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _rewardsCoordinator) {
+        rewardsCoordinator = IRewardsCoordinator(_rewardsCoordinator);
         _disableInitializers();
     }
 
@@ -137,6 +141,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     // |--------------------------------------------------------------------------------------------|
     // |                                    EigenLayer Restaking                                    |
     // |--------------------------------------------------------------------------------------------|
+
+    /// Set the claimer of the restaking rewards of this contract
+    function setRewardsClaimer(address _claimer) external onlyAdmin {
+        rewardsCoordinator.setClaimerFor(_claimer);
+    }
     
     // delegate to an AVS operator
     function delegateTo(address operator, IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry, bytes32 approverSalt) external onlyAdmin {
@@ -145,19 +154,13 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     // undelegate from the current AVS operator & un-restake all
     function undelegate() external onlyAdmin returns (bytes32[] memory) {
-        revert("FIX BELOW");
+        bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.undelegate(address(this));
 
-        // Un-restake all assets
-        // Currently, only stETH is supported
-        // TokenInfo memory info = tokenInfos[address(lido)];
-        // uint256 shares = eigenLayerStrategyManager.stakerStrategyShares(address(this), info.elStrategy);
-
-        // _queueWithdrawlsByShares(address(lido), shares);
-
-        // bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.undelegate(address(this));
-        // assert(withdrawalRoots.length == 0);
-
-        // return withdrawalRoots;
+        for (uint256 i = 0; i < withdrawalRoots.length; i++) {
+            withdrawalRootsSet.add(withdrawalRoots[i]);
+        }
+        
+        return withdrawalRoots;
     }
 
     // deposit the token in holding into the restaking strategy
@@ -176,115 +179,41 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// @param amount the amount of token to withdraw
     function queueWithdrawals(address token, uint256 amount) public onlyAdmin returns (bytes32[] memory) {
         uint256 shares = getEigenLayerRestakingStrategy(token).underlyingToSharesView(amount);
-        return _queueWithdrawlsByShares(token, shares);
+        return _queueWithdrawalsByShares(token, shares);
     }
 
     /// Advanced version
-    function queueWithdrawals(IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams) public onlyAdmin returns (bytes32[] memory) {
-        revert("FIX BELOW");
-        // uint256 currentNonce = eigenLayerDelegationManager.cumulativeWithdrawalsQueued(address(this));
-        
-        // bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.queueWithdrawals(queuedWithdrawalParams);
-        // IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](queuedWithdrawalParams.length);
+    function queueWithdrawalsWithParams(IDelegationManagerTypes.QueuedWithdrawalParams[] memory params) public onlyAdmin returns (bytes32[] memory) {
+        bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.queueWithdrawals(params);
 
-        // for (uint256 i = 0; i < queuedWithdrawalParams.length; i++) {
-        //     withdrawals[i] = IDelegationManager.Withdrawal({
-        //         staker: address(this),
-        //         delegatedTo: eigenLayerDelegationManager.delegatedTo(address(this)),
-        //         withdrawer: address(this),
-        //         nonce: currentNonce + i,
-        //         startBlock: uint32(block.number),
-        //         strategies: queuedWithdrawalParams[i].strategies,
-        //         shares: queuedWithdrawalParams[i].shares
-        //     });
-
-        //     require(eigenLayerDelegationManager.calculateWithdrawalRoot(withdrawals[i]) == withdrawalRoots[i], "INCORRECT_WITHDRAWAL_ROOT");
-        //     require(eigenLayerDelegationManager.pendingWithdrawals(withdrawalRoots[i]), "WITHDRAWAL_NOT_PENDING");
-
-        //     for (uint256 j = 0; j < queuedWithdrawalParams[i].strategies.length; j++) {
-        //         address token = address(queuedWithdrawalParams[i].strategies[j].underlyingToken());
-        //         tokenInfos[token].elSharesInPendingForWithdrawals += queuedWithdrawalParams[i].shares[j];
-        //     }
-
-        //     withdrawalRootToWithdrawal[withdrawalRoots[i]] = withdrawals[i];
-        //     withdrawalRootsSet.add(withdrawalRoots[i]);
-        // }
-
-        // return withdrawalRoots;
-    }
-
-    /// @notice Complete the queued withdrawals that are ready to be withdrawn
-    /// @param max_cnt the maximum number of withdrawals to complete
-    function completeQueuedWithdrawals(uint256 max_cnt) external onlyAdmin {
-        revert("FIX BELOW");
-        // bytes32[] memory withdrawalRoots = pendingWithdrawalRoots();
-
-        // // process the first `max_cnt` withdrawals
-        // uint256 num_to_process = _min(max_cnt, withdrawalRoots.length);
-
-        // IDelegationManager.Withdrawal[] memory _queuedWithdrawals = new IDelegationManager.Withdrawal[](num_to_process);
-        // IERC20[][] memory _tokens = new IERC20[][](num_to_process);
-        // uint256[] memory _middlewareTimesIndexes = new uint256[](num_to_process);
-
-        // uint256 cnt = 0;
-        // for (uint256 i = 0; i < num_to_process; i++) {
-        //     IDelegationManager.Withdrawal memory withdrawal = withdrawalRootToWithdrawal[withdrawalRoots[i]];
-
-        //     uint256 withdrawalDelay = eigenLayerDelegationManager.getWithdrawalDelay(withdrawal.strategies);
-
-        //     if (withdrawal.startBlock + withdrawalDelay <= block.number) {
-        //         IERC20[] memory tokens = new IERC20[](withdrawal.strategies.length);
-        //         for (uint256 j = 0; j < withdrawal.strategies.length; j++) {
-        //             tokens[j] = withdrawal.strategies[j].underlyingToken();    
-
-        //             assert(tokenInfos[address(tokens[j])].elStrategy == withdrawal.strategies[j]);
-
-        //             tokenInfos[address(tokens[j])].elSharesInPendingForWithdrawals -= withdrawal.shares[j];
-        //         }
-
-        //         _queuedWithdrawals[cnt] = withdrawal;
-        //         _tokens[cnt] = tokens;
-        //         _middlewareTimesIndexes[cnt] = 0;
-        //         cnt += 1;
-        //     }
-        // }
-
-        // if (cnt == 0) return;
-
-        // assembly {
-        //     mstore(_queuedWithdrawals, cnt)
-        //     mstore(_tokens, cnt)
-        //     mstore(_middlewareTimesIndexes, cnt)
-        // }
-
-        // completeQueuedWithdrawals(_queuedWithdrawals, _tokens, _middlewareTimesIndexes);
+        for (uint256 i = 0; i < withdrawalRoots.length; i++) {
+            withdrawalRootsSet.add(withdrawalRoots[i]);
+        }
+        return withdrawalRoots;
     }
 
     /// Advanced version
     /// @notice Used to complete the specified `queuedWithdrawals`. The function caller must match `queuedWithdrawals[...].withdrawer`
     /// @param _queuedWithdrawals The QueuedWithdrawals to complete.
     /// @param _tokens Array of tokens for each QueuedWithdrawal. See `completeQueuedWithdrawal` for the usage of a single array.
-    /// @param _middlewareTimesIndexes One index to reference per QueuedWithdrawal. See `completeQueuedWithdrawal` for the usage of a single index.
-    /// @dev middlewareTimesIndex should be calculated off chain before calling this function by finding the first index that satisfies `slasher.canWithdraw`
-    function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory _queuedWithdrawals, IERC20[][] memory _tokens, uint256[] memory _middlewareTimesIndexes) public onlyAdmin {
-        revert("FIX BELOW");
-        // uint256 num = _queuedWithdrawals.length;
-        // bool[] memory receiveAsTokens = new bool[](num);
-        // for (uint256 i = 0; i < num; i++) {
-        //     bytes32 withdrawalRoot = eigenLayerDelegationManager.calculateWithdrawalRoot(_queuedWithdrawals[i]);
-        //     emit CompletedQueuedWithdrawal(withdrawalRoot);
+    function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory _queuedWithdrawals, IERC20[][] memory _tokens) external onlyAdmin {
+        uint256 num = _queuedWithdrawals.length;
+        bool[] memory receiveAsTokens = new bool[](num);
+        for (uint256 i = 0; i < num; i++) {
+            bytes32 withdrawalRoot = eigenLayerDelegationManager.calculateWithdrawalRoot(_queuedWithdrawals[i]);
+            emit CompletedQueuedWithdrawal(withdrawalRoot);
 
-        //     /// so that the shares withdrawn from the specified strategies are sent to the caller
-        //     receiveAsTokens[i] = true;
-        //     withdrawalRootsSet.remove(withdrawalRoot);
-        // }
+            /// so that the shares withdrawn from the specified strategies are sent to the caller
+            receiveAsTokens[i] = true;
+            require(withdrawalRootsSet.remove(withdrawalRoot), "WITHDRAWAL_ROOT_NOT_FOUND");
+        }
 
-        // /// it will update the erc20 balances of this contract
-        // eigenLayerDelegationManager.completeQueuedWithdrawals(_queuedWithdrawals, _tokens, _middlewareTimesIndexes, receiveAsTokens);
+        /// it will update the erc20 balances of this contract
+        eigenLayerDelegationManager.completeQueuedWithdrawals(_queuedWithdrawals, _tokens, receiveAsTokens);
     }
 
     /// Enumerate the pending withdrawal roots
-    function pendingWithdrawalRoots() public view returns (bytes32[] memory) {
+    function pendingWithdrawalRoots() external view returns (bytes32[] memory) {
         return withdrawalRootsSet.values();
     }
 
@@ -293,11 +222,10 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return withdrawalRootsSet.contains(_withdrawalRoot);
     }
 
-
     // |--------------------------------------------------------------------------------------------|
-    // |                                    VIEW functions                                        |
+    // |                                    VIEW functions                                          |
     // |--------------------------------------------------------------------------------------------|
-    function getTotalPooledEther() public view returns (uint256 total) {
+    function getTotalPooledEther() external view returns (uint256 total) {
         total = address(this).balance + getTotalPooledEther(address(lido));
     }
 
@@ -307,11 +235,18 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
     
     function getRestakedAmount(address _token) public view returns (uint256) {
-        revert("FIX BELOW");
-        // TokenInfo memory info = tokenInfos[_token];
-        // uint256 shares = eigenLayerStrategyManager.stakerStrategyShares(address(this), info.elStrategy);
-        // uint256 restaked = info.elStrategy.sharesToUnderlyingView(shares);
-        // return restaked;
+        TokenInfo memory info = tokenInfos[_token];
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = info.elStrategy;
+
+        // get the shares locked in the EigenPod
+        // - `withdrawableShares` reflects the slashing on 'depositShares'
+        (uint256[] memory withdrawableShares, ) = eigenLayerDelegationManager.getWithdrawableShares(address(this), strategies);
+
+        // convert the share amount to the token's balance amount
+        uint256 restaked = info.elStrategy.sharesToUnderlyingView(withdrawableShares[0]);
+
+        return restaked;
     }
 
     function getEigenLayerRestakingStrategy(address _token) public view returns (IStrategy) {
@@ -326,21 +261,24 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         TokenInfo memory info = tokenInfos[_token];
         if (info.elStrategy != IStrategy(address(0))) {
             uint256 restakedTokenAmount = getRestakedAmount(_token);
-            restaked = liquifier.quoteByFairValue(_token, restakedTokenAmount); /// restaked & pending for withdrawals
-            unrestaking = getEthAmountInEigenLayerPendingForWithdrawals(_token);
+            uint256 unrestakingTokenAmount = getAmountInEigenLayerPendingForWithdrawals(_token);
+            restaked = liquifier.quoteByFairValue(_token, restakedTokenAmount); // restaked & pending for withdrawals
+            unrestaking = liquifier.quoteByFairValue(_token, unrestakingTokenAmount); // restaked & pending for withdrawals
         }
         holding = liquifier.quoteByFairValue(_token, IERC20(_token).balanceOf(address(this))); /// eth value for erc20 holdings
-        pendingForWithdrawals = getEthAmountPendingForRedemption(_token);
+        pendingForWithdrawals = liquifier.quoteByFairValue(_token, getAmountPendingForRedemption(_token));
     }
 
-    function getEthAmountInEigenLayerPendingForWithdrawals(address _token) public view returns (uint256) {
+    // get the amount of token restaked in EigenLayer pending for withdrawals
+    function getAmountInEigenLayerPendingForWithdrawals(address _token) public view returns (uint256) {
         TokenInfo memory info = tokenInfos[_token];
         if (info.elStrategy == IStrategy(address(0))) return 0;
         uint256 amount = info.elStrategy.sharesToUnderlyingView(info.elSharesInPendingForWithdrawals);
         return amount;
     }
 
-    function getEthAmountPendingForRedemption(address _token) public view returns (uint256) {
+    // get the amount of token pending for redemption. e.g., pending in Lido's withdrawal queue
+    function getAmountPendingForRedemption(address _token) public view returns (uint256) {
         uint256 total = 0;
         if (_token == address(lido)) {
             uint256[] memory stEthWithdrawalRequestIds = lidoWithdrawalQueue.getWithdrawalRequests(address(this));
@@ -373,22 +311,20 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     // INTERNAL functions
-    function _queueWithdrawlsByShares(address token, uint256 shares) internal returns (bytes32[] memory) {
-        revert("FIX BELOW");
-        // IStrategy strategy = tokenInfos[token].elStrategy;
-        // IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
-        // IStrategy[] memory strategies = new IStrategy[](1);
-        // strategies[0] = strategy;
-        // uint256[] memory sharesArr = new uint256[](1);
-        // sharesArr[0] = shares;
+    function _queueWithdrawalsByShares(address _token, uint256 _shares) internal returns (bytes32[] memory) {
+        IDelegationManagerTypes.QueuedWithdrawalParams[] memory params = new IDelegationManagerTypes.QueuedWithdrawalParams[](1);
+        IStrategy[] memory strategies = new IStrategy[](1);
+        uint256[] memory shares = new uint256[](1);
 
-        // params[0] = IDelegationManager.QueuedWithdrawalParams({
-        //     strategies: strategies,
-        //     shares: sharesArr,
-        //     withdrawer: address(this)
-        // });
+        strategies[0] = tokenInfos[_token].elStrategy;
+        shares[0] = _shares;
+        params[0] = IDelegationManagerTypes.QueuedWithdrawalParams({
+            strategies: strategies,
+            depositShares: shares,
+            withdrawer: address(this)
+        });
 
-        // return queueWithdrawals(params);
+        return queueWithdrawalsWithParams(params);
     }
 
     function _min(uint256 _a, uint256 _b) internal pure returns (uint256) {

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -145,17 +145,19 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     // undelegate from the current AVS operator & un-restake all
     function undelegate() external onlyAdmin returns (bytes32[] memory) {
+        revert("FIX BELOW");
+
         // Un-restake all assets
         // Currently, only stETH is supported
-        TokenInfo memory info = tokenInfos[address(lido)];
-        uint256 shares = eigenLayerStrategyManager.stakerStrategyShares(address(this), info.elStrategy);
+        // TokenInfo memory info = tokenInfos[address(lido)];
+        // uint256 shares = eigenLayerStrategyManager.stakerStrategyShares(address(this), info.elStrategy);
 
-        _queueWithdrawlsByShares(address(lido), shares);
+        // _queueWithdrawlsByShares(address(lido), shares);
 
-        bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.undelegate(address(this));
-        assert(withdrawalRoots.length == 0);
+        // bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.undelegate(address(this));
+        // assert(withdrawalRoots.length == 0);
 
-        return withdrawalRoots;
+        // return withdrawalRoots;
     }
 
     // deposit the token in holding into the restaking strategy
@@ -179,81 +181,83 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     /// Advanced version
     function queueWithdrawals(IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams) public onlyAdmin returns (bytes32[] memory) {
-        uint256 currentNonce = eigenLayerDelegationManager.cumulativeWithdrawalsQueued(address(this));
+        revert("FIX BELOW");
+        // uint256 currentNonce = eigenLayerDelegationManager.cumulativeWithdrawalsQueued(address(this));
         
-        bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.queueWithdrawals(queuedWithdrawalParams);
-        IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](queuedWithdrawalParams.length);
+        // bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.queueWithdrawals(queuedWithdrawalParams);
+        // IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](queuedWithdrawalParams.length);
 
-        for (uint256 i = 0; i < queuedWithdrawalParams.length; i++) {
-            withdrawals[i] = IDelegationManager.Withdrawal({
-                staker: address(this),
-                delegatedTo: eigenLayerDelegationManager.delegatedTo(address(this)),
-                withdrawer: address(this),
-                nonce: currentNonce + i,
-                startBlock: uint32(block.number),
-                strategies: queuedWithdrawalParams[i].strategies,
-                shares: queuedWithdrawalParams[i].shares
-            });
+        // for (uint256 i = 0; i < queuedWithdrawalParams.length; i++) {
+        //     withdrawals[i] = IDelegationManager.Withdrawal({
+        //         staker: address(this),
+        //         delegatedTo: eigenLayerDelegationManager.delegatedTo(address(this)),
+        //         withdrawer: address(this),
+        //         nonce: currentNonce + i,
+        //         startBlock: uint32(block.number),
+        //         strategies: queuedWithdrawalParams[i].strategies,
+        //         shares: queuedWithdrawalParams[i].shares
+        //     });
 
-            require(eigenLayerDelegationManager.calculateWithdrawalRoot(withdrawals[i]) == withdrawalRoots[i], "INCORRECT_WITHDRAWAL_ROOT");
-            require(eigenLayerDelegationManager.pendingWithdrawals(withdrawalRoots[i]), "WITHDRAWAL_NOT_PENDING");
+        //     require(eigenLayerDelegationManager.calculateWithdrawalRoot(withdrawals[i]) == withdrawalRoots[i], "INCORRECT_WITHDRAWAL_ROOT");
+        //     require(eigenLayerDelegationManager.pendingWithdrawals(withdrawalRoots[i]), "WITHDRAWAL_NOT_PENDING");
 
-            for (uint256 j = 0; j < queuedWithdrawalParams[i].strategies.length; j++) {
-                address token = address(queuedWithdrawalParams[i].strategies[j].underlyingToken());
-                tokenInfos[token].elSharesInPendingForWithdrawals += queuedWithdrawalParams[i].shares[j];
-            }
+        //     for (uint256 j = 0; j < queuedWithdrawalParams[i].strategies.length; j++) {
+        //         address token = address(queuedWithdrawalParams[i].strategies[j].underlyingToken());
+        //         tokenInfos[token].elSharesInPendingForWithdrawals += queuedWithdrawalParams[i].shares[j];
+        //     }
 
-            withdrawalRootToWithdrawal[withdrawalRoots[i]] = withdrawals[i];
-            withdrawalRootsSet.add(withdrawalRoots[i]);
-        }
+        //     withdrawalRootToWithdrawal[withdrawalRoots[i]] = withdrawals[i];
+        //     withdrawalRootsSet.add(withdrawalRoots[i]);
+        // }
 
-        return withdrawalRoots;
+        // return withdrawalRoots;
     }
 
     /// @notice Complete the queued withdrawals that are ready to be withdrawn
     /// @param max_cnt the maximum number of withdrawals to complete
     function completeQueuedWithdrawals(uint256 max_cnt) external onlyAdmin {
-        bytes32[] memory withdrawalRoots = pendingWithdrawalRoots();
+        revert("FIX BELOW");
+        // bytes32[] memory withdrawalRoots = pendingWithdrawalRoots();
 
-        // process the first `max_cnt` withdrawals
-        uint256 num_to_process = _min(max_cnt, withdrawalRoots.length);
+        // // process the first `max_cnt` withdrawals
+        // uint256 num_to_process = _min(max_cnt, withdrawalRoots.length);
 
-        IDelegationManager.Withdrawal[] memory _queuedWithdrawals = new IDelegationManager.Withdrawal[](num_to_process);
-        IERC20[][] memory _tokens = new IERC20[][](num_to_process);
-        uint256[] memory _middlewareTimesIndexes = new uint256[](num_to_process);
+        // IDelegationManager.Withdrawal[] memory _queuedWithdrawals = new IDelegationManager.Withdrawal[](num_to_process);
+        // IERC20[][] memory _tokens = new IERC20[][](num_to_process);
+        // uint256[] memory _middlewareTimesIndexes = new uint256[](num_to_process);
 
-        uint256 cnt = 0;
-        for (uint256 i = 0; i < num_to_process; i++) {
-            IDelegationManager.Withdrawal memory withdrawal = withdrawalRootToWithdrawal[withdrawalRoots[i]];
+        // uint256 cnt = 0;
+        // for (uint256 i = 0; i < num_to_process; i++) {
+        //     IDelegationManager.Withdrawal memory withdrawal = withdrawalRootToWithdrawal[withdrawalRoots[i]];
 
-            uint256 withdrawalDelay = eigenLayerDelegationManager.getWithdrawalDelay(withdrawal.strategies);
+        //     uint256 withdrawalDelay = eigenLayerDelegationManager.getWithdrawalDelay(withdrawal.strategies);
 
-            if (withdrawal.startBlock + withdrawalDelay <= block.number) {
-                IERC20[] memory tokens = new IERC20[](withdrawal.strategies.length);
-                for (uint256 j = 0; j < withdrawal.strategies.length; j++) {
-                    tokens[j] = withdrawal.strategies[j].underlyingToken();    
+        //     if (withdrawal.startBlock + withdrawalDelay <= block.number) {
+        //         IERC20[] memory tokens = new IERC20[](withdrawal.strategies.length);
+        //         for (uint256 j = 0; j < withdrawal.strategies.length; j++) {
+        //             tokens[j] = withdrawal.strategies[j].underlyingToken();    
 
-                    assert(tokenInfos[address(tokens[j])].elStrategy == withdrawal.strategies[j]);
+        //             assert(tokenInfos[address(tokens[j])].elStrategy == withdrawal.strategies[j]);
 
-                    tokenInfos[address(tokens[j])].elSharesInPendingForWithdrawals -= withdrawal.shares[j];
-                }
+        //             tokenInfos[address(tokens[j])].elSharesInPendingForWithdrawals -= withdrawal.shares[j];
+        //         }
 
-                _queuedWithdrawals[cnt] = withdrawal;
-                _tokens[cnt] = tokens;
-                _middlewareTimesIndexes[cnt] = 0;
-                cnt += 1;
-            }
-        }
+        //         _queuedWithdrawals[cnt] = withdrawal;
+        //         _tokens[cnt] = tokens;
+        //         _middlewareTimesIndexes[cnt] = 0;
+        //         cnt += 1;
+        //     }
+        // }
 
-        if (cnt == 0) return;
+        // if (cnt == 0) return;
 
-        assembly {
-            mstore(_queuedWithdrawals, cnt)
-            mstore(_tokens, cnt)
-            mstore(_middlewareTimesIndexes, cnt)
-        }
+        // assembly {
+        //     mstore(_queuedWithdrawals, cnt)
+        //     mstore(_tokens, cnt)
+        //     mstore(_middlewareTimesIndexes, cnt)
+        // }
 
-        completeQueuedWithdrawals(_queuedWithdrawals, _tokens, _middlewareTimesIndexes);
+        // completeQueuedWithdrawals(_queuedWithdrawals, _tokens, _middlewareTimesIndexes);
     }
 
     /// Advanced version
@@ -263,19 +267,20 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// @param _middlewareTimesIndexes One index to reference per QueuedWithdrawal. See `completeQueuedWithdrawal` for the usage of a single index.
     /// @dev middlewareTimesIndex should be calculated off chain before calling this function by finding the first index that satisfies `slasher.canWithdraw`
     function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory _queuedWithdrawals, IERC20[][] memory _tokens, uint256[] memory _middlewareTimesIndexes) public onlyAdmin {
-        uint256 num = _queuedWithdrawals.length;
-        bool[] memory receiveAsTokens = new bool[](num);
-        for (uint256 i = 0; i < num; i++) {
-            bytes32 withdrawalRoot = eigenLayerDelegationManager.calculateWithdrawalRoot(_queuedWithdrawals[i]);
-            emit CompletedQueuedWithdrawal(withdrawalRoot);
+        revert("FIX BELOW");
+        // uint256 num = _queuedWithdrawals.length;
+        // bool[] memory receiveAsTokens = new bool[](num);
+        // for (uint256 i = 0; i < num; i++) {
+        //     bytes32 withdrawalRoot = eigenLayerDelegationManager.calculateWithdrawalRoot(_queuedWithdrawals[i]);
+        //     emit CompletedQueuedWithdrawal(withdrawalRoot);
 
-            /// so that the shares withdrawn from the specified strategies are sent to the caller
-            receiveAsTokens[i] = true;
-            withdrawalRootsSet.remove(withdrawalRoot);
-        }
+        //     /// so that the shares withdrawn from the specified strategies are sent to the caller
+        //     receiveAsTokens[i] = true;
+        //     withdrawalRootsSet.remove(withdrawalRoot);
+        // }
 
-        /// it will update the erc20 balances of this contract
-        eigenLayerDelegationManager.completeQueuedWithdrawals(_queuedWithdrawals, _tokens, _middlewareTimesIndexes, receiveAsTokens);
+        // /// it will update the erc20 balances of this contract
+        // eigenLayerDelegationManager.completeQueuedWithdrawals(_queuedWithdrawals, _tokens, _middlewareTimesIndexes, receiveAsTokens);
     }
 
     /// Enumerate the pending withdrawal roots
@@ -302,10 +307,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
     
     function getRestakedAmount(address _token) public view returns (uint256) {
-        TokenInfo memory info = tokenInfos[_token];
-        uint256 shares = eigenLayerStrategyManager.stakerStrategyShares(address(this), info.elStrategy);
-        uint256 restaked = info.elStrategy.sharesToUnderlyingView(shares);
-        return restaked;
+        revert("FIX BELOW");
+        // TokenInfo memory info = tokenInfos[_token];
+        // uint256 shares = eigenLayerStrategyManager.stakerStrategyShares(address(this), info.elStrategy);
+        // uint256 restaked = info.elStrategy.sharesToUnderlyingView(shares);
+        // return restaked;
     }
 
     function getEigenLayerRestakingStrategy(address _token) public view returns (IStrategy) {
@@ -368,20 +374,21 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     // INTERNAL functions
     function _queueWithdrawlsByShares(address token, uint256 shares) internal returns (bytes32[] memory) {
-        IStrategy strategy = tokenInfos[token].elStrategy;
-        IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategy;
-        uint256[] memory sharesArr = new uint256[](1);
-        sharesArr[0] = shares;
+        revert("FIX BELOW");
+        // IStrategy strategy = tokenInfos[token].elStrategy;
+        // IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
+        // IStrategy[] memory strategies = new IStrategy[](1);
+        // strategies[0] = strategy;
+        // uint256[] memory sharesArr = new uint256[](1);
+        // sharesArr[0] = shares;
 
-        params[0] = IDelegationManager.QueuedWithdrawalParams({
-            strategies: strategies,
-            shares: sharesArr,
-            withdrawer: address(this)
-        });
+        // params[0] = IDelegationManager.QueuedWithdrawalParams({
+        //     strategies: strategies,
+        //     shares: sharesArr,
+        //     withdrawer: address(this)
+        // });
 
-        return queueWithdrawals(params);
+        // return queueWithdrawals(params);
     }
 
     function _min(uint256 _a, uint256 _b) internal pure returns (uint256) {

--- a/src/helpers/EtherFiViewer.sol
+++ b/src/helpers/EtherFiViewer.sol
@@ -43,11 +43,11 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function EigenPod_hasRestaked(uint256[] memory _validatorIds) external view returns (bool[] memory _hasRestaked) {
-        revert("FIX BELOW");
-        // _hasRestaked = new bool[](_validatorIds.length);
-        // for (uint256 i = 0; i < _validatorIds.length; i++) {
-        //     _hasRestaked[i] = _getEigenPod(_validatorIds[i]).hasRestaked();
-        // }
+        _hasRestaked = new bool[](_validatorIds.length);
+        for (uint256 i = 0; i < _validatorIds.length; i++) {
+            // now every validator within eigenlayer is guaranteed to have this flag set
+            _hasRestaked[i] = _getEtherFiNode(_validatorIds[i]).isRestakingEnabled();
+        }
     }
 
     function EigenPod_withdrawableRestakedExecutionLayerGwei(uint256[] memory _validatorIds) external view returns (uint256[] memory _withdrawableRestakedExecutionLayerGwei) {
@@ -55,22 +55,6 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         for (uint256 i = 0; i < _validatorIds.length; i++) {
             _withdrawableRestakedExecutionLayerGwei[i] = _getEigenPod(_validatorIds[i]).withdrawableRestakedExecutionLayerGwei();
         }
-    }
-
-    function EigenPod_nonBeaconChainETHBalanceWei(uint256[] memory _validatorIds) external view returns (uint256[] memory _nonBeaconChainETHBalanceWei) {
-        revert("FIX BELOW");
-        // _nonBeaconChainETHBalanceWei = new uint256[](_validatorIds.length);
-        // for (uint256 i = 0; i < _validatorIds.length; i++) {
-        //     _nonBeaconChainETHBalanceWei[i] = _getEigenPod(_validatorIds[i]).nonBeaconChainETHBalanceWei();
-        // }
-    }
-
-    function EigenPod_mostRecentWithdrawalTimestamp(uint256[] memory _validatorIds) external view returns (uint256[] memory _mostRecentWithdrawalTimestamp) {
-        revert("FIX BELOW");
-        // _mostRecentWithdrawalTimestamp = new uint256[](_validatorIds.length);
-        // for (uint256 i = 0; i < _validatorIds.length; i++) {
-        //     _mostRecentWithdrawalTimestamp[i] = _getEigenPod(_validatorIds[i]).mostRecentWithdrawalTimestamp();
-        // }
     }
 
     function EigenPod_validatorPubkeyHashToInfo(uint256[] memory _validatorIds, bytes[][] memory _validatorPubkeys) external view returns (IEigenPod.ValidatorInfo[][] memory _validatorInfos) {
@@ -103,13 +87,13 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         }
     }
 
-    function EigenPodManager_podOwnerShares(uint256[] memory _validatorIds) external view returns (int256[] memory _podOwnerShares) {
-        revert("FIX BELOW");
-        // _podOwnerShares = new int256[](_validatorIds.length);
-        // for (uint256 i = 0; i < _validatorIds.length; i++) {
-        //     address podOwner = address(_getEtherFiNode(_validatorIds[i]));
-        //     _podOwnerShares[i] = _getEigenPodManager().podOwnerShares(podOwner);
-        // }
+    // WARNING: these shares have not been scaled by any slashing events
+    function EigenPodManager_podOwnerDepositShares(uint256[] memory _validatorIds) external view returns (int256[] memory _podOwnerShares) {
+        _podOwnerShares = new int256[](_validatorIds.length);
+        for (uint256 i = 0; i < _validatorIds.length; i++) {
+            address podOwner = address(_getEtherFiNode(_validatorIds[i]));
+            _podOwnerShares[i] = _getEigenPodManager().podOwnerDepositShares(podOwner);
+        }
     }
 
     function DelegationManager_delegatedTo(uint256[] memory _validatorIds) external view returns (address[] memory _delegatedTo) {
@@ -118,14 +102,6 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
             address podOwner = address(_getEtherFiNode(_validatorIds[i]));
             _delegatedTo[i] = _getDelegationManager().delegatedTo(podOwner);
         }
-    }
-
-    function DelegationManager_operatorDetails(address[] memory _operators) external view returns (IDelegationManager.OperatorDetails[] memory _operatorDetails) {
-        revert("FIX BELOW");
-        // _operatorDetails = new IDelegationManager.OperatorDetails[](_operators.length);
-        // for (uint256 i = 0; i < _operators.length; i++) {
-        //     _operatorDetails[i] = _getDelegationManager().operatorDetails(_operators[i]);
-        // }
     }
 
     function EtherFiNodesManager_etherFiNodeAddress(uint256[] memory _validatorIds) external view returns (address[] memory _etherFiNodeAddresses) {

--- a/src/helpers/EtherFiViewer.sol
+++ b/src/helpers/EtherFiViewer.sol
@@ -43,10 +43,11 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function EigenPod_hasRestaked(uint256[] memory _validatorIds) external view returns (bool[] memory _hasRestaked) {
-        _hasRestaked = new bool[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            _hasRestaked[i] = _getEigenPod(_validatorIds[i]).hasRestaked();
-        }
+        revert("FIX BELOW");
+        // _hasRestaked = new bool[](_validatorIds.length);
+        // for (uint256 i = 0; i < _validatorIds.length; i++) {
+        //     _hasRestaked[i] = _getEigenPod(_validatorIds[i]).hasRestaked();
+        // }
     }
 
     function EigenPod_withdrawableRestakedExecutionLayerGwei(uint256[] memory _validatorIds) external view returns (uint256[] memory _withdrawableRestakedExecutionLayerGwei) {
@@ -57,17 +58,19 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function EigenPod_nonBeaconChainETHBalanceWei(uint256[] memory _validatorIds) external view returns (uint256[] memory _nonBeaconChainETHBalanceWei) {
-        _nonBeaconChainETHBalanceWei = new uint256[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            _nonBeaconChainETHBalanceWei[i] = _getEigenPod(_validatorIds[i]).nonBeaconChainETHBalanceWei();
-        }
+        revert("FIX BELOW");
+        // _nonBeaconChainETHBalanceWei = new uint256[](_validatorIds.length);
+        // for (uint256 i = 0; i < _validatorIds.length; i++) {
+        //     _nonBeaconChainETHBalanceWei[i] = _getEigenPod(_validatorIds[i]).nonBeaconChainETHBalanceWei();
+        // }
     }
 
     function EigenPod_mostRecentWithdrawalTimestamp(uint256[] memory _validatorIds) external view returns (uint256[] memory _mostRecentWithdrawalTimestamp) {
-        _mostRecentWithdrawalTimestamp = new uint256[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            _mostRecentWithdrawalTimestamp[i] = _getEigenPod(_validatorIds[i]).mostRecentWithdrawalTimestamp();
-        }
+        revert("FIX BELOW");
+        // _mostRecentWithdrawalTimestamp = new uint256[](_validatorIds.length);
+        // for (uint256 i = 0; i < _validatorIds.length; i++) {
+        //     _mostRecentWithdrawalTimestamp[i] = _getEigenPod(_validatorIds[i]).mostRecentWithdrawalTimestamp();
+        // }
     }
 
     function EigenPod_validatorPubkeyHashToInfo(uint256[] memory _validatorIds, bytes[][] memory _validatorPubkeys) external view returns (IEigenPod.ValidatorInfo[][] memory _validatorInfos) {
@@ -101,11 +104,12 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function EigenPodManager_podOwnerShares(uint256[] memory _validatorIds) external view returns (int256[] memory _podOwnerShares) {
-        _podOwnerShares = new int256[](_validatorIds.length);
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            address podOwner = address(_getEtherFiNode(_validatorIds[i]));
-            _podOwnerShares[i] = _getEigenPodManager().podOwnerShares(podOwner);
-        }
+        revert("FIX BELOW");
+        // _podOwnerShares = new int256[](_validatorIds.length);
+        // for (uint256 i = 0; i < _validatorIds.length; i++) {
+        //     address podOwner = address(_getEtherFiNode(_validatorIds[i]));
+        //     _podOwnerShares[i] = _getEigenPodManager().podOwnerShares(podOwner);
+        // }
     }
 
     function DelegationManager_delegatedTo(uint256[] memory _validatorIds) external view returns (address[] memory _delegatedTo) {
@@ -117,10 +121,11 @@ contract EtherFiViewer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function DelegationManager_operatorDetails(address[] memory _operators) external view returns (IDelegationManager.OperatorDetails[] memory _operatorDetails) {
-        _operatorDetails = new IDelegationManager.OperatorDetails[](_operators.length);
-        for (uint256 i = 0; i < _operators.length; i++) {
-            _operatorDetails[i] = _getDelegationManager().operatorDetails(_operators[i]);
-        }
+        revert("FIX BELOW");
+        // _operatorDetails = new IDelegationManager.OperatorDetails[](_operators.length);
+        // for (uint256 i = 0; i < _operators.length; i++) {
+        //     _operatorDetails[i] = _getDelegationManager().operatorDetails(_operators[i]);
+        // }
     }
 
     function EtherFiNodesManager_etherFiNodeAddress(uint256[] memory _validatorIds) external view returns (address[] memory _etherFiNodeAddresses) {

--- a/src/interfaces/IEtherFiNode.sol
+++ b/src/interfaces/IEtherFiNode.sol
@@ -66,14 +66,13 @@ interface IEtherFiNode {
 
     // Non-VIEW functions
     function initialize(address _etherFiNodesManager) external;
-    function DEPRECATED_claimDelayedWithdrawalRouterWithdrawals() external;
     function createEigenPod() external;
     function isRestakingEnabled() external view returns (bool);
     function processNodeExit(uint256 _validatorId) external returns (bytes32[] memory withdrawalRoots);
     function processFullWithdraw(uint256 _validatorId) external;
     function queueEigenpodFullWithdrawal() external returns (bytes32[] memory withdrawalRoots);
-    function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory withdrawals, uint256[] calldata middlewareTimesIndexes, bool _receiveAsTokens) external;
-    function completeQueuedWithdrawal(IDelegationManager.Withdrawal memory withdrawals, uint256 middlewareTimesIndexes, bool _receiveAsTokens) external;
+    function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory withdrawals, bool _receiveAsTokens) external;
+    function completeQueuedWithdrawal(IDelegationManager.Withdrawal memory withdrawals, bool _receiveAsTokens) external;
     function updateNumberOfAssociatedValidators(uint16 _up, uint16 _down) external;
     function updateNumExitedValidators(uint16 _up, uint16 _down) external;
     function registerValidator(uint256 _validatorId, bool _enableRestaking) external;

--- a/test/EigenLayerIntegration.t.sol
+++ b/test/EigenLayerIntegration.t.sol
@@ -142,34 +142,35 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
 
     // https://holesky.beaconcha.in/validator/1644305#deposits
     function test_verifyWithdrawalCredentials_32ETH() public {
+        revert("FIX BELOW");
 
-        vm.selectFork(vm.createFork(vm.envString("HISTORICAL_PROOF_RPC_URL")));
+        // vm.selectFork(vm.createFork(vm.envString("HISTORICAL_PROOF_RPC_URL")));
 
-        int256 initialShares = eigenLayerEigenPodManager.podOwnerShares(podOwner);
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyToInfo(pubkey);
-        assertTrue(validatorInfo.status == IEigenPod.VALIDATOR_STATUS.INACTIVE, "Validator status should be INACTIVE");
-        assertEq(validatorInfo.validatorIndex, 0);
-        assertEq(validatorInfo.restakedBalanceGwei, 0);
-        assertEq(validatorInfo.mostRecentBalanceUpdateTimestamp, 0);
+        // int256 initialShares = eigenLayerEigenPodManager.podOwnerShares(podOwner);
+        // IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyToInfo(pubkey);
+        // assertTrue(validatorInfo.status == IEigenPod.VALIDATOR_STATUS.INACTIVE, "Validator status should be INACTIVE");
+        // assertEq(validatorInfo.validatorIndex, 0);
+        // assertEq(validatorInfo.restakedBalanceGwei, 0);
+        // assertEq(validatorInfo.mostRecentBalanceUpdateTimestamp, 0);
 
-        _beacon_process_32ETH_deposit();
-        console2.log("initialShares:", initialShares);
+        // _beacon_process_32ETH_deposit();
+        // console2.log("initialShares:", initialShares);
 
-        bytes4 selector = bytes4(keccak256("verifyWithdrawalCredentials(uint64,(bytes32,bytes),uint40[],bytes[],bytes32[][])"));
-        bytes[] memory data = new bytes[](1);
-        data[0] = abi.encodeWithSelector(selector, oracleTimestamp, stateRootProof, validatorIndices, withdrawalCredentialProofs, validatorFields);
-        vm.prank(owner);
-        managerInstance.forwardEigenpodCall(validatorIds, data);
+        // bytes4 selector = bytes4(keccak256("verifyWithdrawalCredentials(uint64,(bytes32,bytes),uint40[],bytes[],bytes32[][])"));
+        // bytes[] memory data = new bytes[](1);
+        // data[0] = abi.encodeWithSelector(selector, oracleTimestamp, stateRootProof, validatorIndices, withdrawalCredentialProofs, validatorFields);
+        // vm.prank(owner);
+        // managerInstance.forwardEigenpodCall(validatorIds, data);
 
-        int256 updatedShares = eigenLayerEigenPodManager.podOwnerShares(podOwner);
-        console2.log("updatedShares:", updatedShares);
+        // int256 updatedShares = eigenLayerEigenPodManager.podOwnerShares(podOwner);
+        // console2.log("updatedShares:", updatedShares);
 
-        validatorInfo = eigenPod.validatorPubkeyToInfo(pubkey);
-        assertEq(updatedShares, initialShares+32e18, "Shares should be 32 ETH in wei after verifying withdrawal credentials");
-        assertTrue(validatorInfo.status == IEigenPod.VALIDATOR_STATUS.ACTIVE, "Validator status should be ACTIVE");
-        assertEq(validatorInfo.validatorIndex, validatorIndices[0], "Validator index should be set");
-        assertEq(validatorInfo.restakedBalanceGwei, 32 ether / 1e9, "Restaked balance should be 32 eth");
-        assertEq(validatorInfo.mostRecentBalanceUpdateTimestamp, oracleTimestamp, "Most recent balance update timestamp should be set");
+        // validatorInfo = eigenPod.validatorPubkeyToInfo(pubkey);
+        // assertEq(updatedShares, initialShares+32e18, "Shares should be 32 ETH in wei after verifying withdrawal credentials");
+        // assertTrue(validatorInfo.status == IEigenPod.VALIDATOR_STATUS.ACTIVE, "Validator status should be ACTIVE");
+        // assertEq(validatorInfo.validatorIndex, validatorIndices[0], "Validator index should be set");
+        // assertEq(validatorInfo.restakedBalanceGwei, 32 ether / 1e9, "Restaked balance should be 32 eth");
+        // assertEq(validatorInfo.mostRecentBalanceUpdateTimestamp, oracleTimestamp, "Most recent balance update timestamp should be set");
     }
 
     function test_verifyBalanceUpdates_FAIL_1() public {
@@ -229,19 +230,20 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
         managerInstance.forwardEigenpodCall(validatorIds, data);
     }
 
-    function _registerAsOperator(address avs_operator) internal {
-        assertEq(eigenLayerDelegationManager.isOperator(avs_operator), false);
+    function _registerAsOperator(address avs_operator) internal {        
+        revert("FIX BELOW");
+        // assertEq(eigenLayerDelegationManager.isOperator(avs_operator), false);
 
-        vm.startPrank(avs_operator);
-        IDelegationManager.OperatorDetails memory detail = IDelegationManager.OperatorDetails({
-            earningsReceiver: address(treasuryInstance),
-            delegationApprover: address(0),
-            stakerOptOutWindowBlocks: 0
-        });
-        eigenLayerDelegationManager.registerAsOperator(detail, "");
-        vm.stopPrank();
+        // vm.startPrank(avs_operator);
+        // IDelegationManager.OperatorDetails memory detail = IDelegationManager.OperatorDetails({
+        //     earningsReceiver: address(treasuryInstance),
+        //     delegationApprover: address(0),
+        //     stakerOptOutWindowBlocks: 0
+        // });
+        // eigenLayerDelegationManager.registerAsOperator(detail, "");
+        // vm.stopPrank();
 
-        assertEq(eigenLayerDelegationManager.isOperator(avs_operator), true);
+        // assertEq(eigenLayerDelegationManager.isOperator(avs_operator), true);
     }
 
     function test_registerAsOperator() public {
@@ -257,7 +259,6 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
         etherfi_avs_operator_1 = 0xfB487f216CA24162119C0C6Ae015d680D7569C2f;
 
         address operator = etherfi_avs_operator_1;
-        address mainnet_earningsReceiver = 0x88C3c0AeAC97287E71D78bb97138727A60b2623b;
         address delegationManager = address(managerInstance.delegationManager());
         address delayedWithdrawalRouter = address(managerInstance.delayedWithdrawalRouter());
 
@@ -274,7 +275,6 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
         managerInstance.updateAllowedForwardedExternalCalls(selector, delegationManager, true);
 
         // Confirm, the earningsReceiver is set to treasuryInstance
-        assertEq(eigenLayerDelegationManager.earningsReceiver(operator), address(mainnet_earningsReceiver));
         assertEq(eigenLayerDelegationManager.isDelegated(podOwner), false);
 
         vm.startPrank(owner);
@@ -326,123 +326,125 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
     }
 
     function test_completeQueuedWithdrawals_338_for_withdrawal_from_undelegate() public {
-        uint256[] memory validatorIds = new uint256[](1);
-        validatorIds[0] = 338;
-        uint32[] memory timeStamps = new uint32[](1);
-        timeStamps[0] = 0;
-        address nodeAddress = managerInstance.etherfiNodeAddress(validatorIds[0]);
+        revert("FIX BELOW");
+        // uint256[] memory validatorIds = new uint256[](1);
+        // validatorIds[0] = 338;
+        // uint32[] memory timeStamps = new uint32[](1);
+        // timeStamps[0] = 0;
+        // address nodeAddress = managerInstance.etherfiNodeAddress(validatorIds[0]);
 
-        IDelegationManager mgr = managerInstance.delegationManager();
+        // IDelegationManager mgr = managerInstance.delegationManager();
 
-        // 1. completeQueuedWithdrawal
-        // the withdrawal was queued by `undelegate` in https://etherscan.io/tx/0xd0e400ecd6711cf2f8e5ea97585c864db6d3ffb4d248d3e6d97a66b3683ec98b
-        {
-            // 
-            // {
-            // 'staker': '0x7aC9b51aB907715194F407C15191fce0F3771254',
-            // 'delegatedTo': '0x5b9B3Cf0202a1a3Dc8f527257b7E6002D23D8c85', 
-            // 'withdrawer': '0x7aC9b51aB907715194F407C15191fce0F3771254', 
-            // 'nonce': 0, 
-            // 'startBlock': 19692808, 
-            // 'strategies': ['0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0'], 
-            // 'shares': [32000000000000000000]
-            // }
-            IDelegationManager.Withdrawal memory withdrawal;
-            IERC20[] memory tokens = new IERC20[](1);
-            IStrategy[] memory strategies = new IStrategy[](1);
-            strategies[0] = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
-            uint256[] memory shares = new uint256[](1);
-            shares[0] = 32000000000000000000;
-            withdrawal = IDelegationManager.Withdrawal({
-                staker: 0x7aC9b51aB907715194F407C15191fce0F3771254,
-                delegatedTo: 0x5b9B3Cf0202a1a3Dc8f527257b7E6002D23D8c85,
-                withdrawer: 0x7aC9b51aB907715194F407C15191fce0F3771254,
-                nonce: 0,
-                startBlock: 19692808,
-                strategies: strategies,
-                shares: shares
-            });      
+        // // 1. completeQueuedWithdrawal
+        // // the withdrawal was queued by `undelegate` in https://etherscan.io/tx/0xd0e400ecd6711cf2f8e5ea97585c864db6d3ffb4d248d3e6d97a66b3683ec98b
+        // {
+        //     // 
+        //     // {
+        //     // 'staker': '0x7aC9b51aB907715194F407C15191fce0F3771254',
+        //     // 'delegatedTo': '0x5b9B3Cf0202a1a3Dc8f527257b7E6002D23D8c85', 
+        //     // 'withdrawer': '0x7aC9b51aB907715194F407C15191fce0F3771254', 
+        //     // 'nonce': 0, 
+        //     // 'startBlock': 19692808, 
+        //     // 'strategies': ['0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0'], 
+        //     // 'shares': [32000000000000000000]
+        //     // }
+        //     IDelegationManager.Withdrawal memory withdrawal;
+        //     IERC20[] memory tokens = new IERC20[](1);
+        //     IStrategy[] memory strategies = new IStrategy[](1);
+        //     strategies[0] = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
+        //     uint256[] memory shares = new uint256[](1);
+        //     shares[0] = 32000000000000000000;
+        //     withdrawal = IDelegationManager.Withdrawal({
+        //         staker: 0x7aC9b51aB907715194F407C15191fce0F3771254,
+        //         delegatedTo: 0x5b9B3Cf0202a1a3Dc8f527257b7E6002D23D8c85,
+        //         withdrawer: 0x7aC9b51aB907715194F407C15191fce0F3771254,
+        //         nonce: 0,
+        //         startBlock: 19692808,
+        //         strategies: strategies,
+        //         shares: shares
+        //     });      
             
-            bytes32 withdrawalRoot = mgr.calculateWithdrawalRoot(withdrawal);
-            assertTrue(mgr.pendingWithdrawals(withdrawalRoot));
+        //     bytes32 withdrawalRoot = mgr.calculateWithdrawalRoot(withdrawal);
+        //     assertTrue(mgr.pendingWithdrawals(withdrawalRoot));
 
-            IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
-            uint256[] memory middlewareTimesIndexes = new uint256[](1);
-            withdrawals[0] = withdrawal;
-            middlewareTimesIndexes[0] = 0;
+        //     IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
+        //     uint256[] memory middlewareTimesIndexes = new uint256[](1);
+        //     withdrawals[0] = withdrawal;
+        //     middlewareTimesIndexes[0] = 0;
 
-            vm.prank(owner);
-            vm.expectRevert();
-            EtherFiNode(payable(nodeAddress)).completeQueuedWithdrawals(withdrawals, middlewareTimesIndexes, false);
+        //     vm.prank(owner);
+        //     vm.expectRevert();
+        //     EtherFiNode(payable(nodeAddress)).completeQueuedWithdrawals(withdrawals, middlewareTimesIndexes, false);
 
-            vm.prank(owner);
-            vm.expectRevert();
-            managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
+        //     vm.prank(owner);
+        //     vm.expectRevert();
+        //     managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
 
-            vm.prank(owner);
-            managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, false);
-        }
+        //     vm.prank(owner);
+        //     managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, false);
+        // }
     }
 
     function test_completeQueuedWithdrawals_338_e2e() public {
-        uint256[] memory validatorIds = new uint256[](1);
-        validatorIds[0] = 338;
-        uint32[] memory timeStamps = new uint32[](1);
-        timeStamps[0] = 0;
-        address nodeAddress = managerInstance.etherfiNodeAddress(validatorIds[0]);
+        revert("FIX BELOW");
+        // uint256[] memory validatorIds = new uint256[](1);
+        // validatorIds[0] = 338;
+        // uint32[] memory timeStamps = new uint32[](1);
+        // timeStamps[0] = 0;
+        // address nodeAddress = managerInstance.etherfiNodeAddress(validatorIds[0]);
 
-        IDelegationManager mgr = managerInstance.delegationManager();
+        // IDelegationManager mgr = managerInstance.delegationManager();
 
-        // 1. completeQueuedWithdrawal for withdrawal from undelegate
-        test_completeQueuedWithdrawals_338_for_withdrawal_from_undelegate();
+        // // 1. completeQueuedWithdrawal for withdrawal from undelegate
+        // test_completeQueuedWithdrawals_338_for_withdrawal_from_undelegate();
 
-        // 2. call `ProcessNodeExit` to initiate the queued withdrawal
-        IDelegationManager.Withdrawal memory withdrawal;
-        {
-            IStrategy[] memory strategies = new IStrategy[](1);
-            strategies[0] = mgr.beaconChainETHStrategy();
-            uint256[] memory shares = new uint256[](1);
-            shares[0] = 32 ether;
-            withdrawal = IDelegationManager.Withdrawal({
-                staker: nodeAddress,
-                delegatedTo: mgr.delegatedTo(nodeAddress),
-                withdrawer: nodeAddress,
-                nonce: mgr.cumulativeWithdrawalsQueued(nodeAddress),
-                startBlock: uint32(block.number),
-                strategies: strategies,
-                shares: shares
-            });      
-        }
+        // // 2. call `ProcessNodeExit` to initiate the queued withdrawal
+        // IDelegationManager.Withdrawal memory withdrawal;
+        // {
+        //     IStrategy[] memory strategies = new IStrategy[](1);
+        //     strategies[0] = mgr.beaconChainETHStrategy();
+        //     uint256[] memory shares = new uint256[](1);
+        //     shares[0] = 32 ether;
+        //     withdrawal = IDelegationManager.Withdrawal({
+        //         staker: nodeAddress,
+        //         delegatedTo: mgr.delegatedTo(nodeAddress),
+        //         withdrawer: nodeAddress,
+        //         nonce: mgr.cumulativeWithdrawalsQueued(nodeAddress),
+        //         startBlock: uint32(block.number),
+        //         strategies: strategies,
+        //         shares: shares
+        //     });      
+        // }
         
-        vm.prank(owner);
-        managerInstance.processNodeExit(validatorIds, timeStamps);
+        // vm.prank(owner);
+        // managerInstance.processNodeExit(validatorIds, timeStamps);
     
-        // 3. Wait
-        // Wait 'minDelayBlock' after the `verifyAndProcessWithdrawals`
-        {
-            uint256 minDelayBlock = Math.max(mgr.minWithdrawalDelayBlocks(), mgr.strategyWithdrawalDelayBlocks(mgr.beaconChainETHStrategy()));
-            vm.roll(block.number + minDelayBlock);
-        }
+        // // 3. Wait
+        // // Wait 'minDelayBlock' after the `verifyAndProcessWithdrawals`
+        // {
+        //     uint256 minDelayBlock = Math.max(mgr.minWithdrawalDelayBlocks(), mgr.strategyWithdrawalDelayBlocks(mgr.beaconChainETHStrategy()));
+        //     vm.roll(block.number + minDelayBlock);
+        // }
 
 
-        // 4. DelegationManager.completeQueuedWithdrawal            
-        bytes32 withdrawalRoot = mgr.calculateWithdrawalRoot(withdrawal);
+        // // 4. DelegationManager.completeQueuedWithdrawal            
+        // bytes32 withdrawalRoot = mgr.calculateWithdrawalRoot(withdrawal);
 
-        IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
-        uint256[] memory middlewareTimesIndexes = new uint256[](1);
-        withdrawals[0] = withdrawal;
-        middlewareTimesIndexes[0] = 0;
+        // IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
+        // uint256[] memory middlewareTimesIndexes = new uint256[](1);
+        // withdrawals[0] = withdrawal;
+        // middlewareTimesIndexes[0] = 0;
 
-        vm.prank(owner);
-        vm.expectRevert();
-        EtherFiNode(payable(nodeAddress)).completeQueuedWithdrawals(withdrawals, middlewareTimesIndexes, false);
+        // vm.prank(owner);
+        // vm.expectRevert();
+        // EtherFiNode(payable(nodeAddress)).completeQueuedWithdrawals(withdrawals, middlewareTimesIndexes, false);
 
-        vm.prank(owner);
-        vm.expectRevert();
-        managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, false);
+        // vm.prank(owner);
+        // vm.expectRevert();
+        // managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, false);
 
-        vm.prank(owner);
-        managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
+        // vm.prank(owner);
+        // managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
     }
 
     // Only {operatingAdmin / Admin / Owner} can perform EigenLayer-related actions

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -152,10 +152,11 @@ contract EtherFiNodeTest is TestSetup {
 
         vm.roll(block.number + (50400) + 1);
 
-        safeInstance.DEPRECATED_claimDelayedWithdrawalRouterWithdrawals();
+        revert("FIX BELOW");
+        // safeInstance.DEPRECATED_claimDelayedWithdrawalRouterWithdrawals();
 
-        assertEq(address(safeInstance).balance, 2 ether);
-        assertEq(address(safeInstance.eigenPod()).balance, 0 ether);
+        // assertEq(address(safeInstance).balance, 2 ether);
+        // assertEq(address(safeInstance.eigenPod()).balance, 0 ether);
     }
 
     function test_splitBalanceInExecutionLayer() public {
@@ -321,20 +322,21 @@ contract EtherFiNodeTest is TestSetup {
         assertEq(safeInstance.withdrawableBalanceInExecutionLayer(), 1 ether);
 
         // claim that withdrawal
-        safeInstance.DEPRECATED_claimDelayedWithdrawalRouterWithdrawals();
-        assertEq(safeInstance.totalBalanceInExecutionLayer(), 2 ether);
-        assertEq(address(safeInstance).balance, 1 ether);
-        assertEq(safeInstance.withdrawableBalanceInExecutionLayer(), 1 ether);
+        revert("FIX BELOW");
+        // safeInstance.DEPRECATED_claimDelayedWithdrawalRouterWithdrawals();
+        // assertEq(safeInstance.totalBalanceInExecutionLayer(), 2 ether);
+        // assertEq(address(safeInstance).balance, 1 ether);
+        // assertEq(safeInstance.withdrawableBalanceInExecutionLayer(), 1 ether);
 
-        // queue multiple but only some that are claimable
-        _withdrawNonBeaconChainETHBalanceWei(validatorId);
-        _transferTo(safeInstance.eigenPod(), 1 ether);
-        _withdrawNonBeaconChainETHBalanceWei(validatorId);
-        vm.roll(block.number + (50400) + 1);
-        _transferTo(safeInstance.eigenPod(), 1 ether);
-        _withdrawNonBeaconChainETHBalanceWei(validatorId);
-        assertEq(safeInstance.withdrawableBalanceInExecutionLayer(), 3 ether);
-        assertEq(safeInstance.totalBalanceInExecutionLayer(), 4 ether);
+        // // queue multiple but only some that are claimable
+        // _withdrawNonBeaconChainETHBalanceWei(validatorId);
+        // _transferTo(safeInstance.eigenPod(), 1 ether);
+        // _withdrawNonBeaconChainETHBalanceWei(validatorId);
+        // vm.roll(block.number + (50400) + 1);
+        // _transferTo(safeInstance.eigenPod(), 1 ether);
+        // _withdrawNonBeaconChainETHBalanceWei(validatorId);
+        // assertEq(safeInstance.withdrawableBalanceInExecutionLayer(), 3 ether);
+        // assertEq(safeInstance.totalBalanceInExecutionLayer(), 4 ether);
     }
 
     function _withdrawNonBeaconChainETHBalanceWei(uint256 validatorId) public {
@@ -1752,140 +1754,143 @@ contract EtherFiNodeTest is TestSetup {
     }
 
     function test_mainnet_369_queueWithdrawals_by_rando_fails() public {
-        initializeRealisticFork(MAINNET_FORK);
-        _upgrade_etherfi_node_contract();   
-        _upgrade_etherfi_nodes_manager_contract(); 
+        revert("FIX BELOW");
+        // initializeRealisticFork(MAINNET_FORK);
+        // _upgrade_etherfi_node_contract();   
+        // _upgrade_etherfi_nodes_manager_contract(); 
 
-        _mainnet_369_verifyAndProcessWithdrawals(true, true);
+        // _mainnet_369_verifyAndProcessWithdrawals(true, true);
 
-        uint256 validatorId = 369;
-        address nodeAddress = managerInstance.etherfiNodeAddress(validatorId);
-        IEigenPod eigenPod = IEigenPod(managerInstance.getEigenPod(validatorId));
-        IDelegationManager mgr = managerInstance.delegationManager();
-        IEigenPodManager eigenPodManager = managerInstance.eigenPodManager();
+        // uint256 validatorId = 369;
+        // address nodeAddress = managerInstance.etherfiNodeAddress(validatorId);
+        // IEigenPod eigenPod = IEigenPod(managerInstance.getEigenPod(validatorId));
+        // IDelegationManager mgr = managerInstance.delegationManager();
+        // IEigenPodManager eigenPodManager = managerInstance.eigenPodManager();
 
-        IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
-        IStrategy[] memory strategies = new IStrategy[](1);
-        uint256[] memory shares = new uint256[](1);
+        // IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
+        // IStrategy[] memory strategies = new IStrategy[](1);
+        // uint256[] memory shares = new uint256[](1);
 
-        strategies[0] = mgr.beaconChainETHStrategy();
-        shares[0] = uint256(eigenPod.withdrawableRestakedExecutionLayerGwei()) * uint256(1 gwei);
-        params[0] = IDelegationManager.QueuedWithdrawalParams({
-            strategies: strategies,
-            shares: shares,
-            withdrawer: nodeAddress
-        });
+        // strategies[0] = mgr.beaconChainETHStrategy();
+        // shares[0] = uint256(eigenPod.withdrawableRestakedExecutionLayerGwei()) * uint256(1 gwei);
+        // params[0] = IDelegationManager.QueuedWithdrawalParams({
+        //     strategies: strategies,
+        //     shares: shares,
+        //     withdrawer: nodeAddress
+        // });
 
-        // Caller != withdrawer
-        vm.expectRevert("DelegationManager.queueWithdrawal: withdrawer must be staker");
-        vm.prank(alice);
-        mgr.queueWithdrawals(params);
+        // // Caller != withdrawer
+        // vm.expectRevert("DelegationManager.queueWithdrawal: withdrawer must be staker");
+        // vm.prank(alice);
+        // mgr.queueWithdrawals(params);
     }
 
     function test_mainnet_369_processNodeExit_success() public returns (IDelegationManager.Withdrawal memory) {
+        revert("FIX BELOW");
         // test_mainnet_369_verifyAndProcessWithdrawals();  
-        initializeRealisticFork(MAINNET_FORK);
+        // initializeRealisticFork(MAINNET_FORK);
 
-        vm.warp(block.timestamp + 7 * 24 * 3600);
+        // vm.warp(block.timestamp + 7 * 24 * 3600);
 
-        uint256 validatorId = 338;
-        address nodeAddress = managerInstance.etherfiNodeAddress(validatorId);
-        IEigenPod eigenPod = IEigenPod(managerInstance.getEigenPod(validatorId));
-        IDelegationManager mgr = managerInstance.delegationManager();
-        IEigenPodManager eigenPodManager = managerInstance.eigenPodManager();
+        // uint256 validatorId = 338;
+        // address nodeAddress = managerInstance.etherfiNodeAddress(validatorId);
+        // IEigenPod eigenPod = IEigenPod(managerInstance.getEigenPod(validatorId));
+        // IDelegationManager mgr = managerInstance.delegationManager();
+        // IEigenPodManager eigenPodManager = managerInstance.eigenPodManager();
 
-        // Calculate TVL does not work once the eigenPod's balance goes above 16 ether since we cannot tell if it is the reward or exited fund
-        // ether.fi will perform `verifyAndProcessWithdrawals` and `processNodeExit` to mark the validator as exited
-        // Then, it will call `calculateTVL` to get the correct TVL
-        vm.expectRevert();
-        managerInstance.calculateTVL(validatorId, 0 ether);
+        // // Calculate TVL does not work once the eigenPod's balance goes above 16 ether since we cannot tell if it is the reward or exited fund
+        // // ether.fi will perform `verifyAndProcessWithdrawals` and `processNodeExit` to mark the validator as exited
+        // // Then, it will call `calculateTVL` to get the correct TVL
+        // vm.expectRevert();
+        // managerInstance.calculateTVL(validatorId, 0 ether);
 
-        IDelegationManager.Withdrawal memory withdrawal;
-        IERC20[] memory tokens = new IERC20[](1);
-        {
-            IStrategy[] memory strategies = new IStrategy[](1);
-            strategies[0] = mgr.beaconChainETHStrategy();
-            uint256[] memory shares = new uint256[](1);
-            shares[0] = uint256(eigenPod.withdrawableRestakedExecutionLayerGwei()) * 1 gwei;
-            withdrawal = IDelegationManager.Withdrawal({
-                staker: nodeAddress,
-                delegatedTo: mgr.delegatedTo(nodeAddress),
-                withdrawer: nodeAddress,
-                nonce: mgr.cumulativeWithdrawalsQueued(nodeAddress),
-                startBlock: uint32(block.number),
-                strategies: strategies,
-                shares: shares
-            });      
+        // IDelegationManager.Withdrawal memory withdrawal;
+        // IERC20[] memory tokens = new IERC20[](1);
+        // {
+        //     IStrategy[] memory strategies = new IStrategy[](1);
+        //     strategies[0] = mgr.beaconChainETHStrategy();
+        //     uint256[] memory shares = new uint256[](1);
+        //     shares[0] = uint256(eigenPod.withdrawableRestakedExecutionLayerGwei()) * 1 gwei;
+        //     withdrawal = IDelegationManager.Withdrawal({
+        //         staker: nodeAddress,
+        //         delegatedTo: mgr.delegatedTo(nodeAddress),
+        //         withdrawer: nodeAddress,
+        //         nonce: mgr.cumulativeWithdrawalsQueued(nodeAddress),
+        //         startBlock: uint32(block.number),
+        //         strategies: strategies,
+        //         shares: shares
+        //     });      
 
-            bytes32 withdrawalRoot = mgr.calculateWithdrawalRoot(withdrawal);
-        }
+        //     bytes32 withdrawalRoot = mgr.calculateWithdrawalRoot(withdrawal);
+        // }
 
-        // 2. call `ProcessNodeExit` to initiate the queued withdrawal
-        uint256[] memory validatorIds = new uint256[](1);
-        {
-            uint32[] memory exitTimestamps = new uint32[](1);
-            validatorIds[0] = validatorId;
-            exitTimestamps[0] = uint32(block.timestamp);
+        // // 2. call `ProcessNodeExit` to initiate the queued withdrawal
+        // uint256[] memory validatorIds = new uint256[](1);
+        // {
+        //     uint32[] memory exitTimestamps = new uint32[](1);
+        //     validatorIds[0] = validatorId;
+        //     exitTimestamps[0] = uint32(block.timestamp);
             
-            hoax(managerInstance.owner());
-            managerInstance.processNodeExit(validatorIds, exitTimestamps);
-            // It calls `DelegationManager::undelegate` which emits the event `WithdrawalQueued`
-        }
+        //     hoax(managerInstance.owner());
+        //     managerInstance.processNodeExit(validatorIds, exitTimestamps);
+        //     // It calls `DelegationManager::undelegate` which emits the event `WithdrawalQueued`
+        // }
 
-        // 'calculateTVL' now works
-        managerInstance.calculateTVL(validatorId, 0 ether);
+        // // 'calculateTVL' now works
+        // managerInstance.calculateTVL(validatorId, 0 ether);
 
-        // it reamins the same even after queueing the withdrawal until it is claimed
-        assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), 32 ether / 1 gwei);
+        // // it reamins the same even after queueing the withdrawal until it is claimed
+        // assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), 32 ether / 1 gwei);
 
-        return withdrawal;
+        // return withdrawal;
     }
 
     function test_mainnet_369_completeQueuedWithdrawal() public {
-        IDelegationManager.Withdrawal memory withdrawal = test_mainnet_369_processNodeExit_success();
+        revert("FIX BELOW");
+        // IDelegationManager.Withdrawal memory withdrawal = test_mainnet_369_processNodeExit_success();
 
-        uint256 validatorId = 369;
-        address nodeAddress = managerInstance.etherfiNodeAddress(validatorId);
-        IEigenPod eigenPod = IEigenPod(managerInstance.getEigenPod(validatorId));
-        IDelegationManager mgr = managerInstance.delegationManager();
-        IEigenPodManager eigenPodManager = managerInstance.eigenPodManager();
-        uint256[] memory validatorIds = new uint256[](1);
-        validatorIds[0] = validatorId;
+        // uint256 validatorId = 369;
+        // address nodeAddress = managerInstance.etherfiNodeAddress(validatorId);
+        // IEigenPod eigenPod = IEigenPod(managerInstance.getEigenPod(validatorId));
+        // IDelegationManager mgr = managerInstance.delegationManager();
+        // IEigenPodManager eigenPodManager = managerInstance.eigenPodManager();
+        // uint256[] memory validatorIds = new uint256[](1);
+        // validatorIds[0] = validatorId;
 
-        // mgr.completeQueuedWithdrawal(withdrawal, tokens, 0, true);
-        IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
-        uint256[] memory middlewareTimesIndexes = new uint256[](1);
-        withdrawals[0] = withdrawal;
-        middlewareTimesIndexes[0] = 0;
+        // // mgr.completeQueuedWithdrawal(withdrawal, tokens, 0, true);
+        // IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
+        // uint256[] memory middlewareTimesIndexes = new uint256[](1);
+        // withdrawals[0] = withdrawal;
+        // middlewareTimesIndexes[0] = 0;
         
-        IERC20[] memory tokens = new IERC20[](1);
-        bytes[] memory data = new bytes[](1);
-        data[0] = abi.encodeWithSelector(IDelegationManager.completeQueuedWithdrawal.selector, withdrawal, tokens, 0, true);
+        // IERC20[] memory tokens = new IERC20[](1);
+        // bytes[] memory data = new bytes[](1);
+        // data[0] = abi.encodeWithSelector(IDelegationManager.completeQueuedWithdrawal.selector, withdrawal, tokens, 0, true);
 
-        // FAIL, the forward call is not allowed for `completeQueuedWithdrawal`
-        vm.expectRevert("NOT_ALLOWED");
-        vm.prank(owner);
-        managerInstance.forwardExternalCall(validatorIds, data, address(managerInstance.delegationManager()));
+        // // FAIL, the forward call is not allowed for `completeQueuedWithdrawal`
+        // vm.expectRevert("NOT_ALLOWED");
+        // vm.prank(owner);
+        // managerInstance.forwardExternalCall(validatorIds, data, address(managerInstance.delegationManager()));
 
-        // FAIL, if the `minWithdrawalDelayBlocks` is not passed
-        vm.prank(owner);
-        vm.expectRevert("DelegationManager._completeQueuedWithdrawal: minWithdrawalDelayBlocks period has not yet passed");
-        managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
+        // // FAIL, if the `minWithdrawalDelayBlocks` is not passed
+        // vm.prank(owner);
+        // vm.expectRevert("DelegationManager._completeQueuedWithdrawal: minWithdrawalDelayBlocks period has not yet passed");
+        // managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
 
-        // 1. Wait
-        // Wait 'minDelayBlock' after the `verifyAndProcessWithdrawals`
-        {
-            uint256 minDelayBlock = Math.max(mgr.minWithdrawalDelayBlocks(), mgr.strategyWithdrawalDelayBlocks(mgr.beaconChainETHStrategy()));
-            vm.roll(block.number + minDelayBlock);
-        }
+        // // 1. Wait
+        // // Wait 'minDelayBlock' after the `verifyAndProcessWithdrawals`
+        // {
+        //     uint256 minDelayBlock = Math.max(mgr.minWithdrawalDelayBlocks(), mgr.strategyWithdrawalDelayBlocks(mgr.beaconChainETHStrategy()));
+        //     vm.roll(block.number + minDelayBlock);
+        // }
 
-        // 2. DelegationManager.completeQueuedWithdrawal
-        uint256 prevEtherFiNodeAddress = address(nodeAddress).balance;
-        managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
+        // // 2. DelegationManager.completeQueuedWithdrawal
+        // uint256 prevEtherFiNodeAddress = address(nodeAddress).balance;
+        // managerInstance.completeQueuedWithdrawals(validatorIds, withdrawals, middlewareTimesIndexes, true);
 
-        assertEq(address(nodeAddress).balance, prevEtherFiNodeAddress + 32 ether);
-        assertEq(eigenPodManager.podOwnerShares(nodeAddress), 0);
-        assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), 0);
+        // assertEq(address(nodeAddress).balance, prevEtherFiNodeAddress + 32 ether);
+        // assertEq(eigenPodManager.podOwnerShares(nodeAddress), 0);
+        // assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), 0);
     }
 
     function test_mainnet_369_fullWithdraw_success() public {

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -130,37 +130,7 @@ contract EtherFiNodeTest is TestSetup {
 
     }
 
-    function test_claimMixedSafeAndPodFunds() public {
-        initializeTestingFork(MAINNET_FORK);
-
-        uint256 bidId = depositAndRegisterValidator(true);
-        safeInstance = EtherFiNode(payable(managerInstance.etherfiNodeAddress(bidId)));
-
-        // simulate 1 eth of already claimed staking rewards and 1 eth of unclaimed restaked rewards
-        _transferTo(address(safeInstance.eigenPod()), 1 ether);
-        _transferTo(address(safeInstance), 1 ether);
-
-        assertEq(address(safeInstance).balance, 1 ether);
-        assertEq(address(safeInstance.eigenPod()).balance, 1 ether);
-
-        // claim the restaked rewards
-        // safeInstance.queueRestakedWithdrawal();
-        uint256[] memory validatorIds = new uint256[](1);
-        validatorIds[0] = bidId;
-        vm.prank(alice); // alice is admin
-        managerInstance.batchQueueRestakedWithdrawal(validatorIds);
-
-        vm.roll(block.number + (50400) + 1);
-
-        revert("FIX BELOW");
-        // safeInstance.DEPRECATED_claimDelayedWithdrawalRouterWithdrawals();
-
-        // assertEq(address(safeInstance).balance, 2 ether);
-        // assertEq(address(safeInstance.eigenPod()).balance, 0 ether);
-    }
-
     function test_splitBalanceInExecutionLayer() public {
-
         initializeTestingFork(MAINNET_FORK);
 
         uint256 validatorId = depositAndRegisterValidator(true);
@@ -222,8 +192,6 @@ contract EtherFiNodeTest is TestSetup {
     }
 
     function test_FullWithdrawWhenBalanceBelow16EthFails() public {
-        initializeTestingFork(MAINNET_FORK);
-
         // create a restaked validator
         uint256 validatorId = depositAndRegisterValidator(false);
         EtherFiNode node = EtherFiNode(payable(managerInstance.etherfiNodeAddress(validatorId)));
@@ -354,9 +322,7 @@ contract EtherFiNodeTest is TestSetup {
         managerInstance.forwardEigenpodCall(validatorIds, data);
     }
 
-    function testFullWithdrawBurnsTNFT() public {
-        initializeTestingFork(MAINNET_FORK);
-
+    function test_FullWithdrawBurnsTNFT() public {
         uint256 validatorId = depositAndRegisterValidator(false);
         safeInstance = EtherFiNode(payable(managerInstance.etherfiNodeAddress(validatorId)));
 
@@ -2147,28 +2113,6 @@ contract EtherFiNodeTest is TestSetup {
         }
     }
 
-    function test_ForcedPartialWithdrawal_succeeds() public {
-        uint256[] memory validatorIds = launch_validator(1, 0, false);
-        uint256 validatorId = validatorIds[0];
-        address etherfiNode = managerInstance.etherfiNodeAddress(validatorId);
-
-        assertTrue(managerInstance.phase(validatorIds[0]) == IEtherFiNode.VALIDATOR_PHASE.LIVE);
-        assertEq(IEtherFiNode(etherfiNode).numAssociatedValidators(), 1);
-
-        // launch 3 more validators
-        uint256[] memory newValidatorIds = launch_validator(3, validatorId, false);
-        assertEq(IEtherFiNode(etherfiNode).numAssociatedValidators(), 4);
-
-        // Earned >= 16 ether
-        _transferTo(etherfiNode, 16 ether);
-
-        vm.expectRevert(EtherFiNodesManager.NotAdmin.selector);
-        managerInstance.partialWithdraw(validatorId);
-
-        vm.prank(alice);
-        managerInstance.partialWithdraw(validatorId);
-    }
-
     function test_lp_as_bnft_holders_cant_mix_up_1() public {
         uint256[] memory validatorIds = launch_validator(1, 0, false);
         uint256 validatorId = validatorIds[0];
@@ -2401,25 +2345,6 @@ contract EtherFiNodeTest is TestSetup {
         vm.stopPrank();
     }
 
-    function _perform_pepe_upgrade() internal {
-        address eigenlayerAdmin = address(0xBE1685C81aA44FF9FB319dD389addd9374383e90);
-        ITimelock eigenlayerTimelock = ITimelock(0xA6Db1A8C5a981d1536266D2a393c5F8dDb210EAF);
-
-
-        // wait until timelock is finished and perform upgrade
-        vm.warp(block.timestamp + (60 * 60 * 24 * 8));
-        vm.roll(block.number + (7200*8));
-
-        address target = 0x369e6F597e22EaB55fFb173C6d9cD234BD699111;
-        uint256 value = 0;
-        string memory signature = "";
-        bytes memory data = hex"6A76120200000000000000000000000040A2ACCBD92BCA938B02010E17A5B8929B49130D0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002E000000000000000000000000000000000000000000000000000000000000001648D80FF0A00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000112005A2A4F2F3C18F09179B6703E63D9EDD165909073000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000243659CFE60000000000000000000000006D225E974FA404D25FFB84ED6E242FFA18EF6430008B9566ADA63B64D1E1DCF1418B43FD1433B724440000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004499A88EC400000000000000000000000091E677B07F7AF907EC9A428AAFA9FC14A0D3A338000000000000000000000000731A0AD160E407393FF662231ADD6DD145AD3FEA0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041000000000000000000000000A6DB1A8C5A981D1536266D2A393C5F8DDB210EAF00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000";
-        uint256 eta = 1725458400;
-
-        vm.prank(eigenlayerAdmin);
-        eigenlayerTimelock.executeTransaction(target, value, signature, data, eta);
-    }
-
     function test_mainnet_pepe_calculateTVL() public {
         initializeRealisticFork(MAINNET_FORK);
 
@@ -2429,7 +2354,6 @@ contract EtherFiNodeTest is TestSetup {
 
         (uint256 toOperator, uint256 toTnft, uint256 toBnft, uint256 toTreasury) = managerInstance.calculateTVL(validatorId, 32 ether);
 
-        _perform_pepe_upgrade();
         _upgrade_etherfi_node_contract();   
         _upgrade_etherfi_nodes_manager_contract();
 
@@ -2438,7 +2362,7 @@ contract EtherFiNodeTest is TestSetup {
 
         // TODO: this is broken and the Oracle handles these calculations separately
         // This needs to be fixed 
-        // _transferTo(eigenPod, 32 ether);
-        // (toOperator, toTnft, toBnft, toTreasury) = managerInstance.calculateTVL(validatorId, 0 ether);
+        _transferTo(eigenPod, 32 ether);
+        (toOperator, toTnft, toBnft, toTreasury) = managerInstance.calculateTVL(validatorId, 0 ether);
     }
 }

--- a/test/EtherFiRestaker.t.sol
+++ b/test/EtherFiRestaker.t.sol
@@ -125,22 +125,23 @@ contract EtherFiRestakerTest is TestSetup {
     }
 
     function test_queueWithdrawals_2() public returns (bytes32[] memory) {
-        test_restake_stEth();
+        revert("FIX BELOW");
+        // test_restake_stEth();
 
-        IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = etherFiRestakerInstance.getEigenLayerRestakingStrategy(address(stEth));
-        uint256[] memory shares = new uint256[](1);
-        shares[0] = eigenLayerStrategyManager.stakerStrategyShares(address(etherFiRestakerInstance), strategies[0]);
+        // IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
+        // IStrategy[] memory strategies = new IStrategy[](1);
+        // strategies[0] = etherFiRestakerInstance.getEigenLayerRestakingStrategy(address(stEth));
+        // uint256[] memory shares = new uint256[](1);
+        // shares[0] = eigenLayerStrategyManager.stakerStrategyShares(address(etherFiRestakerInstance), strategies[0]);
         
-        params[0] = IDelegationManager.QueuedWithdrawalParams({
-            strategies: strategies,
-            shares: shares,
-            withdrawer: address(etherFiRestakerInstance)
-        });
+        // params[0] = IDelegationManager.QueuedWithdrawalParams({
+        //     strategies: strategies,
+        //     shares: shares,
+        //     withdrawer: address(etherFiRestakerInstance)
+        // });
 
-        vm.prank(etherfiOperatingAdmin);
-        return etherFiRestakerInstance.queueWithdrawals(params);
+        // vm.prank(etherfiOperatingAdmin);
+        // return etherFiRestakerInstance.queueWithdrawals(params);
     }
 
     function test_completeQueuedWithdrawals_1() public {

--- a/test/EtherFiRestaker.t.sol
+++ b/test/EtherFiRestaker.t.sol
@@ -64,14 +64,14 @@ contract EtherFiRestakerTest is TestSetup {
 
         _deposit_stEth(amount);
 
-        assertEq(etherFiRestakerInstance.getEthAmountPendingForRedemption(address(stEth)), 0);
+        assertEq(etherFiRestakerInstance.getAmountPendingForRedemption(address(stEth)), 0);
 
         vm.startPrank(alice);
         uint256 stEthBalance = stEth.balanceOf(address(etherFiRestakerInstance));
         uint256[] memory reqIds = etherFiRestakerInstance.stEthRequestWithdrawal(stEthBalance);
         vm.stopPrank();
         
-        assertApproxEqAbs(etherFiRestakerInstance.getEthAmountPendingForRedemption(address(stEth)), amount, 2 wei);
+        assertApproxEqAbs(etherFiRestakerInstance.getAmountPendingForRedemption(address(stEth)), amount, 2 wei);
         assertApproxEqAbs(etherFiRestakerInstance.getTotalPooledEther(), amount, 2 wei);
         assertApproxEqAbs(liquidityPoolInstance.getTotalPooledEther(), lpTvl + amount, 2 wei);
 
@@ -85,7 +85,7 @@ contract EtherFiRestakerTest is TestSetup {
         etherFiRestakerInstance.lidoWithdrawalQueue().finalize(reqIds[reqIds.length-1], currentRate);
         vm.stopPrank();
 
-        assertApproxEqAbs(etherFiRestakerInstance.getEthAmountPendingForRedemption(address(stEth)), amount, 2 wei);
+        assertApproxEqAbs(etherFiRestakerInstance.getAmountPendingForRedemption(address(stEth)), amount, 2 wei);
         assertApproxEqAbs(etherFiRestakerInstance.getTotalPooledEther(), amount, 2 wei);
         assertApproxEqAbs(liquidityPoolInstance.getTotalPooledEther(), lpTvl + amount, 2 wei);
 
@@ -96,7 +96,7 @@ contract EtherFiRestakerTest is TestSetup {
         etherFiRestakerInstance.stEthClaimWithdrawals(reqIds, hints);
 
         // the cycle completes
-        assertApproxEqAbs(etherFiRestakerInstance.getEthAmountPendingForRedemption(address(stEth)), 0, 2 wei);
+        assertApproxEqAbs(etherFiRestakerInstance.getAmountPendingForRedemption(address(stEth)), 0, 2 wei);
         assertApproxEqAbs(etherFiRestakerInstance.getTotalPooledEther(), 0, 2 wei);
         assertApproxEqAbs(address(etherFiRestakerInstance).balance, 0, 2);
 
@@ -125,40 +125,40 @@ contract EtherFiRestakerTest is TestSetup {
     }
 
     function test_queueWithdrawals_2() public returns (bytes32[] memory) {
-        revert("FIX BELOW");
-        // test_restake_stEth();
+        test_restake_stEth();
 
-        // IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
-        // IStrategy[] memory strategies = new IStrategy[](1);
-        // strategies[0] = etherFiRestakerInstance.getEigenLayerRestakingStrategy(address(stEth));
-        // uint256[] memory shares = new uint256[](1);
-        // shares[0] = eigenLayerStrategyManager.stakerStrategyShares(address(etherFiRestakerInstance), strategies[0]);
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = etherFiRestakerInstance.getEigenLayerRestakingStrategy(address(stEth));
+        (uint256[] memory withdrawableShares, ) = eigenLayerDelegationManager.getWithdrawableShares(address(this), strategies);
         
-        // params[0] = IDelegationManager.QueuedWithdrawalParams({
-        //     strategies: strategies,
-        //     shares: shares,
-        //     withdrawer: address(etherFiRestakerInstance)
-        // });
+        IDelegationManagerTypes.QueuedWithdrawalParams[] memory params = new IDelegationManagerTypes.QueuedWithdrawalParams[](1);
+        params[0] = IDelegationManagerTypes.QueuedWithdrawalParams({
+            strategies: strategies,
+            depositShares: withdrawableShares,
+            withdrawer: address(etherFiRestakerInstance)
+        });
 
-        // vm.prank(etherfiOperatingAdmin);
-        // return etherFiRestakerInstance.queueWithdrawals(params);
+        vm.prank(etherfiOperatingAdmin);
+        return etherFiRestakerInstance.queueWithdrawalsWithParams(params);
     }
 
     function test_completeQueuedWithdrawals_1() public {
         bytes32[] memory withdrawalRoots = test_queueWithdrawals_1();
         assertTrue(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots[0]));
 
+        revert("FIX BELOW");
+
         vm.startPrank(etherfiOperatingAdmin);
-        // It won't complete the withdrawal because the withdrawal is still pending
-        etherFiRestakerInstance.completeQueuedWithdrawals(1000);
-        assertTrue(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots[0]));
-        assertApproxEqAbs(etherFiRestakerInstance.getEthAmountInEigenLayerPendingForWithdrawals(address(stEth)), 5 ether, 2 wei);
+        // // It won't complete the withdrawal because the withdrawal is still pending
+        // etherFiRestakerInstance.completeQueuedWithdrawals(1000);
+        // assertTrue(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots[0]));
+        // assertApproxEqAbs(etherFiRestakerInstance.getEthAmountInEigenLayerPendingForWithdrawals(address(stEth)), 5 ether, 2 wei);
 
-        vm.roll(block.number + 50400);
+        // vm.roll(block.number + 50400);
 
-        etherFiRestakerInstance.completeQueuedWithdrawals(1000);
-        assertFalse(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots[0]));
-        assertApproxEqAbs(etherFiRestakerInstance.getEthAmountInEigenLayerPendingForWithdrawals(address(stEth)), 0, 2 wei);
+        // etherFiRestakerInstance.completeQueuedWithdrawals(1000);
+        // assertFalse(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots[0]));
+        // assertApproxEqAbs(etherFiRestakerInstance.getEthAmountInEigenLayerPendingForWithdrawals(address(stEth)), 0, 2 wei);
         vm.stopPrank();
     }
 
@@ -174,20 +174,22 @@ contract EtherFiRestakerTest is TestSetup {
 
         vm.roll(block.number + 50400 / 2);
 
+        revert("FIX BELOW");
+
         // The first withdrawal is completed
         // But, the second withdrawal is still pending
         // Therefore, `completeQueuedWithdrawals` will not complete the second withdrawal
-        vm.startPrank(etherfiOperatingAdmin);
-        etherFiRestakerInstance.completeQueuedWithdrawals(1000);
+        // vm.startPrank(etherfiOperatingAdmin);
+        // etherFiRestakerInstance.completeQueuedWithdrawals(1000);
 
-        assertFalse(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots1[0]));
-        assertTrue(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots2[0]));
+        // assertFalse(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots1[0]));
+        // assertTrue(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots2[0]));
 
-        vm.roll(block.number + 50400 / 2);
+        // vm.roll(block.number + 50400 / 2);
 
-        etherFiRestakerInstance.completeQueuedWithdrawals(1000);
-        assertFalse(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots1[0]));
-        assertFalse(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots2[0]));
+        // etherFiRestakerInstance.completeQueuedWithdrawals(1000);
+        // assertFalse(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots1[0]));
+        // assertFalse(etherFiRestakerInstance.isPendingWithdrawal(withdrawalRoots2[0]));
         vm.stopPrank();
     }
 
@@ -226,4 +228,19 @@ contract EtherFiRestakerTest is TestSetup {
         etherFiRestakerInstance.delegateTo(avsOperator2, signature, 0x0);
         vm.stopPrank();
     }
+
+    function test_claimer_upgrade() public {
+        initializeRealisticFork(MAINNET_FORK);
+        EtherFiRestaker restaker = EtherFiRestaker(payable(0x1B7a4C3797236A1C37f8741c0Be35c2c72736fFf));
+        address _claimer = vm.addr(433);
+
+        address newRestakerImpl = address(new EtherFiRestaker(address(eigenLayerRewardsCoordinator)));
+        vm.startPrank(restaker.owner());
+
+        restaker.upgradeTo(newRestakerImpl);
+        restaker.setRewardsClaimer(_claimer);
+
+        assertEq(eigenLayerRewardsCoordinator.claimerFor(address(restaker)), _claimer);
+    }
+
 }

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import "forge-std/console.sol";
+
 
 
 import "../src/eigenlayer-interfaces/IDelayedWithdrawalRouter.sol";
@@ -86,6 +86,7 @@ contract TestSetup is Test, ContractCodeChecker {
     BeaconChainOracleMock public beaconChainOracleMock;
     IEigenPodManager public eigenLayerEigenPodManager;
     IDelegationManager public eigenLayerDelegationManager;
+    IRewardsCoordinator public eigenLayerRewardsCoordinator;
     ITimelock public eigenLayerTimelock;
 
     ILidoWithdrawalQueue public lidoWithdrawalQueue;
@@ -341,6 +342,7 @@ contract TestSetup is Test, ContractCodeChecker {
             eigenLayerStrategyManager = IEigenLayerStrategyManager(0x858646372CC42E1A627fcE94aa7A7033e7CF075A);
             eigenLayerEigenPodManager = IEigenPodManager(0x91E677b07F7AF907ec9a428aafA9fc14a0d3A338);
             eigenLayerDelegationManager = IDelegationManager(0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A);
+            eigenLayerRewardsCoordinator = IRewardsCoordinator(0x7750d328b314EfFa365A0402CcfD489B80B0adda);
             eigenLayerTimelock = ITimelock(0xA6Db1A8C5a981d1536266D2a393c5F8dDb210EAF);
 
         } else if (forkEnum == TESTNET_FORK) {
@@ -363,6 +365,7 @@ contract TestSetup is Test, ContractCodeChecker {
             eigenLayerStrategyManager = IEigenLayerStrategyManager(0xdfB5f6CE42aAA7830E94ECFCcAd411beF4d4D5b6);
             eigenLayerEigenPodManager = IEigenPodManager(0x30770d7E3e71112d7A6b7259542D1f680a70e315);
             eigenLayerDelegationManager = IDelegationManager(0xA44151489861Fe9e3055d95adC98FbD462B948e7);
+            eigenLayerRewardsCoordinator == IRewardsCoordinator(0x7750d328b314EfFa365A0402CcfD489B80B0adda);
             eigenLayerTimelock = ITimelock(0xcF19CE0561052a7A7Ff21156730285997B350A7D);
 
         } else {
@@ -421,7 +424,7 @@ contract TestSetup is Test, ContractCodeChecker {
     }
 
     function deployEtherFiRestaker() internal {
-        etherFiRestakerImplementation = new EtherFiRestaker();
+        etherFiRestakerImplementation = new EtherFiRestaker(address(0x1B7a4C3797236A1C37f8741c0Be35c2c72736fFf));
         etherFiRestakerProxy = new UUPSProxy(address(etherFiRestakerImplementation), "");
         etherFiRestakerInstance = EtherFiRestaker(payable(etherFiRestakerProxy));
 
@@ -573,7 +576,7 @@ contract TestSetup is Test, ContractCodeChecker {
         etherFiOracleProxy = new UUPSProxy(address(etherFiOracleImplementation), "");
         etherFiOracleInstance = EtherFiOracle(payable(etherFiOracleProxy));
 
-        etherFiRestakerImplementation = new EtherFiRestaker();
+        etherFiRestakerImplementation = new EtherFiRestaker(address(0));
         etherFiRestakerProxy = new UUPSProxy(address(etherFiRestakerImplementation), "");
         etherFiRestakerInstance = EtherFiRestaker(payable(etherFiRestakerProxy));
 


### PR DESCRIPTION
- removed the usage of `middlewareTimesIndexes`
- removed the usage of `eigenPod.balance`
- updated `splitBalanceInExecutionLayer`, `totalBalanceInExecutionLayer`, `withdrawableBalanceInExecutionLayer`
    - removed the deprecated delayedWithdrawal router code
    - used the provided functions by EL
- deprecated EtherFiNode's {`pendingWithdrawalFromRestakingInGwei`, `completedWithdrawalFromRestakingInGwei`}
- `_queueEigenpodFullWithdrawal` is fixed so that the beacon withdrawal <32 eth can be processed
- marked all contracts & tests broken with `FIX BELOW`. these are TODOs
- TODO: write tests