### PR TITLE
Update EtherFiOracle.conf

### DIFF
--- a/certora/config/EtherFiOracle.conf
+++ b/certora/config/EtherFiOracle.conf
@@ -1,16 +1,44 @@
 {
-    "files": [
-        "src/EtherFiOracle.sol"
-    ],
-    "packages": [
-        "@openzeppelin=lib/openzeppelin-contracts",
-        "@openzeppelin-upgradeable=lib/openzeppelin-contracts-upgradeable",
-        "forge-std=lib/forge-std/src",
-        "./interfaces=src/interfaces"
-    ],
-    "verify": "EtherFiOracle:certora/specs/EtherFiOracle.spec",
-    "rule_sanity": "basic",
-    "optimistic_loop": true,
-    "loop_iter": "3",
-    "msg": "Invariant and parametric examples"
+  // --- Core Configuration and Target Files ---
+  
+  // List of Solidity files to be analyzed by the Certora Prover.
+  "files": [
+    "src/EtherFiOracle.sol"
+  ],
+  
+  // --- Package Remappings (Dependencies) ---
+  
+  // Defines import remappings, essential for resolving external dependencies
+  // (e.g., OpenZeppelin, Forge-Std) during compilation for the Certora Prover.
+  "packages": [
+    "@openzeppelin=lib/openzeppelin-contracts",
+    "@openzeppelin-upgradeable=lib/openzeppelin-contracts-upgradeable",
+    "forge-std=lib/forge-std/src",
+    "./interfaces=src/interfaces"
+  ],
+  
+  // --- Formal Verification Settings ---
+  
+  // Specifies the main verification task: target contract and the spec file containing 
+  // the formal rules (invariants, properties).
+  "verify": "EtherFiOracle:certora/specs/EtherFiOracle.spec",
+  
+  // "rule_sanity" is often set to "none" or omitted when specific rules in the .spec file are used.
+  // Using "auto" enables a wider range of built-in sanity checks than "basic".
+  "rule_sanity": "auto", 
+  
+  // --- Loop Unrolling (Performance vs. Completeness Trade-off) ---
+  
+  // Enables optimistic loop unrolling, trading completeness for speed.
+  "optimistic_loop": true,
+  
+  // Defines the maximum number of loop iterations the Prover will check.
+  // Increased from "3" to "5" for deeper loop validation, reducing the risk 
+  // of missed bugs in longer loops.
+  "loop_iter": "5",
+  
+  // --- Run Description ---
+  
+  // A descriptive message for the verification run.
+  "msg": "Invariant verification run for EtherFiOracle, focusing on key parametric security properties."
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Certora config for `EtherFiOracle` to use `rule_sanity: "auto"`, increase `loop_iter` to 5, and add a clearer run message with structured comments.
> 
> - **Certora Config (`certora/config/EtherFiOracle.conf`)**:
>   - Switch `rule_sanity` from `"basic"` to `"auto"`.
>   - Increase `loop_iter` from `3` to `5`.
>   - Update `msg` to a more descriptive run description.
>   - Restructure file with organized sections and explanatory comments (no functional change otherwise).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4b974d4d5e2a7453b42a7d4a2f0af1af0cb8c3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->