### PR TITLE
Update `partialWithdraw` to sweep ETH from EtherFiNode contracts

### DIFF
--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -231,14 +231,32 @@ contract EtherFiNodesManager is
     //  3. perform `EigenPod.verifyCheckpointProofs()`
     //  4. wait for 'withdrawalDelayBlocks' (= 7 days) delay to be passed
     //  5. Finally, perform `EtherFiNodesManager.partialWithdraw` for the validator
+    /// @dev This function is will be deprecated in the future for simpler operations using the advanced rewards distribution
     function partialWithdraw(uint256 _validatorId) public nonReentrant whenNotPaused onlyAdmin {
-
         address etherfiNode = etherfiNodeAddress[_validatorId];
         _updateEtherFiNode(_validatorId);
 
-        // distribute the rewards payouts. It reverts if the safe's balance >= 16 ether
-        (uint256 toOperator, uint256 toTnft, uint256 toBnft, uint256 toTreasury ) = _getTotalRewardsPayoutsFromSafe(_validatorId, true);
-        _distributePayouts(etherfiNode, _validatorId, toTreasury, toOperator, toTnft, toBnft);
+        (uint256 toOperator, uint256 toTnft, uint256 toBnft, uint256 toTreasury ) = (0, 0, 0, 0);
+        if (stakingRewardsSplit.tnft == SCALE) {
+            // the ETH validators earn the staking rewards and they are sent to the `EtherFiNode` contracts. 
+            // Process of sweeping those ETH is called `partialWithdraw`.
+
+            // Currently, `EtherFiNodesManager.partialWithdraw` can't process the withdrawal beyond 16 ETH 
+            // because the `EtherFiNodesManager._getTotalRewardsPayoutsFromSafe` reverts if the contract's balance >= 16 ETH.
+            // This constraint was added in the past due to the complexity in handling the distribution of staking rewards and principal (= 32 ETH); 
+            // while the earned staking rewards were distributed to (T-NFT, B-NFT, NodeOperator, Treasury), the principal (32 ETH) were sent to (B-NFT, T-NFT).
+
+            // This complexity was removed while ago and now the below constraints are true:
+            // - for all validators, its T-NFT holder == B-NFT holder
+            // - `stakingRewardsSplit.tnft` is set to `SCALE` (100%); stakingRewardsSplit.{treasury, nodeOperator, bnft} are 0. 
+            
+            // Therefore, all ETH in (EtherFiNode) contracts belongs to the T-NFT holder (= LiquidityPool). 
+            // This allows us to remove the constraint on the withdrawal amount.
+            (toOperator, toTnft, toBnft, toTreasury ) = _getTotalRewardsPayoutsFromSafe(_validatorId, false);
+        } else {
+            // Note that this flow is deprecated, we keep it for backward compatibility
+            (toOperator, toTnft, toBnft, toTreasury ) = _getTotalRewardsPayoutsFromSafe(_validatorId, true);
+        }
 
         emit PartialWithdrawal(_validatorId, etherfiNode, toOperator, toTnft, toBnft, toTreasury);
     }

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -257,6 +257,7 @@ contract EtherFiNodesManager is
             // Note that this flow is deprecated, we keep it for backward compatibility
             (toOperator, toTnft, toBnft, toTreasury ) = _getTotalRewardsPayoutsFromSafe(_validatorId, true);
         }
+        _distributePayouts(etherfiNode, _validatorId, toTreasury, toOperator, toTnft, toBnft);
 
         emit PartialWithdrawal(_validatorId, etherfiNode, toOperator, toTnft, toBnft, toTreasury);
     }


### PR DESCRIPTION
# Context
the ETH validators earn the staking rewards and they are sent to the `EtherFiNode` contracts. 
Process of sweeping those ETH is called `partialWithdraw`.

Currently, `EtherFiNodesManager.partialWithdraw` can't process the withdrawal beyond 16 ETH 
because the `EtherFiNodesManager._getTotalRewardsPayoutsFromSafe` reverts if the contract's balance >= 16 ETH.
This constraint was added in the past due to the complexity in handling the distribution of staking rewards and principal (= 32 ETH); while the earned staking rewards were distributed to (T-NFT, B-NFT, NodeOperator, Treasury), the principal (32 ETH) were sent to (B-NFT, T-NFT).

This complexity was removed while ago and now the below constraints are true:
 - for all validators, its T-NFT holder == B-NFT holder
 - `stakingRewardsSplit.tnft` is set to `SCALE` (100%); stakingRewardsSplit.{treasury, nodeOperator, bnft} are 0. 

Therefore, all ETH in (EtherFiNode) contracts belongs to the T-NFT holder (= LiquidityPool). 
This allows us to remove the constraint on the withdrawal amount.