### PR TITLE
Fix Tests: Handle Partial Remainder Test Fix

### DIFF
--- a/script/deploys/Deployed.s.sol
+++ b/script/deploys/Deployed.s.sol
@@ -61,8 +61,6 @@ contract Deployed {
     address public constant ETHERFI_UPGRADE_ADMIN = 0xcdd57D11476c22d265722F68390b036f3DA48c21; // upgrade admin
     address public constant ADMIN_EOA = 0x12582A27E5e19492b4FcD194a60F8f5e1aa31B0F; // admin eoa
 
-    address public constant ADMIN_EOA = 0x12582A27E5e19492b4FcD194a60F8f5e1aa31B0F; // admin eoa
-
     address public constant AVS_OPERATOR_1 = 0xDd777e5158Cb11DB71B4AF93C75A96eA11A2A615;
     address public constant AVS_OPERATOR_2 = 0x2c7cB7d5dC4aF9caEE654553a144C76F10D4b320;
 

--- a/script/el-exits/val-consolidations/topUpFork.s.sol
+++ b/script/el-exits/val-consolidations/topUpFork.s.sol
@@ -43,8 +43,6 @@ contract TopUpFork is Script, Deployed, Utils, ArrayTestHelper {
     EtherFiAdmin constant etherFiAdminInstance = EtherFiAdmin(payable(ETHERFI_ADMIN));
     WithdrawRequestNFT constant withdrawRequestNFTInstance = WithdrawRequestNFT(payable(WITHDRAW_REQUEST_NFT));
     address constant NODE_ADDRESS = 0xfbD914e11dF3DB8f475ae9C36ED46eE0c48f6B79;
-    address constant AVS_OPERATOR_1 = 0xDd777e5158Cb11DB71B4AF93C75A96eA11A2A615;
-    address constant AVS_OPERATOR_2 = 0x2c7cB7d5dC4aF9caEE654553a144C76F10D4b320;
 
     uint256 constant BID_ID = 110766;
     bytes constant PUBKEY = hex"a538a38970260348b6258eec086b932a76d369c96b5c87de5645807657c6128312e0c76bcd9987469ffe16d425bc971e";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens coverage of remainder handling and tidies address definitions.
> 
> - Update `Handle-Remainder-Shares.t.sol` to create 20 withdrawal requests with larger deposits, perform minimal rebase, handle half the remainder then the rest, and lower the remainder threshold to `> 0.05 ether`
> - Refactor `topUpFork.s.sol` to use `AVS_OPERATOR_*` from `Deployed` instead of local constants (no logic change)
> - Remove duplicate `ADMIN_EOA` definition in `Deployed.s.sol`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd32d8b0e894ce6386f4dc992196b54963987355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->