### PR TITLE
fix tests in EtherFiRestaker.t.sol

### DIFF
--- a/test/EtherFiRestaker.t.sol
+++ b/test/EtherFiRestaker.t.sol
@@ -42,10 +42,8 @@ contract EtherFiRestakerTest is TestSetup {
         stEth.submit{value: _amount}(address(0));
 
         stEth.approve(address(liquifierInstance), _amount);
-        
-        ILiquidityPool.PermitInput memory permitInput = createPermitInput(2, address(liquifierInstance), _amount, stEth.nonces(alice), 2**256 - 1, stEth.DOMAIN_SEPARATOR());
-        ILiquifier.PermitInput memory permitInput2 = ILiquifier.PermitInput({value: permitInput.value, deadline: permitInput.deadline, v: permitInput.v, r: permitInput.r, s: permitInput.s});
-        liquifierInstance.depositWithERC20WithPermit(address(stEth), _amount, address(0), permitInput2);
+
+        liquifierInstance.depositWithERC20(address(stEth), _amount, address(0));
 
 
         // Aliice has 10 ether eETH


### PR DESCRIPTION
Ran 12 tests for test/EtherFiRestaker.t.sol:EtherFiRestakerTest
[PASS] test_change_operator() (gas: 708251)
[PASS] test_claimer_upgrade() (gas: 234585)
[PASS] test_completeQueuedWithdrawals_1() (gas: 1000229)
[PASS] test_completeQueuedWithdrawals_2() (gas: 1703926)
[PASS] test_data() (gas: 10712)
[PASS] test_data_2() (gas: 10671)
[PASS] test_delegate_to() (gas: 696448)
[PASS] test_queueWithdrawals_1() (gas: 981624)
[PASS] test_queueWithdrawals_2() (gas: 991221)
[PASS] test_restake_stEth() (gas: 676675)
[PASS] test_undelegate() (gas: 1024939)
[PASS] test_withdrawal_of_non_restaked_stEth() (gas: 953060)
Suite result: ok. 12 passed; 0 failed; 0 skipped; finished in 21.97s (111.37s CPU time)

Ran 1 test suite in 21.97s (21.97s CPU time): 12 tests passed, 0 failed, 0 skipped (12 total tests)