### PR TITLE
Cross pod val approval

### DIFF
--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -108,6 +108,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
     error IncorrectRole();
     error InvalidEtherFiNode();
     error InvalidValidatorSize();
+    error InvalidArrayLengths();
 
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
@@ -309,6 +310,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
     ) external whenNotPaused {
         if (!roleRegistry.hasRole(LIQUIDITY_POOL_VALIDATOR_APPROVER_ROLE, msg.sender)) revert IncorrectRole();
         if (validatorSizeWei < 32 ether || validatorSizeWei > 2048 ether) revert InvalidValidatorSize();
+        if (_validatorIds.length == 0 || _validatorIds.length != _pubkeys.length || _validatorIds.length != _signatures.length) revert InvalidArrayLengths();
 
         // we have already deposited the initial amount to create the validator on the beacon chain
         uint256 remainingEthPerValidator = validatorSizeWei - stakingManager.initialDepositAmount();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `batchApproveRegistration` to support validators from different nodes and adds strict array length checks.
> 
> - **LiquidityPool.sol**:
>   - **batchApproveRegistration**:
>     - Supports cross-node approvals by deriving `withdrawalCredentials` per-validator (`etherfiNode.getEigenPod()` in-loop).
>     - Removes single-node enforcement (no `InvalidEtherFiNode` check across the batch).
>     - Adds strict input validation for non-empty, equal-length `_validatorIds`, `_pubkeys`, `_signatures` with new `InvalidArrayLengths` error.
>     - Maintains funding calculation based on `validatorSizeWei` and calls `confirmAndFundBeaconValidators` with constructed `depositData`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99ded4276ae6c9cfd2ef70b78ccbfcd949d012c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->