### PR TITLE
refactor: Update EtherFiRedemptionManager tests

### DIFF
--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -208,12 +208,12 @@ contract EtherFiRedemptionManagerTest is TestSetup {
             assertApproxEqAbs(
                 eETHInstance.balanceOf(address(treasuryInstance)),
                 treasuryBalanceBefore + treasuryFee,
-                1e2
+                1e3
             );
             assertApproxEqAbs(
                 address(user).balance,
                 userBalanceBefore + userReceives,
-                1e2
+                1e3
             );
 
         } else {
@@ -394,6 +394,11 @@ contract EtherFiRedemptionManagerTest is TestSetup {
     function test_mainnet_redeem_eEth_for_stETH() public {
         setUp_Fork();
         ILido stEth = ILido(address(etherFiRestakerInstance.lido()));
+        
+        vm.startPrank(op_admin);
+        etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(0, address(etherFiRestakerInstance.lido()));
+        vm.stopPrank();
+        
         vm.deal(user, 2010 ether);
         vm.startPrank(user);
         liquidityPoolInstance.deposit{value: 2005 ether}();
@@ -425,6 +430,10 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
     function test_mainnet_redeem_weEth_with_rebase() public {
         setUp_Fork();
+        
+        vm.startPrank(op_admin);
+        etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(0, address(etherFiRestakerInstance.lido()));
+        vm.stopPrank();
 
         vm.deal(alice, 50000 ether);
         vm.prank(alice);
@@ -532,6 +541,10 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
     function test_redeem_stETH_share_price() public {
         setUp_Fork();
+        vm.startPrank(op_admin);
+        etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(0, address(etherFiRestakerInstance.lido()));
+        vm.stopPrank();
+
         vm.startPrank(user);
         vm.deal(user, 10 ether);
         liquidityPoolInstance.deposit{value: 10 ether}();
@@ -569,6 +582,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         //set fee to 0
         vm.startPrank(op_admin);
         etherFiRedemptionManagerInstance.setExitFeeBasisPoints(0, address(etherFiRestakerInstance.lido()));
+        etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(0, address(etherFiRestakerInstance.lido()));
         vm.stopPrank();
         //get number of shares for 1 ether
         vm.startPrank(user);
@@ -596,6 +610,10 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
     function test_redeem_eEth_share_price() public {
         setUp_Fork();
+        vm.startPrank(op_admin);
+        etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(0, ETH_ADDRESS);
+        vm.stopPrank();
+        
         vm.startPrank(user);
         vm.deal(user, 10 ether);
         liquidityPoolInstance.deposit{value: 10 ether}();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Loosens assertion tolerances and explicitly sets low-watermark to 0 via admin in several mainnet redemption tests for ETH and stETH.
> 
> - **Tests (`test/EtherFiRedemptionManager.t.sol`)**:
>   - *Fuzz weETH redemption*: Relax `assertApproxEqAbs` tolerances from `1e2` to `1e3`.
>   - *Mainnet redemption setups*:
>     - Add `op_admin` calls to `setLowWatermarkInBpsOfTvl(0, ...)` before redemptions:
>       - `lido` token in `test_mainnet_redeem_eEth_for_stETH`, `test_mainnet_redeem_weEth_with_rebase`, and `test_redeem_stETH_share_price`.
>       - `ETH_ADDRESS` in `test_redeem_eEth_share_price`.
>     - Also set low watermark to 0 alongside zero exit fee in `test_redeem_stETH_share_price_with_not_fee`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 129db5bff8297273c0d26a2bbf5da5508701da2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->