### PR TITLE
Update Handling Withdrawal Fee

### DIFF
--- a/script/deploys/DeployV2Dot49.s.sol
+++ b/script/deploys/DeployV2Dot49.s.sol
@@ -72,7 +72,7 @@ contract DeployV2Dot49Script is Script {
         etherFiRewardsRouterInstance = EtherFiRewardsRouter(payable(address(0x73f7b1184B5cD361cC0f7654998953E2a251dd58)));
         liquidityPoolInstance = LiquidityPool(payable(addressProvider.getContractAddress("LiquidityPool")));
         weETHInstance = WeETH(addressProvider.getContractAddress("WeETH"));
-        withdrawRequestNFTInstance = WithdrawRequestNFT(addressProvider.getContractAddress("WithdrawRequestNFT"));
+        withdrawRequestNFTInstance = WithdrawRequestNFT(payable(addressProvider.getContractAddress("WithdrawRequestNFT")));
         etherFiRedemptionManagerInstance = EtherFiRedemptionManager(payable(address(0xDadEf1fFBFeaAB4f68A9fD181395F68b4e4E7Ae0)));
         eETHInstance = EETH(addressProvider.getContractAddress("EETH"));
         

--- a/script/upgrades/WithdrawRequestNFTUpgradeScript.s.sol
+++ b/script/upgrades/WithdrawRequestNFTUpgradeScript.s.sol
@@ -19,7 +19,7 @@ contract WithdrawRequestNFTUpgrade is Script {
 
         vm.startBroadcast(deployerPrivateKey);
 
-        WithdrawRequestNFT oracleInstance = WithdrawRequestNFT(proxyAddress);
+        WithdrawRequestNFT oracleInstance = WithdrawRequestNFT(payable(proxyAddress));
         WithdrawRequestNFT v2Implementation = new WithdrawRequestNFT(address(0));
 
         oracleInstance.upgradeTo(address(v2Implementation));

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -192,7 +192,8 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     // Seize the request simply by transferring it to another recipient
-    function seizeInvalidRequest(uint256 requestId, address recipient) external onlyOwner {
+    function seizeInvalidRequest(uint256 requestId, address recipient) external {
+        if(msg.sender != roleRegistry.owner()) revert IncorrectRole();
         require(!_requests[requestId].isValid, "Request is valid");
         require(_exists(requestId), "Request does not exist");
 
@@ -235,7 +236,8 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         emit WithdrawRequestValidated(uint32(requestId));
     }
 
-    function updateShareRemainderSplitToTreasuryInBps(uint16 _shareRemainderSplitToTreasuryInBps) external onlyOwner {
+    function updateShareRemainderSplitToTreasuryInBps(uint16 _shareRemainderSplitToTreasuryInBps) external {
+        if(msg.sender != roleRegistry.owner()) revert IncorrectRole();
         require(_shareRemainderSplitToTreasuryInBps <= BASIS_POINT_SCALE, "INVALID");
         shareRemainderSplitToTreasuryInBps = _shareRemainderSplitToTreasuryInBps;
     }
@@ -308,7 +310,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         }
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+    function _authorizeUpgrade(address newImplementation) internal override {
+        roleRegistry.onlyProtocolUpgrader(msg.sender);
+    }
 
     function getImplementation() external view returns (address) {
         return _getImplementation();

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -329,7 +329,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         uint256 totalSupplyBefore = eETHInstance.totalSupply();
         uint256 eethBalanceTreasuryBefore = eETHInstance.balanceOf(etherFiRedemptionManagerInstance.treasury());
         vm.startPrank(admin);
-        etherFiRedemptionManagerInstance.handleRemainder(totalFee);
+        etherFiRedemptionManagerInstance.handleRedemptionFee(totalFee);
         vm.stopPrank();
         uint256 lpBalanceAfter = address(liquidityPoolInstance).balance;
         uint256 totalSupplyAfter = eETHInstance.totalSupply();

--- a/test/TenderlyTest.s.sol
+++ b/test/TenderlyTest.s.sol
@@ -134,7 +134,7 @@ contract TenderlyExecute is Script {
         nodeOperatorManagerInstance = NodeOperatorManager(addressProviderInstance.getContractAddress("NodeOperatorManager"));
         node = EtherFiNode(payable(addressProviderInstance.getContractAddress("EtherFiNode")));
         earlyAdopterPoolInstance = EarlyAdopterPool(payable(addressProviderInstance.getContractAddress("EarlyAdopterPool")));
-        withdrawRequestNFTInstance = WithdrawRequestNFT(addressProviderInstance.getContractAddress("WithdrawRequestNFT"));
+        withdrawRequestNFTInstance = WithdrawRequestNFT(payable(addressProviderInstance.getContractAddress("WithdrawRequestNFT")));
         liquifierInstance = Liquifier(payable(addressProviderInstance.getContractAddress("Liquifier")));
         etherFiTimelockInstance = EtherFiTimelock(payable(addressProviderInstance.getContractAddress("EtherFiTimelock")));
         etherFiAdminInstance = EtherFiAdmin(payable(addressProviderInstance.getContractAddress("EtherFiAdmin")));

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -410,6 +410,7 @@ contract TestSetup is Test, ContractCodeChecker {
         etherFiAdminInstance = EtherFiAdmin(payable(addressProviderInstance.getContractAddress("EtherFiAdmin")));
         etherFiOracleInstance = EtherFiOracle(payable(addressProviderInstance.getContractAddress("EtherFiOracle")));
         roleRegistryInstance = RoleRegistry(addressProviderInstance.getContractAddress("RoleRegistry"));
+        etherFiRedemptionManagerInstance = EtherFiRedemptionManager(payable(addressProviderInstance.getContractAddress("EtherFiRedemptionManager")));
         
     }
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -202,7 +202,7 @@ contract TestSetup is Test, ContractCodeChecker {
     EtherFiTimelock public etherFiTimelockInstance;
     BucketRateLimiter public bucketRateLimiter;
 
-    bool public shouldSetupRoleRegistry = true;
+    bool public shouldSetupRoleRegistry = false;
 
     bytes32 root;
     bytes32 rootMigration;
@@ -404,14 +404,13 @@ contract TestSetup is Test, ContractCodeChecker {
         nodeOperatorManagerInstance = NodeOperatorManager(addressProviderInstance.getContractAddress("NodeOperatorManager"));
         node = EtherFiNode(payable(addressProviderInstance.getContractAddress("EtherFiNode")));
         earlyAdopterPoolInstance = EarlyAdopterPool(payable(addressProviderInstance.getContractAddress("EarlyAdopterPool")));
-        withdrawRequestNFTInstance = WithdrawRequestNFT(addressProviderInstance.getContractAddress("WithdrawRequestNFT"));
+        withdrawRequestNFTInstance = WithdrawRequestNFT(payable(addressProviderInstance.getContractAddress("WithdrawRequestNFT")));
         liquifierInstance = Liquifier(payable(addressProviderInstance.getContractAddress("Liquifier")));
         etherFiTimelockInstance = EtherFiTimelock(payable(addressProviderInstance.getContractAddress("EtherFiTimelock")));
         etherFiAdminInstance = EtherFiAdmin(payable(addressProviderInstance.getContractAddress("EtherFiAdmin")));
         etherFiOracleInstance = EtherFiOracle(payable(addressProviderInstance.getContractAddress("EtherFiOracle")));
-        if (shouldSetupRoleRegistry) {
-            setupRoleRegistry();
-        }
+        roleRegistryInstance = RoleRegistry(addressProviderInstance.getContractAddress("RoleRegistry"));
+        
     }
 
     function updateShouldSetRoleRegistry(bool shouldSetup) public {

--- a/test/VTwoDotFourEndToEndTest.t.sol
+++ b/test/VTwoDotFourEndToEndTest.t.sol
@@ -69,7 +69,7 @@ contract VTwoDotFourEndToEndTest is TestSetup {
         etherFiRewardsRouterImplementation = EtherFiRewardsRouter(payable(0xe94bF0DF71002ff0165CF4daB461dEBC3978B0fa));
         liquidityPoolImplementation = LiquidityPool(payable(0xA6099d83A67a2c653feB5e4e48ec24C5aeE1C515));
         weEthImplementation = WeETH(0x353E98F34b6E5a8D9d1876Bf6dF01284d05837cB);
-        withdrawRequestNFTImplementation = WithdrawRequestNFT(0x685870a508b56c7f1002EEF5eFCFa01304474F61);
+        withdrawRequestNFTImplementation = WithdrawRequestNFT(payable(0x685870a508b56c7f1002EEF5eFCFa01304474F61));
         etherFiNodesManagerImplementation = EtherFiNodesManager(payable(0x572E25fD70b6eB9a3CaD1CE1D48E3CfB938767F1));
     }
     


### PR DESCRIPTION
Redemption Manager- User does not pay for transfer to treasury and fee to protocol
-No more burning of shares but instead withdraw and send eth to LP
-No logic for remainder just does split in handleRemainder method

WithdrawRequestNFT- new role for handleRemainder
-No burning of shares