### PR TITLE
generate tx to claim + instant wds parameters

### DIFF
--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -429,7 +429,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         earlyAdopterPoolInstance = EarlyAdopterPool(payable(addressProviderInstance.getContractAddress("EarlyAdopterPool")));
         withdrawRequestNFTInstance = WithdrawRequestNFT(addressProviderInstance.getContractAddress("WithdrawRequestNFT"));
         liquifierInstance = Liquifier(payable(addressProviderInstance.getContractAddress("Liquifier")));
-        etherFiTimelockInstance = EtherFiTimelock(payable(addressProviderInstance.getContractAddress("EtherFiTimelock")));
+        etherFiTimelockInstance = EtherFiTimelock(payable(0xcD425f44758a08BaAB3C4908f3e3dE5776e45d7a));
         etherFiAdminInstance = EtherFiAdmin(payable(addressProviderInstance.getContractAddress("EtherFiAdmin")));
         etherFiOracleInstance = EtherFiOracle(payable(addressProviderInstance.getContractAddress("EtherFiOracle")));
         etherFiRedemptionManagerInstance = EtherFiRedemptionManager(payable(address(0xDadEf1fFBFeaAB4f68A9fD181395F68b4e4E7Ae0)));
@@ -1705,9 +1705,12 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         vm.stopPrank();
     }
 
-    function _batch_execute_timelock(address[] memory targets, bytes[] memory data, uint256[] memory values, bool _schedule, bool _log_schedule, bool _execute, bool _log_execute) internal {
-        vm.startPrank(0xcdd57D11476c22d265722F68390b036f3DA48c21);
-
+    function _batch_execute_timelock(address[] memory targets, bytes[] memory data, uint256[] memory values, bool _schedule, bool _log_schedule, bool _execute, bool _log_execute) internal { 
+        if(address(0x9f26d4C958fD811A1F59B01B86Be7dFFc9d20761) == address(etherFiTimelockInstance)) { // 3 Day Timelock
+            vm.startPrank(0xcdd57D11476c22d265722F68390b036f3DA48c21);
+        } else { // 8hr Timelock
+            vm.startPrank(0x2aCA71020De61bb532008049e1Bd41E451aE8AdC);
+        }
         bytes32 salt = keccak256(abi.encode(targets, data, block.number));
         if (_schedule) etherFiTimelockInstance.scheduleBatch(targets, values, data, bytes32(0), salt, etherFiTimelockInstance.getMinDelay());
         if (_log_schedule) _batch_output_schedule_txn(targets, data, values, bytes32(0), salt, etherFiTimelockInstance.getMinDelay());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes are confined to fork tests/helpers, but they alter which timelock address and executor are used when generating/executing timelock transactions, which could lead to incorrect onchain tx generation if misconfigured.
> 
> **Overview**
> Adds new mainnet-fork timelock tests that (1) build and execute a real `EtherFiRestaker.completeQueuedWithdrawals` call and subsequent `stEthRequestWithdrawal`, and (2) schedule/execute a batch update on `EtherFiRedemptionManager` to set *0 exit fee*, increase capacity, and adjust refill rate, then simulate a large instant redemption flow.
> 
> Updates forked `TestSetup` to use a hardcoded `EtherFiTimelock` address and changes `_batch_execute_timelock` to pick the prank executor based on whether the configured timelock is the 3-day vs 8-hour timelock address.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32cfb04146d16727357a427fd6ade1fd3a813f16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->