### PR TITLE
feat: new call forwarding strategy

### DIFF
--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -48,7 +48,6 @@ contract EtherFiNodesManager is
     bytes32 public constant ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE = keccak256("ETHERFI_NODES_MANAGER_CALL_FORWARDER_ROLE");
     bytes32 public constant ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE = keccak256("ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE");
 
-
     //-------------------------------------------------------------------------
     //-----------------------------  Rate Limiter Buckets ---------------------
     //-------------------------------------------------------------------------

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -427,25 +427,6 @@ contract EtherFiNodesManager is
         }
     }
 
-    /// @notice Batch update the whitelist for external calls (convenience function)
-    /// @param user The address to grant/revoke permissions for
-    /// @param selectors Array of method selectors
-    /// @param targets Array of call targets for forwarded calls
-    /// @param allowed Array of enable/disable flags
-    function batchUpdateAllowedForwardedExternalCalls(
-        address user,
-        bytes4[] calldata selectors, 
-        address[] calldata targets, 
-        bool[] calldata allowed
-    ) external onlyAdmin {
-        if (selectors.length != targets.length || selectors.length != allowed.length) revert LengthMismatch();
-
-        for (uint256 i = 0; i < selectors.length; i++) {
-            allowedForwardedExternalCalls[user][selectors[i]][targets[i]] = allowed[i];
-            emit UserAllowedForwardedExternalCallsUpdated(user, selectors[i], targets[i], allowed[i]);
-        }
-    }
-
     //--------------------------------------------------------------------------------------
     //-----------------------------------  HELPERS  ----------------------------------------
     //--------------------------------------------------------------------------------------

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -49,10 +49,16 @@ interface IEtherFiNodesManager {
     // call forwarding
     function updateAllowedForwardedExternalCalls(bytes4 selector, address target, bool allowed) external;
     function updateAllowedForwardedEigenpodCalls(bytes4 selector, bool allowed) external;
+    function updateUserAllowedForwardedExternalCalls(address user, bytes4 selector, address target, bool allowed) external;
+    function updateUserAllowedForwardedEigenpodCalls(address user, bytes4 selector, bool allowed) external;
+    function batchUpdateAllowedForwardedExternalCalls(bytes4[] calldata selectors, address[] calldata targets, bool[] calldata allowed) external;
+    function batchUpdateUserAllowedForwardedExternalCalls(address user, bytes4[] calldata selectors, address[] calldata targets, bool[] calldata allowed) external;
     function forwardExternalCall(address[] calldata nodes, bytes[] calldata data, address target) external returns (bytes[] memory returnData);
     function forwardEigenPodCall(address[] calldata nodes, bytes[] calldata data) external returns (bytes[] memory returnData);
-    function allowedForwardedEigenpodCalls(bytes4 selector) external returns (bool);
-    function allowedForwardedExternalCalls(bytes4 selector, address to) external returns (bool);
+    function allowedForwardedEigenpodCalls(bytes4 selector) external view returns (bool);
+    function allowedForwardedExternalCalls(bytes4 selector, address to) external view returns (bool);
+    function userAllowedForwardedEigenpodCalls(address user, bytes4 selector) external view returns (bool);
+    function userAllowedForwardedExternalCalls(address user, bytes4 selector, address to) external view returns (bool);
 
     // protocol
     function pauseContract() external;
@@ -123,6 +129,8 @@ interface IEtherFiNodesManager {
     event PubkeyLinked(bytes32 indexed pubkeyHash, address indexed nodeAddress, uint256 indexed legacyId, bytes pubkey);
     event AllowedForwardedExternalCallsUpdated(bytes4 indexed selector, address indexed _target, bool _allowed);
     event AllowedForwardedEigenpodCallsUpdated(bytes4 indexed selector, bool _allowed);
+    event UserAllowedForwardedExternalCallsUpdated(address indexed user, bytes4 indexed selector, address indexed _target, bool _allowed);
+    event UserAllowedForwardedEigenpodCallsUpdated(address indexed user, bytes4 indexed selector, bool _allowed);
     event FundsTransferred(address indexed nodeAddress, uint256 amount);
     event ValidatorWithdrawalRequestSent(address indexed pod, bytes32 indexed validatorPubkeyHash, bytes validatorPubkey);
     event ValidatorSwitchToCompoundingRequested(address indexed pod, bytes32 indexed validatorPubkeyHash, bytes validatorPubkey);

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -47,18 +47,13 @@ interface IEtherFiNodesManager {
     function EXIT_REQUEST_LIMIT_ID() external view returns (bytes32);
 
     // call forwarding
-    function updateAllowedForwardedExternalCalls(bytes4 selector, address target, bool allowed) external;
-    function updateAllowedForwardedEigenpodCalls(bytes4 selector, bool allowed) external;
-    function updateUserAllowedForwardedExternalCalls(address user, bytes4 selector, address target, bool allowed) external;
-    function updateUserAllowedForwardedEigenpodCalls(address user, bytes4 selector, bool allowed) external;
-    function batchUpdateAllowedForwardedExternalCalls(bytes4[] calldata selectors, address[] calldata targets, bool[] calldata allowed) external;
-    function batchUpdateUserAllowedForwardedExternalCalls(address user, bytes4[] calldata selectors, address[] calldata targets, bool[] calldata allowed) external;
+    function updateAllowedForwardedExternalCalls(address user, bytes4 selector, address target, bool allowed) external;
+    function updateAllowedForwardedEigenpodCalls(address user, bytes4 selector, bool allowed) external;
+    function batchUpdateAllowedForwardedExternalCalls(address user, bytes4[] calldata selectors, address[] calldata targets, bool[] calldata allowed) external;
     function forwardExternalCall(address[] calldata nodes, bytes[] calldata data, address target) external returns (bytes[] memory returnData);
     function forwardEigenPodCall(address[] calldata nodes, bytes[] calldata data) external returns (bytes[] memory returnData);
-    function allowedForwardedEigenpodCalls(bytes4 selector) external view returns (bool);
-    function allowedForwardedExternalCalls(bytes4 selector, address to) external view returns (bool);
-    function userAllowedForwardedEigenpodCalls(address user, bytes4 selector) external view returns (bool);
-    function userAllowedForwardedExternalCalls(address user, bytes4 selector, address to) external view returns (bool);
+    function allowedForwardedEigenpodCalls(address user, bytes4 selector) external view returns (bool);
+    function allowedForwardedExternalCalls(address user, bytes4 selector, address to) external view returns (bool);
 
     // protocol
     function pauseContract() external;
@@ -127,8 +122,6 @@ interface IEtherFiNodesManager {
     //---------------------------------------------------------------------------
 
     event PubkeyLinked(bytes32 indexed pubkeyHash, address indexed nodeAddress, uint256 indexed legacyId, bytes pubkey);
-    event AllowedForwardedExternalCallsUpdated(bytes4 indexed selector, address indexed _target, bool _allowed);
-    event AllowedForwardedEigenpodCallsUpdated(bytes4 indexed selector, bool _allowed);
     event UserAllowedForwardedExternalCallsUpdated(address indexed user, bytes4 indexed selector, address indexed _target, bool _allowed);
     event UserAllowedForwardedEigenpodCallsUpdated(address indexed user, bytes4 indexed selector, bool _allowed);
     event FundsTransferred(address indexed nodeAddress, uint256 amount);

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -49,7 +49,6 @@ interface IEtherFiNodesManager {
     // call forwarding
     function updateAllowedForwardedExternalCalls(address user, bytes4 selector, address target, bool allowed) external;
     function updateAllowedForwardedEigenpodCalls(address user, bytes4 selector, bool allowed) external;
-    function batchUpdateAllowedForwardedExternalCalls(address user, bytes4[] calldata selectors, address[] calldata targets, bool[] calldata allowed) external;
     function forwardExternalCall(address[] calldata nodes, bytes[] calldata data, address target) external returns (bytes[] memory returnData);
     function forwardEigenPodCall(address[] calldata nodes, bytes[] calldata data) external returns (bytes[] memory returnData);
     function allowedForwardedEigenpodCalls(address user, bytes4 selector) external view returns (bool);


### PR DESCRIPTION
## Summary

Implemented a new granular call forwarding whitelist strategy for `EtherFiNodesManager` that adds user-specific permissions instead of the previous function-level permissions. This addresses security concerns where hot wallets with `CALL_FORWARDER_ROLE` had access to all whitelisted functions.

#### Storage Structure changes

```solidity 
// OLD - Function-level permissions
mapping(bytes4 => bool) public allowedForwardedEigenpodCalls;
mapping(bytes4 => mapping(address => bool)) public allowedForwardedExternalCalls;

 // NEW - User-specific permissions
mapping(address => mapping(bytes4 => bool)) public allowedForwardedEigenpodCalls;
mapping(address => mapping(bytes4 => mapping(address => bool))) public allowedForwardedExternalCalls;
```

#### Interface & Events Update
- Updated `IEtherFiNodesManager` interface to match new function signatures
- Consolidated events to user-specific variants only
- Updated view functions to accept user parameter

### why:
- Before: Any address with `CALL_FORWARDER_ROLE` could call ANY whitelisted function
- After: Each address can only call functions they're specifically granted permission for

### Remaining work:

- Add script for cleaning old storage use
