### PR TITLE
WIP: track deployed nodes which enables many refactors

### DIFF
--- a/script/V3PreludeTransactions.sol
+++ b/script/V3PreludeTransactions.sol
@@ -17,6 +17,7 @@ import "../lib/openzeppelin-contracts/contracts/access/IAccessControl.sol";
 import "forge-std/console2.sol";
 
 contract V3PreludeTransactions is Script {
+    /*
 
     EtherFiTimelock etherFiTimelock = EtherFiTimelock(payable(0x9f26d4C958fD811A1F59B01B86Be7dFFc9d20761));
 
@@ -152,9 +153,9 @@ contract V3PreludeTransactions is Script {
             targets,
             values,
             data,
-            bytes32(0)/*=predecessor*/,
+            bytes32(0), // predecessor
             timelockSalt,
-            259200/*=minDelay*/
+            259200 // minDelay
         );
 
         console2.log("Schedule Tx:");
@@ -166,7 +167,7 @@ contract V3PreludeTransactions is Script {
             targets,
             values,
             data,
-            bytes32(0)/*=predecessor*/,
+            bytes32(0), //predecessor
             timelockSalt
         );
 
@@ -174,10 +175,10 @@ contract V3PreludeTransactions is Script {
         console2.logBytes(executeCalldata);
 
         // uncomment to run against fork
-        //etherFiTimelock.scheduleBatch(targets, values, data, bytes32(0)/*=predecessor*/, timelockSalt, 259200/*=minDelay*/);
+        //etherFiTimelock.scheduleBatch(targets, values, data, bytes32(0), timelockSalt, 259200);
 
         //bytes32 timelockSalt = TODO set as salt from schedule;
-        //etherFiTimelock.executeBatch(targets, values, data, bytes32(0)/*=predecessor*/, timelockSalt);
+        //etherFiTimelock.executeBatch(targets, values, data, bytes32(0), timelockSalt);
     }
 
 
@@ -219,9 +220,9 @@ contract V3PreludeTransactions is Script {
             targets,
             values,
             data,
-            bytes32(0)/*=predecessor*/,
+            bytes32(0), // predecessor
             timelockSalt,
-            259200/*=minDelay*/
+            259200 // minDelay
         );
 
         console2.log("Rollback Schedule Tx:");
@@ -233,7 +234,7 @@ contract V3PreludeTransactions is Script {
             targets,
             values,
             data,
-            bytes32(0)/*=predecessor*/,
+            bytes32(0), //predecessor
             timelockSalt
         );
 
@@ -241,13 +242,14 @@ contract V3PreludeTransactions is Script {
         console2.logBytes(executeCalldata);
 
         // uncomment to run against fork
-        //etherFiTimelock.scheduleBatch(targets, values, data, bytes32(0)/*=predecessor*/, timelockSalt, 259200/*=minDelay*/);
+        //etherFiTimelock.scheduleBatch(targets, values, data, bytes32(0), timelockSalt, 259200);
 
-        //etherFiTimelock.executeBatch(targets, values, data, bytes32(0)/*=predecessor*/, timelockSalt);
+        //etherFiTimelock.executeBatch(targets, values, data, bytes32(0), timelockSalt);
 
     }
 
     function _encodeRoleGrant(bytes32 role, address account) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(RoleRegistry.grantRole.selector, role, account);
     }
+    */
 }

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -26,21 +26,13 @@ contract EtherFiNode is IEtherFiNode {
     IEigenPodManager public immutable eigenPodManager;
     IDelegationManager public immutable delegationManager;
     uint32 public constant EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS = 100800;
+    address public constant BEACON_ETH_STRATEGY_ADDRESS = address(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
     //---------------------------------------------------------------------------
     //-----------------------------  Storage  -----------------------------------
     //---------------------------------------------------------------------------
 
     LegacyNodeState legacyState; // all legacy state in this contract has been deprecated
-
-    //--------------------------------------------------------------------------------------
-    //-------------------------------------  ROLES  ---------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    bytes32 public constant ETHERFI_NODE_EIGENLAYER_ADMIN_ROLE = keccak256("ETHERFI_NODE_EIGENLAYER_ADMIN_ROLE");
-    bytes32 public constant ETHERFI_NODE_CALL_FORWARDER_ROLE = keccak256("ETHERFI_NODE_CALL_FORWARDER_ROLE");
-    bytes32 public constant ETHERFI_NODE_UNRESTAKER_ROLE = keccak256("ETHERFI_NODE_UNRESTAKER_ROLE");
-    address public constant BEACON_ETH_STRATEGY_ADDRESS = address(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
     //-------------------------------------------------------------------------
     //-----------------------------  Admin  -----------------------------------
@@ -68,32 +60,29 @@ contract EtherFiNode is IEtherFiNode {
 
     /// @dev creates a new eigenpod and returns its address. Reverts if a pod already exists for this node.
     ///      This address is deterministic and you can pre-compute it if necessary.
-    function createEigenPod() external onlyEigenlayerAdmin returns (address) {
+    function createEigenPod() external onlyEtherFiNodesManager returns (address) {
         return eigenPodManager.createPod();
     }
 
     /// @dev specify another address with permissions to submit checkpoint and withdrawal credential proofs
-    function setProofSubmitter(address _newProofSubmitter) external onlyEigenlayerAdmin {
+    function setProofSubmitter(address _newProofSubmitter) external onlyEtherFiNodesManager {
         getEigenPod().setProofSubmitter(_newProofSubmitter);
     }
 
     /// @dev start an eigenlayer checkpoint proof. Once a checkpoint is started, it must be completed
-    function startCheckpoint() external onlyEigenlayerAdmin {
+    function startCheckpoint() external onlyEtherFiNodesManager {
         bool revertIfNoBalance = true; // protect from wasting gas if checkpoint will not increase shares
         getEigenPod().startCheckpoint(revertIfNoBalance);
     }
 
     /// @dev submit a subset of proofs for the currently active checkpoint
-    function verifyCheckpointProofs(BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyEigenlayerAdmin {
+    function verifyCheckpointProofs(BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyEtherFiNodesManager {
         getEigenPod().verifyCheckpointProofs(balanceContainerProof, proofs);
     }
 
     /// @dev convenience function to queue a beaconETH withdrawal from eigenlayer. You must wait EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS before claiming.
     ///   It is fine to queue a withdrawal before validators have finished exiting on the beacon chain.
-    function queueETHWithdrawal(uint256 amount) external returns (bytes32 withdrawalRoot) {
-        if (!roleRegistry.hasRole(ETHERFI_NODE_UNRESTAKER_ROLE, msg.sender)) revert IncorrectRole();
-
-        etherFiNodesManager.consumeUnrestakingCapacity(amount);
+    function queueETHWithdrawal(uint256 amount) external onlyEtherFiNodesManager returns (bytes32 withdrawalRoot) {
 
         // beacon eth is always 1 to 1 with deposit shares
         uint256[] memory depositShares = new uint256[](1);
@@ -116,11 +105,12 @@ contract EtherFiNode is IEtherFiNode {
     ///   Note that since the node is usually delegated to an operator,
     ///   most of the time this should be called with "receiveAsTokens" = true because
     ///   receiving shares while delegated will simply redelegate the shares.
-    function completeQueuedETHWithdrawals(bool receiveAsTokens) external onlyEigenlayerAdmin returns (uint256 balance) {
+    function completeQueuedETHWithdrawals(bool receiveAsTokens) external onlyEtherFiNodesManager returns (uint256 balance) {
 
         // because we are just dealing with beacon eth we don't need to populate the tokens[] array
         IERC20[] memory tokens = new IERC20[](1);
 
+        bool anyWithdrawalsCompleted = false;
         (IDelegationManager.Withdrawal[] memory queuedWithdrawals, ) = delegationManager.getQueuedWithdrawals(address(this));
         for (uint256 i = 0; i < queuedWithdrawals.length; i++) {
 
@@ -131,7 +121,9 @@ contract EtherFiNode is IEtherFiNode {
             if (queuedWithdrawals[i].strategies[0] != IStrategy(BEACON_ETH_STRATEGY_ADDRESS)) continue;
 
             delegationManager.completeQueuedWithdrawal(queuedWithdrawals[i], tokens, receiveAsTokens);
+            anyWithdrawalsCompleted = true;
         }
+        if (!anyWithdrawalsCompleted) revert NoCompleteableWithdrawals(); // bad dev experience if function completes but nothing happened
 
         // if there are available rewards, forward them to the liquidityPool
         uint256 balance = address(this).balance;
@@ -145,20 +137,7 @@ contract EtherFiNode is IEtherFiNode {
 
     /// @dev queue a withdrawal from eigenlayer. You must wait EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS before claiming.
     ///   For the general case of queuing a beaconETH withdrawal you can use queueETHWithdrawal instead.
-    function queueWithdrawals(IDelegationManager.QueuedWithdrawalParams[] calldata params) external returns (bytes32[] memory withdrawalRoots) {
-        if (!roleRegistry.hasRole(ETHERFI_NODE_UNRESTAKER_ROLE, msg.sender)) revert IncorrectRole();
-        
-        // Calculate total beaconETH amount for rate limiting - only rate limit beaconETH strategy withdrawals
-        uint256 totalBeaconEth = 0;
-        for (uint256 i = 0; i < params.length; i++) {
-            for (uint256 j = 0; j < params[i].strategies.length; j++) {
-                if (params[i].strategies[j] == IStrategy(BEACON_ETH_STRATEGY_ADDRESS)) {
-                    totalBeaconEth += params[i].depositShares[j];
-                }
-            }
-        }
-        etherFiNodesManager.consumeUnrestakingCapacity(totalBeaconEth);
-
+    function queueWithdrawals(IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyEtherFiNodesManager returns (bytes32[] memory withdrawalRoots) {
         return delegationManager.queueWithdrawals(params);
     }
 
@@ -168,14 +147,14 @@ contract EtherFiNode is IEtherFiNode {
         IDelegationManager.Withdrawal[] calldata withdrawals,
         IERC20[][] calldata tokens,
         bool[] calldata receiveAsTokens
-    ) external onlyEigenlayerAdmin {
+    ) external onlyEtherFiNodesManager {
         delegationManager.completeQueuedWithdrawals(withdrawals, tokens, receiveAsTokens);
     }
 
     // @notice transfers any funds held by the node to the liquidity pool.
     // @dev under normal operations it is not expected for eth to accumulate in the nodes,
     //    this is just to handle any exceptional cases such as someone sending directly to the node.
-    function sweepFunds() external onlyEigenlayerAdmin returns (uint256 balance) {
+    function sweepFunds() external onlyEtherFiNodesManager returns (uint256 balance) {
         uint256 balance = address(this).balance;
         if (balance > 0) {
             (bool sent, ) = payable(address(liquidityPool)).call{value: balance, gas: 20000}("");
@@ -188,20 +167,14 @@ contract EtherFiNode is IEtherFiNode {
     //-------------------------------------------------------------------
     //-------------  Execution-Layer Triggered Withdrawals  -------------
     //-------------------------------------------------------------------
-    function requestWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable {
-        if (msg.sender != address(etherFiNodesManager)) {
-            revert InvalidCaller();
-        }
+    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable onlyEtherFiNodesManager {
         getEigenPod().requestWithdrawal{value: msg.value}(requests);
     }
 
     //-------------------------------------------------------------------
     //-------------  Execution-Layer Triggered Consolidations  ----------
     //-------------------------------------------------------------------
-    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable {
-        if (msg.sender != address(etherFiNodesManager)) {
-            revert InvalidCaller();
-        }
+    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable onlyEtherFiNodesManager {
         getEigenPod().requestConsolidation{value: msg.value}(requests);
     }
 
@@ -209,7 +182,7 @@ contract EtherFiNode is IEtherFiNode {
     //-------------------------------- CALL FORWARDING  ------------------------------------
     //--------------------------------------------------------------------------------------
 
-    function forwardEigenPodCall(bytes calldata data) external onlyCallForwarder returns (bytes memory) {
+    function forwardEigenPodCall(bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
 
         // validate the call
         if (data.length < 4) revert InvalidForwardedCall();
@@ -220,7 +193,7 @@ contract EtherFiNode is IEtherFiNode {
         return LibCall.callContract(address(getEigenPod()), 0, data);
     }
 
-    function forwardExternalCall(address to, bytes calldata data) external onlyCallForwarder returns (bytes memory) {
+    function forwardExternalCall(address to, bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
 
         // validate the call
         if (data.length < 4) revert InvalidForwardedCall();
@@ -234,13 +207,8 @@ contract EtherFiNode is IEtherFiNode {
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
 
-    modifier onlyEigenlayerAdmin() {
-        if (!roleRegistry.hasRole(ETHERFI_NODE_EIGENLAYER_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
-        _;
-    }
-
-    modifier onlyCallForwarder() {
-        if (!roleRegistry.hasRole(ETHERFI_NODE_CALL_FORWARDER_ROLE, msg.sender)) revert IncorrectRole();
+    modifier onlyEtherFiNodesManager() {
+        if (msg.sender != address(etherFiNodesManager)) revert InvalidCaller();
         _;
     }
 

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -183,23 +183,11 @@ contract EtherFiNode is IEtherFiNode {
     //--------------------------------------------------------------------------------------
 
     function forwardEigenPodCall(bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
-
-        // validate the call
-        if (data.length < 4) revert InvalidForwardedCall();
-        bytes4 selector = bytes4(data[:4]);
-        if (!etherFiNodesManager.allowedForwardedEigenpodCalls(selector)) revert ForwardedCallNotAllowed();
-
         // callContract will revert if targeting an EOA so it is safe if getEigenPod() returns the zero address
         return LibCall.callContract(address(getEigenPod()), 0, data);
     }
 
     function forwardExternalCall(address to, bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
-
-        // validate the call
-        if (data.length < 4) revert InvalidForwardedCall();
-        bytes4 selector = bytes4(data[:4]);
-        if (!etherFiNodesManager.allowedForwardedExternalCalls(selector, to)) revert ForwardedCallNotAllowed();
-
         return LibCall.callContract(to, 0, data);
     }
 

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -99,6 +99,11 @@ contract EtherFiNodesManager is
     // tooling which used to operate on a per-validator level instead of per-pod/per-node.
     // Over time we will migrate to directly calling the associated method on the EtherFiNode contract where applicable.
 
+    function createEigenPod(address node) external onlyEigenlayerAdmin whenNotPaused returns (address) {
+        if (!stakingManager.deployedEtherFiNodes(node)) revert UnknownNode();
+        return IEtherFiNode(node).createEigenPod();
+    }
+
     function getEigenPod(uint256 id) public view returns (address) {
         return address(IEtherFiNode(etherfiNodeAddress(id)).getEigenPod());
     }

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -47,7 +47,6 @@ contract EtherFiNodesManager is
     bytes32 public constant ETHERFI_NODES_MANAGER_POD_PROVER_ROLE = keccak256("ETHERFI_NODES_MANAGER_POD_PROVER_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE = keccak256("ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE = keccak256("ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE");
-    bytes32 public constant ETHERFI_NODES_MANAGER_UNRESTAKER_ROLE = keccak256("ETHERFI_NODES_MANAGER_UNRESTAKER_ROLE");
 
     //-------------------------------------------------------------------------
     //-----------------------------  Rate Limiter Buckets ---------------------
@@ -254,7 +253,7 @@ contract EtherFiNodesManager is
 
         // eigenlayer will revert if all validators don't belong to the same pod
         bytes32 pubKeyHash = calculateValidatorPubkeyHash(requests[0].srcPubkey);
-        IEtherFiNode node = etherFiNodeFromPubkeyHash[pubKeyHash];      
+        IEtherFiNode node = etherFiNodeFromPubkeyHash[pubKeyHash];
         IEigenPod pod = node.getEigenPod();
 
         // submitting an execution layer consolidation request requires paying a fee per request
@@ -273,13 +272,6 @@ contract EtherFiNodesManager is
             }
             unchecked { ++i; }
         }
-    }
-
-
-    function consumeUnrestakingCapacity(uint256 amount) external {
-        if (!roleRegistry.hasRole(ETHERFI_NODES_MANAGER_UNRESTAKER_ROLE, msg.sender)) revert IncorrectRole(); 
-        uint256 amountGwei = amount / 1 gwei;
-        rateLimiter.consume(UNRESTAKING_LIMIT_ID, SafeCast.toUint64(amountGwei));
     }
 
     // returns withdrawal fee per each request

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -33,15 +33,14 @@ contract EtherFiNodesManager is
     //---------------------------------------------------------------------------
     //-----------------------------  Storage  -----------------------------------
     //---------------------------------------------------------------------------
-
     LegacyNodesManagerState private legacyState;
     mapping(bytes4 => bool) public allowedForwardedEigenpodCalls; // Call Forwarding: functionSelector -> allowed
     mapping(bytes4 => mapping(address => bool)) public allowedForwardedExternalCalls; // Call Forwarding: functionSelector -> targetAddress -> allowed
     mapping(bytes32 => IEtherFiNode) public etherFiNodeFromPubkeyHash;
+
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ROLES  ----------------------------------------
     //--------------------------------------------------------------------------------------
-
     bytes32 public constant ETHERFI_NODES_MANAGER_ADMIN_ROLE = keccak256("ETHERFI_NODES_MANAGER_ADMIN_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_EIGENLAYER_ADMIN_ROLE = keccak256("ETHERFI_NODES_MANAGER_EIGENLAYER_ADMIN_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE = keccak256("ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE");
@@ -318,6 +317,7 @@ contract EtherFiNodesManager is
             emit PubkeyLinked(pubkeyHash, nodeAddress, validatorIds[i], pubkeys[i]);
         }
     }
+
 
     //--------------------------------------------------------------------------------------
     //-------------------------------- CALL FORWARDING  ------------------------------------

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -44,6 +44,7 @@ contract EtherFiNodesManager is
     //--------------------------------------------------------------------------------------
     bytes32 public constant ETHERFI_NODES_MANAGER_ADMIN_ROLE = keccak256("ETHERFI_NODES_MANAGER_ADMIN_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_EIGENLAYER_ADMIN_ROLE = keccak256("ETHERFI_NODES_MANAGER_EIGENLAYER_ADMIN_ROLE");
+    bytes32 public constant ETHERFI_NODES_MANAGER_POD_PROVER_ROLE = keccak256("ETHERFI_NODES_MANAGER_POD_PROVER_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE = keccak256("ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE = keccak256("ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_UNRESTAKER_ROLE = keccak256("ETHERFI_NODES_MANAGER_UNRESTAKER_ROLE");
@@ -107,18 +108,18 @@ contract EtherFiNodesManager is
         return address(IEtherFiNode(node).getEigenPod());
     }
 
-    function startCheckpoint(uint256 id) external onlyEigenlayerAdmin whenNotPaused {
+    function startCheckpoint(uint256 id) external onlyPodProver whenNotPaused {
         IEtherFiNode(etherfiNodeAddress(id)).startCheckpoint();
     }
-    function startCheckpoint(address node) external onlyEigenlayerAdmin whenNotPaused {
+    function startCheckpoint(address node) external onlyPodProver whenNotPaused {
         if (!stakingManager.deployedEtherFiNodes(node)) revert UnknownNode();
         IEtherFiNode(node).startCheckpoint();
     }
 
-    function verifyCheckpointProofs(uint256 id, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyEigenlayerAdmin whenNotPaused {
+    function verifyCheckpointProofs(uint256 id, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyPodProver whenNotPaused {
         IEtherFiNode(etherfiNodeAddress(id)).verifyCheckpointProofs(balanceContainerProof, proofs);
     }
-    function verifyCheckpointProofs(address node, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyEigenlayerAdmin whenNotPaused {
+    function verifyCheckpointProofs(address node, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyPodProver whenNotPaused {
         if (!stakingManager.deployedEtherFiNodes(node)) revert UnknownNode();
         IEtherFiNode(node).verifyCheckpointProofs(balanceContainerProof, proofs);
     }
@@ -431,6 +432,11 @@ contract EtherFiNodesManager is
 
     modifier onlyCallForwarder() {
         if (!roleRegistry.hasRole(ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE, msg.sender)) revert IncorrectRole();
+        _;
+    }
+
+    modifier onlyPodProver() {
+        if (!roleRegistry.hasRole(ETHERFI_NODES_MANAGER_POD_PROVER_ROLE, msg.sender)) revert IncorrectRole();
         _;
     }
 }

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -343,7 +343,6 @@ contract EtherFiNodesManager is
         }
     }
 
-
     /// @dev this method is for linking our old legacy validator ids that were created before
     ///    we started tracking the pubkeys onchain. We can delete this method once we have linked all of our legacy validators
     function linkLegacyValidatorIds(uint256[] calldata validatorIds, bytes[] calldata pubkeys) external onlyAdmin {

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -202,12 +202,13 @@ contract StakingManager is
 
         BeaconProxy proxy = new BeaconProxy(address(etherFiNodeBeacon), "");
         address node = address(proxy);
-        if (_createEigenPod) {
-            IEtherFiNode(node).createEigenPod();
-        }
 
         deployedEtherFiNodes[node] = true;
         emit EtherFiNodeDeployed(node);
+
+        if (_createEigenPod) {
+            etherFiNodesManager.createEigenPod(node);
+        }
 
         return node;
     }

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -41,12 +41,14 @@ contract StakingManager is
     //---------------------------------------------------------------------------
 
     LegacyStakingManagerState legacyState; // all legacy state in this contract has been deprecated
+    mapping(address => bool) public deployedEtherFiNodes;
 
     //---------------------------------------------------------------------------
     //---------------------------  ROLES  ---------------------------------------
     //---------------------------------------------------------------------------
 
     bytes32 public constant STAKING_MANAGER_NODE_CREATOR_ROLE = keccak256("STAKING_MANAGER_NODE_CREATOR_ROLE");
+    bytes32 public constant STAKING_MANAGER_ADMIN_ROLE = keccak256("STAKING_MANAGER_ADMIN_ROLE");
 
     //-------------------------------------------------------------------------
     //-----------------------------  Admin  -----------------------------------
@@ -203,7 +205,32 @@ contract StakingManager is
         if (_createEigenPod) {
             IEtherFiNode(node).createEigenPod();
         }
+
+        deployedEtherFiNodes[node] = true;
+        emit EtherFiNodeDeployed(node);
+
         return node;
+    }
+
+    /// @dev this method is for backfilling the addresses of etherFiNodes the protocol has previously deployed
+    ///    Once this data has been backfilled we can delete this method
+    function backfillExistingEtherFiNodes(address[] calldata nodes) external onlyAdmin {
+        for (uint256 i = 0; i < nodes.length; i++) {
+            address node = nodes[i];
+            if (deployedEtherFiNodes[node]) continue; // already linked
+
+            deployedEtherFiNodes[node] = true;
+            emit EtherFiNodeDeployed(node);
+        }
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  MODIFIERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    modifier onlyAdmin() {
+        if (!roleRegistry.hasRole(STAKING_MANAGER_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        _;
     }
 
 }

--- a/src/interfaces/IEtherFiNode.sol
+++ b/src/interfaces/IEtherFiNode.sol
@@ -19,7 +19,7 @@ interface IEtherFiNode {
     function queueWithdrawals(IDelegationManager.QueuedWithdrawalParams[] calldata params) external returns (bytes32[] memory withdrawalRoot);
     function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external;
     function sweepFunds() external returns (uint256 balance);
-    function requestWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable;
+    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable;
     function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable;
 
 
@@ -94,5 +94,6 @@ interface IEtherFiNode {
     error ForwardedCallNotAllowed();
     error InvalidForwardedCall();
     error InvalidCaller();
+    error NoCompleteableWithdrawals();
 
 }

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -49,8 +49,8 @@ interface IEtherFiNodesManager {
     // call forwarding
     function updateAllowedForwardedExternalCalls(bytes4 selector, address target, bool allowed) external;
     function updateAllowedForwardedEigenpodCalls(bytes4 selector, bool allowed) external;
-    function forwardExternalCall(uint256[] calldata ids, bytes[] calldata data, address target) external returns (bytes[] memory returnData);
-    function forwardEigenPodCall(uint256[] calldata ids, bytes[] calldata data) external returns (bytes[] memory returnData);
+    function forwardExternalCall(address[] calldata nodes, bytes[] calldata data, address target) external returns (bytes[] memory returnData);
+    function forwardEigenPodCall(address[] calldata nodes, bytes[] calldata data) external returns (bytes[] memory returnData);
     function allowedForwardedEigenpodCalls(bytes4 selector) external returns (bool);
     function allowedForwardedExternalCalls(bytes4 selector, address to) external returns (bool);
 

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.13;
 
 import "../interfaces/IEtherFiNode.sol";
+import "../interfaces/IStakingManager.sol";
 import "../eigenlayer-interfaces/IDelegationManager.sol";
+import "../eigenlayer-interfaces/IEigenPod.sol";
 import {BeaconChainProofs} from "../eigenlayer-libraries/BeaconChainProofs.sol";
 
 interface IEtherFiNodesManager {
@@ -14,7 +16,7 @@ interface IEtherFiNodesManager {
     function linkPubkeyToNode(bytes calldata pubkey, address nodeAddress, uint256 legacyId) external;
     function calculateValidatorPubkeyHash(bytes memory pubkey) external pure returns (bytes32);
 
-    function stakingManager() external view returns (address);
+    function stakingManager() external view returns (IStakingManager);
 
     // eigenlayer interactions
     function getEigenPod(uint256 id) external view returns (address);
@@ -26,10 +28,10 @@ interface IEtherFiNodesManager {
     function queueWithdrawals(uint256 id, IDelegationManager.QueuedWithdrawalParams[] calldata params) external;
     function completeQueuedWithdrawals(uint256 id, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external;
     function sweepFunds(uint256 id) external;
+    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable;
+    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable;
 
-    // unrestaking rate limiting
-    function consumeUnrestakingCapacity(uint256 amount) external;
-    
+
     // rate limiting constants
     function UNRESTAKING_LIMIT_ID() external view returns (bytes32);
     function EXIT_REQUEST_LIMIT_ID() external view returns (bytes32);

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -19,15 +19,25 @@ interface IEtherFiNodesManager {
     function stakingManager() external view returns (IStakingManager);
 
     // eigenlayer interactions
+    function createEigenPod(address node) external returns (address);
     function getEigenPod(uint256 id) external view returns (address);
+    function getEigenPod(address node) external view returns (address);
     function startCheckpoint(uint256 id) external;
+    function startCheckpoint(address node) external;
     function verifyCheckpointProofs(uint256 id, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external;
+    function verifyCheckpointProofs(address node, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external;
     function setProofSubmitter(uint256 id, address newProofSubmitter) external;
+    function setProofSubmitter(address node, address newProofSubmitter) external;
     function queueETHWithdrawal(uint256 id, uint256 amount) external returns (bytes32 withdrawalRoot);
+    function queueETHWithdrawal(address node, uint256 amount) external returns (bytes32 withdrawalRoot);
     function completeQueuedETHWithdrawals(uint256 id, bool receiveAsTokens) external;
+    function completeQueuedETHWithdrawals(address node, bool receiveAsTokens) external;
     function queueWithdrawals(uint256 id, IDelegationManager.QueuedWithdrawalParams[] calldata params) external;
+    function queueWithdrawals(address node, IDelegationManager.QueuedWithdrawalParams[] calldata params) external;
     function completeQueuedWithdrawals(uint256 id, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external;
+    function completeQueuedWithdrawals(address node, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external;
     function sweepFunds(uint256 id) external;
+    //function sweepFunds(address node) external;
     function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable;
     function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable;
 

--- a/src/interfaces/IStakingManager.sol
+++ b/src/interfaces/IStakingManager.sol
@@ -72,6 +72,7 @@ interface IStakingManager {
     event validatorCreated(bytes32 indexed pubkeyHash, address indexed etherFiNode, bytes pubkey);
     event validatorConfirmed(bytes32 indexed pubkeyHash, address indexed bnftRecipient, address indexed tnftRecipient, bytes pubkey);
     event linkLegacyValidatorId(bytes32 indexed pubkeyHash, uint256 indexed legacyId);
+    event EtherFiNodeDeployed(address indexed etheFiNode);
 
     // legacy event still being emitted in its original form to play nice with existing external tooling
     event ValidatorRegistered(address indexed operator, address indexed bNftOwner, address indexed tNftOwner, uint256 validatorId, bytes validatorPubKey, string ipfsHashForEncryptedValidatorKey);

--- a/src/interfaces/IStakingManager.sol
+++ b/src/interfaces/IStakingManager.sol
@@ -22,6 +22,7 @@ interface IStakingManager {
     // EtherFiNode Beacon Proxy
     function upgradeEtherFiNode(address _newImplementation) external;
     function getEtherFiNodeBeacon() external view returns (address);
+    function deployedEtherFiNodes(address etherFiNode) external view returns (bool);
 
     // protocol
     function pauseContract() external;

--- a/test/EtherFiRateLimiter.t.sol
+++ b/test/EtherFiRateLimiter.t.sol
@@ -709,54 +709,6 @@ contract EtherFiRateLimiterTest is Test {
     }
 
     //--------------------------------------------------------------------------------------
-    //-------------------------------- Migration Tests ------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    function test_migrateFromLegacyLimiter() public {
-        // Create legacy limit structure
-        BucketLimiter.Limit memory legacyLimit = BucketLimiter.Limit({
-            capacity: DEFAULT_CAPACITY,
-            remaining: DEFAULT_CAPACITY / 2,
-            lastRefill: uint64(block.timestamp), // Use current timestamp to avoid underflow
-            refillRate: DEFAULT_REFILL_RATE
-        });
-
-        vm.expectEmit(true, false, false, true);
-        emit LimiterCreated(LIMIT_ID_1, DEFAULT_CAPACITY, DEFAULT_REFILL_RATE);
-
-        vm.prank(admin);
-        rateLimiter.migrateFromLegacyLimiter(LIMIT_ID_1, legacyLimit);
-
-        assertTrue(rateLimiter.limitExists(LIMIT_ID_1));
-        
-        (uint64 capacity, uint64 remaining, uint64 refillRate, uint256 lastRefill) = 
-            rateLimiter.getLimit(LIMIT_ID_1);
-
-        assertEq(capacity, legacyLimit.capacity);
-        assertEq(remaining, legacyLimit.remaining);
-        assertEq(refillRate, legacyLimit.refillRate);
-        assertEq(lastRefill, legacyLimit.lastRefill);
-    }
-
-    function test_cannotMigrateDuplicateLimiter() public {
-        // Create regular limiter first
-        vm.prank(admin);
-        rateLimiter.createNewLimiter(LIMIT_ID_1, DEFAULT_CAPACITY, DEFAULT_REFILL_RATE);
-
-        // Try to migrate over it
-        BucketLimiter.Limit memory legacyLimit = BucketLimiter.Limit({
-            capacity: DEFAULT_CAPACITY * 2,
-            remaining: DEFAULT_CAPACITY,
-            lastRefill: uint64(block.timestamp),
-            refillRate: DEFAULT_REFILL_RATE * 2
-        });
-
-        vm.prank(admin);
-        vm.expectRevert(IEtherFiRateLimiter.LimitAlreadyExists.selector);
-        rateLimiter.migrateFromLegacyLimiter(LIMIT_ID_1, legacyLimit);
-    }
-
-    //--------------------------------------------------------------------------------------
     //-------------------------------- Integration Tests ----------------------------------
     //--------------------------------------------------------------------------------------
 

--- a/test/common/ArrayTestHelper.sol
+++ b/test/common/ArrayTestHelper.sol
@@ -31,6 +31,11 @@ contract ArrayTestHelper {
         vals[0] = val;
         return vals;
     }
+    function toArray(address val) public pure returns (address[] memory) {
+        address[] memory vals = new address[](1);
+        vals[0] = val;
+        return vals;
+    }
     function toArray(IDelegationManager.Withdrawal memory withdrawal) public pure returns (IDelegationManager.Withdrawal[] memory) {
         IDelegationManager.Withdrawal[] memory vals = new IDelegationManager.Withdrawal[](1);
         vals[0] = withdrawal;

--- a/test/prelude.t.sol
+++ b/test/prelude.t.sol
@@ -109,15 +109,9 @@ contract PreludeTest is Test, ArrayTestHelper {
 
         // permissions
         vm.startPrank(roleRegistry.owner());
-        roleRegistry.grantRole(etherFiNodeImpl.ETHERFI_NODE_EIGENLAYER_ADMIN_ROLE(), address(etherFiNodesManager));
-        roleRegistry.grantRole(etherFiNodeImpl.ETHERFI_NODE_EIGENLAYER_ADMIN_ROLE(), address(stakingManager));
-        roleRegistry.grantRole(etherFiNodeImpl.ETHERFI_NODE_EIGENLAYER_ADMIN_ROLE(), eigenlayerAdmin);
-        roleRegistry.grantRole(etherFiNodeImpl.ETHERFI_NODE_CALL_FORWARDER_ROLE(), address(etherFiNodesManager));
         roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_ADMIN_ROLE(), admin);
         roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE(), callForwarder);
         roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_EIGENLAYER_ADMIN_ROLE(), eigenlayerAdmin);
-        roleRegistry.grantRole(etherFiNodeImpl.ETHERFI_NODE_UNRESTAKER_ROLE(), eigenlayerAdmin);
-        roleRegistry.grantRole(etherFiNodeImpl.ETHERFI_NODE_UNRESTAKER_ROLE(), address(etherFiNodesManager));
         roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_UNRESTAKER_ROLE(), eigenlayerAdmin);
         roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE(), elExiter);
         roleRegistry.grantRole(stakingManager.STAKING_MANAGER_NODE_CREATOR_ROLE(), admin);
@@ -364,7 +358,6 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.startPrank(roleRegistry.owner());
         {
             roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE(), user);
-            roleRegistry.grantRole(EtherFiNode(payable(address(etherFiNode))).ETHERFI_NODE_CALL_FORWARDER_ROLE(), user);
         }
         vm.stopPrank();
 
@@ -916,7 +909,7 @@ contract PreludeTest is Test, ArrayTestHelper {
     }
 
     // ---------- tests for EL exits ----------
-    function test_requestWithdrawal_samePod_fullExit_success() public {
+    function test_requestExecutionLayerTriggeredWithdrawal_samePod_fullExit_success() public {
 
         bytes[] memory pubkeys = new bytes[](3);
         uint256[] memory legacyIds = new uint256[](3);
@@ -970,10 +963,10 @@ contract PreludeTest is Test, ArrayTestHelper {
         }
 
         vm.prank(elExiter);
-        etherFiNodesManager.requestWithdrawal{value: valueToSend}(reqs);
+        etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: valueToSend}(reqs);
     }
 
-    function test_requestWithdrawal_samePod_partialExit_success() public {
+    function test_requestExecutionLayerTriggeredWithdrawal_samePod_partialExit_success() public {
 
         bytes[] memory pubkeys = new bytes[](3);
         uint256[] memory legacyIds = new uint256[](3);
@@ -1027,7 +1020,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         }
 
         vm.prank(elExiter);
-        etherFiNodesManager.requestWithdrawal{value: valueToSend}(reqs);
+        etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: valueToSend}(reqs);
     }
 
     function test_rateLimitSetters_access_control() public {
@@ -1071,7 +1064,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         etherFiNodesManager.setProofSubmitter(legacyIds[0], address(1));
     }
 
-    function test_requestWithdrawal_requires_role_reverts() public {
+    function test_requestExecutionLayerTriggeredWithdrawal_requires_role_reverts() public {
 
         bytes[] memory pubkeys = new bytes[](3);
         uint256[] memory legacyIds = new uint256[](3);
@@ -1106,7 +1099,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.deal(address(this), 1 ether);
 
         vm.expectRevert();
-        etherFiNodesManager.requestWithdrawal{value: valueToSend}(reqs);
+        etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: valueToSend}(reqs);
     }
 
     // ---------- tests for unrestaking rate limiter ----------
@@ -1258,7 +1251,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         // This should succeed (1 ETH << 5000 ETH capacity)
         vm.deal(elExiter, 1 ether);
         vm.prank(elExiter);
-        etherFiNodesManager.requestWithdrawal{value: valueToSend}(reqs);
+        etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: valueToSend}(reqs);
     }
     
     function test_exitRequestsRateLimiting_capacity_admin_functions() public {

--- a/test/prelude.t.sol
+++ b/test/prelude.t.sol
@@ -430,6 +430,54 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.assertTrue(stakingManager.deployedEtherFiNodes(oldNodes[1]), "not added to mapping");
     }
 
+    function test_etherFiNodeAllowedCallers() public {
+
+        vm.prank(admin);
+        IEtherFiNode node = IEtherFiNode(stakingManager.instantiateEtherFiNode(true));
+
+        // methods should only be callable by EFNM
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.createEigenPod();
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.setProofSubmitter(address(0x123));
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.startCheckpoint();
+
+        BeaconChainProofs.BalanceContainerProof memory containerProof = BeaconChainProofs.BalanceContainerProof({balanceContainerRoot: bytes32(uint256(1)),proof: ""});
+        BeaconChainProofs.BalanceProof[] memory balanceProofs = new BeaconChainProofs.BalanceProof[](1);
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.verifyCheckpointProofs(containerProof, balanceProofs);
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.queueETHWithdrawal(1000);
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.completeQueuedETHWithdrawals(true);
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.queueWithdrawals(new IDelegationManager.QueuedWithdrawalParams[](0));
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.completeQueuedWithdrawals(new IDelegationManager.Withdrawal[](0), new IERC20[][](0), new bool[](0));
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.sweepFunds();
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.requestExecutionLayerTriggeredWithdrawal(new IEigenPod.WithdrawalRequest[](0));
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.requestConsolidation(new IEigenPod.ConsolidationRequest[](0));
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.forwardEigenPodCall(hex"00000000");
+
+        vm.expectRevert(IEtherFiNode.InvalidCaller.selector);
+        node.forwardExternalCall(address(0x123), hex"00000000");
+    }
+
     function test_StakingManagerUpgradePermissions() public {
 
         // deploy new staking manager implementation


### PR DESCRIPTION
* Staking manager tracks all etherFiNode contracts it deploys
  * admin method to backfill old node date
* All key methods of etherFiNode now called from EFNM. No more direct calls
  * Remove lots of unused roles from above change
* No more circular dependencies rate limits
* remove UNRESTAKER role from EFNM that is no longer necessary
* New POD_PROVER role so prover server can be removed from forwarding whitelist improving security
* Handful of small dev-xp changes for painpoints after v3-prelude

Multiple tests that need to be fixed, and new tests for some of the new functionality need to be written