### PR TITLE
Handling remainder shares Integration tests

### DIFF
--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -414,7 +414,6 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         liquidityPoolInstance = LiquidityPool(payable(addressProviderInstance.getContractAddress("LiquidityPool")));
         eETHInstance = EETH(addressProviderInstance.getContractAddress("EETH"));
         weEthInstance = WeETH(addressProviderInstance.getContractAddress("WeETH"));
-        membershipManagerV1Instance = MembershipManager(payable(addressProviderInstance.getContractAddress("MembershipManager")));
         membershipNftInstance = MembershipNFT(addressProviderInstance.getContractAddress("MembershipNFT"));
         auctionInstance = AuctionManager(addressProviderInstance.getContractAddress("AuctionManager"));
         stakingManagerInstance = StakingManager(addressProviderInstance.getContractAddress("StakingManager"));

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -36,7 +36,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         withdrawRequestNFTInstance.claimWithdraw(requestId);
 
         uint256 remainderAmount = withdrawRequestNFTInstance.getEEthRemainderAmount();
-        vm.assume(remainderAmount > 0); // Skip if no remainder was created
+        assertGt(remainderAmount, 0, "Remainder amount should be greater than 0");
 
         // Grant the IMPLICIT_FEE_CLAIMER_ROLE to alice
         vm.startPrank(address(roleRegistryInstance.owner()));
@@ -101,7 +101,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         withdrawRequestNFTInstance.claimWithdraw(requestId);
 
         uint256 remainderAmount = withdrawRequestNFTInstance.getEEthRemainderAmount();
-        vm.assume(remainderAmount > 1 ether); // Need enough for partial handling
+        assertGt(remainderAmount, 1 ether, "Remainder amount should be greater than 1 ether for partial handling");
 
         vm.startPrank(address(roleRegistryInstance.owner()));
         withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet))));
@@ -130,7 +130,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
         // Remaining remainder should be available for further handling
         uint256 remainingRemainder = withdrawRequestNFTInstance.getEEthRemainderAmount();
-        vm.assume(remainingRemainder > 0);
+        assertGt(remainingRemainder, 0, "Remaining remainder should be greater than 0");
 
         // Handle remaining remainder
         vm.prank(alice);
@@ -177,7 +177,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
             withdrawRequestNFTInstance.claimWithdraw(requestId);
 
             uint256 remainderAmount = withdrawRequestNFTInstance.getEEthRemainderAmount();
-            vm.assume(remainderAmount > 0);
+            assertGt(remainderAmount, 0, "Remainder amount should be greater than 0");
 
             // Update split ratio
             vm.prank(withdrawRequestNFTInstance.owner());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces comprehensive integration coverage for handling eETH remainder shares and aligns test setup to use the deployed membership manager on mainnet forks.
> 
> - Adds `test/integration-tests/Handle-Remainder-Shares.t.sol` with scenarios for full handling, partial handling, and varying treasury split ratios; verifies event emission, treasury transfers, share movements, and remainder tracking
> - Updates `test/TestSetup.sol` to initialize `membershipManagerV1Instance` from `Deployed.MEMBERSHIP_MANAGER()` on mainnet and removes fetching `MembershipManager` from `AddressProvider`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15c86e18c4cfe2d47a0f049fa1d9df48e330cf28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->