### PR TITLE
feat: add validators consolidation support EIP-7251

### DIFF
--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -157,7 +157,7 @@ contract EtherFiNode is IEtherFiNode {
             }
         }
         etherFiNodesManager.consumeUnrestakingCapacity(totalBeaconEth);
-        
+
         return delegationManager.queueWithdrawals(params);
     }
 

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -195,11 +195,11 @@ contract EtherFiNode is IEtherFiNode {
     //-------------------------------------------------------------------
     //-------------  Execution-Layer Triggered Consolidations  ----------
     //-------------------------------------------------------------------
-    function requestConsolidation(IEigenPod pod, IEigenPod.ConsolidationRequest[] calldata requests) external payable {
+    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable {
         if (msg.sender != address(etherFiNodesManager)) {
             revert InvalidCaller();
         }
-        pod.requestConsolidation{value: msg.value}(requests);
+        getEigenPod().requestConsolidation{value: msg.value}(requests);
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -192,6 +192,16 @@ contract EtherFiNode is IEtherFiNode {
         pod.requestWithdrawal{value: msg.value}(requests);
     }
 
+    //-------------------------------------------------------------------
+    //-------------  Execution-Layer Triggered Consolidations  ----------
+    //-------------------------------------------------------------------
+    function requestConsolidation(IEigenPod pod, IEigenPod.ConsolidationRequest[] calldata requests) external payable {
+        if (msg.sender != address(etherFiNodesManager)) {
+            revert InvalidCaller();
+        }
+        pod.requestConsolidation{value: msg.value}(requests);
+    }
+
     //--------------------------------------------------------------------------------------
     //-------------------------------- CALL FORWARDING  ------------------------------------
     //--------------------------------------------------------------------------------------

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -205,9 +205,7 @@ contract EtherFiNodesManager is
         // Get node and pod from first validator
         bytes32 pkHash0 = calculateValidatorPubkeyHash(requests[0].srcPubkey);
         IEtherFiNode node0 = etherFiNodeFromPubkeyHash[pkHash0];      
-        if (address(node0) == address(0)) revert UnknownValidatorPubkey(); 
         IEigenPod pod = node0.getEigenPod();
-        if (address(pod) == address(0)) revert UnknownEigenPod();
         uint256 feePer = pod.getConsolidationRequestFee();
         
         // Emit events for tracking

--- a/src/eigenlayer-interfaces/IEigenPod.sol
+++ b/src/eigenlayer-interfaces/IEigenPod.sol
@@ -109,6 +109,18 @@ interface IEigenPodTypes {
         bytes pubkey;
         uint64 amountGwei;
     }
+
+    /**
+     * @param srcPubkey the pubkey of the source validator for the consolidation
+     * @param targetPubkey the pubkey of the target validator for the consolidation
+     * @dev Note that if srcPubkey == targetPubkey, this is a "switch request," and will
+     * change the validator's withdrawal credential type from 0x01 to 0x02.
+     * For more notes on usage, see `requestConsolidation`
+     */
+    struct ConsolidationRequest {
+        bytes srcPubkey;
+        bytes targetPubkey;
+    }
 }
 
 interface IEigenPodEvents is IEigenPodTypes {
@@ -150,6 +162,12 @@ interface IEigenPodEvents is IEigenPodTypes {
 
     /// @notice Emitted when a partial withdrawal request is initiated
     event WithdrawalRequested(bytes32 indexed validatorPubkeyHash, uint64 withdrawalAmountGwei);
+
+    /// @notice Emitted when a consolidation request is initiated where source == target
+    event SwitchToCompoundingRequested(bytes32 indexed validatorPubkeyHash);
+
+    /// @notice Emitted when a standard consolidation request is initiated
+    event ConsolidationRequested(bytes32 indexed sourcePubkeyHash, bytes32 indexed targetPubkeyHash);
 
 }
 
@@ -276,6 +294,43 @@ interface IEigenPod is IEigenPodErrors, IEigenPodEvents, ISemVerMixin {
         WithdrawalRequest[] calldata requests
     ) external payable;
 
+    /// @notice Allows the owner or proof submitter to initiate one or more consolidation requests.
+    /// @param requests Array of consolidation requests consisting of source and target validator pubkeys
+    /// @dev The consolidation request predeploy requires a fee is sent with each request;
+    /// this is pulled from msg.value. After submitting all requests, any remaining fee is
+    /// refunded to the caller by calling its fallback function.
+    /// @dev This contract exposes `getConsolidationRequestFee` to query the current fee for
+    /// a single request. If submitting multiple requests in a single block, the total fee
+    /// is equal to (fee * requests.length). This fee is updated at the end of each block.
+    ///
+    /// (See https://eips.ethereum.org/EIPS/eip-7251#fee-calculation for details)
+    ///
+    /// @dev Note on beacon chain behavior:
+    /// - If request.srcPubkey == request.targetPubkey, this is a "switch request" that converts
+    ///   a validator's withdrawal credentials from 0x01 to 0x02 (compounding).
+    /// - Otherwise, this consolidates multiple validators by transferring the source validator's
+    ///   balance to the target validator and exiting the source validator.
+    /// - Target validators for consolidation MUST have 0x02 withdrawal credentials.
+    /// - Switch requests require the validator to have 0x01 withdrawal credentials.
+    ///
+    /// @dev Note that consolidation requests CAN FAIL for a variety of reasons. Failures occur when the request
+    /// is processed on the beacon chain, and are invisible to the pod. The pod and predeploy cannot guarantee
+    /// a request will succeed; it's up to the pod owner to determine this for themselves. If your request fails,
+    /// you can retry by initiating another request via this method.
+    ///
+    /// Some requirements that are NOT checked by the pod:
+    /// - request.srcPubkey MUST be a valid validator pubkey
+    /// - request.srcPubkey MUST belong to a validator whose withdrawal credentials are this pod
+    /// - If srcPubkey == targetPubkey, the validator MUST have 0x01 credentials
+    /// - If srcPubkey != targetPubkey, the target validator MUST have 0x02 credentials
+    /// - Both source and target validators MUST be active and MUST NOT have initiated exits
+    /// - The source validator MUST NOT have pending partial withdrawal requests
+    ///
+    /// For further reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_consolidation_request
+    function requestConsolidation(
+        ConsolidationRequest[] calldata requests
+    ) external payable;
+
     /**
      * @dev Prove that one of this pod's active validators was slashed on the beacon chain. A successful
      * staleness proof allows the caller to start a checkpoint.
@@ -383,6 +438,11 @@ interface IEigenPod is IEigenPodErrors, IEigenPodEvents, ISemVerMixin {
     /// @dev Note that the predeploy updates its fee every block according to https://eips.ethereum.org/EIPS/eip-7002#fee-update-rule
     /// Consider overestimating the amount sent to ensure the fee does not update before your transaction.
     function getWithdrawalRequestFee() external view returns (uint256);
+
+    /// @notice Returns the fee required to add a consolidation request to the EIP-7251 predeploy this block.
+    /// @dev Note that the predeploy updates its fee every block according to https://eips.ethereum.org/EIPS/eip-7251#fee-calculation
+    /// Consider overestimating the amount sent to ensure the fee does not update before your transaction.
+    function getConsolidationRequestFee() external view returns (uint256);
 
     /// @notice For each checkpoint, the total balance attributed to exited validators, in gwei
     ///

--- a/src/interfaces/IEtherFiNode.sol
+++ b/src/interfaces/IEtherFiNode.sol
@@ -20,7 +20,7 @@ interface IEtherFiNode {
     function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external;
     function sweepFunds() external returns (uint256 balance);
     function requestWithdrawal(IEigenPod pod, IEigenPod.WithdrawalRequest[] calldata requests) external payable;
-    function requestConsolidation(IEigenPod pod, IEigenPod.ConsolidationRequest[] calldata requests) external payable;
+    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable;
 
 
     // call forwarding

--- a/src/interfaces/IEtherFiNode.sol
+++ b/src/interfaces/IEtherFiNode.sol
@@ -20,6 +20,7 @@ interface IEtherFiNode {
     function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external;
     function sweepFunds() external returns (uint256 balance);
     function requestWithdrawal(IEigenPod pod, IEigenPod.WithdrawalRequest[] calldata requests) external payable;
+    function requestConsolidation(IEigenPod pod, IEigenPod.ConsolidationRequest[] calldata requests) external payable;
 
 
     // call forwarding

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -110,6 +110,8 @@ interface IEtherFiNodesManager {
     event AllowedForwardedEigenpodCallsUpdated(bytes4 indexed selector, bool _allowed);
     event FundsTransferred(address indexed nodeAddress, uint256 amount);
     event ValidatorWithdrawalRequestSent(address indexed initiator, address indexed pod, bytes32 indexed validatorPubkeyHash, uint64 amountGwei, uint256 feePerRequest);
+    event ValidatorSwitchToCompoundingRequested(address indexed initiator, address indexed pod, bytes32 indexed validatorPubkeyHash, uint256 feePerRequest);
+    event ValidatorConsolidationRequested(address indexed initiator, address indexed pod, bytes32 indexed sourcePubkeyHash, bytes32 targetPubkeyHash, uint256 feePerRequest);
 
     //--------------------------------------------------------------------------
     //-----------------------------  Errors  -----------------------------------
@@ -124,7 +126,9 @@ interface IEtherFiNodesManager {
     error ForwardedCallNotAllowed();
     error InvalidForwardedCall();
     error EmptyWithdrawalsRequest();
+    error EmptyConsolidationRequest();
     error InsufficientWithdrawalFees();
+    error InsufficientConsolidationFees();
     error ExitRateLimitExceeded();
     error ExitRateLimitExceededForPod();
     error UnknownValidatorPubkey();

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -109,8 +109,8 @@ interface IEtherFiNodesManager {
     event AllowedForwardedEigenpodCallsUpdated(bytes4 indexed selector, bool _allowed);
     event FundsTransferred(address indexed nodeAddress, uint256 amount);
     event ValidatorWithdrawalRequestSent(address indexed pod, bytes32 indexed validatorPubkeyHash, bytes validatorPubkey);
-    event ValidatorSwitchToCompoundingRequested(address indexed initiator, address indexed pod, bytes32 indexed validatorPubkeyHash, uint256 feePerRequest);
-    event ValidatorConsolidationRequested(address indexed initiator, address indexed pod, bytes32 indexed sourcePubkeyHash, bytes32 targetPubkeyHash, uint256 feePerRequest);
+    event ValidatorSwitchToCompoundingRequested(address indexed pod, bytes32 indexed validatorPubkeyHash, bytes validatorPubkey);
+    event ValidatorConsolidationRequested(address indexed pod, bytes32 indexed sourcePubkeyHash, bytes sourcePubkey, bytes32 targetPubkeyHash, bytes targetPubkey);
 
     //--------------------------------------------------------------------------
     //-----------------------------  Errors  -----------------------------------

--- a/test/mocks/MockEigenPodBase.sol
+++ b/test/mocks/MockEigenPodBase.sol
@@ -107,4 +107,6 @@ contract MockEigenPodBase is IEigenPod {
     function getParentBlockRoot(uint64 timestamp) external virtual view returns (bytes32) {}
     function getWithdrawalRequestFee() external view returns (uint256){}
     function requestWithdrawal(WithdrawalRequest[] calldata requests) external payable {}
+    function getConsolidationRequestFee() external view returns (uint256){}
+    function requestConsolidation(ConsolidationRequest[] calldata requests) external payable {}
 }

--- a/test/prelude.t.sol
+++ b/test/prelude.t.sol
@@ -1490,18 +1490,21 @@ contract PreludeTest is Test, ArrayTestHelper {
         uint256 valueToSend = feePer * reqs.length;
         
         // Expect consolidation events
-        bytes32 srcHash0 = etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[0]);
-        bytes32 targetHash0 = etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[1]);
-        bytes32 srcHash1 = etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[1]);
-        bytes32 targetHash1 = etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[2]);
-        
         vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
         emit IEtherFiNodesManager.ValidatorConsolidationRequested(
-            admin, address(pod0), srcHash0, targetHash0, feePer
+            address(pod0), 
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[0]), 
+            pubkeys[0], 
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[1]), 
+            pubkeys[1]
         );
         vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
         emit IEtherFiNodesManager.ValidatorConsolidationRequested(
-            admin, address(pod0), srcHash1, targetHash1, feePer
+            address(pod0), 
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[1]), 
+            pubkeys[1], 
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[2]), 
+            pubkeys[2]
         );
         vm.deal(admin, 1 ether);
         vm.prank(admin);
@@ -1531,14 +1534,14 @@ contract PreludeTest is Test, ArrayTestHelper {
         uint256 valueToSend = feePer * reqs.length;
         
         // Expect switch to compounding event
-        bytes32 pubkeyHash = etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[0]);
-        
-        vm.deal(admin, 1 ether);
-        vm.prank(admin);
         vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
         emit IEtherFiNodesManager.ValidatorSwitchToCompoundingRequested(
-            admin, address(pod0), pubkeyHash, feePer
+            address(pod0), 
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[0]), 
+            pubkeys[0]
         );
+        vm.deal(admin, 1 ether);
+        vm.prank(admin);
         etherFiNodesManager.requestConsolidation{value: valueToSend}(reqs);
     }
     

--- a/test/prelude.t.sol
+++ b/test/prelude.t.sol
@@ -1628,5 +1628,292 @@ contract PreludeTest is Test, ArrayTestHelper {
         
         assertEq(directFee, managerFee);
     }
+
+    // ---------- Fork Tests for EIP-7251 Consolidation ----------
+    
+    function test_requestConsolidation_samePod_fullConsolidation_success() public {
+        bytes[] memory pubkeys = new bytes[](3);
+        uint256[] memory legacyIds = new uint256[](3);
+        pubkeys[0] = PK_16171;
+        pubkeys[1] = PK_16172;
+        pubkeys[2] = PK_16173;
+        legacyIds[0] = 51715;
+        legacyIds[1] = 51716;
+        legacyIds[2] = 51717;
+        
+        vm.startPrank(admin);
+        etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
+        vm.stopPrank();
+        
+        (, IEigenPod pod0) = _resolvePod(pubkeys[0]);
+        (, IEigenPod pod1) = _resolvePod(pubkeys[1]);
+        (, IEigenPod pod2) = _resolvePod(pubkeys[2]);
+        
+        // Sanity check: all same pod
+        assertEq(address(pod0), address(pod1));
+        assertEq(address(pod1), address(pod2));
+        
+        // Create consolidation requests: pubkeys[0] -> pubkeys[1] -> pubkeys[2] (chain consolidation)
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = new IEigenPodTypes.ConsolidationRequest[](2);
+        reqs[0] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[0],
+            targetPubkey: pubkeys[1]
+        });
+        reqs[1] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[1],
+            targetPubkey: pubkeys[2]
+        });
+        
+        uint256 feePer = pod0.getConsolidationRequestFee();
+        uint256 valueToSend = feePer * reqs.length;
+        
+        // Expect consolidation events
+        vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
+        emit IEtherFiNodesManager.ValidatorConsolidationRequested(
+            address(pod0),
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[0]),
+            pubkeys[0],
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[1]),
+            pubkeys[1]
+        );
+        vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
+        emit IEtherFiNodesManager.ValidatorConsolidationRequested(
+            address(pod0),
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[1]),
+            pubkeys[1],
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[2]),
+            pubkeys[2]
+        );
+        
+        vm.deal(admin, 1 ether);
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: valueToSend}(reqs);
+    }
+    
+    function test_requestConsolidation_samePod_switchToCompounding_success() public {
+        bytes[] memory pubkeys = new bytes[](2);
+        uint256[] memory legacyIds = new uint256[](2);
+        pubkeys[0] = PK_16171;
+        pubkeys[1] = PK_16172;
+        legacyIds[0] = 51715;
+        legacyIds[1] = 51716;
+        
+        vm.startPrank(admin);
+        etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
+        vm.stopPrank();
+        
+        (, IEigenPod pod0) = _resolvePod(pubkeys[0]);
+        (, IEigenPod pod1) = _resolvePod(pubkeys[1]);
+        
+        // Sanity check: all same pod
+        assertEq(address(pod0), address(pod1));
+        
+        // Create switch to compounding requests (srcPubkey == targetPubkey)
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = new IEigenPodTypes.ConsolidationRequest[](2);
+        reqs[0] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[0],
+            targetPubkey: pubkeys[0]  // Same pubkey = switch to compounding
+        });
+        reqs[1] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[1],
+            targetPubkey: pubkeys[1]  // Same pubkey = switch to compounding
+        });
+        
+        uint256 feePer = pod0.getConsolidationRequestFee();
+        uint256 valueToSend = feePer * reqs.length;
+        
+        // Expect switch to compounding events
+        vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
+        emit IEtherFiNodesManager.ValidatorSwitchToCompoundingRequested(
+            address(pod0),
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[0]),
+            pubkeys[0]
+        );
+        vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
+        emit IEtherFiNodesManager.ValidatorSwitchToCompoundingRequested(
+            address(pod0),
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[1]),
+            pubkeys[1]
+        );
+        
+        vm.deal(admin, 1 ether);
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: valueToSend}(reqs);
+    }
+    
+    function test_requestConsolidation_mixedOperations_success() public {
+        bytes[] memory pubkeys = new bytes[](3);
+        uint256[] memory legacyIds = new uint256[](3);
+        pubkeys[0] = PK_16171;
+        pubkeys[1] = PK_16172;
+        pubkeys[2] = PK_16173;
+        legacyIds[0] = 51715;
+        legacyIds[1] = 51716;
+        legacyIds[2] = 51717;
+        
+        vm.startPrank(admin);
+        etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
+        vm.stopPrank();
+        
+        (, IEigenPod pod0) = _resolvePod(pubkeys[0]);
+        
+        // Mixed operations: consolidation + switch to compounding
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = new IEigenPodTypes.ConsolidationRequest[](2);
+        reqs[0] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[0],
+            targetPubkey: pubkeys[1]  // Consolidation
+        });
+        reqs[1] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[2],
+            targetPubkey: pubkeys[2]  // Switch to compounding
+        });
+        
+        uint256 feePer = pod0.getConsolidationRequestFee();
+        uint256 valueToSend = feePer * reqs.length;
+        
+        // Expect mixed events
+        vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
+        emit IEtherFiNodesManager.ValidatorConsolidationRequested(
+            address(pod0),
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[0]),
+            pubkeys[0],
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[1]),
+            pubkeys[1]
+        );
+        vm.expectEmit(true, true, true, true, address(etherFiNodesManager));
+        emit IEtherFiNodesManager.ValidatorSwitchToCompoundingRequested(
+            address(pod0),
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkeys[2]),
+            pubkeys[2]
+        );
+        
+        vm.deal(admin, 1 ether);
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: valueToSend}(reqs);
+    }
+    
+    function test_requestConsolidation_accessControl_onlyAdmin() public {
+        bytes[] memory pubkeys = new bytes[](1);
+        uint256[] memory legacyIds = new uint256[](1);
+        pubkeys[0] = PK_16171;
+        legacyIds[0] = 51715;
+        
+        vm.startPrank(admin);
+        etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
+        vm.stopPrank();
+        
+        (, IEigenPod pod0) = _resolvePod(pubkeys[0]);
+        
+        // Create consolidation request
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = new IEigenPodTypes.ConsolidationRequest[](1);
+        reqs[0] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[0],
+            targetPubkey: pubkeys[0]
+        });
+        
+        uint256 feePer = pod0.getConsolidationRequestFee();
+        uint256 valueToSend = feePer * reqs.length;
+        
+        // Non-admin should revert
+        address nonAdmin = vm.addr(123);
+        vm.deal(nonAdmin, 1 ether);
+        vm.expectRevert();
+        vm.prank(nonAdmin);
+        etherFiNodesManager.requestConsolidation{value: valueToSend}(reqs);
+        
+        // Admin should succeed
+        vm.deal(admin, 1 ether);
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: valueToSend}(reqs);
+    }
+    
+    function test_requestConsolidation_insufficientFee_reverts() public {
+        bytes[] memory pubkeys = new bytes[](2);
+        uint256[] memory legacyIds = new uint256[](2);
+        pubkeys[0] = PK_16171;
+        pubkeys[1] = PK_16172;
+        legacyIds[0] = 51715;
+        legacyIds[1] = 51716;
+        
+        vm.startPrank(admin);
+        etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
+        vm.stopPrank();
+        
+        (, IEigenPod pod0) = _resolvePod(pubkeys[0]);
+        
+        // Create consolidation requests
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = new IEigenPodTypes.ConsolidationRequest[](2);
+        reqs[0] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[0],
+            targetPubkey: pubkeys[1]
+        });
+        reqs[1] = IEigenPodTypes.ConsolidationRequest({
+            srcPubkey: pubkeys[1],
+            targetPubkey: pubkeys[0]
+        });
+        
+        uint256 feePer = pod0.getConsolidationRequestFee();
+        uint256 correctFee = feePer * reqs.length;
+        
+        // Test insufficient fee (if fee > 0)
+        if (feePer > 0) {
+            vm.deal(admin, 1 ether);
+            vm.expectRevert(IEtherFiNodesManager.InsufficientConsolidationFees.selector);
+            vm.prank(admin);
+            etherFiNodesManager.requestConsolidation{value: correctFee - 1}(reqs);
+        }
+        
+        // Test correct fee should work
+        vm.deal(admin, 1 ether);
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: correctFee}(reqs);
+    }
+    
+    function test_requestConsolidation_emptyRequests_reverts() public {
+        // Empty request array should revert
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = new IEigenPodTypes.ConsolidationRequest[](0);
+
+        vm.deal(admin, 1 ether);
+        vm.expectRevert(IEtherFiNodesManager.EmptyConsolidationRequest.selector);
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: 0}(reqs);
+    }
+    
+    function test_requestConsolidation_feeCalculation_accuracy() public {
+        bytes[] memory pubkeys = new bytes[](3);
+        uint256[] memory legacyIds = new uint256[](3);
+        pubkeys[0] = PK_16171;
+        pubkeys[1] = PK_16172;
+        pubkeys[2] = PK_16173;
+        legacyIds[0] = 51715;
+        legacyIds[1] = 51716;
+        legacyIds[2] = 51717;
+        
+        vm.startPrank(admin);
+        etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
+        vm.stopPrank();
+        
+        (, IEigenPod pod0) = _resolvePod(pubkeys[0]);
+        
+        // Test different batch sizes for fee calculation accuracy using only known working pubkeys
+        uint256 feePer = pod0.getConsolidationRequestFee();
+        
+        for (uint256 batchSize = 1; batchSize <= 3; batchSize++) {
+            IEigenPodTypes.ConsolidationRequest[] memory reqs = new IEigenPodTypes.ConsolidationRequest[](batchSize);
+            for (uint256 i = 0; i < batchSize; i++) {
+                reqs[i] = IEigenPodTypes.ConsolidationRequest({
+                    srcPubkey: pubkeys[i],
+                    targetPubkey: pubkeys[(i + 1) % pubkeys.length]
+                });
+            }
+            
+            uint256 expectedFee = feePer * batchSize;
+            
+            vm.deal(admin, 2 ether);
+            vm.prank(admin);
+            etherFiNodesManager.requestConsolidation{value: expectedFee}(reqs);
+        }
+    }
+
 }
 


### PR DESCRIPTION
## Summary

This PR implements EIP-7251 validator consolidation functionality for the etherFi protocol, following the same EIP-7002 withdrawal request patterns. This enables validator consolidation and switching from `0x01` to `0x02` (compounding withdrawal credentials)

### Notes:
- Combine multiple validators into single validators with up to 2,048 ETH
- Switch validators from `0x01` to `0x02` credentials for automatic reward compounding
- Up to 64x reduction in proof size and gas costs for large restakers
