### PR TITLE
rename roles

### DIFF
--- a/script/deploys/DeployEtherFiRewardsRouter.s.sol
+++ b/script/deploys/DeployEtherFiRewardsRouter.s.sol
@@ -28,7 +28,7 @@ contract DeployEtherFiRewardsRouter is Script {
         vm.startBroadcast();
 
         RoleRegistry roleRegistryInstance = RoleRegistry(roleRegistryProxyAddress);
-        roleRegistryInstance.grantRole(keccak256("ETHERFI_REWARDS_ROUTER_ADMIN"), etherfiRouterAdmin);
+        roleRegistryInstance.grantRole(keccak256("ETHERFI_REWARDS_ROUTER_ADMIN_ROLE"), etherfiRouterAdmin);
 
         addressProvider = AddressProvider(addressProviderAddress);
 

--- a/script/deploys/DeployEtherFiRewardsRouter.s.sol
+++ b/script/deploys/DeployEtherFiRewardsRouter.s.sol
@@ -28,7 +28,7 @@ contract DeployEtherFiRewardsRouter is Script {
         vm.startBroadcast();
 
         RoleRegistry roleRegistryInstance = RoleRegistry(roleRegistryProxyAddress);
-        roleRegistryInstance.grantRole(keccak256("ETHERFI_ROUTER_ADMIN"), etherfiRouterAdmin);
+        roleRegistryInstance.grantRole(keccak256("ETHERFI_REWARDS_ROUTER_ADMIN"), etherfiRouterAdmin);
 
         addressProvider = AddressProvider(addressProviderAddress);
 

--- a/script/deploys/DeployV2Dot49.s.sol
+++ b/script/deploys/DeployV2Dot49.s.sol
@@ -83,7 +83,7 @@ contract DeployV2Dot49Script is Script {
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), address(hypernativeEoa)); 
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), address(etherfiMultisig));
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_UNPAUSER(), address(etherFiAdminInstance));
-        roleRegistryInstance.grantRole(etherFiRewardsRouterInstance.ETHERFI_REWARDS_ROUTER_ADMIN(), address(etherfiMultisig));
+        roleRegistryInstance.grantRole(etherFiRewardsRouterInstance.ETHERFI_REWARDS_ROUTER_ADMIN_ROLE(), address(etherfiMultisig));
         roleRegistryInstance.transferOwnership(address(timelockInstance));
         vm.stopBroadcast();
     }

--- a/script/deploys/DeployV2Dot49.s.sol
+++ b/script/deploys/DeployV2Dot49.s.sol
@@ -76,14 +76,14 @@ contract DeployV2Dot49Script is Script {
 
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
         roleRegistryInstance.grantRole(liquidityPoolInstance.LIQUIDITY_POOL_ADMIN_ROLE(), liquidityPoolAdmin);
-        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ADMIN_ADMIN_ROLE(), etherfiOracleAdmin);
-        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ADMIN_TASK_EXECUTOR_ROLE(), etherfiOracleAdmin);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), etherfiOracleAdmin);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE(), etherfiOracleAdmin);
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_UNPAUSER(), etherfiMultisig); 
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), address(etherFiAdminInstance));
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), address(hypernativeEoa)); 
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), address(etherfiMultisig));
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_UNPAUSER(), address(etherFiAdminInstance));
-        roleRegistryInstance.grantRole(etherFiRewardsRouterInstance.ETHERFI_ROUTER_ADMIN(), address(etherfiMultisig));
+        roleRegistryInstance.grantRole(etherFiRewardsRouterInstance.ETHERFI_REWARDS_ROUTER_ADMIN(), address(etherfiMultisig));
         roleRegistryInstance.transferOwnership(address(timelockInstance));
         vm.stopBroadcast();
     }

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -60,8 +60,8 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     RoleRegistry public roleRegistry;
 
-    bytes32 public constant ETHERFI_ADMIN_ADMIN_ROLE = keccak256("ETHERFI_ADMIN_ADMIN_ROLE");
-    bytes32 public constant ETHERFI_ADMIN_TASK_EXECUTOR_ROLE = keccak256("ETHERFI_ADMIN_TASK_EXECUTOR_ROLE");
+    bytes32 public constant ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE = keccak256("ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE");
+    bytes32 public constant ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE = keccak256("ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE");
 
     event AdminUpdated(address _address, bool _isAdmin);
     event AdminOperationsExecuted(address indexed _address, bytes32 indexed _reportHash);
@@ -168,7 +168,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
 
     function setValidatorTaskBatchSize(uint16 _batchSize) external {
-        if(!roleRegistry.hasRole(ETHERFI_ADMIN_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if(!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
         validatorTaskBatchSize = _batchSize;
     }
 
@@ -184,7 +184,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function executeTasks(IEtherFiOracle.OracleReport calldata _report) external {
-        if (!roleRegistry.hasRole(ETHERFI_ADMIN_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE, msg.sender)) revert IncorrectRole();
 
         bytes32 reportHash = etherFiOracle.generateReportHash(_report);
         uint32 current_slot = etherFiOracle.computeSlotAtTimestamp(block.timestamp);
@@ -209,7 +209,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     //_timestamp will only be used for TaskType.ProcessNodeExit and pubkeys and signatures will only be used for TaskType.ValidatorApproval
     function executeValidatorManagementTask(bytes32 _reportHash, uint256[] calldata _validators, uint32[] calldata _timestamps, bytes[] calldata _pubKeys, bytes[] calldata _signatures) external {
-        if (!roleRegistry.hasRole(ETHERFI_ADMIN_TASK_EXECUTOR_ROLE, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE, msg.sender)) revert IncorrectRole();
 
         require(etherFiOracle.isConsensusReached(_reportHash), "EtherFiAdmin: report didn't reach consensus");
         bytes32 taskHash = keccak256(abi.encode(_reportHash, _validators, _timestamps));
@@ -232,7 +232,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function invalidateValidatorManagementTask(bytes32 _reportHash, uint256[] calldata _validators, uint32[] calldata _timestamps) external {
-        if (!roleRegistry.hasRole(ETHERFI_ADMIN_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
 
         bytes32 taskHash = keccak256(abi.encode(_reportHash, _validators, _timestamps));
         require(validatorManagementTaskStatus[taskHash].exists, "EtherFiAdmin: task doesn't exist");
@@ -330,12 +330,12 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function updateAcceptableRebaseApr(int32 _acceptableRebaseAprInBps) external {
-        if (!roleRegistry.hasRole(ETHERFI_ADMIN_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
         acceptableRebaseAprInBps = _acceptableRebaseAprInBps;
     }
 
     function updatePostReportWaitTimeInSlots(uint16 _postReportWaitTimeInSlots) external {
-        if (!roleRegistry.hasRole(ETHERFI_ADMIN_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
 
         postReportWaitTimeInSlots = _postReportWaitTimeInSlots;
     }

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -33,9 +33,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
     uint256 private constant BUCKET_UNIT_SCALE = 1e12;
     uint256 private constant BASIS_POINT_SCALE = 1e4;
 
-    bytes32 public constant PROTOCOL_PAUSER = keccak256("PROTOCOL_PAUSER");
-    bytes32 public constant PROTOCOL_UNPAUSER = keccak256("PROTOCOL_UNPAUSER");
-    bytes32 public constant PROTOCOL_ADMIN = keccak256("PROTOCOL_ADMIN");
+    bytes32 public constant ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE = keccak256("ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE");
 
     RoleRegistry public immutable roleRegistry;
     address public immutable treasury;
@@ -197,7 +195,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
      * @dev Sets the maximum size of the bucket that can be consumed in a given time period.
      * @param capacity The capacity of the bucket.
      */
-    function setCapacity(uint256 capacity) external hasRole(PROTOCOL_ADMIN) {
+    function setCapacity(uint256 capacity) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
         // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
         uint64 bucketUnit = _convertToBucketUnit(capacity, Math.Rounding.Down);
         BucketLimiter.setCapacity(limit, bucketUnit);
@@ -207,7 +205,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
      * @dev Sets the rate at which the bucket is refilled per second.
      * @param refillRate The rate at which the bucket is refilled per second.
      */
-    function setRefillRatePerSecond(uint256 refillRate) external hasRole(PROTOCOL_ADMIN) {
+    function setRefillRatePerSecond(uint256 refillRate) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
         // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
         uint64 bucketUnit = _convertToBucketUnit(refillRate, Math.Rounding.Down);
         BucketLimiter.setRefillRate(limit, bucketUnit);
@@ -217,26 +215,26 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
      * @dev Sets the exit fee.
      * @param _exitFeeInBps The exit fee.
      */
-    function setExitFeeBasisPoints(uint16 _exitFeeInBps) external hasRole(PROTOCOL_ADMIN) {
+    function setExitFeeBasisPoints(uint16 _exitFeeInBps) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
         require(_exitFeeInBps <= BASIS_POINT_SCALE, "INVALID");
         exitFeeInBps = _exitFeeInBps;
     }
 
-    function setLowWatermarkInBpsOfTvl(uint16 _lowWatermarkInBpsOfTvl) external hasRole(PROTOCOL_ADMIN) {
+    function setLowWatermarkInBpsOfTvl(uint16 _lowWatermarkInBpsOfTvl) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
         require(_lowWatermarkInBpsOfTvl <= BASIS_POINT_SCALE, "INVALID");
         lowWatermarkInBpsOfTvl = _lowWatermarkInBpsOfTvl;
     }
 
-    function setExitFeeSplitToTreasuryInBps(uint16 _exitFeeSplitToTreasuryInBps) external hasRole(PROTOCOL_ADMIN) {
+    function setExitFeeSplitToTreasuryInBps(uint16 _exitFeeSplitToTreasuryInBps) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
         require(_exitFeeSplitToTreasuryInBps <= BASIS_POINT_SCALE, "INVALID");
         exitFeeSplitToTreasuryInBps = _exitFeeSplitToTreasuryInBps;
     }
 
-    function pauseContract() external hasRole(PROTOCOL_PAUSER) {
+    function pauseContract() external hasRole(roleRegistry.PROTOCOL_PAUSER()) {
         _pause();
     }
 
-    function unPauseContract() external hasRole(PROTOCOL_UNPAUSER) {
+    function unPauseContract() external hasRole(roleRegistry.PROTOCOL_UNPAUSER()) {
         _unpause();
     }
 

--- a/src/EtherFiRewardsRouter.sol
+++ b/src/EtherFiRewardsRouter.sol
@@ -15,7 +15,7 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
     address public immutable liquidityPool;
     RoleRegistry public immutable roleRegistry;
 
-    bytes32 public constant ETHERFI_ROUTER_ADMIN = keccak256("ETHERFI_ROUTER_ADMIN");
+    bytes32 public constant ETHERFI_REWARDS_ROUTER_ADMIN = keccak256("ETHERFI_REWARDS_ROUTER_ADMIN");
 
     event EthReceived(address indexed from, uint256 value);
     event EthSent(address indexed from, address indexed to, uint256 value);
@@ -52,7 +52,7 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
     }
 
     function recoverERC20(address _token, uint256 _amount) external {
-        if (!roleRegistry.hasRole(ETHERFI_ROUTER_ADMIN, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_REWARDS_ROUTER_ADMIN, msg.sender)) revert IncorrectRole();
 
         IERC20(_token).safeTransfer(treasury, _amount);
 
@@ -60,7 +60,7 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
     }
 
     function recoverERC721(address _token, uint256 _tokenId) external {
-        if (!roleRegistry.hasRole(ETHERFI_ROUTER_ADMIN, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_REWARDS_ROUTER_ADMIN, msg.sender)) revert IncorrectRole();
 
         IERC721(_token).transferFrom(address(this), treasury, _tokenId);
 

--- a/src/EtherFiRewardsRouter.sol
+++ b/src/EtherFiRewardsRouter.sol
@@ -15,7 +15,7 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
     address public immutable liquidityPool;
     RoleRegistry public immutable roleRegistry;
 
-    bytes32 public constant ETHERFI_REWARDS_ROUTER_ADMIN = keccak256("ETHERFI_REWARDS_ROUTER_ADMIN");
+    bytes32 public constant ETHERFI_REWARDS_ROUTER_ADMIN_ROLE = keccak256("ETHERFI_REWARDS_ROUTER_ADMIN_ROLE");
 
     event EthReceived(address indexed from, uint256 value);
     event EthSent(address indexed from, address indexed to, uint256 value);
@@ -52,7 +52,7 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
     }
 
     function recoverERC20(address _token, uint256 _amount) external {
-        if (!roleRegistry.hasRole(ETHERFI_REWARDS_ROUTER_ADMIN, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_REWARDS_ROUTER_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
 
         IERC20(_token).safeTransfer(treasury, _amount);
 
@@ -60,7 +60,7 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
     }
 
     function recoverERC721(address _token, uint256 _tokenId) external {
-        if (!roleRegistry.hasRole(ETHERFI_REWARDS_ROUTER_ADMIN, msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(ETHERFI_REWARDS_ROUTER_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
 
         IERC721(_token).transferFrom(address(this), treasury, _tokenId);
 

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -45,7 +45,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     RoleRegistry public roleRegistry;
 
 
-    bytes32 public constant WITHDRAWAL_ADMIN_ROLE = keccak256("WITHDRAWAL_ADMIN_ROLE");
+    bytes32 public constant WITHDRAW_REQUEST_NFT_ADMIN_ROLE = keccak256("WITHDRAW_REQUEST_NFT_ADMIN_ROLE");
     
 
     event WithdrawRequestCreated(uint32 indexed requestId, uint256 amountOfEEth, uint256 shareOfEEth, address owner, uint256 fee);
@@ -311,7 +311,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     modifier onlyAdmin() {
-        require(roleRegistry.hasRole(WITHDRAWAL_ADMIN_ROLE, msg.sender), "Caller is not admin");
+        require(roleRegistry.hasRole(WITHDRAW_REQUEST_NFT_ADMIN_ROLE, msg.sender), "Caller is not admin");
         _;
     }
 

--- a/test/EtherFiAdminUpgrade.t.sol
+++ b/test/EtherFiAdminUpgrade.t.sol
@@ -48,8 +48,8 @@ contract EtherFiAdminUpgradeTest is TestSetup {
         vm.startPrank(roleRegistryInstance.owner());
         
         roleRegistryInstance.grantRole(liquidityPoolInstance.LIQUIDITY_POOL_ADMIN_ROLE(), address(etherFiAdminInstance));
-        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ADMIN_ADMIN_ROLE(), committeeMember);
-        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ADMIN_TASK_EXECUTOR_ROLE(), committeeMember);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), committeeMember);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE(), committeeMember);
         vm.startPrank(committeeMember);
         etherFiAdminInstance.setValidatorTaskBatchSize(batchSize);
         vm.stopPrank();

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -18,7 +18,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         initializeRealisticFork(MAINNET_FORK);
 
         vm.startPrank(roleRegistryInstance.owner());
-        roleRegistryInstance.grantRole(keccak256("PROTOCOL_ADMIN"), op_admin);
+        roleRegistryInstance.grantRole(keccak256("ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE"), op_admin);
         vm.stopPrank();
 
     }
@@ -224,7 +224,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
     function testFuzz_role_management(address admin, address pauser, address unpauser, address user) public {
         address owner = roleRegistryInstance.owner();
-        bytes32 PROTOCOL_ADMIN = keccak256("PROTOCOL_ADMIN");
+        bytes32 ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE = keccak256("ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE");
         bytes32 PROTOCOL_PAUSER = keccak256("PROTOCOL_PAUSER");
         bytes32 PROTOCOL_UNPAUSER = keccak256("PROTOCOL_UNPAUSER");
 
@@ -235,7 +235,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
         // Grant roles to respective addresses
         vm.prank(owner);
-        roleRegistryInstance.grantRole(PROTOCOL_ADMIN, admin);
+        roleRegistryInstance.grantRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE, admin);
         vm.prank(owner);
         roleRegistryInstance.grantRole(PROTOCOL_PAUSER, pauser);
         vm.prank(owner);
@@ -262,9 +262,9 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         assertFalse(etherFiRedemptionManagerInstance.paused());
         vm.stopPrank();
 
-        // Revoke PROTOCOL_ADMIN role from admin
+        // Revoke ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE role from admin
         vm.prank(owner);
-        roleRegistryInstance.revokeRole(PROTOCOL_ADMIN, admin);
+        roleRegistryInstance.revokeRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE, admin);
 
         // Admin attempts admin-only actions after role revocation
         vm.startPrank(admin);

--- a/test/TenderlyTest.s.sol
+++ b/test/TenderlyTest.s.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import "forge-std/Test.sol";
+import {EtherFiRedemptionManager} from "../src/EtherFiRedemptionManager.sol";
+import {TestSetup} from "./TestSetup.sol";
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+
+import "../src/eigenlayer-interfaces/IDelayedWithdrawalRouter.sol";
+import "../src/eigenlayer-interfaces/IEigenPodManager.sol";
+import "../src/eigenlayer-interfaces/IBeaconChainOracle.sol";
+import "../src/eigenlayer-interfaces/IDelegationManager.sol";
+import "./eigenlayer-mocks/BeaconChainOracleMock.sol";
+import "../src/eigenlayer-interfaces/ITimelock.sol";
+
+import "../src/interfaces/IStakingManager.sol";
+import "../src/interfaces/IEtherFiNode.sol";
+import "../src/interfaces/ILiquidityPool.sol";
+import "../src/interfaces/ILiquifier.sol";
+import "../src/EtherFiNodesManager.sol";
+import "../src/StakingManager.sol";
+import "../src/NodeOperatorManager.sol";
+import "../src/archive/RegulationsManager.sol";
+import "../src/AuctionManager.sol";
+import "../src/archive/ProtocolRevenueManager.sol";
+import "../src/BNFT.sol";
+import "../src/TNFT.sol";
+import "../src/Treasury.sol";
+import "../src/EtherFiNode.sol";
+import "../src/LiquidityPool.sol";
+import "../src/Liquifier.sol";
+import "../src/EtherFiRestaker.sol";
+import "../src/EETH.sol";
+import "../src/WeETH.sol";
+import "../src/MembershipManager.sol";
+import "../src/MembershipNFT.sol";
+import "../src/EarlyAdopterPool.sol";
+import "../src/TVLOracle.sol";
+import "../src/UUPSProxy.sol";
+import "../src/WithdrawRequestNFT.sol";
+import "../src/NFTExchange.sol";
+import "../src/helpers/AddressProvider.sol";
+import "./DepositDataGeneration.sol";
+import "./DepositContract.sol";
+import "./Attacker.sol";
+import "./TestERC20.sol";
+
+import "../src/archive/MembershipManagerV0.sol";
+import "../src/EtherFiOracle.sol";
+import "../src/EtherFiAdmin.sol";
+import "../src/EtherFiTimelock.sol";
+
+import "../src/BucketRateLimiter.sol";
+import "../src/EtherFiRedemptionManager.sol";
+
+import "../script/ContractCodeChecker.sol";
+import "../script/Create2Factory.sol";
+import "../src/RoleRegistry.sol";
+
+import "forge-std/Script.sol";
+
+contract TenderlyExecute is Script {
+    EtherFiRedemptionManager public redemptionManager;
+    EtherFiNodesManager public managerInstance;
+    LiquidityPool public liquidityPoolInstance;
+    EETH public eETHInstance;
+    WeETH public weEthInstance;
+    AuctionManager public auctionInstance;
+    StakingManager public stakingManagerInstance;
+    Treasury public treasuryInstance;
+    NodeOperatorManager public nodeOperatorManagerInstance;
+    EtherFiNode public node;
+    EarlyAdopterPool public earlyAdopterPoolInstance;
+    WithdrawRequestNFT public withdrawRequestNFTInstance;
+    Liquifier public liquifierInstance;
+    EtherFiTimelock public etherFiTimelockInstance;
+    EtherFiAdmin public etherFiAdminInstance;
+    EtherFiOracle public etherFiOracleInstance;
+    AddressProvider public addressProviderInstance;
+    DepositDataGeneration public depGen;
+    bytes32 zeroRoot = 0x0000000000000000000000000000000000000000000000000000000000000000;
+
+    function _prepareForValidatorRegistration(uint256[] memory _validatorIds) internal returns (IStakingManager.DepositData[] memory, bytes32[] memory, bytes[] memory, bytes[] memory pubKey) {
+        IStakingManager.DepositData[] memory depositDataArray = new IStakingManager.DepositData[](_validatorIds.length);
+        bytes32[] memory depositDataRootsForApproval = new bytes32[](_validatorIds.length);
+        bytes[] memory sig = new bytes[](_validatorIds.length);
+        bytes[] memory pubKey = new bytes[](_validatorIds.length);
+
+        for (uint256 i = 0; i < _validatorIds.length; i++) {
+            pubKey[i] = hex"8f9c0aab19ee7586d3d470f132842396af606947a0589382483308fdffdaf544078c3be24210677a9c471ce70b3b4c2c";
+            bytes32 root = depGen.generateDepositRoot(
+                pubKey[i],
+                hex"877bee8d83cac8bf46c89ce50215da0b5e370d282bb6c8599aabdbc780c33833687df5e1f5b5c2de8a6cd20b6572c8b0130b1744310a998e1079e3286ff03e18e4f94de8cdebecf3aaac3277b742adb8b0eea074e619c20d13a1dda6cba6e3df",
+                managerInstance.getWithdrawalCredentials(_validatorIds[i]),
+                1 ether
+            );
+            depositDataArray[i] = IStakingManager.DepositData({
+                publicKey: pubKey[i],
+                signature: hex"877bee8d83cac8bf46c89ce50215da0b5e370d282bb6c8599aabdbc780c33833687df5e1f5b5c2de8a6cd20b6572c8b0130b1744310a998e1079e3286ff03e18e4f94de8cdebecf3aaac3277b742adb8b0eea074e619c20d13a1dda6cba6e3df",
+                depositDataRoot: root,
+                ipfsHashForEncryptedValidatorKey: "test_ipfs"
+            });
+
+            depositDataRootsForApproval[i] = depGen.generateDepositRoot(
+                pubKey[i],
+                hex"ad899d85dcfcc2506a8749020752f81353dd87e623b2982b7bbfbbdd7964790eab4e06e226917cba1253f063d64a7e5407d8542776631b96c4cea78e0968833b36d4e0ae0b94de46718f905ca6d9b8279e1044a41875640f8cb34dc3f6e4de65",
+                managerInstance.getWithdrawalCredentials(_validatorIds[i]),
+                31 ether
+            );
+
+            sig[i] = hex"ad899d85dcfcc2506a8749020752f81353dd87e623b2982b7bbfbbdd7964790eab4e06e226917cba1253f063d64a7e5407d8542776631b96c4cea78e0968833b36d4e0ae0b94de46718f905ca6d9b8279e1044a41875640f8cb34dc3f6e4de65";
+        
+        }
+
+        return (depositDataArray, depositDataRootsForApproval, sig, pubKey);
+    }
+
+    function setUp() public {
+        redemptionManager = EtherFiRedemptionManager(payable(address(0x69e03a920FE2e2FcD970fC20095B5cC664DC0C8b)));
+
+        addressProviderInstance = AddressProvider(vm.envAddress("CONTRACT_REGISTRY"));
+        managerInstance = EtherFiNodesManager(payable(addressProviderInstance.getContractAddress("EtherFiNodesManager")));
+        liquidityPoolInstance = LiquidityPool(payable(addressProviderInstance.getContractAddress("LiquidityPool")));
+        eETHInstance = EETH(addressProviderInstance.getContractAddress("EETH"));
+        weEthInstance = WeETH(addressProviderInstance.getContractAddress("WeETH"));
+        auctionInstance = AuctionManager(addressProviderInstance.getContractAddress("AuctionManager"));
+        stakingManagerInstance = StakingManager(addressProviderInstance.getContractAddress("StakingManager"));
+        treasuryInstance = Treasury(payable(addressProviderInstance.getContractAddress("Treasury")));
+        nodeOperatorManagerInstance = NodeOperatorManager(addressProviderInstance.getContractAddress("NodeOperatorManager"));
+        node = EtherFiNode(payable(addressProviderInstance.getContractAddress("EtherFiNode")));
+        earlyAdopterPoolInstance = EarlyAdopterPool(payable(addressProviderInstance.getContractAddress("EarlyAdopterPool")));
+        withdrawRequestNFTInstance = WithdrawRequestNFT(addressProviderInstance.getContractAddress("WithdrawRequestNFT"));
+        liquifierInstance = Liquifier(payable(addressProviderInstance.getContractAddress("Liquifier")));
+        etherFiTimelockInstance = EtherFiTimelock(payable(addressProviderInstance.getContractAddress("EtherFiTimelock")));
+        etherFiAdminInstance = EtherFiAdmin(payable(addressProviderInstance.getContractAddress("EtherFiAdmin")));
+        etherFiOracleInstance = EtherFiOracle(payable(addressProviderInstance.getContractAddress("EtherFiOracle")));
+
+
+        depGen = new DepositDataGeneration();
+    }
+
+    function run() public {
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+        setUp();
+        newStakingFlow();
+    }
+
+    function newStakingFlow() public {
+        uint256 numOfBatches = 10;
+        uint256 numValsPerBatch = 60;
+        uint256 numValsToRegister = numOfBatches * numValsPerBatch;
+       //0x6A54cF0befD629A8F74348Bb622a84A63f944532 
+        //uint256[] memory bidIds = auctionInstance.createBid{value: numValsToRegister * 1100000000000000}(numValsToRegister, 1100000000000000);
+        uint256[] memory bidIds = new uint256[](numValsToRegister);
+        for (uint256 i; i < numValsToRegister; i++) {
+            bidIds[i] = i + 87866;
+        }
+        //liquidityPoolInstance.registerValidatorSpawner(address(0xc351788DDb96cD98d99E62C97f57952A8b3Fc1B5));
+        for (uint256 i; i < 1; i++) {
+            uint256[] memory bidIdsToRegister = new uint256[](numValsPerBatch);
+            for (uint256 j; j < numValsPerBatch; j++) {
+                bidIdsToRegister[j] = bidIds[i * numValsPerBatch + j];
+            }
+            //liquidityPoolInstance.batchDeposit(bidIdsToRegister, numValsPerBatch);
+            (IStakingManager.DepositData[] memory depositDataArray, bytes32[] memory depositDataRootsForApproval, bytes[] memory sig, bytes[] memory pubKey) = _prepareForValidatorRegistration(bidIdsToRegister);
+            //liquidityPoolInstance.batchRegister(zeroRoot, bidIdsToRegister, depositDataArray, depositDataRootsForApproval, sig);
+            liquidityPoolInstance.batchApproveRegistration(bidIdsToRegister, pubKey, sig);
+        }
+    }
+}

--- a/test/TenderlyTest.t.sol
+++ b/test/TenderlyTest.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import "forge-std/Test.sol";
+import {TestSetup} from "./TestSetup.sol";
+import {EtherFiRedemptionManager} from "../src/EtherFiRedemptionManager.sol";
+import {EETH} from "../src/eETH.sol";
+import {EtherFiAdmin} from "../src/EtherFiAdmin.sol";
+import {LiquidityPool} from "../src/LiquidityPool.sol";
+import {AuctionManager} from "../src/AuctionManager.sol";
+import {IStakingManager} from "../src/interfaces/IStakingManager.sol";
+
+contract TenderlyTest is TestSetup {
+    EtherFiRedemptionManager public redemptionManager;
+
+    function setUp() public {
+        initializeRealisticFork(MAINNET_FORK);
+        redemptionManager = EtherFiRedemptionManager(payable(address(0x69e03a920FE2e2FcD970fC20095B5cC664DC0C8b)));
+    }
+
+    function test_EtherFiRedemptionManagerWithdrawal() public {
+        vm.startPrank(address(0x7f7b39E09d1E2fA470AB5c68bD270538A8590EEa));
+        uint256 balanceBefore = eETHInstance.balanceOf(address(0x7f7b39E09d1E2fA470AB5c68bD270538A8590EEa));
+        uint256 etherBalanceBefore = address(0x7f7b39E09d1E2fA470AB5c68bD270538A8590EEa).balance;
+        eETHInstance.approve(address(0x7f7b39E09d1E2fA470AB5c68bD270538A8590EEa), 200 ether);
+        redemptionManager.redeemEEth(200 ether, address(0x7f7b39E09d1E2fA470AB5c68bD270538A8590EEa));
+        uint256 balanceAfter = eETHInstance.balanceOf(address(0x7f7b39E09d1E2fA470AB5c68bD270538A8590EEa));
+    }
+
+    function test_AsyncAdminTask() public {
+        vm.startPrank(address(0x7f7b39E09d1E2fA470AB5c68bD270538A8590EEa));
+        redemptionManager.initialize(100, 100, 100, 100, 100);
+    }
+
+    function test_newStakingFlow() public {
+        uint256 numOfBatches = 10;
+        uint256 numValsPerBatch = 60;
+        uint256 numValsToRegister = numOfBatches * numValsPerBatch;
+        
+        vm.deal(address(0x6A54cF0befD629A8F74348Bb622a84A63f944532), 10 ether);
+        vm.prank(address(0x6A54cF0befD629A8F74348Bb622a84A63f944532));
+        uint256[] memory bidIds = auctionInstance.createBid{value: numValsToRegister * 1100000000000000}(numValsToRegister, 1100000000000000);
+        //return
+        // return;
+        // vm.startPrank(address(0xc351788DDb96cD98d99E62C97f57952A8b3Fc1B5));
+        // liquidityPoolInstance.registerValidatorSpawner(address(0xc351788DDb96cD98d99E62C97f57952A8b3Fc1B5));
+        // for (uint256 i; i < numOfBatches; i++) {
+        //     uint256[] memory bidIdsToRegister = new uint256[](numValsPerBatch);
+        //     for (uint256 j; j < numValsPerBatch; j++) {
+        //         bidIdsToRegister[j] = bidIds[i * numValsPerBatch + j];
+        //     }
+        //     liquidityPoolInstance.batchDeposit(bidIdsToRegister, numValsPerBatch);
+        //     (IStakingManager.DepositData[] memory depositDataArray, bytes32[] memory depositDataRootsForApproval, bytes[] memory sig, bytes[] memory pubKey) = _prepareForValidatorRegistration(bidIdsToRegister);
+        //     liquidityPoolInstance.batchRegister(zeroRoot, bidIdsToRegister, depositDataArray, depositDataRootsForApproval, sig);
+        //     liquidityPoolInstance.batchApproveRegistration(bidIdsToRegister, pubKey, sig);
+        // }
+        // vm.stopPrank();
+    }
+
+
+    function test_etherFiAdmin() public {
+        vm.startPrank(address(0x7f7b39E09d1E2fA470AB5c68bD270538A8590EEa));
+    }
+}

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -610,7 +610,7 @@ contract TestSetup is Test, ContractCodeChecker {
         etherFiRedemptionManagerInstance = EtherFiRedemptionManager(payable(etherFiRedemptionManagerProxy));
         etherFiRedemptionManagerInstance.initialize(10_00, 1_00, 1_00, 5 ether, 0.001 ether);
 
-        roleRegistryInstance.grantRole(keccak256("PROTOCOL_ADMIN"), owner);
+        roleRegistryInstance.grantRole(keccak256("ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE"), owner);
         
         liquidityPoolInstance.initialize(address(eETHInstance), address(stakingManagerInstance), address(etherFiNodeManagerProxy), address(membershipManagerInstance), address(TNFTInstance), address(etherFiAdminProxy), address(withdrawRequestNFTInstance));
         liquidityPoolInstance.initializeVTwoDotFourNine(address(roleRegistryInstance), address(etherFiRedemptionManagerInstance));
@@ -708,14 +708,14 @@ contract TestSetup is Test, ContractCodeChecker {
         );
         etherFiAdminInstance.initializeRoleRegistry(address(roleRegistryInstance));
         roleRegistryInstance.grantRole(liquidityPoolInstance.LIQUIDITY_POOL_ADMIN_ROLE(), address(etherFiAdminInstance));
-        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ADMIN_ADMIN_ROLE(), alice);
-        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ADMIN_TASK_EXECUTOR_ROLE(), alice);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), alice);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE(), alice);
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), address(etherFiAdminInstance));
         roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_UNPAUSER(), address(etherFiAdminInstance));
 
-        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAWAL_ADMIN_ROLE(), address(alice));
-        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAWAL_ADMIN_ROLE(), address(etherFiAdminInstance));
-        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAWAL_ADMIN_ROLE(), address(admin));
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), address(alice));
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), address(etherFiAdminInstance));
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), address(admin));
 
         vm.startPrank(alice);
         etherFiAdminInstance.setValidatorTaskBatchSize(100);
@@ -846,8 +846,8 @@ contract TestSetup is Test, ContractCodeChecker {
         roleRegistryInstance.grantRole(liquidityPoolInstance.LIQUIDITY_POOL_ADMIN_ROLE(), alice);
         roleRegistryInstance.grantRole(liquidityPoolInstance.LIQUIDITY_POOL_ADMIN_ROLE(), owner);
         roleRegistryInstance.grantRole(liquidityPoolInstance.LIQUIDITY_POOL_ADMIN_ROLE(), chad);
-        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ADMIN_ADMIN_ROLE(), alice);
-        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ADMIN_TASK_EXECUTOR_ROLE(), alice);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), alice);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE(), alice);
         vm.startPrank(alice);
         etherFiAdminInstance.setValidatorTaskBatchSize(100);
         vm.stopPrank();

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -386,7 +386,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     function test_handleRemainder() public {
         test_aggregateSumEEthShareAmount();
         vm.startPrank(etherfi_admin_wallet);
-        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAWAL_ADMIN_ROLE(), etherfi_admin_wallet);
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), etherfi_admin_wallet);
         vm.stopPrank();
         vm.prank(etherfi_admin_wallet);
         
@@ -579,7 +579,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // Admin invalidates request
         vm.startPrank(address(0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf));
-        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAWAL_ADMIN_ROLE(), admin);
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), admin);
         vm.stopPrank();
         vm.prank(admin);
         withdrawRequestNFTInstance.invalidateRequest(requestId);

--- a/test/eethPayoutUpgrade.t.sol
+++ b/test/eethPayoutUpgrade.t.sol
@@ -107,7 +107,7 @@ contract eethPayoutUpgradeTest is TestSetup {
         etherFiOracleInstance.submitReport(report);
         skip(1000);
         vm.startPrank(alice);
-        bool isAdmin = roleRegistryInstance.hasRole(etherFiAdminInstance.ETHERFI_ADMIN_ADMIN_ROLE(), alice);
+        bool isAdmin = roleRegistryInstance.hasRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), alice);
         etherFiAdminInstance.executeTasks(report);
         uint256 balOfTreasury = eETHInstance.balanceOf(treasury);
         assertApproxEqAbs(balOfTreasury, _protocolFees, 10);
@@ -192,7 +192,7 @@ contract eethPayoutUpgradeTest is TestSetup {
         etherFiOracleInstance.submitReport(report);
         skip(1000);
         vm.startPrank(alice);
-        bool isAdmin = roleRegistryInstance.hasRole(etherFiAdminInstance.ETHERFI_ADMIN_ADMIN_ROLE(), alice);
+        bool isAdmin = roleRegistryInstance.hasRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), alice);
         vm.expectRevert("EtherFiAdmin: protocol fees exceed 20% total rewards");
         etherFiAdminInstance.executeTasks(report);
         vm.stopPrank(); 


### PR DESCRIPTION
1. Rename roles with naming convention <contract-name>_<role type (ie. admin)>_role
EtherFiAdmin only expection where instead of contract name we used EtherFiOracleExecutor as that will be the name in future upgrade and ETHERFI_ADMIN_ADMIN_ROLE was awkward

2. Changed permission of executeTasks. Original admin role called executeTasks but now Task_Manager calls executeTasks as an eoa makes a call to executeTasks and executeValidatorManagementTask and everything else should be behind admin multisig