### PR TITLE
refactor: fix DepositAdapterTest tests

### DIFF
--- a/test/DepositAdapter.t.sol
+++ b/test/DepositAdapter.t.sol
@@ -130,15 +130,15 @@ contract DepositAdapterTest is TestSetup {
         uint256 wstETHAmount = wstETHmainnet.wrap(5 ether);
 
         // valid wstETH deposit
-        uint256 protocolSeETHBeforeDeposit = stEth.balanceOf(address(liquifierInstance));
+        uint256 protocolSeETHBeforeDeposit = stEth.balanceOf(address(etherFiRestakerInstance));
         ILiquidityPool.PermitInput memory permitInput = createPermitInput(2, address(depositAdapterInstance), wstETHAmount, wstETHmainnet.nonces(alice), 2**256 - 1, wstETHmainnet.DOMAIN_SEPARATOR());
         ILiquifier.PermitInput memory liquifierPermitInput = ILiquifier.PermitInput({value: permitInput.value, deadline: permitInput.deadline, v: permitInput.v, r: permitInput.r, s: permitInput.s});
 
         depositAdapterInstance.depositWstETHForWeETHWithPermit(wstETHAmount, bob, liquifierPermitInput);
-
+        uint256 eETHAmountFromWstETH = liquifierInstance.quoteByDiscountedValue(address(stEth), 5 ether);
         assertEq(wstETHmainnet.balanceOf(address(alice)), 0);
-        assertApproxEqAbs(weEthInstance.balanceOf(address(alice)), weEthInstance.getWeETHByeETH(5 ether), 3);
-        assertApproxEqAbs(stEth.balanceOf(address(liquifierInstance)), protocolSeETHBeforeDeposit + 5 ether, 3);
+        assertApproxEqAbs(weEthInstance.balanceOf(address(alice)), weEthInstance.getWeETHByeETH(eETHAmountFromWstETH), 3);
+        assertApproxEqAbs(stEth.balanceOf(address(etherFiRestakerInstance)), protocolSeETHBeforeDeposit + 5 ether, 3);
 
         // deposit with insufficient balance
         permitInput = createPermitInput(2, address(depositAdapterInstance), 1 ether, wstETHmainnet.nonces(alice), 2**256 - 1, wstETHmainnet.DOMAIN_SEPARATOR());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust DepositAdapter tests to account for discounted eETH quotes, route stETH accounting to `etherFiRestakerInstance`, and relax a revert check; also raise deposit caps and reset `alice` code.
> 
> - **Tests (`test/DepositAdapter.t.sol`)**:
>   - **Accounting/targets**:
>     - Assert `stETH` balances against `etherFiRestakerInstance` instead of `liquifierInstance`.
>   - **Pricing logic**:
>     - Compute eETH via `liquifierInstance.quoteByDiscountedValue(...)` and assert `weETH` using discounted amounts for `stETH` and `wstETH` deposits.
>   - **Reverts**:
>     - Change empty-request check to `vm.expectRevert()` (no selector).
>   - **Setup**:
>     - Increase caps via `updateDepositCap(address(stEth), 600000, 4000000)`.
>     - `vm.etch(alice, "")` before `startHoax(alice)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 557e085592beb7c37eecf6c6bdfdb4868ea52eed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->