### PR TITLE
fix: speed up consolidation forge script and add --skip-forge-sim flag

### DIFF
--- a/script/operations/consolidations/query_validators_consolidation.py
+++ b/script/operations/consolidations/query_validators_consolidation.py
@@ -686,10 +686,12 @@ def convert_to_output_format(plan: Dict) -> Dict:
         consolidations_output.append({
             'target': target_output,
             'sources': sources_output,
+            'source_count': len(sources_output),
             'post_consolidation_balance_eth': c['post_consolidation_balance_eth']
         })
     
     return {
+        'num_consolidations': len(consolidations_output),
         'consolidations': consolidations_output,
         'summary': plan['summary'],
         'validation': plan['validation'],


### PR DESCRIPTION
## Summary

- **Fix JSON parsing bottleneck**: Added `num_consolidations` and `source_count` to the Python-generated JSON, so the Solidity script reads counts directly instead of iterating ~2000+ times with `stdJson.keyExists` (each call re-parses the full JSON)
- **Skip manual gas estimation**: In broadcast mode, each batch was simulated via `vm.prank` before broadcasting even with forge's `--skip-simulation`. Added `SKIP_GAS_ESTIMATE` env var to bypass this
- **New shell flags**: `--skip-forge-sim` (passes `--skip-simulation` + `SKIP_GAS_ESTIMATE` to forge), `--verbose`/`-v` (opt-in `-vvvv` traces, was previously always-on and caused hangs on large runs)

## Context

Running `run-consolidation.sh` with 1000+ validators caused the forge script to appear hung for 30+ minutes after "No files changed, compilation skipped" with no output. Root causes:
1. `_countSources()` and `_countConsolidations()` looped one-by-one through JSON entries
2. `-vvvv` was hardcoded (massive trace output)
3. Manual gas estimation ran even with `--skip-simulation`

## Usage

```bash
# Fast mainnet broadcast (no simulation, no verbose traces)
./script/operations/consolidations/run-consolidation.sh \
  --operator "ebunker" --count 1000 --mainnet --skip-forge-sim

# With full traces if needed for debugging
./script/operations/consolidations/run-consolidation.sh \
  --operator "ebunker" --count 50 --mainnet --verbose
```

## Test plan

- [ ] Verify `--skip-forge-sim` passes `--skip-simulation` and `SKIP_GAS_ESTIMATE=true` to forge
- [ ] Verify `--verbose` enables `-vvvv` traces
- [ ] Verify default run (no flags) has no `-vvvv` and no `--skip-simulation`
- [ ] Run with small count (e.g. `--count 10`) to confirm JSON counts are read correctly
- [ ] Backward compatible: old JSON files without `num_consolidations`/`source_count` fall back to iteration


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect mainnet broadcast execution paths (gas estimation and forge simulation flags), so misconfiguration could reduce safety checks even though defaults remain conservative and fallbacks preserve compatibility.
> 
> **Overview**
> Improves consolidation tooling performance by having `query_validators_consolidation.py` write precomputed `num_consolidations` and per-target `source_count`, and updating `ConsolidateToTarget.s.sol` to read these counts directly (with a fallback to the old iterative `stdJson.keyExists` loops).
> 
> Adds an opt-out for pre-broadcast gas estimation via `SKIP_GAS_ESTIMATE`/`Config.skipGasEstimate`, and extends `run-consolidation.sh` with `--skip-forge-sim` (passes `--skip-simulation` plus `SKIP_GAS_ESTIMATE=true`) and `--verbose/-v` (enables `-vvvv`, which is no longer always-on).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 437e04f43bfc4f8065ffc482d62fc39b22379bad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->