### PR TITLE
Add SCROLL_RPC_URL to test environment variables

### DIFF
--- a/.github/workflows/run-forge-tests.yaml
+++ b/.github/workflows/run-forge-tests.yaml
@@ -47,6 +47,7 @@ jobs:
           fi
         env:
           MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+          SCROLL_RPC_URL: ${{ secrets.SCROLL_RPC_URL }}
           HISTORICAL_PROOF_812_WITHDRAWAL_RPC_URL: ${{ secrets.HISTORICAL_PROOF_812_WITHDRAWAL_RPC_URL }}
           HISTORICAL_PROOF_RPC_URL: ${{ secrets.HISTORICAL_PROOF_RPC_URL }}
       


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Forge CI workflow to include the Scroll RPC secret for tests and coverage.
> 
> - Adds `SCROLL_RPC_URL` to env for `Run tests` and `Generate coverage report` in `.github/workflows/run-forge-tests.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da415b73f5432ee404d8118fce0122041dc073a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->