### PR TITLE
El slashing mock testing

### DIFF
--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -581,8 +581,7 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
     function createEigenPod() public {
         if (eigenPod != address(0x0)) return; // already have pod
         IEigenPodManager eigenPodManager = IEigenPodManager(IEtherFiNodesManager(etherFiNodesManager).eigenPodManager());
-        eigenPodManager.createPod();
-        eigenPod = address(eigenPodManager.getPod(address(this)));
+        eigenPod = eigenPodManager.createPod();
         emit EigenPodCreated(address(this), eigenPod);
     }
 
@@ -614,6 +613,7 @@ contract EtherFiNode is IEtherFiNode, IERC1271 {
         // 
         // TODO: revisit for Pectra where a validator can have more than 32 ether
         uint256 depositSharesToWithdraw;
+
         if (numAssociatedValidators() == 1) {
             require(IEigenPod(eigenPod).activeValidatorCount() == 0, "ACTIVE_VALIDATOR_EXISTS");
             depositSharesToWithdraw = depositShares[0];

--- a/test/ArrayTestHelper.sol
+++ b/test/ArrayTestHelper.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import "../src/eigenlayer-interfaces/IDelegationManager.sol";
+
+contract ArrayTestHelper {
+    // Common types used throughout our and eigenlayers protocol
+    function toArray_u256(uint256 val) public returns (uint256[] memory) {
+        uint256[] memory vals = new uint256[](1);
+        vals[0] = val;
+        return vals;
+    }
+    function toArray_u256(uint32 val) public returns (uint256[] memory) {
+        uint256[] memory vals = new uint256[](1);
+        vals[0] = val;
+        return vals;
+    }
+    function toArray_u32(uint32 val) public returns (uint32[] memory) {
+        uint32[] memory vals = new uint32[](1);
+        vals[0] = val;
+        return vals;
+    }
+    function toArray_u40(uint40 val) public returns (uint40[] memory) {
+        uint40[] memory vals = new uint40[](1);
+        vals[0] = val;
+        return vals;
+    }
+    function toArray(IDelegationManager.Withdrawal memory withdrawal) public returns (IDelegationManager.Withdrawal[] memory) {
+        IDelegationManager.Withdrawal[] memory vals = new IDelegationManager.Withdrawal[](1);
+        vals[0] = withdrawal;
+        return vals;
+    }
+}

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -2365,4 +2365,10 @@ contract EtherFiNodeTest is TestSetup {
         _transferTo(eigenPod, 32 ether);
         (toOperator, toTnft, toBnft, toTreasury) = managerInstance.calculateTVL(validatorId, 0 ether);
     }
+
+    function test_postSlashingWithdrawal() public {
+        uint256 validator1 = depositAndRegisterValidator(true);
+
+        // set etherfinodesmanager.eigenpodManager
+    }
 }

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -10,8 +10,32 @@ import "../src/eigenlayer-interfaces/IDelayedWithdrawalRouter.sol";
 
 import "forge-std/console2.sol";
 
+contract ArrayTestHelper {
+    // Common types used throughout our and eigenlayers protocol
+    function toArray_u256(uint256 val) public returns (uint256[] memory) {
+        uint256[] memory vals = new uint256[](1);
+        vals[0] = val;
+        return vals;
+    }
+    function toArray_u256(uint32 val) public returns (uint256[] memory) {
+        uint256[] memory vals = new uint256[](1);
+        vals[0] = val;
+        return vals;
+    }
+    function toArray_u32(uint32 val) public returns (uint32[] memory) {
+        uint32[] memory vals = new uint32[](1);
+        vals[0] = val;
+        return vals;
+    }
+    function toArray_u40(uint40 val) public returns (uint40[] memory) {
+        uint40[] memory vals = new uint40[](1);
+        vals[0] = val;
+        return vals;
+    }
+}
 
-contract EtherFiNodeTest is TestSetup {
+
+contract EtherFiNodeTest is TestSetup, ArrayTestHelper {
 
     // from EtherFiNodesManager.sol
     uint256 TreasuryRewardSplit = 50_000;
@@ -2366,9 +2390,47 @@ contract EtherFiNodeTest is TestSetup {
         (toOperator, toTnft, toBnft, toTreasury) = managerInstance.calculateTVL(validatorId, 0 ether);
     }
 
-    function test_postSlashingWithdrawal() public {
-        uint256 validator1 = depositAndRegisterValidator(true);
+    // exit flow
+    /// Full Flow of the full withdrawal for a validator
+    //  1. validator is exited & fund is withdrawn from the beacon chain
+    //  2. perform `EigenPod.startCheckpoint()`
+    //  3. perform `EigenPod.verifyCheckpointProofs()`
+    //  4. perform `EtherFiNodesManager.processNodeExit` which calls `DelegationManager.queueWithdrawals`
+    //  5. wait for 'minWithdrawalDelayBlocks' (= 7 days) delay to be passed
+    //  6. perform `EtherFiNodesManager.completeQueuedWithdrawals` which calls `DelegationManager.completeQueuedWithdrawal`
+    //  7. Finally, perform `EtherFiNodesManager.fullWithdraw`
 
-        // set etherfinodesmanager.eigenpodManager
+    function test_postSlashingWithdrawal() public {
+        uint256 validator = depositAndRegisterValidator(true);
+        uint32 exitTimestamp = 5;
+
+        address admin = managerInstance.owner();
+
+        uint256[] memory validators = toArray_u256(validator);
+        uint32[] memory timestamps = toArray_u32(exitTimestamp);
+
+        vm.prank(owner);
+        managerInstance.processNodeExit(validators, timestamps);
+
+
     }
 }
+
+
+
+/*
+library arrayTestHelper {
+    function toArray_u32(uint32 val) external returns (uint32[] memory) {
+        uint32[] memory vals = new uint32[](1);
+        vals[0] = val;
+        return vals;
+    }
+
+   function toArray_u256(uint256 val) external returns (uint256[] memory) {
+        uint256[] memory vals = new uint256[](1);
+        vals[0] = val;
+        return vals;
+    }
+
+}
+*/

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -2401,14 +2401,26 @@ contract EtherFiNodeTest is TestSetup, ArrayTestHelper {
     //  7. Finally, perform `EtherFiNodesManager.fullWithdraw`
 
     function test_postSlashingWithdrawal() public {
-        uint256 validator = depositAndRegisterValidator(true);
-        uint32 exitTimestamp = 5;
-
         address admin = managerInstance.owner();
+        uint256 validator = depositAndRegisterValidator(true);
+        uint32 exitTimestamp = 5; // arbitrary
 
         uint256[] memory validators = toArray_u256(validator);
         uint32[] memory timestamps = toArray_u32(exitTimestamp);
 
+        address eigenPod = managerInstance.getEigenPod(validator);
+
+        /*
+        // simulate multiple validators tied to this pod
+        MockEigenPod mockPod = MockEigenPod(managerInstance.getEigenPod(validator));
+        mockPod.mockSet_activeValidatorCount(0);
+        */
+
+        // able to withdraw 32 non-slashed ether
+        MockDelegationManager delegationManager = MockDelegationManager(address(managerInstance.delegationManager()));
+        delegationManager.mockSet_withdrawableShares(eigenPod, delegationManager.beaconChainETHStrategy(), 32 ether, 32 ether);
+
+        // exit the validator
         vm.prank(owner);
         managerInstance.processNodeExit(validators, timestamps);
 

--- a/test/EtherFiNode.t.sol
+++ b/test/EtherFiNode.t.sol
@@ -7,38 +7,9 @@ import "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "../src/eigenlayer-interfaces/IEigenPodManager.sol";
 import "../src/eigenlayer-interfaces/IDelayedWithdrawalRouter.sol";
+import "../test/ArrayTestHelper.sol";
 
 import "forge-std/console2.sol";
-
-contract ArrayTestHelper {
-    // Common types used throughout our and eigenlayers protocol
-    function toArray_u256(uint256 val) public returns (uint256[] memory) {
-        uint256[] memory vals = new uint256[](1);
-        vals[0] = val;
-        return vals;
-    }
-    function toArray_u256(uint32 val) public returns (uint256[] memory) {
-        uint256[] memory vals = new uint256[](1);
-        vals[0] = val;
-        return vals;
-    }
-    function toArray_u32(uint32 val) public returns (uint32[] memory) {
-        uint32[] memory vals = new uint32[](1);
-        vals[0] = val;
-        return vals;
-    }
-    function toArray_u40(uint40 val) public returns (uint40[] memory) {
-        uint40[] memory vals = new uint40[](1);
-        vals[0] = val;
-        return vals;
-    }
-    function toArray(IDelegationManager.Withdrawal memory withdrawal) public returns (IDelegationManager.Withdrawal[] memory) {
-        IDelegationManager.Withdrawal[] memory vals = new IDelegationManager.Withdrawal[](1);
-        vals[0] = withdrawal;
-        return vals;
-    }
-}
-
 
 contract EtherFiNodeTest is TestSetup, ArrayTestHelper {
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -9,6 +9,7 @@ import "../src/eigenlayer-interfaces/IEigenPodManager.sol";
 import "../src/eigenlayer-interfaces/IBeaconChainOracle.sol";
 import "../src/eigenlayer-interfaces/IDelegationManager.sol";
 import "./eigenlayer-mocks/BeaconChainOracleMock.sol";
+import "./eigenlayer-mocks/MockEigenPodManager.sol";
 import "../src/eigenlayer-interfaces/ITimelock.sol";
 
 import "../src/interfaces/IStakingManager.sol";
@@ -579,6 +580,8 @@ contract TestSetup is Test, ContractCodeChecker {
         etherFiRestakerImplementation = new EtherFiRestaker(address(0));
         etherFiRestakerProxy = new UUPSProxy(address(etherFiRestakerImplementation), "");
         etherFiRestakerInstance = EtherFiRestaker(payable(etherFiRestakerProxy));
+
+        eigenLayerEigenPodManager = new MockEigenPodManager();
 
         liquidityPoolInstance.initialize(address(eETHInstance), address(stakingManagerInstance), address(etherFiNodeManagerProxy), address(membershipManagerInstance), address(TNFTInstance), address(etherFiAdminProxy), address(withdrawRequestNFTInstance));
         membershipNftInstance.initialize("https://etherfi-cdn/{id}.json", address(membershipManagerInstance));

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -10,6 +10,7 @@ import "../src/eigenlayer-interfaces/IBeaconChainOracle.sol";
 import "../src/eigenlayer-interfaces/IDelegationManager.sol";
 import "./eigenlayer-mocks/BeaconChainOracleMock.sol";
 import "./eigenlayer-mocks/MockEigenPodManager.sol";
+import "./eigenlayer-mocks/MockDelegationManager.sol";
 import "../src/eigenlayer-interfaces/ITimelock.sol";
 
 import "../src/interfaces/IStakingManager.sol";
@@ -582,6 +583,7 @@ contract TestSetup is Test, ContractCodeChecker {
         etherFiRestakerInstance = EtherFiRestaker(payable(etherFiRestakerProxy));
 
         eigenLayerEigenPodManager = new MockEigenPodManager();
+        eigenLayerDelegationManager = new MockDelegationManager();
 
         liquidityPoolInstance.initialize(address(eETHInstance), address(stakingManagerInstance), address(etherFiNodeManagerProxy), address(membershipManagerInstance), address(TNFTInstance), address(etherFiAdminProxy), address(withdrawRequestNFTInstance));
         membershipNftInstance.initialize("https://etherfi-cdn/{id}.json", address(membershipManagerInstance));

--- a/test/eigenlayer-mocks/DelegationManagerMock.sol
+++ b/test/eigenlayer-mocks/DelegationManagerMock.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 import "src/eigenlayer-interfaces/IDelegationManager.sol";
 import "src/eigenlayer-interfaces/IStrategyManager.sol";
 import "src/eigenlayer-libraries/SlashingLib.sol";
+import "src/eigenlayer-interfaces/IStrategy.sol";
 
 contract DelegationManagerMock is Test {
     receive() external payable {}
@@ -24,6 +25,7 @@ contract DelegationManagerMock is Test {
     function setIsOperator(address operator, bool _isOperatorReturnValue) external {
         isOperator[operator] = _isOperatorReturnValue;
     }
+
 
     function burnOperatorShares(
         address operator,

--- a/test/eigenlayer-mocks/MockDelegationManager.sol
+++ b/test/eigenlayer-mocks/MockDelegationManager.sol
@@ -6,6 +6,8 @@ import "test/eigenlayer-mocks/MockStrategy.sol";
 import "forge-std/Test.sol";
 import "forge-std/console2.sol";
 
+
+// See MockDelegationManager contract below this contract for testing overrides
 contract MockDelegationManagerBase is IDelegationManager, Test {
 
      /**

--- a/test/eigenlayer-mocks/MockDelegationManager.sol
+++ b/test/eigenlayer-mocks/MockDelegationManager.sol
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/eigenlayer-interfaces/IDelegationManager.sol";
+
+contract MockDelegationManagerBase is IDelegationManager {
+
+        /**
+     * @dev Initializes the initial owner and paused status.
+     */
+    function initialize(address initialOwner, uint256 initialPausedStatus) external {}
+
+    /**
+     * @notice Registers the caller as an operator in EigenLayer.
+     * @param initDelegationApprover is an address that, if set, must provide a signature when stakers delegate
+     * to an operator.
+     * @param allocationDelay The delay before allocations take effect.
+     * @param metadataURI is a URI for the operator's metadata, i.e. a link providing more details on the operator.
+     *
+     * @dev Once an operator is registered, they cannot 'deregister' as an operator, and they will forever be considered "delegated to themself".
+     * @dev This function will revert if the caller is already delegated to an operator.
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `OperatorMetadataURIUpdated` event
+     */
+    function registerAsOperator(
+        address initDelegationApprover,
+        uint32 allocationDelay,
+        string calldata metadataURI
+    ) external {}
+
+    /**
+     * @notice Updates an operator's stored `delegationApprover`.
+     * @param operator is the operator to update the delegationApprover for
+     * @param newDelegationApprover is the new delegationApprover for the operator
+     *
+     * @dev The caller must have previously registered as an operator in EigenLayer.
+     */
+    function modifyOperatorDetails(address operator, address newDelegationApprover) external {}
+
+    /**
+     * @notice Called by an operator to emit an `OperatorMetadataURIUpdated` event indicating the information has updated.
+     * @param operator The operator to update metadata for
+     * @param metadataURI The URI for metadata associated with an operator
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `OperatorMetadataURIUpdated` event
+     */
+    function updateOperatorMetadataURI(address operator, string calldata metadataURI) external {}
+
+    /**
+     * @notice Caller delegates their stake to an operator.
+     * @param operator The account (`msg.sender`) is delegating its assets to for use in serving applications built on EigenLayer.
+     * @param approverSignatureAndExpiry Verifies the operator approves of this delegation
+     * @param approverSalt A unique single use value tied to an individual signature.
+     * @dev The approverSignatureAndExpiry is used in the event that the operator's `delegationApprover` address is set to a non-zero value.
+     * @dev In the event that `approverSignatureAndExpiry` is not checked, its content is ignored entirely {} it's recommended to use an empty input
+     * in this case to save on complexity + gas costs
+     * @dev If the staker delegating has shares in a strategy that the operator was slashed 100% for (the operator's maxMagnitude = 0),
+     * then delegation is blocked and will revert.
+     */
+    function delegateTo(
+        address operator,
+        SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 approverSalt
+    ) external {}
+
+    /**
+     * @notice Undelegates the staker from the operator who they are delegated to.
+     * Queues withdrawals of all of the staker's withdrawable shares in the StrategyManager (to the staker) and/or EigenPodManager, if necessary.
+     * @param staker The account to be undelegated.
+     * @return withdrawalRoots The roots of the newly queued withdrawals, if a withdrawal was queued. Otherwise just bytes32(0).
+     *
+     * @dev Reverts if the `staker` is also an operator, since operators are not allowed to undelegate from themselves.
+     * @dev Reverts if the caller is not the staker, nor the operator who the staker is delegated to, nor the operator's specified "delegationApprover"
+     * @dev Reverts if the `staker` is already undelegated.
+     */
+    function undelegate(
+        address staker
+    ) external returns (bytes32[] memory withdrawalRoots) {}
+
+    /**
+     * @notice Undelegates the staker from their current operator, and redelegates to `newOperator`
+     * Queues a withdrawal for all of the staker's withdrawable shares. These shares will only be
+     * delegated to `newOperator` AFTER the withdrawal is completed.
+     * @dev This method acts like a call to `undelegate`, then `delegateTo`
+     * @param newOperator the new operator that will be delegated all assets
+     * @dev NOTE: the following 2 params are ONLY checked if `newOperator` has a `delegationApprover`.
+     * If not, they can be left empty.
+     * @param newOperatorApproverSig A signature from the operator's `delegationApprover`
+     * @param approverSalt A unique single use value tied to the approver's signature
+     */
+    function redelegate(
+        address newOperator,
+        SignatureWithExpiry memory newOperatorApproverSig,
+        bytes32 approverSalt
+    ) external returns (bytes32[] memory withdrawalRoots) {}
+
+    /**
+     * @notice Allows a staker to withdraw some shares. Withdrawn shares/strategies are immediately removed
+     * from the staker. If the staker is delegated, withdrawn shares/strategies are also removed from
+     * their operator.
+     *
+     * All withdrawn shares/strategies are placed in a queue and can be withdrawn after a delay. Withdrawals
+     * are still subject to slashing during the delay period so the amount withdrawn on completion may actually be less
+     * than what was queued if slashing has occurred in that period.
+     *
+     * @dev To view what the staker is able to queue withdraw, see `getWithdrawableShares()`
+     */
+    function queueWithdrawals(
+        QueuedWithdrawalParams[] calldata params
+    ) external returns (bytes32[] memory) {}
+
+    /**
+     * @notice Used to complete the lastest queued withdrawal.
+     * @param withdrawal The withdrawal to complete.
+     * @param tokens Array in which the i-th entry specifies the `token` input to the 'withdraw' function of the i-th Strategy in the `withdrawal.strategies` array.
+     * @param receiveAsTokens If true, the shares calculated to be withdrawn will be withdrawn from the specified strategies themselves
+     * and sent to the caller, through calls to `withdrawal.strategies[i].withdraw`. If false, then the shares in the specified strategies
+     * will simply be transferred to the caller directly.
+     * @dev beaconChainETHStrategy shares are non-transferrable, so if `receiveAsTokens = false` and `withdrawal.withdrawer != withdrawal.staker`, note that
+     * any beaconChainETHStrategy shares in the `withdrawal` will be _returned to the staker_, rather than transferred to the withdrawer, unlike shares in
+     * any other strategies, which will be transferred to the withdrawer.
+     */
+    function completeQueuedWithdrawal(
+        Withdrawal calldata withdrawal,
+        IERC20[] calldata tokens,
+        bool receiveAsTokens
+    ) external {}
+
+    /**
+     * @notice Used to complete the all queued withdrawals.
+     * Used to complete the specified `withdrawals`. The function caller must match `withdrawals[...].withdrawer`
+     * @param withdrawals Array of Withdrawals to complete. See `completeQueuedWithdrawal` for the usage of a single Withdrawal.
+     * @param tokens Array of tokens for each Withdrawal. See `completeQueuedWithdrawal` for the usage of a single array.
+     * @param receiveAsTokens Whether or not to complete each withdrawal as tokens. See `completeQueuedWithdrawal` for the usage of a single boolean.
+     * @dev See `completeQueuedWithdrawal` for relevant dev tags
+     */
+    function completeQueuedWithdrawals(
+        Withdrawal[] calldata withdrawals,
+        IERC20[][] calldata tokens,
+        bool[] calldata receiveAsTokens
+    ) external {}
+
+    /**
+     * @notice Increases a staker's delegated share balance in a strategy. Note that before adding to operator shares,
+     * the delegated delegatedShares. The staker's depositScalingFactor is updated here.
+     * @param staker The address to increase the delegated shares for their operator.
+     * @param strategy The strategy in which to increase the delegated shares.
+     * @param prevDepositShares The number of deposit shares the staker already had in the strategy. This is the shares amount stored in the
+     * StrategyManager/EigenPodManager for the staker's shares.
+     * @param addedShares The number of shares added to the staker's shares in the strategy
+     *
+     * @dev *If the staker is actively delegated*, then increases the `staker`'s delegated delegatedShares in `strategy`.
+     * Otherwise does nothing.
+     * @dev If the operator was slashed 100% for the strategy (the operator's maxMagnitude = 0), then increasing delegated shares is blocked and will revert.
+     * @dev Callable only by the StrategyManager or EigenPodManager.
+     */
+    function increaseDelegatedShares(
+        address staker,
+        IStrategy strategy,
+        uint256 prevDepositShares,
+        uint256 addedShares
+    ) external {}
+
+    /**
+     * @notice If the staker is delegated, decreases its operator's shares in response to
+     * a decrease in balance in the beaconChainETHStrategy
+     * @param staker the staker whose operator's balance will be decreased
+     * @param curDepositShares the current deposit shares held by the staker
+     * @param beaconChainSlashingFactorDecrease the amount that the staker's beaconChainSlashingFactor has decreased by
+     * @dev Note: `beaconChainSlashingFactorDecrease` are assumed to ALWAYS be < 1 WAD.
+     * These invariants are maintained in the EigenPodManager.
+     */
+    function decreaseDelegatedShares(
+        address staker,
+        uint256 curDepositShares,
+        uint64 beaconChainSlashingFactorDecrease
+    ) external {}
+
+    /**
+     * @notice Decreases the operators shares in storage after a slash and burns the corresponding Strategy shares
+     * by calling into the StrategyManager or EigenPodManager to burn the shares.
+     * @param operator The operator to decrease shares for
+     * @param strategy The strategy to decrease shares for
+     * @param prevMaxMagnitude the previous maxMagnitude of the operator
+     * @param newMaxMagnitude the new maxMagnitude of the operator
+     * @dev Callable only by the AllocationManager
+     * @dev Note: Assumes `prevMaxMagnitude <= newMaxMagnitude`. This invariant is maintained in
+     * the AllocationManager.
+     */
+    function burnOperatorShares(
+        address operator,
+        IStrategy strategy,
+        uint64 prevMaxMagnitude,
+        uint64 newMaxMagnitude
+    ) external {}
+
+    /**
+     *
+     *                         VIEW FUNCTIONS
+     *
+     */
+
+    /**
+     * @notice returns the address of the operator that `staker` is delegated to.
+     * @notice Mapping: staker => operator whom the staker is currently delegated to.
+     * @dev Note that returning address(0) indicates that the staker is not actively delegated to any operator.
+     */
+    function delegatedTo(
+        address staker
+    ) external view returns (address) {}
+
+    /**
+     * @notice Mapping: delegationApprover => 32-byte salt => whether or not the salt has already been used by the delegationApprover.
+     * @dev Salts are used in the `delegateTo` function. Note that this function only processes the delegationApprover's
+     * signature + the provided salt if the operator being delegated to has specified a nonzero address as their `delegationApprover`.
+     */
+    function delegationApproverSaltIsSpent(address _delegationApprover, bytes32 salt) external view returns (bool) {}
+
+    /// @notice Mapping: staker => cumulative number of queued withdrawals they have ever initiated.
+    /// @dev This only increments (doesn't decrement), and is used to help ensure that otherwise identical withdrawals have unique hashes.
+    function cumulativeWithdrawalsQueued(
+        address staker
+    ) external view returns (uint256) {}
+
+    /**
+     * @notice Returns 'true' if `staker` *is* actively delegated, and 'false' otherwise.
+     */
+    function isDelegated(
+        address staker
+    ) external view returns (bool) {}
+
+    /**
+     * @notice Returns true is an operator has previously registered for delegation.
+     */
+    function isOperator(
+        address operator
+    ) external view returns (bool) {}
+
+    /**
+     * @notice Returns the delegationApprover account for an operator
+     */
+    function delegationApprover(
+        address operator
+    ) external view returns (address) {}
+
+    /**
+     * @notice Returns the shares that an operator has delegated to them in a set of strategies
+     * @param operator the operator to get shares for
+     * @param strategies the strategies to get shares for
+     */
+    function getOperatorShares(
+        address operator,
+        IStrategy[] memory strategies
+    ) external view returns (uint256[] memory) {}
+
+    /**
+     * @notice Returns the shares that a set of operators have delegated to them in a set of strategies
+     * @param operators the operators to get shares for
+     * @param strategies the strategies to get shares for
+     */
+    function getOperatorsShares(
+        address[] memory operators,
+        IStrategy[] memory strategies
+    ) external view returns (uint256[][] memory) {}
+
+    /**
+     * @notice Returns amount of withdrawable shares from an operator for a strategy that is still in the queue
+     * and therefore slashable. Note that the *actual* slashable amount could be less than this value as this doesn't account
+     * for amounts that have already been slashed. This assumes that none of the shares have been slashed.
+     * @param operator the operator to get shares for
+     * @param strategy the strategy to get shares for
+     * @return the amount of shares that are slashable in the withdrawal queue for an operator and a strategy
+     */
+    function getSlashableSharesInQueue(address operator, IStrategy strategy) external view returns (uint256) {}
+
+    /**
+     * @notice Given a staker and a set of strategies, return the shares they can queue for withdrawal and the
+     * corresponding depositShares.
+     * This value depends on which operator the staker is delegated to.
+     * The shares amount returned is the actual amount of Strategy shares the staker would receive (subject
+     * to each strategy's underlying shares to token ratio).
+     */
+    function getWithdrawableShares(
+        address staker,
+        IStrategy[] memory strategies
+    ) external view returns (uint256[] memory withdrawableShares, uint256[] memory depositShares) {}
+
+    /**
+     * @notice Returns the number of shares in storage for a staker and all their strategies
+     */
+    function getDepositedShares(
+        address staker
+    ) external view returns (IStrategy[] memory, uint256[] memory) {}
+
+    /**
+     * @notice Returns the scaling factor applied to a staker's deposits for a given strategy
+     */
+    function depositScalingFactor(address staker, IStrategy strategy) external view returns (uint256) {}
+
+    /// @notice Returns a list of pending queued withdrawals for a `staker`, and the `shares` to be withdrawn.
+    function getQueuedWithdrawals(
+        address staker
+    ) external view returns (Withdrawal[] memory withdrawals, uint256[][] memory shares) {}
+
+    /**
+     * @notice Converts shares for a set of strategies to deposit shares, likely in order to input into `queueWithdrawals`
+     * @param staker the staker to convert shares for
+     * @param strategies the strategies to convert shares for
+     * @param withdrawableShares the shares to convert
+     * @return the deposit shares
+     * @dev will be a few wei off due to rounding errors
+     */
+    function convertToDepositShares(
+        address staker,
+        IStrategy[] memory strategies,
+        uint256[] memory withdrawableShares
+    ) external view returns (uint256[] memory) {}
+
+    /// @notice Returns the keccak256 hash of `withdrawal`.
+    function calculateWithdrawalRoot(
+        Withdrawal memory withdrawal
+    ) external pure returns (bytes32) {}
+
+    /**
+     * @notice Calculates the digest hash to be signed by the operator's delegationApprove and used in the `delegateTo` function.
+     * @param staker The account delegating their stake
+     * @param operator The account receiving delegated stake
+     * @param _delegationApprover the operator's `delegationApprover` who will be signing the delegationHash (in general)
+     * @param approverSalt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid
+     */
+    function calculateDelegationApprovalDigestHash(
+        address staker,
+        address operator,
+        address _delegationApprover,
+        bytes32 approverSalt,
+        uint256 expiry
+    ) external view returns (bytes32) {}
+
+    /// @notice return address of the beaconChainETHStrategy
+    function beaconChainETHStrategy() external view returns (IStrategy) {}
+
+    /**
+     * @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.
+     * Also applies to legacy withdrawals so any withdrawals not completed prior to the slashing upgrade will be subject
+     * to this longer delay.
+     * @dev Backwards-compatible interface to return the internal `MIN_WITHDRAWAL_DELAY_BLOCKS` value
+     * @dev Previous value in storage was deprecated. See `__deprecated_minWithdrawalDelayBlocks`
+     */
+    function minWithdrawalDelayBlocks() external view returns (uint32) {}
+
+    /// @notice The EIP-712 typehash for the DelegationApproval struct used by the contract
+    function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32) {}
+
+}
+
+contract MockDelegationManager is MockDelegationManagerBase {
+
+    mapping(address => mapping(IStrategy => uint256)) public mock_withdrawableShares;
+    mapping(address => mapping(IStrategy => uint256)) public mock_depositShares;
+    function mockSet_withdrawableShares(address staker, IStrategy strategy, uint256 withdrawableShares, uint256 depositShares) external {
+        mock_withdrawableShares[staker][strategy] = withdrawableShares;
+        mock_depositShares[staker][strategy] = depositShares;
+    }
+
+
+}

--- a/test/eigenlayer-mocks/MockDelegationManager.sol
+++ b/test/eigenlayer-mocks/MockDelegationManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.27;
 
 import "src/eigenlayer-interfaces/IDelegationManager.sol";
+import "test/eigenlayer-mocks/MockStrategy.sol";
 
 contract MockDelegationManagerBase is IDelegationManager {
 
@@ -105,7 +106,7 @@ contract MockDelegationManagerBase is IDelegationManager {
      */
     function queueWithdrawals(
         QueuedWithdrawalParams[] calldata params
-    ) external returns (bytes32[] memory) {}
+    ) external virtual returns (bytes32[] memory) {}
 
     /**
      * @notice Used to complete the lastest queued withdrawal.
@@ -281,7 +282,7 @@ contract MockDelegationManagerBase is IDelegationManager {
     function getWithdrawableShares(
         address staker,
         IStrategy[] memory strategies
-    ) external view returns (uint256[] memory withdrawableShares, uint256[] memory depositShares) {}
+    ) external virtual view returns (uint256[] memory withdrawableShares, uint256[] memory depositShares) {}
 
     /**
      * @notice Returns the number of shares in storage for a staker and all their strategies
@@ -336,7 +337,7 @@ contract MockDelegationManagerBase is IDelegationManager {
     ) external view returns (bytes32) {}
 
     /// @notice return address of the beaconChainETHStrategy
-    function beaconChainETHStrategy() external view returns (IStrategy) {}
+    function beaconChainETHStrategy() external virtual view returns (IStrategy) {}
 
     /**
      * @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.
@@ -354,12 +355,45 @@ contract MockDelegationManagerBase is IDelegationManager {
 
 contract MockDelegationManager is MockDelegationManagerBase {
 
+    constructor() {
+        mock_beaconChainETHStrategy = new MockStrategy();
+    }
+
+    //************************************************************
+    // beaconChainETHStrategy()
+    //************************************************************
+    IStrategy mock_beaconChainETHStrategy;
+    function beaconChainETHStrategy() external view override returns (IStrategy) {
+        return mock_beaconChainETHStrategy;
+    }
+
+    //************************************************************
+    // withdrawableShares()
+    //************************************************************
     mapping(address => mapping(IStrategy => uint256)) public mock_withdrawableShares;
     mapping(address => mapping(IStrategy => uint256)) public mock_depositShares;
     function mockSet_withdrawableShares(address staker, IStrategy strategy, uint256 withdrawableShares, uint256 depositShares) external {
         mock_withdrawableShares[staker][strategy] = withdrawableShares;
         mock_depositShares[staker][strategy] = depositShares;
     }
+    function getWithdrawableShares(address staker, IStrategy[] memory strategies) external override view returns (uint256[] memory withdrawableShares, uint256[] memory depositShares) {
+        withdrawableShares = new uint256[](strategies.length);
+        depositShares = new uint256[](strategies.length);
+        for (uint256 i; i < strategies.length; i++) {
+            withdrawableShares[i] = mock_withdrawableShares[staker][strategies[i]];
+            depositShares[i] = mock_depositShares[staker][strategies[i]];
+        }
+    }
+
+    //************************************************************
+    // queueWithdrawals()
+    //************************************************************
+    function queueWithdrawals(QueuedWithdrawalParams[] calldata params) external override returns (bytes32[] memory) {
+        bytes32[] memory withdrawalRoots = new bytes32[](params.length);
+        return withdrawalRoots;
+    }
+
+
 
 
 }

--- a/test/eigenlayer-mocks/MockDelegationManager.sol
+++ b/test/eigenlayer-mocks/MockDelegationManager.sol
@@ -361,6 +361,7 @@ contract MockDelegationManager is MockDelegationManagerBase {
         mock_beaconChainETHStrategy = new MockStrategy();
     }
 
+    // OVERRIDES
 
     //************************************************************
     // beaconChainETHStrategy()

--- a/test/eigenlayer-mocks/MockEigenPod.sol
+++ b/test/eigenlayer-mocks/MockEigenPod.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 import "forge-std/Test.sol";
 import "src/eigenlayer-interfaces/IEigenPod.sol";
 
-contract EigenPodMock is IEigenPod, Test {
+contract MockEigenPod is IEigenPod, Test {
 
     function nonBeaconChainETHBalanceWei() external view returns(uint256) {}
 

--- a/test/eigenlayer-mocks/MockEigenPod.sol
+++ b/test/eigenlayer-mocks/MockEigenPod.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.9;
 import "forge-std/Test.sol";
 import "src/eigenlayer-interfaces/IEigenPod.sol";
 
+// See MockEigenPod contract below this contract for testing overrides
 contract MockEigenPodBase is IEigenPod, Test {
 
     function nonBeaconChainETHBalanceWei() external view returns(uint256) {}
@@ -107,8 +108,12 @@ contract MockEigenPodBase is IEigenPod, Test {
 
 contract MockEigenPod is MockEigenPodBase {
 
+    // OVERRIDES
+
+    //************************************************************
+    // activeValidatorCount()
+    //************************************************************
     function activeValidatorCount() external override view returns (uint256) { return mock_activeValidatorCount; }
     uint256 public mock_activeValidatorCount;
     function mockSet_activeValidatorCount(uint256 count) public { mock_activeValidatorCount = count; }
-
 }

--- a/test/eigenlayer-mocks/MockEigenPod.sol
+++ b/test/eigenlayer-mocks/MockEigenPod.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 import "forge-std/Test.sol";
 import "src/eigenlayer-interfaces/IEigenPod.sol";
 
-contract MockEigenPod is IEigenPod, Test {
+contract MockEigenPodBase is IEigenPod, Test {
 
     function nonBeaconChainETHBalanceWei() external view returns(uint256) {}
 
@@ -44,7 +44,7 @@ contract MockEigenPod is IEigenPod, Test {
     function validatorStatus(bytes32 pubkeyHash) external view returns(VALIDATOR_STATUS) {}
 
     /// @notice Number of validators with proven withdrawal credentials, who do not have proven full withdrawals
-    function activeValidatorCount() external view returns (uint256) {}
+    function activeValidatorCount() external virtual view returns (uint256) {}
 
     /// @notice The timestamp of the last checkpoint finalized
     function lastCheckpointTimestamp() external view returns (uint64) {}
@@ -102,4 +102,13 @@ contract MockEigenPod is IEigenPod, Test {
     /// to an existing slot within the last 24 hours. If the slot at `timestamp` was skipped, this method
     /// will revert.
     function getParentBlockRoot(uint64 timestamp) external view returns (bytes32) {}
+}
+
+
+contract MockEigenPod is MockEigenPodBase {
+
+    function activeValidatorCount() external override view returns (uint256) { return mock_activeValidatorCount; }
+    uint256 public mock_activeValidatorCount;
+    function mockSet_activeValidatorCount(uint256 count) public { mock_activeValidatorCount = count; }
+
 }

--- a/test/eigenlayer-mocks/MockEigenPodManager.sol
+++ b/test/eigenlayer-mocks/MockEigenPodManager.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/eigenlayer-interfaces/IEigenPodManager.sol";
+import "../../test/eigenlayer-mocks/MockEigenPod.sol";
+
+contract MockEigenPodManagerBase is IEigenPodManager {
+        /**
+     * @notice Creates an EigenPod for the sender.
+     * @dev Function will revert if the `msg.sender` already has an EigenPod.
+     * @dev Returns EigenPod address
+     */
+    function createPod() external virtual returns (address) {}
+
+    /**
+     * @notice Stakes for a new beacon chain validator on the sender's EigenPod.
+     * Also creates an EigenPod for the sender if they don't have one already.
+     * @param pubkey The 48 bytes public key of the beacon chain validator.
+     * @param signature The validator's signature of the deposit data.
+     * @param depositDataRoot The root/hash of the deposit data for the validator's deposit.
+     */
+    function stake(bytes calldata pubkey, bytes calldata signature, bytes32 depositDataRoot) external payable {}
+
+    /**
+     * @notice Changes the `podOwner`'s shares by `sharesDelta` and performs a call to the DelegationManager
+     * to ensure that delegated shares are also tracked correctly
+     * @param podOwner is the pod owner whose balance is being updated.
+     * @param prevRestakedBalanceWei is the total amount restaked through the pod before the balance update
+     * @param balanceDeltaWei is the amount the balance changed
+     * @dev Callable only by the podOwner's EigenPod contract.
+     * @dev Reverts if `sharesDelta` is not a whole Gwei amount
+     */
+    function recordBeaconChainETHBalanceUpdate(
+        address podOwner,
+        uint256 prevRestakedBalanceWei,
+        int256 balanceDeltaWei
+    ) external {}
+
+    /// @notice Returns the address of the `podOwner`'s EigenPod if it has been deployed.
+    function ownerToPod(
+        address podOwner
+    ) external view returns (IEigenPod) {}
+
+    /// @notice Returns the address of the `podOwner`'s EigenPod (whether it is deployed yet or not).
+    function getPod(
+        address podOwner
+    ) external view returns (IEigenPod) {}
+
+    /// @notice The ETH2 Deposit Contract
+    function ethPOS() external view returns (IETHPOSDeposit) {}
+
+    /// @notice Beacon proxy to which the EigenPods point
+    function eigenPodBeacon() external view returns (IBeacon) {}
+
+    /// @notice Returns 'true' if the `podOwner` has created an EigenPod, and 'false' otherwise.
+    function hasPod(
+        address podOwner
+    ) external view returns (bool) {}
+
+    /// @notice Returns the number of EigenPods that have been created
+    function numPods() external view returns (uint256) {}
+
+    /**
+     * @notice Mapping from Pod owner owner to the number of shares they have in the virtual beacon chain ETH strategy.
+     * @dev The share amount can become negative. This is necessary to accommodate the fact that a pod owner's virtual beacon chain ETH shares can
+     * decrease between the pod owner queuing and completing a withdrawal.
+     * When the pod owner's shares would otherwise increase, this "deficit" is decreased first _instead_.
+     * Likewise, when a withdrawal is completed, this "deficit" is decreased and the withdrawal amount is decreased {} We can think of this
+     * as the withdrawal "paying off the deficit".
+     */
+    function podOwnerDepositShares(
+        address podOwner
+    ) external view returns (int256) {}
+
+    /// @notice returns canonical, virtual beaconChainETH strategy
+    function beaconChainETHStrategy() external view returns (IStrategy) {}
+
+    /**
+     * @notice Returns the historical sum of proportional balance decreases a pod owner has experienced when
+     * updating their pod's balance.
+     */
+    function beaconChainSlashingFactor(
+        address staker
+    ) external view returns (uint64) {}
+
+        /// @notice Address of the `PauserRegistry` contract that this contract defers to for determining access control (for pausing).
+    function pauserRegistry() external view returns (IPauserRegistry) {}
+
+    /**
+     * @notice This function is used to pause an EigenLayer contract's functionality.
+     * It is permissioned to the `pauser` address, which is expected to be a low threshold multisig.
+     * @param newPausedStatus represents the new value for `_paused` to take, which means it may flip several bits at once.
+     * @dev This function can only pause functionality, and thus cannot 'unflip' any bit in `_paused` from 1 to 0.
+     */
+    function pause(
+        uint256 newPausedStatus
+    ) external {}
+
+    /**
+     * @notice Alias for `pause(type(uint256).max)`.
+     */
+    function pauseAll() external {}
+
+    /**
+     * @notice This function is used to unpause an EigenLayer contract's functionality.
+     * It is permissioned to the `unpauser` address, which is expected to be a high threshold multisig or governance contract.
+     * @param newPausedStatus represents the new value for `_paused` to take, which means it may flip several bits at once.
+     * @dev This function can only unpause functionality, and thus cannot 'flip' any bit in `_paused` from 0 to 1.
+     */
+    function unpause(
+        uint256 newPausedStatus
+    ) external {}
+
+    /// @notice Returns the current paused status as a uint256.
+    function paused() external view returns (uint256) {}
+
+    /// @notice Returns 'true' if the `indexed`th bit of `_paused` is 1, and 'false' otherwise
+    function paused(
+        uint8 index
+    ) external view returns (bool) {}
+
+        /// @notice Used by the DelegationManager to remove a Staker's shares from a particular strategy when entering the withdrawal queue
+    /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
+    function removeDepositShares(address staker, IStrategy strategy, uint256 depositSharesToRemove) external {}
+
+    /// @notice Used by the DelegationManager to award a Staker some shares that have passed through the withdrawal queue
+    /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
+    /// @dev token is not validated when talking to the EigenPodManager
+    /// @return existingDepositShares the shares the staker had before any were added
+    /// @return addedShares the new shares added to the staker's balance
+    function addShares(
+        address staker,
+        IStrategy strategy,
+        IERC20 token,
+        uint256 shares
+    ) external returns (uint256, uint256) {}
+
+    /// @notice Used by the DelegationManager to convert withdrawn descaled shares to tokens and send them to a staker
+    /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
+    /// @dev token is not validated when talking to the EigenPodManager
+    function withdrawSharesAsTokens(address staker, IStrategy strategy, IERC20 token, uint256 shares) external {}
+
+    /// @notice Returns the current shares of `user` in `strategy`
+    /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
+    /// @dev returns 0 if the user has negative shares
+    function stakerDepositShares(address user, IStrategy strategy) external view returns (uint256 depositShares) {}
+}
+
+contract MockEigenPodManager is MockEigenPodManagerBase {
+
+    function createPod() external override returns (address) {
+        return address(new MockEigenPod());
+    }
+}

--- a/test/eigenlayer-mocks/MockStrategy.sol
+++ b/test/eigenlayer-mocks/MockStrategy.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.27;
 
 import "src/eigenlayer-interfaces/IStrategy.sol";
 
+// See MockStrategy contract below this contract for testing overrides
 contract MockStrategyBase is IStrategy {
 
      /**

--- a/test/eigenlayer-mocks/MockStrategy.sol
+++ b/test/eigenlayer-mocks/MockStrategy.sol
@@ -46,7 +46,7 @@ contract MockStrategyBase is IStrategy {
      */
     function underlyingToShares(
         uint256 amountUnderlying
-    ) external returns (uint256) {}
+    ) external virtual returns (uint256) {}
 
     /**
      * @notice convenience function for fetching the current underlying value of all of the `user`'s shares in
@@ -106,12 +106,23 @@ contract MockStrategyBase is IStrategy {
 
 contract MockStrategy is MockStrategyBase {
 
-    //*****************************************************
-    //*                   OVERRIDES                       *
-    //*****************************************************
+    // OVERRIDES
+
+    //************************************************************
+    // sharesToUnderlying()
+    //************************************************************
     uint256 internal mock_sharesToUnderlying;
     function mockSet_sharesToUnderlying(uint256 underlying) public { mock_sharesToUnderlying = underlying; }
     function sharesToUnderlying(uint256) external override view returns (uint256) {
         return mock_sharesToUnderlying;
+    }
+
+
+    //************************************************************
+    // underlyingToShares()
+    //************************************************************
+    function underlyingToShares(uint256 amountUnderlying) external override returns (uint256) {
+        // just return the same amount assuming unslashed beacon eth
+        return amountUnderlying;
     }
 }

--- a/test/eigenlayer-mocks/MockStrategy.sol
+++ b/test/eigenlayer-mocks/MockStrategy.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/eigenlayer-interfaces/IStrategy.sol";
+
+contract MockStrategyBase is IStrategy {
+
+     /**
+     * @notice Used to deposit tokens into this Strategy
+     * @param token is the ERC20 token being deposited
+     * @param amount is the amount of token being deposited
+     * @dev This function is only callable by the strategyManager contract. It is invoked inside of the strategyManager's
+     * `depositIntoStrategy` function, and individual share balances are recorded in the strategyManager as well.
+     * @return newShares is the number of new shares issued at the current exchange ratio.
+     */
+    function deposit(IERC20 token, uint256 amount) external returns (uint256) {}
+
+    /**
+     * @notice Used to withdraw tokens from this Strategy, to the `recipient`'s address
+     * @param recipient is the address to receive the withdrawn funds
+     * @param token is the ERC20 token being transferred out
+     * @param amountShares is the amount of shares being withdrawn
+     * @dev This function is only callable by the strategyManager contract. It is invoked inside of the strategyManager's
+     * other functions, and individual share balances are recorded in the strategyManager as well.
+     */
+    function withdraw(address recipient, IERC20 token, uint256 amountShares) external {}
+
+
+    /**
+     * @notice Used to convert a number of shares to the equivalent amount of underlying tokens for this strategy.
+     * @notice In contrast to `sharesToUnderlyingView`, this function **may** make state modifications
+     * @param amountShares is the amount of shares to calculate its conversion into the underlying token
+     * @return The amount of underlying tokens corresponding to the input `amountShares`
+     * @dev Implementation for these functions in particular may vary significantly for different strategies
+     */
+    function sharesToUnderlying(
+        uint256 amountShares
+    ) external virtual returns (uint256) {}
+
+    /**
+     * @notice Used to convert an amount of underlying tokens to the equivalent amount of shares in this strategy.
+     * @notice In contrast to `underlyingToSharesView`, this function **may** make state modifications
+     * @param amountUnderlying is the amount of `underlyingToken` to calculate its conversion into strategy shares
+     * @return The amount of underlying tokens corresponding to the input `amountShares`
+     * @dev Implementation for these functions in particular may vary significantly for different strategies
+     */
+    function underlyingToShares(
+        uint256 amountUnderlying
+    ) external returns (uint256) {}
+
+    /**
+     * @notice convenience function for fetching the current underlying value of all of the `user`'s shares in
+     * this strategy. In contrast to `userUnderlyingView`, this function **may** make state modifications
+     */
+    function userUnderlying(
+        address user
+    ) external returns (uint256) {}
+
+    /**
+     * @notice convenience function for fetching the current total shares of `user` in this strategy, by
+     * querying the `strategyManager` contract
+     */
+    function shares(
+        address user
+    ) external view returns (uint256) {}
+
+    /**
+     * @notice Used to convert a number of shares to the equivalent amount of underlying tokens for this strategy.
+     * @notice In contrast to `sharesToUnderlying`, this function guarantees no state modifications
+     * @param amountShares is the amount of shares to calculate its conversion into the underlying token
+     * @return The amount of shares corresponding to the input `amountUnderlying`
+     * @dev Implementation for these functions in particular may vary significantly for different strategies
+     */
+    function sharesToUnderlyingView(
+        uint256 amountShares
+    ) external view returns (uint256) {}
+
+    /**
+     * @notice Used to convert an amount of underlying tokens to the equivalent amount of shares in this strategy.
+     * @notice In contrast to `underlyingToShares`, this function guarantees no state modifications
+     * @param amountUnderlying is the amount of `underlyingToken` to calculate its conversion into strategy shares
+     * @return The amount of shares corresponding to the input `amountUnderlying`
+     * @dev Implementation for these functions in particular may vary significantly for different strategies
+     */
+    function underlyingToSharesView(
+        uint256 amountUnderlying
+    ) external view returns (uint256) {}
+
+    /**
+     * @notice convenience function for fetching the current underlying value of all of the `user`'s shares in
+     * this strategy. In contrast to `userUnderlying`, this function guarantees no state modifications
+     */
+    function userUnderlyingView(
+        address user
+    ) external view returns (uint256) {}
+
+    /// @notice The underlying token for shares in this Strategy
+    function underlyingToken() external view returns (IERC20) {}
+
+    /// @notice The total number of extant shares in this Strategy
+    function totalShares() external view returns (uint256) {}
+
+    /// @notice Returns either a brief string explaining the strategy's goal & purpose, or a link to metadata that explains in more detail.
+    function explanation() external view returns (string memory) {}
+}
+
+contract MockStrategy is MockStrategyBase {
+
+    //*****************************************************
+    //*                   OVERRIDES                       *
+    //*****************************************************
+    uint256 internal mock_sharesToUnderlying;
+    function mockSet_sharesToUnderlying(uint256 underlying) public { mock_sharesToUnderlying = underlying; }
+    function sharesToUnderlying(uint256) external override view returns (uint256) {
+        return mock_sharesToUnderlying;
+    }
+}


### PR DESCRIPTION
* INCLUDES A SINGLE LINE CHANGE TO `EtherfiNode.sol` that improves mock testing setup
* Mocks for core eigenlayer contracts required for withdrawals
* Helper library for arrays to clean up our code frequently creating arrays of 1 item
* Tests for
  * withdrawing last unslashed validator
  * withdrawing last slashed validator
  * withdrawing last validator with rewards
  * withdrawing non-final validator