### PR TITLE
feat: add EL-triggerable batch exit support (EIP-7002) in EtherFiNodesManager

### DIFF
--- a/src/eigenlayer-interfaces/IEigenPod.sol
+++ b/src/eigenlayer-interfaces/IEigenPod.sol
@@ -97,21 +97,33 @@ interface IEigenPodTypes {
         int64 balanceDeltasGwei;
         uint64 prevBeaconBalanceGwei;
     }
+
+    /**
+     * @param pubkey the pubkey of the validator to withdraw from
+     * @param amountGwei the amount (in gwei) to withdraw from the beacon chain to the pod
+     * @dev Note that if amountGwei == 0, this is a "full exit request," and will fully exit
+     * the validator to the pod.
+     * For more notes on usage, see `requestWithdrawal`
+     */
+    struct WithdrawalRequest {
+        bytes pubkey;
+        uint64 amountGwei;
+    }
 }
 
 interface IEigenPodEvents is IEigenPodTypes {
     /// @notice Emitted when an ETH validator stakes via this eigenPod
-    event EigenPodStaked(bytes pubkey);
+    event EigenPodStaked(bytes32 pubkeyHash);
 
     /// @notice Emitted when a pod owner updates the proof submitter address
     event ProofSubmitterUpdated(address prevProofSubmitter, address newProofSubmitter);
 
     /// @notice Emitted when an ETH validator's withdrawal credentials are successfully verified to be pointed to this eigenPod
-    event ValidatorRestaked(uint40 validatorIndex);
+    event ValidatorRestaked(bytes32 pubkeyHash);
 
     /// @notice Emitted when an ETH validator's  balance is proven to be updated.  Here newValidatorBalanceGwei
     //  is the validator's balance that is credited on EigenLayer.
-    event ValidatorBalanceUpdated(uint40 validatorIndex, uint64 balanceTimestamp, uint64 newValidatorBalanceGwei);
+    event ValidatorBalanceUpdated(bytes32 pubkeyHash, uint64 balanceTimestamp, uint64 newValidatorBalanceGwei);
 
     /// @notice Emitted when restaked beacon chain ETH is withdrawn from the eigenPod.
     event RestakedBeaconChainETHWithdrawn(address indexed recipient, uint256 amount);
@@ -128,10 +140,17 @@ interface IEigenPodEvents is IEigenPodTypes {
     event CheckpointFinalized(uint64 indexed checkpointTimestamp, int256 totalShareDeltaWei);
 
     /// @notice Emitted when a validator is proven for a given checkpoint
-    event ValidatorCheckpointed(uint64 indexed checkpointTimestamp, uint40 indexed validatorIndex);
+    event ValidatorCheckpointed(uint64 indexed checkpointTimestamp, bytes32 indexed pubkeyHash);
 
     /// @notice Emitted when a validaor is proven to have 0 balance at a given checkpoint
     event ValidatorWithdrawn(uint64 indexed checkpointTimestamp, uint40 indexed validatorIndex);
+
+    /// @notice Emitted when a withdrawal request is initiated where request.amountGwei == 0
+    event ExitRequested(bytes32 indexed validatorPubkeyHash);
+
+    /// @notice Emitted when a partial withdrawal request is initiated
+    event WithdrawalRequested(bytes32 indexed validatorPubkeyHash, uint64 withdrawalAmountGwei);
+
 }
 
 /**
@@ -212,6 +231,50 @@ interface IEigenPod is IEigenPodErrors, IEigenPodEvents, ISemVerMixin {
         bytes[] calldata validatorFieldsProofs,
         bytes32[][] calldata validatorFields
     ) external;
+
+    /// @notice Allows the owner or proof submitter to initiate one or more requests to
+    /// withdraw funds from validators on the beacon chain.
+    /// @param requests An array of requests consisting of the source validator and an
+    /// amount to withdraw
+    /// @dev The withdrawal request predeploy requires a fee is sent with each request;
+    /// this is pulled from msg.value. After submitting all requests, any remaining fee is
+    /// refunded to the caller by calling its fallback function.
+    /// @dev This contract exposes `getWithdrawalRequestFee` to query the current fee for
+    /// a single request. If submitting multiple requests in a single block, the total fee
+    /// is equal to (fee * requests.length). This fee is updated at the end of each block.
+    ///
+    /// (See https://eips.ethereum.org/EIPS/eip-7002#fee-update-rule for details)
+    ///
+    /// @dev Note on beacon chain behavior:
+    /// - Withdrawal requests have two types: full exit requests, and partial exit requests.
+    ///   Partial exit requests will be skipped if the validator has 0x01 withdrawal credentials.
+    ///   If you want your validators to have access to partial exits, use `requestConsolidation`
+    ///   to change their withdrawal credentials to compounding (0x02).
+    /// - If request.amount == 0, this is a FULL exit request. A full exit request initiates a
+    ///   standard validator exit.
+    /// - Other amounts are treated as PARTIAL exit requests. A partial exit request will NOT result
+    ///   in a validator with less than 32 ETH balance. Any requested amount above this is ignored.
+    /// - The actual amount withdrawn for a partial exit is given by the formula:
+    ///   min(request.amount, state.balances[vIdx] - 32 ETH - pending_balance_to_withdraw)
+    ///   (where `pending_balance_to_withdraw` is the sum of any outstanding partial exit requests)
+    ///   (Note that this means you may request more than is actually withdrawn!)
+    ///
+    /// @dev Note that withdrawal requests CAN FAIL for a variety of reasons. Failures occur when the request
+    /// is processed on the beacon chain, and are invisible to the pod. The pod and predeploy cannot guarantee
+    /// a request will succeed; it's up to the pod owner to determine this for themselves. If your request fails,
+    /// you can retry by initiating another request via this method.
+    ///
+    /// Some requirements that are NOT checked by the pod:
+    /// - request.pubkey MUST be a valid validator pubkey
+    /// - request.pubkey MUST belong to a validator whose withdrawal credentials are this pod
+    /// - If request.amount is for a partial exit, the validator MUST have 0x02 withdrawal credentials
+    /// - If request.amount is for a full exit, the validator MUST NOT have any pending partial exits
+    /// - The validator MUST be active and MUST NOT have initiated exit
+    ///
+    /// For further reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_withdrawal_request
+    function requestWithdrawal(
+        WithdrawalRequest[] calldata requests
+    ) external payable;
 
     /**
      * @dev Prove that one of this pod's active validators was slashed on the beacon chain. A successful
@@ -294,12 +357,12 @@ interface IEigenPod is IEigenPodErrors, IEigenPodEvents, ISemVerMixin {
         bytes calldata validatorPubkey
     ) external view returns (ValidatorInfo memory);
 
-    /// @notice This returns the status of a given validator
+    /// @notice Returns the validator status for a given validator pubkey hash
     function validatorStatus(
         bytes32 pubkeyHash
     ) external view returns (VALIDATOR_STATUS);
 
-    /// @notice This returns the status of a given validator pubkey
+    /// @notice Returns the validator status for a given validator pubkey
     function validatorStatus(
         bytes calldata validatorPubkey
     ) external view returns (VALIDATOR_STATUS);
@@ -315,6 +378,11 @@ interface IEigenPod is IEigenPodErrors, IEigenPodEvents, ISemVerMixin {
 
     /// @notice Returns the currently-active checkpoint
     function currentCheckpoint() external view returns (Checkpoint memory);
+
+    /// @notice Returns the current fee required to add a withdrawal request to the EIP-7002 predeploy.
+    /// @dev Note that the predeploy updates its fee every block according to https://eips.ethereum.org/EIPS/eip-7002#fee-update-rule
+    /// Consider overestimating the amount sent to ensure the fee does not update before your transaction.
+    function getWithdrawalRequestFee() external view returns (uint256);
 
     /// @notice For each checkpoint, the total balance attributed to exited validators, in gwei
     ///


### PR DESCRIPTION
## Summary

This PR implements Execution Layer-triggerable exits (EIP-7002) in the EtherFi smart contract by adding a new `batchWithdrawalRequests` method in `EtherFiNodesManager.sol`. This method allows authorized operators to submit one or more withdrawal requests to an EigenPod in a single transaction, enabling both full exits and partial withdrawals via the EIP-7002 predeploy mechanism.

### Notes

- Added a new Role `ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE` to control which operators can trigger EL exits.
- Update eigenPod interface (hopefully non-breaking!)