### PR TITLE
Feature: Add Venn Firewall to eETH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/Vectorized/solady
+[submodule "lib/ironblocks/firewall-consumer-v2"]
+	path = lib/ironblocks/firewall-consumer-v2
+	url = https://github.com/ironblocks/firewall-consumer-v2

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ gas_reports = ["*"]
 optimizer_runs = 2000
 extra_output = ["storageLayout"]
 bytecode_hash = 'none'
-solc-version = '0.8.24'
+solc-version = '0.8.25'
 
 [fuzz]
 max_shrink_iters = 100

--- a/remappings.txt
+++ b/remappings.txt
@@ -7,3 +7,6 @@ forge-std/=lib/forge-std/src/
 @layerzerolabs/lz-evm-protocol-v2/contracts/=lib/Etherfi-SyncPools/node_modules/@layerzerolabs/lz-evm-protocol-v2/contracts/
 @layerzerolabs/lz-evm-messagelib-v2/contracts/=lib/Etherfi-SyncPools/node_modules/@layerzerolabs/lz-evm-messagelib-v2/contracts/
 @layerzerolabs/lz-evm-oapp-v2/contracts-upgradeable/=lib/Etherfi-SyncPools/node_modules/layerzero-v2/oapp/contracts/
+
+@ironblocks/contracts=lib/ironblocks/firewall-consumer-v2/contracts
+@openzeppelin/contracts-upgradeable=lib/openzeppelin-contracts-upgradeable/

--- a/src/interfaces/IERC20UpgradeablePayable.sol
+++ b/src/interfaces/IERC20UpgradeablePayable.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.6.0) (token/ERC20/IERC20.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20UpgradeablePayable {
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `to`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(
+        address to,
+        uint256 amount
+    ) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(
+        address owner,
+        address spender
+    ) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(
+        address spender,
+        uint256 amount
+    ) external payable returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `from` to `to` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) external returns (bool);
+}

--- a/src/interfaces/IeETH.sol
+++ b/src/interfaces/IeETH.sol
@@ -24,9 +24,9 @@ interface IeETH {
     function burnShares(address _user, uint256 _share) external;
     function transferFrom(address _sender, address _recipient, uint256 _amount) external returns (bool);
     function transfer(address _recipient, uint256 _amount) external returns (bool);
-    function approve(address _spender, uint256 _amount) external returns (bool);
+    function approve(address _spender, uint256 _amount) external payable returns (bool);
     function increaseAllowance(address _spender, uint256 _increaseAmount) external returns (bool);
     function decreaseAllowance(address _spender, uint256 _decreaseAmount) external returns (bool);
 
-    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external payable;
 }

--- a/src/interfaces/draft-IERC20PermitUpgradeablePayable.sol
+++ b/src/interfaces/draft-IERC20PermitUpgradeablePayable.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (token/ERC20/extensions/draft-IERC20Permit.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
+ * https://eips.ethereum.org/EIPS/eip-2612[EIP-2612].
+ *
+ * Adds the {permit} method, which can be used to change an account's ERC20 allowance (see {IERC20-allowance}) by
+ * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't
+ * need to send a transaction, and thus is not required to hold Ether at all.
+ */
+interface IERC20PermitUpgradeablePayable {
+    /**
+     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,
+     * given ``owner``'s signed approval.
+     *
+     * IMPORTANT: The same issues {IERC20-approve} has related to transaction
+     * ordering also apply here.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `deadline` must be a timestamp in the future.
+     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
+     * over the EIP712-formatted function arguments.
+     * - the signature must use ``owner``'s current nonce (see {nonces}).
+     *
+     * For more information on the signature format, see the
+     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
+     * section].
+     */
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external payable;
+
+    /**
+     * @dev Returns the current nonce for `owner`. This value must be
+     * included whenever a signature is generated for {permit}.
+     *
+     * Every successful call to {permit} increases ``owner``'s nonce by one. This
+     * prevents a signature from being used multiple times.
+     */
+    function nonces(address owner) external view returns (uint256);
+
+    /**
+     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}


### PR DESCRIPTION
This PR introduces the Venn Firewall onto `eETH.sol`.

## Protected Methods
- `approve`
- `permit`

## Prerequisites
1. Update `foundry.toml` to use Solidity `0.8.25`
2. Replace
  2.1. `IERC20Upgradeable.sol` with `IERC20UpgradeablePayable.sol`
  2.2 `draft-IERC20PermitUpgradeable.sol` with `draft-IERC20PermitUpgradeablePayable.sol`
  2.3 ...both of which are identical versions, the only difference being that `approve` and `permit` are now `payable`
3. Mark `eETH.approve()` and `eETH.permit()` as `payable`

## Venn Integration
1. Install [firewall-consumer-v2](https://github.com/ironblocks/firewall-consumer-v2) as a dependency
2. Make the `eETH.sol` contract inherit from `ProxyVennFirewallConsumer.sol`
3. Add the `firewallProtected` modifier to protected methods
4. Add a new `initializeFirewallAdmin` method to allow the EtherFi team to set a new Firewall Admin after deploying the new eETH implementation

