### PR TITLE
feat/pause-transfers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ release/logs/txns/*
 cache
 artifacts
 
+# Lock files
+foundry.lock
+
 .DS_Store
 .certora_internal/*
 

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -16,7 +16,7 @@ import "./interfaces/IRoleRegistry.sol";
 
 contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20PermitUpgradeable, IeETH, AssetRecovery {
     using CountersUpgradeable for CountersUpgradeable.Counter;
-    ILiquidityPool public liquidityPool;
+    ILiquidityPool public DEPRECATED_liquidityPool;
 
     uint256 public totalShares;
     mapping (address => uint256) public shares;
@@ -36,6 +36,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     bytes32 private immutable _TYPE_HASH;
 
     IRoleRegistry public immutable roleRegistry;
+    ILiquidityPool public immutable liquidityPool;
 
     bytes32 public constant EETH_OPERATING_ADMIN_ROLE = keccak256("EETH_OPERATING_ADMIN_ROLE");
     bytes32 public constant EETH_PAUSER_ROLE = keccak256("EETH_PAUSER_ROLE");
@@ -53,7 +54,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     error IncorrectRole();
 
     // TODO: Figure our what `name` and `version` are for
-    constructor(address _roleRegistry) {
+    constructor(address _roleRegistry, address _liquidityPool) {
         bytes32 hashedName = keccak256("EETH");
         bytes32 hashedVersion = keccak256("1");
         bytes32 typeHash = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
@@ -64,18 +65,17 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         _CACHED_THIS = address(this);
         _TYPE_HASH = typeHash;
 
-        require(_roleRegistry != address(0), "must set role registry");
+        require(_liquidityPool != address(0), "No zero addresses");
+        require(_roleRegistry != address(0), "No zero addresses");
         roleRegistry = IRoleRegistry(_roleRegistry);
+        liquidityPool = ILiquidityPool(_liquidityPool);
 
         _disableInitializers(); 
     }
 
-    function initialize(address _liquidityPool) external initializer {
-        require(_liquidityPool != address(0), "No zero addresses");
-        
+    function initialize() external initializer {    
         __UUPSUpgradeable_init();
         __Ownable_init();
-        liquidityPool = ILiquidityPool(_liquidityPool);
     }
 
     function mintShares(address _user, uint256 _share) external onlyPoolContract {

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -153,7 +153,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     function unpause() external {
         require(roleRegistry.hasRole(EETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
         if (pausedUntil >= block.timestamp) {
-            pausedUntil = uint64(block.timestamp) - 1;
+            pausedUntil = 0;
         }
         paused = false;
         emit Unpaused();
@@ -211,10 +211,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     }
 
     function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal {
+        require(!paused && pausedUntil < block.timestamp, "PAUSED");
         require(_sender != address(0), "TRANSFER_FROM_THE_ZERO_ADDRESS");
         require(_recipient != address(0), "TRANSFER_TO_THE_ZERO_ADDRESS");
         require(_sharesAmount <= shares[_sender], "TRANSFER_AMOUNT_EXCEEDS_BALANCE");
-        require(!paused && pausedUntil < block.timestamp, "PAUSED");
 
         shares[_sender] -= _sharesAmount;
         shares[_recipient] += _sharesAmount;

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -39,7 +39,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
 
     bytes32 public constant EETH_OPERATING_ADMIN_ROLE = keccak256("EETH_OPERATING_ADMIN_ROLE");
     bytes32 public constant EETH_PAUSER_ROLE = keccak256("EETH_PAUSER_ROLE");
-    bytes32 public constant EETH_EXTEND_PAUSER_ROLE = keccak256("EETH_EXTEND_PAUSER_ROLE");
+    bytes32 public constant EETH_PAUSER_UNTIL_ROLE = keccak256("EETH_PAUSER_UNTIL_ROLE");
 
     mapping(address => bool) public paused;
     mapping(address => uint64) public pausedUntil;
@@ -78,6 +78,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     }
 
     function mintShares(address _user, uint256 _share) external onlyPoolContract {
+        require(!paused[_user] && pausedUntil[_user] < block.timestamp, "MINT PAUSED");
         shares[_user] += _share;
         totalShares += _share;
 
@@ -87,6 +88,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
 
     function burnShares(address _user, uint256 _share) external {
         require(msg.sender == address(liquidityPool), "Incorrect Caller");
+        require(!paused[_user] && pausedUntil[_user] < block.timestamp, "BURN PAUSED");
         require(shares[_user] >= _share, "BURN_AMOUNT_EXCEEDS_BALANCE");
         shares[_user] -= _share;
         totalShares -= _share;
@@ -138,14 +140,14 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
 
     function pause(address _user) external {
         require(_user != address(0), "No zero addresses");
-        require(roleRegistry.hasRole(EETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         paused[_user] = true;
         emit Paused(_user);
     }
 
     function pauseUntil(address _user) external {
         require(_user != address(0), "No zero addresses");
-        require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(roleRegistry.hasRole(EETH_PAUSER_UNTIL_ROLE, msg.sender), "IncorrectRole");
         if (!paused[_user] && pausedUntil[_user] < block.timestamp) {
             pausedUntil[_user] = uint64(block.timestamp) + 1 days;
             emit PausedUntil(_user, pausedUntil[_user]);
@@ -154,7 +156,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
 
     function unpause(address _user) external {
         require(_user != address(0), "No zero addresses");
-        require(roleRegistry.hasRole(EETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         if (pausedUntil[_user] >= block.timestamp) {
             delete pausedUntil[_user];
         }

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -154,11 +154,11 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         }
     }
 
-    function extendPauseUntil(address _user, uint64 _duration) external {
+    function extendPauseUntil(address _user, uint256 _duration) external {
         require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
-            pausedUntil[_user] = block.timestamp + _duration;
+            pausedUntil[_user] += _duration;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -41,13 +41,13 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     bytes32 public constant EETH_PAUSER_ROLE = keccak256("EETH_PAUSER_ROLE");
     bytes32 public constant EETH_EXTEND_PAUSER_ROLE = keccak256("EETH_EXTEND_PAUSER_ROLE");
 
-    bool public paused;
-    uint64 public pausedUntil;
+    mapping(address => bool) public paused;
+    mapping(address => uint64) public pausedUntil;
 
     event TransferShares( address indexed from, address indexed to, uint256 sharesValue);
-    event Paused();
-    event PausedUntil(uint64 pausedUntil);
-    event Unpaused();
+    event Paused(address indexed user);
+    event PausedUntil(address indexed user, uint64 pausedUntil);
+    event Unpaused(address indexed user);
 
     error IncorrectRole();
 
@@ -136,27 +136,30 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         return true;
     }
 
-    function pause() external {
+    function pause(address _user) external {
+        require(_user != address(0), "No zero addresses");
         require(roleRegistry.hasRole(EETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
-        paused = true;
-        emit Paused();
+        paused[_user] = true;
+        emit Paused(_user);
     }
 
-    function pauseUntil() external {
+    function pauseUntil(address _user) external {
+        require(_user != address(0), "No zero addresses");
         require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
-        if (!paused && pausedUntil < block.timestamp) {
-            pausedUntil = uint64(block.timestamp) + 1 days;
-            emit PausedUntil(pausedUntil);
+        if (!paused[_user] && pausedUntil[_user] < block.timestamp) {
+            pausedUntil[_user] = uint64(block.timestamp) + 1 days;
+            emit PausedUntil(_user, pausedUntil[_user]);
         }
     }
 
-    function unpause() external {
+    function unpause(address _user) external {
+        require(_user != address(0), "No zero addresses");
         require(roleRegistry.hasRole(EETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
-        if (pausedUntil >= block.timestamp) {
-            pausedUntil = 0;
+        if (pausedUntil[_user] >= block.timestamp) {
+            delete pausedUntil[_user];
         }
-        paused = false;
-        emit Unpaused();
+        delete paused[_user];
+        emit Unpaused(_user);
     }
 
     function permit(
@@ -211,7 +214,8 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     }
 
     function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal {
-        require(!paused && pausedUntil < block.timestamp, "PAUSED");
+        require(!paused[_sender] && pausedUntil[_sender] < block.timestamp, "SENDER PAUSED");
+        require(!paused[_recipient] && pausedUntil[_recipient] < block.timestamp, "RECIPIENT PAUSED");
         require(_sender != address(0), "TRANSFER_FROM_THE_ZERO_ADDRESS");
         require(_recipient != address(0), "TRANSFER_TO_THE_ZERO_ADDRESS");
         require(_sharesAmount <= shares[_sender], "TRANSFER_AMOUNT_EXCEEDS_BALANCE");

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -42,11 +42,11 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     bytes32 public constant EETH_PAUSER_UNTIL_ROLE = keccak256("EETH_PAUSER_UNTIL_ROLE");
 
     bool public paused;
-    mapping(address => uint64) public pausedUntil;
+    mapping(address => uint256) public pausedUntil;
 
     event TransferShares( address indexed from, address indexed to, uint256 sharesValue);
     event Paused();
-    event PausedUntil(address indexed user, uint64 pausedUntil);
+    event PausedUntil(address indexed user, uint256 pausedUntil);
     event CancelledPauseUntil(address indexed user);
     event Unpaused();
 
@@ -149,7 +149,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         require(_user != address(0), "No zero addresses");
         require(roleRegistry.hasRole(EETH_PAUSER_UNTIL_ROLE, msg.sender), "IncorrectRole");
         if (pausedUntil[_user] < block.timestamp) {
-            pausedUntil[_user] = uint64(block.timestamp) + 1 days;
+            pausedUntil[_user] = block.timestamp + 1 days;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }
@@ -158,7 +158,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
-            pausedUntil[_user] = uint64(block.timestamp) + _duration;
+            pausedUntil[_user] = block.timestamp + _duration;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -41,13 +41,14 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     bytes32 public constant EETH_PAUSER_ROLE = keccak256("EETH_PAUSER_ROLE");
     bytes32 public constant EETH_PAUSER_UNTIL_ROLE = keccak256("EETH_PAUSER_UNTIL_ROLE");
 
-    mapping(address => bool) public paused;
+    bool public paused;
     mapping(address => uint64) public pausedUntil;
 
     event TransferShares( address indexed from, address indexed to, uint256 sharesValue);
-    event Paused(address indexed user);
+    event Paused();
     event PausedUntil(address indexed user, uint64 pausedUntil);
-    event Unpaused(address indexed user);
+    event CancelledPauseUntil(address indexed user);
+    event Unpaused();
 
     error IncorrectRole();
 
@@ -78,7 +79,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     }
 
     function mintShares(address _user, uint256 _share) external onlyPoolContract {
-        require(!paused[_user] && pausedUntil[_user] < block.timestamp, "MINT PAUSED");
+        require(!paused && pausedUntil[_user] < block.timestamp, "MINT PAUSED");
         shares[_user] += _share;
         totalShares += _share;
 
@@ -88,7 +89,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
 
     function burnShares(address _user, uint256 _share) external {
         require(msg.sender == address(liquidityPool), "Incorrect Caller");
-        require(!paused[_user] && pausedUntil[_user] < block.timestamp, "BURN PAUSED");
+        require(!paused && pausedUntil[_user] < block.timestamp, "BURN PAUSED");
         require(shares[_user] >= _share, "BURN_AMOUNT_EXCEEDS_BALANCE");
         shares[_user] -= _share;
         totalShares -= _share;
@@ -138,30 +139,41 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         return true;
     }
 
-    function pause(address _user) external {
-        require(_user != address(0), "No zero addresses");
+    function pause() external {
         require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
-        paused[_user] = true;
-        emit Paused(_user);
+        paused = true;
+        emit Paused();
     }
 
     function pauseUntil(address _user) external {
         require(_user != address(0), "No zero addresses");
         require(roleRegistry.hasRole(EETH_PAUSER_UNTIL_ROLE, msg.sender), "IncorrectRole");
-        if (!paused[_user] && pausedUntil[_user] < block.timestamp) {
+        if (pausedUntil[_user] < block.timestamp) {
             pausedUntil[_user] = uint64(block.timestamp) + 1 days;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }
 
-    function unpause(address _user) external {
-        require(_user != address(0), "No zero addresses");
+    function extendPauseUntil(address _user, uint64 _duration) external {
         require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
-            delete pausedUntil[_user];
+            pausedUntil[_user] = uint64(block.timestamp) + _duration;
+            emit PausedUntil(_user, pausedUntil[_user]);
         }
-        delete paused[_user];
-        emit Unpaused(_user);
+    }
+
+    function cancelPauseUntil(address _user) external {
+        require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(_user != address(0), "No zero addresses");
+        delete pausedUntil[_user];
+        emit CancelledPauseUntil(_user);
+    }
+
+    function unpause() external {
+        require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        paused = false;
+        emit Unpaused();
     }
 
     function permit(
@@ -216,8 +228,9 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     }
 
     function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal {
-        require(!paused[_sender] && pausedUntil[_sender] < block.timestamp, "SENDER PAUSED");
-        require(!paused[_recipient] && pausedUntil[_recipient] < block.timestamp, "RECIPIENT PAUSED");
+        require(!paused, "PAUSED");
+        require(pausedUntil[_sender] < block.timestamp, "SENDER PAUSED");
+        require(pausedUntil[_recipient] < block.timestamp, "RECIPIENT PAUSED");
         require(_sender != address(0), "TRANSFER_FROM_THE_ZERO_ADDRESS");
         require(_recipient != address(0), "TRANSFER_TO_THE_ZERO_ADDRESS");
         require(_sharesAmount <= shares[_sender], "TRANSFER_AMOUNT_EXCEEDS_BALANCE");

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -266,6 +266,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         return liquidityPool.getTotalEtherClaimOf(_user);
     }
 
+    function isPausedUntil(address _user) external view returns (bool) {
+        return pausedUntil[_user] >= block.timestamp;
+    }
+
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -166,8 +166,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     function cancelPauseUntil(address _user) external {
         require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
-        delete pausedUntil[_user];
-        emit CancelledPauseUntil(_user);
+        if (pausedUntil[_user] >= block.timestamp) {
+            delete pausedUntil[_user];
+            emit CancelledPauseUntil(_user);
+        }
     }
 
     function unpause() external {

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -38,8 +38,16 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     IRoleRegistry public immutable roleRegistry;
 
     bytes32 public constant EETH_OPERATING_ADMIN_ROLE = keccak256("EETH_OPERATING_ADMIN_ROLE");
+    bytes32 public constant EETH_PAUSER_ROLE = keccak256("EETH_PAUSER_ROLE");
+    bytes32 public constant EETH_EXTEND_PAUSER_ROLE = keccak256("EETH_EXTEND_PAUSER_ROLE");
+
+    bool public paused;
+    uint64 public pausedUntil;
 
     event TransferShares( address indexed from, address indexed to, uint256 sharesValue);
+    event Paused();
+    event PausedUntil(uint64 pausedUntil);
+    event Unpaused();
 
     error IncorrectRole();
 
@@ -128,6 +136,29 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         return true;
     }
 
+    function pause() external {
+        require(roleRegistry.hasRole(EETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        paused = true;
+        emit Paused();
+    }
+
+    function pauseUntil() external {
+        require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        if (!paused && pausedUntil < block.timestamp) {
+            pausedUntil = uint64(block.timestamp) + 1 days;
+            emit PausedUntil(pausedUntil);
+        }
+    }
+
+    function unpause() external {
+        require(roleRegistry.hasRole(EETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        if (pausedUntil >= block.timestamp) {
+            pausedUntil = uint64(block.timestamp) - 1;
+        }
+        paused = false;
+        emit Unpaused();
+    }
+
     function permit(
         address owner,
         address spender,
@@ -183,6 +214,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         require(_sender != address(0), "TRANSFER_FROM_THE_ZERO_ADDRESS");
         require(_recipient != address(0), "TRANSFER_TO_THE_ZERO_ADDRESS");
         require(_sharesAmount <= shares[_sender], "TRANSFER_AMOUNT_EXCEEDS_BALANCE");
+        require(!paused && pausedUntil < block.timestamp, "PAUSED");
 
         shares[_sender] -= _sharesAmount;
         shares[_recipient] += _sharesAmount;

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -202,6 +202,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     /// @return uint256 ID of the withdraw request NFT
     function requestWithdraw(uint256 _tokenId, uint256 _amount) external whenNotPaused returns (uint256) {
         _requireTokenOwner(_tokenId);
+        _requireUserNotPaused();
 
         // prevent transfers for several blocks after a withdrawal to prevent frontrunning
         membershipNFT.incrementLock(_tokenId, withdrawalLockBlocks);
@@ -228,6 +229,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     /// @return uint256 ID of the withdraw request NFT
     function requestWithdrawAndBurn(uint256 _tokenId) external whenNotPaused returns (uint256) {
         _requireTokenOwner(_tokenId);
+        _requireUserNotPaused();
 
         // Claim all staking rewards before burn
         _claimStakingRewards(_tokenId);
@@ -457,6 +459,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     }
 
     function _wrapEth(uint256 _amount, uint256 _amountForPoints, address _referral) internal returns (uint256) {
+        _requireUserNotPaused();
         liquidityPool.deposit{value: _amount + _amountForPoints}(msg.sender, _referral);
         uint256 tokenId = _mintMembershipNFT(msg.sender, _amount, _amountForPoints, 0, 0);
         _emitNftUpdateEvent(tokenId);
@@ -602,6 +605,11 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         _incrementTierDeposit(tier, amount);
         
         token.vaultShare = tierData[tier].rewardsGlobalIndex;
+    }
+
+    error UserPaused();
+    function _requireUserNotPaused() internal view {
+        if (eETH.isPausedUntil(msg.sender)) revert UserPaused();
     }
 
 

--- a/src/MembershipNFT.sol
+++ b/src/MembershipNFT.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./interfaces/IMembershipManager.sol";
 import "./interfaces/IMembershipNFT.sol";
 import "./interfaces/ILiquidityPool.sol";
+import "./interfaces/IeETH.sol";
 
 import "forge-std/console.sol";
 
@@ -34,6 +35,7 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     mapping(address => bool) public admins;
 
     ILiquidityPool public liquidityPool;
+    IeETH public immutable eETH;
 
     event MerkleUpdated(bytes32, bytes32);
     event MintingPaused(bool isPaused);
@@ -44,10 +46,12 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     error InvalidEAPRollover();
     error RequireTokenUnlocked();
     error OnlyMembershipManagerContract();
+    error UserPaused();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _eETH) {
         _disableInitializers();
+        eETH = IeETH(_eETH);
     }
 
     function initialize(string calldata _metadataURI, address _membershipManagerInstance) external initializer {
@@ -147,6 +151,8 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
         if (_from == address(0x00) || _to == address(0x00)) {
             return;
         }
+
+        if (eETH.isPausedUntil(_from) || eETH.isPausedUntil(_to)) revert UserPaused();
 
         // prevent transfers if token is locked
         for (uint256 x; x < _ids.length; ++x) {

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -202,4 +202,8 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
+
+    function isPausedUntil(address _user) external view returns (bool) {
+        return pausedUntil[_user] >= block.timestamp;
+    }
 }

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -38,7 +38,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
 
     bytes32 public constant WEETH_OPERATING_ADMIN_ROLE = keccak256("WEETH_OPERATING_ADMIN_ROLE");
     bytes32 public constant WEETH_PAUSER_ROLE = keccak256("WEETH_PAUSER_ROLE");
-    bytes32 public constant WEETH_EXTEND_PAUSER_ROLE = keccak256("WEETH_EXTEND_PAUSER_ROLE");
+    bytes32 public constant WEETH_PAUSER_UNTIL_ROLE = keccak256("WEETH_PAUSER_UNTIL_ROLE");
 
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
@@ -102,14 +102,14 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     }
 
     function pause(address _user) external {
-        require(roleRegistry.hasRole(WEETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         paused[_user] = true;
         emit Paused(_user);
     }
 
     function pauseUntil(address _user) external {
-        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(roleRegistry.hasRole(WEETH_PAUSER_UNTIL_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (!paused[_user] && pausedUntil[_user] < block.timestamp) {
             pausedUntil[_user] = uint64(block.timestamp) + 1 days;
@@ -118,7 +118,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     }
 
     function unpause(address _user) external {
-        require(roleRegistry.hasRole(WEETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
             delete pausedUntil[_user];

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -102,7 +102,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     }
 
     function pause() external {
-        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(roleRegistry.hasRole(WEETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
         paused = true;
         emit Paused();
     }
@@ -116,9 +116,9 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     }
 
     function unpause() external {
-        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(roleRegistry.hasRole(WEETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
         if (pausedUntil >= block.timestamp) {
-            pausedUntil = uint64(block.timestamp) - 1;
+            pausedUntil = 0;
         }
         paused = false;
         emit Unpaused();

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -19,9 +19,9 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     error IncorrectRole();
     error CannotRecoverEETH();
 
-    event Paused();
-    event PausedUntil(uint64 pausedUntil);
-    event Unpaused();
+    event Paused(address indexed user);
+    event PausedUntil(address indexed user, uint64 pausedUntil);
+    event Unpaused(address indexed user);
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  STORAGE  ----------------------------------
@@ -29,8 +29,8 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
 
     IeETH public eETH;
     ILiquidityPool public liquidityPool;
-    bool public paused;
-    uint64 public pausedUntil;
+    mapping(address => bool) public paused;
+    mapping(address => uint64) public pausedUntil;
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ROLES  ---------------------------------------
@@ -101,27 +101,30 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         return eETHAmount;
     }
 
-    function pause() external {
+    function pause(address _user) external {
         require(roleRegistry.hasRole(WEETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
-        paused = true;
-        emit Paused();
+        require(_user != address(0), "No zero addresses");
+        paused[_user] = true;
+        emit Paused(_user);
     }
 
-    function pauseUntil() external {
+    function pauseUntil(address _user) external {
         require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
-        if (!paused && pausedUntil < block.timestamp) {
-            pausedUntil = uint64(block.timestamp) + 1 days;
-            emit PausedUntil(pausedUntil);
+        require(_user != address(0), "No zero addresses");
+        if (!paused[_user] && pausedUntil[_user] < block.timestamp) {
+            pausedUntil[_user] = uint64(block.timestamp) + 1 days;
+            emit PausedUntil(_user, pausedUntil[_user]);
         }
     }
 
-    function unpause() external {
+    function unpause(address _user) external {
         require(roleRegistry.hasRole(WEETH_EXTEND_PAUSER_ROLE, msg.sender), "IncorrectRole");
-        if (pausedUntil >= block.timestamp) {
-            pausedUntil = 0;
+        require(_user != address(0), "No zero addresses");
+        if (pausedUntil[_user] >= block.timestamp) {
+            delete pausedUntil[_user];
         }
-        paused = false;
-        emit Unpaused();
+        delete paused[_user];
+        emit Unpaused(_user);
     }
 
     function recoverETH(address payable to, uint256 amount) external {
@@ -151,11 +154,12 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     }
 
     function _beforeTokenTransfer(
-        address /* from */,
-        address /* to */,
+        address from,
+        address to,
         uint256 /* amount */
     ) internal virtual override {
-        require(!paused && pausedUntil < block.timestamp, "PAUSED");
+        require(!paused[from] && pausedUntil[from] < block.timestamp, "SENDER PAUSED");
+        require(!paused[to] && pausedUntil[to] < block.timestamp, "RECIPIENT PAUSED");
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -20,7 +20,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     error CannotRecoverEETH();
 
     event Paused();
-    event PausedUntil(address indexed user, uint64 pausedUntil);
+    event PausedUntil(address indexed user, uint256 pausedUntil);
     event CancelledPauseUntil(address indexed user);
     event Unpaused();
 
@@ -31,7 +31,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     IeETH public eETH;
     ILiquidityPool public liquidityPool;
     bool public paused;
-    mapping(address => uint64) public pausedUntil;
+    mapping(address => uint256) public pausedUntil;
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ROLES  ---------------------------------------
@@ -112,7 +112,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         require(roleRegistry.hasRole(WEETH_PAUSER_UNTIL_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] < block.timestamp) {
-            pausedUntil[_user] = uint64(block.timestamp) + 1 days;
+            pausedUntil[_user] = block.timestamp + 1 days;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }
@@ -121,7 +121,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
-            pausedUntil[_user] = uint64(block.timestamp) + _duration;
+            pausedUntil[_user] = block.timestamp + _duration;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -14,6 +14,8 @@ import "./interfaces/IRoleRegistry.sol";
 
 contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20PermitUpgradeable, IRateProvider, AssetRecovery {
 
+    IeETH public immutable eETH;
+    ILiquidityPool public immutable liquidityPool;
     IRoleRegistry public immutable roleRegistry;
 
     error IncorrectRole();
@@ -28,8 +30,8 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     //---------------------------------  STORAGE  ----------------------------------
     //--------------------------------------------------------------------------------------
 
-    IeETH public eETH;
-    ILiquidityPool public liquidityPool;
+    IeETH public DEPRECATED_eETH;
+    ILiquidityPool public DEPRECATED_liquidityPool;
     bool public paused;
     mapping(address => uint256) public pausedUntil;
 
@@ -46,22 +48,21 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _roleRegistry) {
-        require(_roleRegistry != address(0), "must set role registry");
+    constructor(address _eETH, address _liquidityPool, address _roleRegistry) {
+        require(_eETH != address(0), "No zero addresses");
+        require(_liquidityPool != address(0), "No zero addresses");
+        require(_roleRegistry != address(0), "No zero addresses");
+        eETH = IeETH(_eETH);
+        liquidityPool = ILiquidityPool(_liquidityPool);
         roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
     }
 
-    function initialize(address _liquidityPool, address _eETH) external initializer {
-        require(_liquidityPool != address(0), "No zero addresses");
-        require(_eETH != address(0), "No zero addresses");
-
+    function initialize() external initializer {
         __ERC20_init("Wrapped eETH", "weETH");
         __ERC20Permit_init("Wrapped eETH");
         __UUPSUpgradeable_init();
         __Ownable_init();
-        eETH = IeETH(_eETH);
-        liquidityPool = ILiquidityPool(_liquidityPool);
     }
 
     /// @dev name changed from the version initially deployed

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -19,18 +19,26 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     error IncorrectRole();
     error CannotRecoverEETH();
 
+    event Paused();
+    event PausedUntil(uint64 pausedUntil);
+    event Unpaused();
+
     //--------------------------------------------------------------------------------------
     //---------------------------------  STORAGE  ----------------------------------
     //--------------------------------------------------------------------------------------
 
     IeETH public eETH;
     ILiquidityPool public liquidityPool;
+    bool public paused;
+    uint64 public pausedUntil;
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ROLES  ---------------------------------------
     //--------------------------------------------------------------------------------------
 
     bytes32 public constant WEETH_OPERATING_ADMIN_ROLE = keccak256("WEETH_OPERATING_ADMIN_ROLE");
+    bytes32 public constant WEETH_PAUSER_ROLE = keccak256("WEETH_PAUSER_ROLE");
+    bytes32 public constant WEETH_EXTEND_PAUSER_ROLE = keccak256("WEETH_EXTEND_PAUSER_ROLE");
 
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
@@ -93,6 +101,29 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         return eETHAmount;
     }
 
+    function pause() external {
+        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        paused = true;
+        emit Paused();
+    }
+
+    function pauseUntil() external {
+        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        if (!paused && pausedUntil < block.timestamp) {
+            pausedUntil = uint64(block.timestamp) + 1 days;
+            emit PausedUntil(pausedUntil);
+        }
+    }
+
+    function unpause() external {
+        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        if (pausedUntil >= block.timestamp) {
+            pausedUntil = uint64(block.timestamp) - 1;
+        }
+        paused = false;
+        emit Unpaused();
+    }
+
     function recoverETH(address payable to, uint256 amount) external {
         if(!roleRegistry.hasRole(WEETH_OPERATING_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
         _recoverETH(to, amount);
@@ -119,6 +150,13 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         roleRegistry.onlyProtocolUpgrader(msg.sender);
     }
 
+    function _beforeTokenTransfer(
+        address /* from */,
+        address /* to */,
+        uint256 /* amount */
+    ) internal virtual override {
+        require(!paused && pausedUntil < block.timestamp, "PAUSED");
+    }
 
     //--------------------------------------------------------------------------------------
     //------------------------------------  GETTERS  ---------------------------------------

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -118,11 +118,11 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         }
     }
 
-    function extendPauseUntil(address _user, uint64 _duration) external {
+    function extendPauseUntil(address _user, uint256 _duration) external {
         require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
-            pausedUntil[_user] = block.timestamp + _duration;
+            pausedUntil[_user] += _duration;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -130,8 +130,10 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     function cancelPauseUntil(address _user) external {
         require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
-        delete pausedUntil[_user];
-        emit CancelledPauseUntil(_user);
+        if (pausedUntil[_user] >= block.timestamp) {
+            delete pausedUntil[_user];
+            emit CancelledPauseUntil(_user);
+        }
     }
 
     function unpause() external {

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -19,9 +19,10 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     error IncorrectRole();
     error CannotRecoverEETH();
 
-    event Paused(address indexed user);
+    event Paused();
     event PausedUntil(address indexed user, uint64 pausedUntil);
-    event Unpaused(address indexed user);
+    event CancelledPauseUntil(address indexed user);
+    event Unpaused();
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  STORAGE  ----------------------------------
@@ -29,7 +30,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
 
     IeETH public eETH;
     ILiquidityPool public liquidityPool;
-    mapping(address => bool) public paused;
+    bool public paused;
     mapping(address => uint64) public pausedUntil;
 
     //--------------------------------------------------------------------------------------
@@ -101,30 +102,41 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         return eETHAmount;
     }
 
-    function pause(address _user) external {
+    function pause() external {
         require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
-        require(_user != address(0), "No zero addresses");
-        paused[_user] = true;
-        emit Paused(_user);
+        paused = true;
+        emit Paused();
     }
 
     function pauseUntil(address _user) external {
         require(roleRegistry.hasRole(WEETH_PAUSER_UNTIL_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
-        if (!paused[_user] && pausedUntil[_user] < block.timestamp) {
+        if (pausedUntil[_user] < block.timestamp) {
             pausedUntil[_user] = uint64(block.timestamp) + 1 days;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }
 
-    function unpause(address _user) external {
+    function extendPauseUntil(address _user, uint64 _duration) external {
         require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
-            delete pausedUntil[_user];
+            pausedUntil[_user] = uint64(block.timestamp) + _duration;
+            emit PausedUntil(_user, pausedUntil[_user]);
         }
-        delete paused[_user];
-        emit Unpaused(_user);
+    }
+
+    function cancelPauseUntil(address _user) external {
+        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        require(_user != address(0), "No zero addresses");
+        delete pausedUntil[_user];
+        emit CancelledPauseUntil(_user);
+    }
+
+    function unpause() external {
+        require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
+        paused = false;
+        emit Unpaused();
     }
 
     function recoverETH(address payable to, uint256 amount) external {
@@ -158,8 +170,9 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         address to,
         uint256 /* amount */
     ) internal virtual override {
-        require(!paused[from] && pausedUntil[from] < block.timestamp, "SENDER PAUSED");
-        require(!paused[to] && pausedUntil[to] < block.timestamp, "RECIPIENT PAUSED");
+        require(!paused, "PAUSED");
+        require(pausedUntil[from] < block.timestamp, "SENDER PAUSED");
+        require(pausedUntil[to] < block.timestamp, "RECIPIENT PAUSED");
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/interfaces/IWeETH.sol
+++ b/src/interfaces/IWeETH.sol
@@ -42,7 +42,7 @@ interface IWeETH is IERC20Upgradeable {
 
     function pause() external;
     function pauseUntil(address _user) external;
-    function extendPauseUntil(address _user, uint64 _duration) external;
+    function extendPauseUntil(address _user, uint256 _duration) external;
     function cancelPauseUntil(address _user) external;
     function unpause() external;
 

--- a/src/interfaces/IWeETH.sol
+++ b/src/interfaces/IWeETH.sol
@@ -22,7 +22,7 @@ interface IWeETH is IERC20Upgradeable {
     function blacklistedRecipient(address recipient) external view returns (bool);
 
     // STATE-CHANGING FUNCTIONS
-    function initialize(address _liquidityPool, address _eETH) external;
+    function initialize() external;
     function wrap(uint256 _eETHAmount) external returns (uint256);
     function wrapWithPermit(uint256 _eETHAmount, ILiquidityPool.PermitInput calldata _permit) external returns (uint256);
     function unwrap(uint256 _weETHAmount) external returns (uint256);

--- a/src/interfaces/IWeETH.sol
+++ b/src/interfaces/IWeETH.sol
@@ -21,6 +21,10 @@ interface IWeETH is IERC20Upgradeable {
     function whitelistedSpender(address spender) external view returns (bool);
     function blacklistedRecipient(address recipient) external view returns (bool);
 
+    function paused() external view returns (bool);
+    function pausedUntil(address _user) external view returns (uint256);
+    function isPausedUntil(address _user) external view returns (bool);
+
     // STATE-CHANGING FUNCTIONS
     function initialize() external;
     function wrap(uint256 _eETHAmount) external returns (uint256);
@@ -35,6 +39,12 @@ interface IWeETH is IERC20Upgradeable {
         bytes32 r,
         bytes32 s
     ) external;
+
+    function pause() external;
+    function pauseUntil(address _user) external;
+    function extendPauseUntil(address _user, uint64 _duration) external;
+    function cancelPauseUntil(address _user) external;
+    function unpause() external;
 
     function setWhitelistedSpender(address[] calldata _spenders, bool _isWhitelisted) external;
     function setBlacklistedRecipient(address[] calldata _recipients, bool _isBlacklisted) external;

--- a/src/interfaces/IeETH.sol
+++ b/src/interfaces/IeETH.sol
@@ -19,6 +19,10 @@ interface IeETH {
     function shares(address _user) external view returns (uint256);
     function balanceOf(address _user) external view returns (uint256);
 
+    function paused() external view returns (bool);
+    function pausedUntil(address _user) external view returns (uint256);
+    function isPausedUntil(address _user) external view returns (bool);
+
     function initialize() external;
     function mintShares(address _user, uint256 _share) external;
     function burnShares(address _user, uint256 _share) external;
@@ -27,6 +31,12 @@ interface IeETH {
     function approve(address _spender, uint256 _amount) external returns (bool);
     function increaseAllowance(address _spender, uint256 _increaseAmount) external returns (bool);
     function decreaseAllowance(address _spender, uint256 _decreaseAmount) external returns (bool);
+
+    function pause() external;
+    function pauseUntil(address _user) external;
+    function extendPauseUntil(address _user, uint64 _duration) external;
+    function cancelPauseUntil(address _user) external;
+    function unpause() external;
 
     function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
 }

--- a/src/interfaces/IeETH.sol
+++ b/src/interfaces/IeETH.sol
@@ -19,7 +19,7 @@ interface IeETH {
     function shares(address _user) external view returns (uint256);
     function balanceOf(address _user) external view returns (uint256);
 
-    function initialize(address _liquidityPool) external;
+    function initialize() external;
     function mintShares(address _user, uint256 _share) external;
     function burnShares(address _user, uint256 _share) external;
     function transferFrom(address _sender, address _recipient, uint256 _amount) external returns (bool);

--- a/src/interfaces/IeETH.sol
+++ b/src/interfaces/IeETH.sol
@@ -34,7 +34,7 @@ interface IeETH {
 
     function pause() external;
     function pauseUntil(address _user) external;
-    function extendPauseUntil(address _user, uint64 _duration) external;
+    function extendPauseUntil(address _user, uint256 _duration) external;
     function cancelPauseUntil(address _user) external;
     function unpause() external;
 

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -487,25 +487,31 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.transfer(bob, 1 ether); // must succeed immediately
     }
 
-    /// @dev M-2-new: cancelPauseUntil emits event even when there's nothing to cancel.
-    function test_cancelPauseUntil_emitsEvenWhenNeverArmed() public {
-        vm.expectEmit(true, false, false, true);
-        emit CancelledPauseUntil(alice);
+    /// @dev I-03 regression: cancelPauseUntil must not emit when the user was never paused.
+    function test_cancelPauseUntil_doesNotEmit_whenNeverArmed() public {
+        vm.recordLogs();
         vm.prank(pauser);
         eETHInstance.cancelPauseUntil(alice);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "no event when there is nothing to cancel (I-03)");
+        assertEq(eETHInstance.pausedUntil(alice), 0);
     }
 
-    function test_cancelPauseUntil_emitsEvenWhenAlreadyExpired() public {
+    /// @dev I-03 regression: cancelPauseUntil is a no-op once the timer has already expired.
+    /// The stale value is harmless (transfer checks treat past timestamps as unpaused).
+    function test_cancelPauseUntil_isNoOp_whenExpired() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 staleDeadline = eETHInstance.pausedUntil(alice);
         vm.warp(block.timestamp + 2 days);
 
-        vm.expectEmit(true, false, false, true);
-        emit CancelledPauseUntil(alice);
+        vm.recordLogs();
         vm.prank(pauser);
         eETHInstance.cancelPauseUntil(alice);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        assertEq(eETHInstance.pausedUntil(alice), 0, "stale timer also cleared");
+        assertEq(logs.length, 0, "no event when timer already expired");
+        assertEq(eETHInstance.pausedUntil(alice), staleDeadline, "expired value is left as-is");
     }
 
     function test_cancelPauseUntil_isPerUser_doesNotTouchOthers() public {

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -12,7 +12,7 @@ import "./TestSetup.sol";
 /// All transfer / mint / burn paths require global !paused AND timer expired for the affected user(s).
 contract EETHPauseTest is TestSetup {
     event Paused();
-    event PausedUntil(address indexed user, uint64 pausedUntil);
+    event PausedUntil(address indexed user, uint256 pausedUntil);
     event CancelledPauseUntil(address indexed user);
     event Unpaused();
     event Transfer(address indexed from, address indexed to, uint256 value);
@@ -304,7 +304,7 @@ contract EETHPauseTest is TestSetup {
     function test_pauseUntil_blockedAtBoundary() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
+        uint256 expiry = eETHInstance.pausedUntil(alice);
         vm.warp(expiry);
 
         vm.prank(alice);
@@ -315,7 +315,7 @@ contract EETHPauseTest is TestSetup {
     function test_pauseUntil_expiresAfterOneDay() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
+        uint256 expiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(uint256(expiry) + 1);
 
@@ -343,7 +343,7 @@ contract EETHPauseTest is TestSetup {
     function test_pauseUntil_cannotExtend_whileTimerActive() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        uint64 firstExpiry = eETHInstance.pausedUntil(alice);
+        uint256 firstExpiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(block.timestamp + 12 hours);
 
@@ -356,7 +356,7 @@ contract EETHPauseTest is TestSetup {
     function test_pauseUntil_canRenew_afterExpiry() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        uint64 firstExpiry = eETHInstance.pausedUntil(alice);
+        uint256 firstExpiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(uint256(firstExpiry) + 1);
 
@@ -422,7 +422,7 @@ contract EETHPauseTest is TestSetup {
     function test_extendPauseUntil_silentNoOp_whenTimerExpired() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
+        uint256 expiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(uint256(expiry) + 1);
 

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "./TestSetup.sol";
+
+/// Unit + fuzz tests for the pause / pauseUntil / unpause feature on EETH.
+/// Role model under test (per branch yash/feat/pause-transfers):
+///   EETH_PAUSER_ROLE         -> monitoring EOA  : can call pauseUntil() (1-day timer)
+///   EETH_EXTEND_PAUSER_ROLE  -> security council: can call pause() and unpause() (indefinite)
+contract EETHPauseTest is TestSetup {
+    // Re-declare events so vm.expectEmit can match by topic.
+    event Paused();
+    event PausedUntil(uint64 pausedUntil);
+    event Unpaused();
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    address pauser;          // monitoring EOA (EETH_PAUSER_ROLE)
+    address extendPauser;    // security council (EETH_EXTEND_PAUSER_ROLE)
+    address unauthorized;    // no pause roles
+
+    uint64 constant ONE_DAY = 1 days;
+
+    function setUp() public {
+        setUpTests();
+
+        pauser = vm.addr(0xA11CE_1);
+        extendPauser = vm.addr(0xA11CE_2);
+        unauthorized = vm.addr(0xA11CE_3);
+
+        // owner owns the RoleRegistry in setUpTests()
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_ROLE(), pauser);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        vm.stopPrank();
+
+        // Deposit so alice/bob have eETH balances for transfer tests.
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+        vm.prank(bob);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+    }
+
+    // -------------------------------------------------------------------
+    //                             ROLE GATING
+    // -------------------------------------------------------------------
+
+    function test_pause_onlyExtendPauserRole() public {
+        // unauthorized caller cannot pause
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.pause();
+
+        // monitoring EOA (only has EETH_PAUSER_ROLE) cannot pause either
+        vm.prank(pauser);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.pause();
+
+        // extendPauser succeeds
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+        assertTrue(eETHInstance.paused());
+    }
+
+    function test_pauseUntil_onlyPauserRole() public {
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.pauseUntil();
+
+        // extendPauser (multisig) does NOT have EETH_PAUSER_ROLE so must fail
+        vm.prank(extendPauser);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.pauseUntil();
+
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+        assertEq(eETHInstance.pausedUntil(), uint64(block.timestamp) + ONE_DAY);
+    }
+
+    function test_unpause_onlyExtendPauserRole() public {
+        // First pause so unpause has meaningful state to clear
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.unpause();
+
+        vm.prank(pauser);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.unpause();
+
+        vm.prank(extendPauser);
+        eETHInstance.unpause();
+        assertFalse(eETHInstance.paused());
+    }
+
+    // -------------------------------------------------------------------
+    //                        TRANSFER BLOCKING
+    // -------------------------------------------------------------------
+
+    function test_transfer_blockedWhen_paused() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_transferFrom_blockedWhen_paused() public {
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        vm.prank(bob);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transferFrom(alice, bob, 1 ether);
+    }
+
+    function test_transfer_blockedWhen_pauseUntilActive() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_transfer_blockedAtBoundary_justBeforeExpiry() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+
+        // Warp to exactly pausedUntil; check still blocks (require uses <, so == is paused).
+        uint64 expiry = eETHInstance.pausedUntil();
+        vm.warp(expiry);
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_transfer_unblockedAfterPauseUntilExpiry() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+
+        uint64 expiry = eETHInstance.pausedUntil();
+        vm.warp(uint256(expiry) + 1);
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_transfer_notBlockedWhen_notPaused() public {
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether);
+        // no revert means success
+    }
+
+    // -------------------------------------------------------------------
+    //              STATE / EVENT SEMANTICS (CURRENT SOURCE)
+    // -------------------------------------------------------------------
+
+    function test_pause_emitsPausedEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit Paused();
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+    }
+
+    function test_pauseUntil_emitsPausedUntilEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit PausedUntil(uint64(block.timestamp) + ONE_DAY);
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+    }
+
+    function test_unpause_emitsUnpausedEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit Unpaused();
+        vm.prank(extendPauser);
+        eETHInstance.unpause();
+    }
+
+    /// @dev Documents CURRENT behavior: pauseUntil is a silent no-op if already paused.
+    /// Flagged as M-1 in the security review.
+    function test_pauseUntil_silentNoOp_whilePaused() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+        uint64 before = eETHInstance.pausedUntil();
+
+        // Should NOT revert, should NOT emit, should NOT change pausedUntil.
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+
+        assertEq(eETHInstance.pausedUntil(), before, "pausedUntil should not change");
+        assertTrue(eETHInstance.paused(), "paused should remain true");
+    }
+
+    /// @dev Documents CURRENT behavior: pauseUntil cannot extend an active timer.
+    /// Flagged as M-1 in the security review.
+    function test_pauseUntil_cannotExtend_whileTimerActive() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+        uint64 firstExpiry = eETHInstance.pausedUntil();
+
+        vm.warp(block.timestamp + 12 hours);
+
+        vm.prank(pauser);
+        eETHInstance.pauseUntil(); // silent no-op
+
+        assertEq(eETHInstance.pausedUntil(), firstExpiry, "pausedUntil should not be extended");
+    }
+
+    function test_pauseUntil_canRenew_afterExpiry() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+        uint64 firstExpiry = eETHInstance.pausedUntil();
+
+        vm.warp(uint256(firstExpiry) + 1);
+
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+
+        assertEq(eETHInstance.pausedUntil(), uint64(block.timestamp) + ONE_DAY);
+        assertGt(eETHInstance.pausedUntil(), firstExpiry);
+    }
+
+    function test_unpause_clearsBothFlags() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        assertTrue(eETHInstance.paused());
+        assertGt(eETHInstance.pausedUntil(), block.timestamp);
+
+        vm.prank(extendPauser);
+        eETHInstance.unpause();
+
+        assertFalse(eETHInstance.paused());
+        assertLt(eETHInstance.pausedUntil(), block.timestamp);
+
+        // Transfer should work.
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_unpause_whenPausedUntilAlreadyExpired_leavesStale() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+        uint64 expiry = eETHInstance.pausedUntil();
+
+        vm.warp(uint256(expiry) + 1);
+
+        vm.prank(extendPauser);
+        eETHInstance.unpause();
+
+        // pausedUntil NOT rewound because the if-branch (pausedUntil >= block.timestamp) is false.
+        assertEq(eETHInstance.pausedUntil(), expiry);
+        assertFalse(eETHInstance.paused());
+    }
+
+    /// @dev CURRENT behavior: unpause() succeeds even when contract was never paused (M-2).
+    function test_unpause_noop_whenNeverPaused() public {
+        vm.prank(extendPauser);
+        eETHInstance.unpause();
+
+        assertFalse(eETHInstance.paused());
+        assertEq(eETHInstance.pausedUntil(), 0);
+    }
+
+    // -------------------------------------------------------------------
+    //                   NON-TRANSFER PATHS DURING PAUSE
+    // -------------------------------------------------------------------
+
+    /// @dev Documents CURRENT behavior (L-2): LiquidityPool deposit path still mints eETH shares
+    ///      while paused because mintShares bypasses the pause check.
+    function test_mintShares_notBlockedByPause() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        uint256 sharesBefore = eETHInstance.shares(alice);
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.mintShares(alice, 5 ether);
+        assertEq(eETHInstance.shares(alice), sharesBefore + 5 ether);
+    }
+
+    function test_burnShares_notBlockedByPause() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        uint256 sharesBefore = eETHInstance.shares(alice);
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.burnShares(alice, 1 ether);
+        assertEq(eETHInstance.shares(alice), sharesBefore - 1 ether);
+    }
+
+    function test_approve_notBlockedByPause() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+        assertEq(eETHInstance.allowance(alice, bob), 1 ether);
+    }
+
+    function test_permit_notBlockedByPause() public {
+        // Alice priv key = 2 (per TestSetup convention)
+        ILiquidityPool.PermitInput memory p = createPermitInput(
+            2,
+            bob,
+            1 ether,
+            eETHInstance.nonces(alice),
+            type(uint256).max,
+            eETHInstance.DOMAIN_SEPARATOR()
+        );
+
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        eETHInstance.permit(alice, bob, 1 ether, type(uint256).max, p.v, p.r, p.s);
+        assertEq(eETHInstance.allowance(alice, bob), 1 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //                  INTERLEAVED / LIFECYCLE SEQUENCES
+    // -------------------------------------------------------------------
+
+    function test_sequence_pauseUntil_then_extendPauser_locks() public {
+        // Monitoring triggers 1-day pause
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+
+        // Security council escalates to indefinite pause
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        // Warp past the 1-day window: paused flag still blocks
+        vm.warp(block.timestamp + 2 days);
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
+
+        // Only extendPauser can release
+        vm.prank(pauser);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.unpause();
+
+        vm.prank(extendPauser);
+        eETHInstance.unpause();
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_sequence_revokeRole_disablesPauser() public {
+        bytes32 role = eETHInstance.EETH_PAUSER_ROLE();
+        vm.prank(owner);
+        roleRegistryInstance.revokeRole(role, pauser);
+
+        vm.prank(pauser);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.pauseUntil();
+    }
+
+    // -------------------------------------------------------------------
+    //                             FUZZING
+    // -------------------------------------------------------------------
+
+    function testFuzz_pause_revertsForNonExtendPauser(address caller) public {
+        vm.assume(caller != extendPauser);
+        // RoleRegistry.hasRole reverts/returns false depending on impl; either way pause() must revert.
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.pause();
+    }
+
+    function testFuzz_pauseUntil_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.pauseUntil();
+    }
+
+    function testFuzz_unpause_revertsForNonExtendPauser(address caller) public {
+        vm.assume(caller != extendPauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.unpause();
+    }
+
+    function testFuzz_pauseUntil_setsOneDayFromWarpedTimestamp(uint64 warpTo) public {
+        // Keep within uint64 bounds; ensure we can add 1 day without overflow.
+        warpTo = uint64(bound(uint256(warpTo), block.timestamp + 1, type(uint64).max - ONE_DAY - 1));
+        vm.warp(warpTo);
+
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+
+        assertEq(eETHInstance.pausedUntil(), warpTo + ONE_DAY);
+    }
+
+    function testFuzz_transferBlockedWhenPaused(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.shares(alice));
+
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transfer(bob, amount);
+    }
+
+    function testFuzz_transferWorksAfterExpiry(uint256 amount, uint64 extra) public {
+        amount = bound(amount, 1, eETHInstance.shares(alice));
+        extra = uint64(bound(uint256(extra), 1, 365 days));
+
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+
+        vm.warp(uint256(eETHInstance.pausedUntil()) + extra);
+
+        uint256 aliceBefore = eETHInstance.shares(alice);
+        uint256 bobBefore = eETHInstance.shares(bob);
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, amount);
+
+        // Share accounting preserved
+        uint256 sharesMoved = aliceBefore - eETHInstance.shares(alice);
+        assertEq(eETHInstance.shares(bob), bobBefore + sharesMoved);
+    }
+
+    function testFuzz_transferAtOrBeforeExpiry_blocks(uint64 delta) public {
+        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
+
+        vm.prank(pauser);
+        eETHInstance.pauseUntil();
+        uint64 expiry = eETHInstance.pausedUntil();
+
+        vm.warp(uint256(expiry) - delta);
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transfer(bob, 1);
+    }
+
+    function testFuzz_unpauseSucceedsRegardlessOfPriorState(bool pauseFirst, bool pauseUntilFirst) public {
+        if (pauseUntilFirst) {
+            vm.prank(pauser);
+            eETHInstance.pauseUntil();
+        }
+        if (pauseFirst) {
+            vm.prank(extendPauser);
+            eETHInstance.pause();
+        }
+
+        vm.prank(extendPauser);
+        eETHInstance.unpause();
+
+        assertFalse(eETHInstance.paused());
+        // pausedUntil is either < now (cleared or never set) or never touched if it was already expired.
+        assertTrue(eETHInstance.pausedUntil() < block.timestamp || eETHInstance.pausedUntil() == 0);
+
+        // Transfer must succeed.
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1);
+    }
+
+    function testFuzz_roleAuthorization_pauseUntil_onlyHolder(address holder, address other) public {
+        bytes32 role = eETHInstance.EETH_PAUSER_ROLE();
+        vm.assume(holder != address(0));
+        vm.assume(other != holder);
+        vm.assume(!roleRegistryInstance.hasRole(role, other));
+
+        vm.prank(owner);
+        roleRegistryInstance.grantRole(role, holder);
+
+        vm.prank(holder);
+        eETHInstance.pauseUntil();
+        assertGt(eETHInstance.pausedUntil(), block.timestamp);
+
+        vm.prank(other);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.pauseUntil();
+    }
+}

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -3,315 +3,446 @@ pragma solidity ^0.8.13;
 
 import "./TestSetup.sol";
 
-/// Unit + fuzz tests for the pause / pauseUntil / unpause feature on EETH.
-/// Role model under test (per branch yash/feat/pause-transfers):
-///   EETH_PAUSER_ROLE         -> monitoring EOA  : can call pauseUntil() (1-day timer)
-///   EETH_EXTEND_PAUSER_ROLE  -> security council: can call pause() and unpause() (indefinite)
+/// Unit + fuzz tests for the per-user FREEZE feature on EETH.
+/// Role model:
+///   EETH_PAUSER_ROLE         -> monitoring EOA   : pauseUntil(user) arms 1-day freeze
+///   EETH_EXTEND_PAUSER_ROLE  -> security council : pause(user) / unpause(user)
+///
+/// Semantics under test:
+/// - `paused` / `pausedUntil` are per-address mappings.
+/// - `_transferShares` blocks if EITHER sender OR recipient is frozen.
+/// - `mintShares` / `burnShares` are NOT gated — documented as C-1 in the review.
 contract EETHPauseTest is TestSetup {
-    // Re-declare events so vm.expectEmit can match by topic.
-    event Paused();
-    event PausedUntil(uint64 pausedUntil);
-    event Unpaused();
+    event Paused(address indexed user);
+    event PausedUntil(address indexed user, uint64 pausedUntil);
+    event Unpaused(address indexed user);
     event Transfer(address indexed from, address indexed to, uint256 value);
 
-    address pauser;          // monitoring EOA (EETH_PAUSER_ROLE)
-    address extendPauser;    // security council (EETH_EXTEND_PAUSER_ROLE)
-    address unauthorized;    // no pause roles
+    address pauser;
+    address extendPauser;
+    address unauthorized;
 
     uint64 constant ONE_DAY = 1 days;
 
     function setUp() public {
         setUpTests();
 
-        pauser = vm.addr(0xA11CE_1);
-        extendPauser = vm.addr(0xA11CE_2);
-        unauthorized = vm.addr(0xA11CE_3);
+        pauser = vm.addr(0xA11CE1);
+        extendPauser = vm.addr(0xA11CE2);
+        unauthorized = vm.addr(0xA11CE3);
 
-        // owner owns the RoleRegistry in setUpTests()
         vm.startPrank(owner);
         roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_ROLE(), pauser);
         roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
         vm.stopPrank();
 
-        // Deposit so alice/bob have eETH balances for transfer tests.
         vm.deal(alice, 100 ether);
         vm.deal(bob, 100 ether);
+        vm.deal(chad, 100 ether);
         vm.prank(alice);
         liquidityPoolInstance.deposit{value: 10 ether}();
         vm.prank(bob);
         liquidityPoolInstance.deposit{value: 10 ether}();
+        vm.prank(chad);
+        liquidityPoolInstance.deposit{value: 10 ether}();
     }
 
     // -------------------------------------------------------------------
-    //                             ROLE GATING
+    //                          ZERO-ADDRESS GUARDS
+    // -------------------------------------------------------------------
+
+    function test_pause_rejectsZeroAddress() public {
+        vm.prank(extendPauser);
+        vm.expectRevert("No zero addresses");
+        eETHInstance.pause(address(0));
+    }
+
+    function test_pauseUntil_rejectsZeroAddress() public {
+        vm.prank(pauser);
+        vm.expectRevert("No zero addresses");
+        eETHInstance.pauseUntil(address(0));
+    }
+
+    function test_unpause_rejectsZeroAddress() public {
+        vm.prank(extendPauser);
+        vm.expectRevert("No zero addresses");
+        eETHInstance.unpause(address(0));
+    }
+
+    // -------------------------------------------------------------------
+    //                              ROLE GATING
     // -------------------------------------------------------------------
 
     function test_pause_onlyExtendPauserRole() public {
-        // unauthorized caller cannot pause
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
-        // monitoring EOA (only has EETH_PAUSER_ROLE) cannot pause either
         vm.prank(pauser);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
-        // extendPauser succeeds
         vm.prank(extendPauser);
-        eETHInstance.pause();
-        assertTrue(eETHInstance.paused());
+        eETHInstance.pause(alice);
+        assertTrue(eETHInstance.paused(alice));
     }
 
     function test_pauseUntil_onlyPauserRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
 
-        // extendPauser (multisig) does NOT have EETH_PAUSER_ROLE so must fail
         vm.prank(extendPauser);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
 
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
-        assertEq(eETHInstance.pausedUntil(), uint64(block.timestamp) + ONE_DAY);
+        eETHInstance.pauseUntil(alice);
+        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
     }
 
     function test_unpause_onlyExtendPauserRole() public {
-        // First pause so unpause has meaningful state to clear
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.unpause();
+        eETHInstance.unpause(alice);
 
         vm.prank(pauser);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.unpause();
+        eETHInstance.unpause(alice);
 
         vm.prank(extendPauser);
-        eETHInstance.unpause();
-        assertFalse(eETHInstance.paused());
+        eETHInstance.unpause(alice);
+        assertFalse(eETHInstance.paused(alice));
     }
 
     // -------------------------------------------------------------------
-    //                        TRANSFER BLOCKING
+    //                      PER-USER FREEZE SELECTIVITY
     // -------------------------------------------------------------------
 
-    function test_transfer_blockedWhen_paused() public {
+    function test_freeze_isPerUser_othersUnaffected() public {
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
-        vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        // bob -> chad must still succeed
+        vm.prank(bob);
+        eETHInstance.transfer(chad, 1 ether);
+
+        // chad -> bob must still succeed
+        vm.prank(chad);
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    function test_transferFrom_blockedWhen_paused() public {
+    function test_freeze_blocksSender() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_freeze_blocksRecipient() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        eETHInstance.transfer(alice, 1 ether);
+    }
+
+    function test_freeze_blocksSelfTransfer() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(alice, 1 ether);
+    }
+
+    function test_freeze_blocksTransferFrom_viaSender() public {
         vm.prank(alice);
         eETHInstance.approve(bob, 1 ether);
 
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice); // owner (sender) frozen
 
         vm.prank(bob);
-        vm.expectRevert("PAUSED");
-        eETHInstance.transferFrom(alice, bob, 1 ether);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transferFrom(alice, chad, 1 ether);
     }
 
-    function test_transfer_blockedWhen_pauseUntilActive() public {
-        vm.prank(pauser);
-        eETHInstance.pauseUntil();
+    function test_freeze_blocksTransferFrom_viaRecipient() public {
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+
+        vm.prank(extendPauser);
+        eETHInstance.pause(chad); // recipient frozen
+
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        eETHInstance.transferFrom(alice, chad, 1 ether);
+    }
+
+    function test_freeze_spenderNotChecked() public {
+        // Spender (bob) being frozen should NOT block transferFrom between unfrozen parties.
+        // Only sender (alice) and recipient (chad) matter.
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+
+        vm.prank(extendPauser);
+        eETHInstance.pause(bob);
+
+        vm.prank(bob);
+        eETHInstance.transferFrom(alice, chad, 1 ether); // must succeed
+    }
+
+    function test_bothPartiesFrozen_sendErrorFiresFirst() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
+        vm.prank(extendPauser);
+        eETHInstance.pause(bob);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("SENDER PAUSED");
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    function test_transfer_blockedAtBoundary_justBeforeExpiry() public {
-        vm.prank(pauser);
-        eETHInstance.pauseUntil();
+    function test_unfreeze_isPerUser() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
+        vm.prank(extendPauser);
+        eETHInstance.pause(bob);
 
-        // Warp to exactly pausedUntil; check still blocks (require uses <, so == is paused).
-        uint64 expiry = eETHInstance.pausedUntil();
-        vm.warp(expiry);
+        // Unfreeze only alice
+        vm.prank(extendPauser);
+        eETHInstance.unpause(alice);
+
+        // Alice can transfer to chad
+        vm.prank(alice);
+        eETHInstance.transfer(chad, 1 ether);
+
+        // Bob is still frozen
+        vm.prank(bob);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(chad, 1 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //                     pauseUntil TIMER SEMANTICS
+    // -------------------------------------------------------------------
+
+    function test_pauseUntil_blocksSender() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil(alice);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("SENDER PAUSED");
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    function test_transfer_unblockedAfterPauseUntilExpiry() public {
+    function test_pauseUntil_blocksRecipient() public {
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
 
-        uint64 expiry = eETHInstance.pausedUntil();
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        eETHInstance.transfer(alice, 1 ether);
+    }
+
+    function test_pauseUntil_expiresAfterOneDay() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+
         vm.warp(uint256(expiry) + 1);
 
         vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    function test_transfer_notBlockedWhen_notPaused() public {
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
-        // no revert means success
-    }
-
-    // -------------------------------------------------------------------
-    //              STATE / EVENT SEMANTICS (CURRENT SOURCE)
-    // -------------------------------------------------------------------
-
-    function test_pause_emitsPausedEvent() public {
-        vm.expectEmit(false, false, false, true);
-        emit Paused();
-        vm.prank(extendPauser);
-        eETHInstance.pause();
-    }
-
-    function test_pauseUntil_emitsPausedUntilEvent() public {
-        vm.expectEmit(false, false, false, true);
-        emit PausedUntil(uint64(block.timestamp) + ONE_DAY);
+    function test_pauseUntil_blockedAtBoundary() public {
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+        vm.warp(expiry); // exactly at boundary — still frozen (require uses <)
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
     }
 
-    function test_unpause_emitsUnpausedEvent() public {
-        vm.expectEmit(false, false, false, true);
-        emit Unpaused();
-        vm.prank(extendPauser);
-        eETHInstance.unpause();
+    function test_pauseUntil_timerIsPerUser() public {
+        vm.prank(pauser);
+        eETHInstance.pauseUntil(alice);
+        assertEq(eETHInstance.pausedUntil(bob), 0, "bob timer untouched");
     }
 
-    /// @dev Documents CURRENT behavior: pauseUntil is a silent no-op if already paused.
-    /// Flagged as M-1 in the security review.
     function test_pauseUntil_silentNoOp_whilePaused() public {
         vm.prank(extendPauser);
-        eETHInstance.pause();
-        uint64 before = eETHInstance.pausedUntil();
+        eETHInstance.pause(alice);
+        uint64 before = eETHInstance.pausedUntil(alice);
 
-        // Should NOT revert, should NOT emit, should NOT change pausedUntil.
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
 
-        assertEq(eETHInstance.pausedUntil(), before, "pausedUntil should not change");
-        assertTrue(eETHInstance.paused(), "paused should remain true");
+        assertEq(eETHInstance.pausedUntil(alice), before, "no change while indefinitely paused (M-1)");
+        assertTrue(eETHInstance.paused(alice));
     }
 
-    /// @dev Documents CURRENT behavior: pauseUntil cannot extend an active timer.
-    /// Flagged as M-1 in the security review.
     function test_pauseUntil_cannotExtend_whileTimerActive() public {
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
-        uint64 firstExpiry = eETHInstance.pausedUntil();
+        eETHInstance.pauseUntil(alice);
+        uint64 firstExpiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(block.timestamp + 12 hours);
 
         vm.prank(pauser);
-        eETHInstance.pauseUntil(); // silent no-op
+        eETHInstance.pauseUntil(alice);
 
-        assertEq(eETHInstance.pausedUntil(), firstExpiry, "pausedUntil should not be extended");
+        assertEq(eETHInstance.pausedUntil(alice), firstExpiry, "cannot extend live timer (M-1)");
     }
 
     function test_pauseUntil_canRenew_afterExpiry() public {
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
-        uint64 firstExpiry = eETHInstance.pausedUntil();
+        eETHInstance.pauseUntil(alice);
+        uint64 firstExpiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(uint256(firstExpiry) + 1);
 
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
 
-        assertEq(eETHInstance.pausedUntil(), uint64(block.timestamp) + ONE_DAY);
-        assertGt(eETHInstance.pausedUntil(), firstExpiry);
+        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
+        assertGt(eETHInstance.pausedUntil(alice), firstExpiry);
     }
 
-    function test_unpause_clearsBothFlags() public {
+    // -------------------------------------------------------------------
+    //                          UNPAUSE SEMANTICS
+    // -------------------------------------------------------------------
+
+    function test_unpause_clearsBothFlags_whenFullyFrozen() public {
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
-        assertTrue(eETHInstance.paused());
-        assertGt(eETHInstance.pausedUntil(), block.timestamp);
+        assertTrue(eETHInstance.paused(alice));
+        assertGt(eETHInstance.pausedUntil(alice), block.timestamp);
 
         vm.prank(extendPauser);
-        eETHInstance.unpause();
+        eETHInstance.unpause(alice);
 
-        assertFalse(eETHInstance.paused());
-        assertLt(eETHInstance.pausedUntil(), block.timestamp);
+        assertFalse(eETHInstance.paused(alice));
+        assertEq(eETHInstance.pausedUntil(alice), 0, "timer cleared since it was active");
 
-        // Transfer should work.
         vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    function test_unpause_whenPausedUntilAlreadyExpired_leavesStale() public {
+    /// @dev Documents M-2: unpause after expiry does not clear pausedUntil.
+    function test_unpause_afterExpiry_leavesStaleTimer() public {
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
-        uint64 expiry = eETHInstance.pausedUntil();
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(uint256(expiry) + 1);
 
         vm.prank(extendPauser);
-        eETHInstance.unpause();
+        eETHInstance.unpause(alice);
 
-        // pausedUntil NOT rewound because the if-branch (pausedUntil >= block.timestamp) is false.
-        assertEq(eETHInstance.pausedUntil(), expiry);
-        assertFalse(eETHInstance.paused());
+        assertEq(eETHInstance.pausedUntil(alice), expiry, "stale expiry remains (M-2)");
+        assertFalse(eETHInstance.paused(alice));
+
+        // Functionally still unfrozen (past timestamp).
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether);
     }
 
-    /// @dev CURRENT behavior: unpause() succeeds even when contract was never paused (M-2).
+    /// @dev Documents M-2: unpause succeeds on never-paused user.
     function test_unpause_noop_whenNeverPaused() public {
         vm.prank(extendPauser);
-        eETHInstance.unpause();
-
-        assertFalse(eETHInstance.paused());
-        assertEq(eETHInstance.pausedUntil(), 0);
+        eETHInstance.unpause(alice);
+        assertFalse(eETHInstance.paused(alice));
+        assertEq(eETHInstance.pausedUntil(alice), 0);
     }
 
     // -------------------------------------------------------------------
-    //                   NON-TRANSFER PATHS DURING PAUSE
+    //                           EVENT EMISSION
     // -------------------------------------------------------------------
 
-    /// @dev Documents CURRENT behavior (L-2): LiquidityPool deposit path still mints eETH shares
-    ///      while paused because mintShares bypasses the pause check.
-    function test_mintShares_notBlockedByPause() public {
+    function test_pause_emitsIndexedUser() public {
+        vm.expectEmit(true, false, false, true);
+        emit Paused(alice);
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
+    }
+
+    function test_pauseUntil_emitsIndexedUserAndExpiry() public {
+        vm.expectEmit(true, false, false, true);
+        emit PausedUntil(alice, uint64(block.timestamp) + ONE_DAY);
+        vm.prank(pauser);
+        eETHInstance.pauseUntil(alice);
+    }
+
+    function test_unpause_emitsIndexedUser() public {
+        vm.expectEmit(true, false, false, true);
+        emit Unpaused(alice);
+        vm.prank(extendPauser);
+        eETHInstance.unpause(alice);
+    }
+
+    // -------------------------------------------------------------------
+    //                  NON-TRANSFER PATHS DURING FREEZE
+    // -------------------------------------------------------------------
+
+    /// @dev CRITICAL (C-1): LiquidityPool can still mint shares for a frozen user.
+    function test_mintShares_bypassesFreeze() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
 
         uint256 sharesBefore = eETHInstance.shares(alice);
         vm.prank(address(liquidityPoolInstance));
         eETHInstance.mintShares(alice, 5 ether);
-        assertEq(eETHInstance.shares(alice), sharesBefore + 5 ether);
+        assertEq(eETHInstance.shares(alice), sharesBefore + 5 ether, "freeze did not stop mintShares (C-1)");
     }
 
-    function test_burnShares_notBlockedByPause() public {
+    /// @dev CRITICAL (C-1): LiquidityPool can still burn shares for a frozen user.
+    function test_burnShares_bypassesFreeze() public {
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
         uint256 sharesBefore = eETHInstance.shares(alice);
         vm.prank(address(liquidityPoolInstance));
         eETHInstance.burnShares(alice, 1 ether);
-        assertEq(eETHInstance.shares(alice), sharesBefore - 1 ether);
+        assertEq(eETHInstance.shares(alice), sharesBefore - 1 ether, "freeze did not stop burnShares (C-1)");
     }
 
-    function test_approve_notBlockedByPause() public {
+    /// @dev CRITICAL (C-1): A frozen user can still deposit via LP end-to-end.
+    function test_LPDeposit_bypassesFreezeOfDepositor() public {
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
+
+        uint256 sharesBefore = eETHInstance.shares(alice);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+        assertGt(eETHInstance.shares(alice), sharesBefore, "deposit path not blocked by freeze");
+    }
+
+    function test_approve_notBlockedByFreeze() public {
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
 
         vm.prank(alice);
         eETHInstance.approve(bob, 1 ether);
         assertEq(eETHInstance.allowance(alice, bob), 1 ether);
     }
 
-    function test_permit_notBlockedByPause() public {
-        // Alice priv key = 2 (per TestSetup convention)
+    function test_permit_notBlockedByFreeze() public {
         ILiquidityPool.PermitInput memory p = createPermitInput(
-            2,
+            2, // alice pk
             bob,
             1 ether,
             eETHInstance.nonces(alice),
@@ -320,39 +451,35 @@ contract EETHPauseTest is TestSetup {
         );
 
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
         eETHInstance.permit(alice, bob, 1 ether, type(uint256).max, p.v, p.r, p.s);
         assertEq(eETHInstance.allowance(alice, bob), 1 ether);
     }
 
     // -------------------------------------------------------------------
-    //                  INTERLEAVED / LIFECYCLE SEQUENCES
+    //                    INTERLEAVED / LIFECYCLE FLOWS
     // -------------------------------------------------------------------
 
     function test_sequence_pauseUntil_then_extendPauser_locks() public {
-        // Monitoring triggers 1-day pause
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
 
-        // Security council escalates to indefinite pause
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
-        // Warp past the 1-day window: paused flag still blocks
         vm.warp(block.timestamp + 2 days);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("SENDER PAUSED");
         eETHInstance.transfer(bob, 1 ether);
 
-        // Only extendPauser can release
         vm.prank(pauser);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.unpause();
+        eETHInstance.unpause(alice);
 
         vm.prank(extendPauser);
-        eETHInstance.unpause();
+        eETHInstance.unpause(alice);
 
         vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether);
@@ -365,55 +492,96 @@ contract EETHPauseTest is TestSetup {
 
         vm.prank(pauser);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
     }
 
     // -------------------------------------------------------------------
-    //                             FUZZING
+    //                                FUZZING
     // -------------------------------------------------------------------
 
     function testFuzz_pause_revertsForNonExtendPauser(address caller) public {
         vm.assume(caller != extendPauser);
-        // RoleRegistry.hasRole reverts/returns false depending on impl; either way pause() must revert.
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
     }
 
     function testFuzz_pauseUntil_revertsForNonPauser(address caller) public {
         vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
     }
 
     function testFuzz_unpause_revertsForNonExtendPauser(address caller) public {
         vm.assume(caller != extendPauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.unpause();
+        eETHInstance.unpause(alice);
     }
 
     function testFuzz_pauseUntil_setsOneDayFromWarpedTimestamp(uint64 warpTo) public {
-        // Keep within uint64 bounds; ensure we can add 1 day without overflow.
         warpTo = uint64(bound(uint256(warpTo), block.timestamp + 1, type(uint64).max - ONE_DAY - 1));
         vm.warp(warpTo);
 
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
 
-        assertEq(eETHInstance.pausedUntil(), warpTo + ONE_DAY);
+        assertEq(eETHInstance.pausedUntil(alice), warpTo + ONE_DAY);
     }
 
-    function testFuzz_transferBlockedWhenPaused(uint256 amount) public {
+    function testFuzz_senderFrozen_blocksAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, eETHInstance.shares(alice));
 
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("SENDER PAUSED");
         eETHInstance.transfer(bob, amount);
+    }
+
+    function testFuzz_recipientFrozen_blocksAnyAmount(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.shares(bob));
+
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        eETHInstance.transfer(alice, amount);
+    }
+
+    function testFuzz_unfrozenUsers_unaffected(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.shares(bob));
+
+        // Freeze a bystander
+        vm.prank(extendPauser);
+        eETHInstance.pause(alice);
+
+        uint256 bobBefore = eETHInstance.shares(bob);
+        uint256 chadBefore = eETHInstance.shares(chad);
+
+        vm.prank(bob);
+        eETHInstance.transfer(chad, amount);
+
+        // Share accounting preserved (allow wei-level rounding from shares/amount conversion)
+        assertLe(eETHInstance.shares(bob), bobBefore);
+        assertGe(eETHInstance.shares(chad), chadBefore);
+    }
+
+    function testFuzz_transferAtOrBeforeExpiry_blocksSender(uint64 delta) public {
+        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
+
+        vm.prank(pauser);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+
+        vm.warp(uint256(expiry) - delta);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(bob, 1);
     }
 
     function testFuzz_transferWorksAfterExpiry(uint256 amount, uint64 extra) public {
@@ -421,9 +589,9 @@ contract EETHPauseTest is TestSetup {
         extra = uint64(bound(uint256(extra), 1, 365 days));
 
         vm.prank(pauser);
-        eETHInstance.pauseUntil();
+        eETHInstance.pauseUntil(alice);
 
-        vm.warp(uint256(eETHInstance.pausedUntil()) + extra);
+        vm.warp(uint256(eETHInstance.pausedUntil(alice)) + extra);
 
         uint256 aliceBefore = eETHInstance.shares(alice);
         uint256 bobBefore = eETHInstance.shares(bob);
@@ -431,62 +599,31 @@ contract EETHPauseTest is TestSetup {
         vm.prank(alice);
         eETHInstance.transfer(bob, amount);
 
-        // Share accounting preserved
         uint256 sharesMoved = aliceBefore - eETHInstance.shares(alice);
         assertEq(eETHInstance.shares(bob), bobBefore + sharesMoved);
     }
 
-    function testFuzz_transferAtOrBeforeExpiry_blocks(uint64 delta) public {
-        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
-
-        vm.prank(pauser);
-        eETHInstance.pauseUntil();
-        uint64 expiry = eETHInstance.pausedUntil();
-
-        vm.warp(uint256(expiry) - delta);
-
-        vm.prank(alice);
-        vm.expectRevert("PAUSED");
-        eETHInstance.transfer(bob, 1);
-    }
-
-    function testFuzz_unpauseSucceedsRegardlessOfPriorState(bool pauseFirst, bool pauseUntilFirst) public {
-        if (pauseUntilFirst) {
-            vm.prank(pauser);
-            eETHInstance.pauseUntil();
-        }
-        if (pauseFirst) {
-            vm.prank(extendPauser);
-            eETHInstance.pause();
-        }
+    function testFuzz_independentUsers_freezingOneDoesNotTouchOther(address userA, address userB) public {
+        vm.assume(userA != address(0) && userB != address(0));
+        vm.assume(userA != userB);
 
         vm.prank(extendPauser);
-        eETHInstance.unpause();
+        eETHInstance.pause(userA);
 
-        assertFalse(eETHInstance.paused());
-        // pausedUntil is either < now (cleared or never set) or never touched if it was already expired.
-        assertTrue(eETHInstance.pausedUntil() < block.timestamp || eETHInstance.pausedUntil() == 0);
-
-        // Transfer must succeed.
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1);
+        assertTrue(eETHInstance.paused(userA));
+        assertFalse(eETHInstance.paused(userB));
+        assertEq(eETHInstance.pausedUntil(userB), 0);
     }
 
-    function testFuzz_roleAuthorization_pauseUntil_onlyHolder(address holder, address other) public {
-        bytes32 role = eETHInstance.EETH_PAUSER_ROLE();
-        vm.assume(holder != address(0));
-        vm.assume(other != holder);
-        vm.assume(!roleRegistryInstance.hasRole(role, other));
+    function testFuzz_pauseUntil_doesNotTouchOtherUser(address userA, address userB) public {
+        vm.assume(userA != address(0) && userB != address(0));
+        vm.assume(userA != userB);
 
-        vm.prank(owner);
-        roleRegistryInstance.grantRole(role, holder);
+        vm.prank(pauser);
+        eETHInstance.pauseUntil(userA);
 
-        vm.prank(holder);
-        eETHInstance.pauseUntil();
-        assertGt(eETHInstance.pausedUntil(), block.timestamp);
-
-        vm.prank(other);
-        vm.expectRevert("IncorrectRole");
-        eETHInstance.pauseUntil();
+        assertGt(eETHInstance.pausedUntil(userA), block.timestamp);
+        assertEq(eETHInstance.pausedUntil(userB), 0);
+        assertFalse(eETHInstance.paused(userB));
     }
 }

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -3,25 +3,23 @@ pragma solidity ^0.8.13;
 
 import "./TestSetup.sol";
 
-/// Unit + fuzz tests for the per-user FREEZE feature on EETH.
-/// Role model (post-rename):
-///   EETH_PAUSER_ROLE        -> security council : pause(user) / unpause(user) (strong)
-///   EETH_PAUSER_UNTIL_ROLE  -> monitoring EOA   : pauseUntil(user) arms 1-day freeze
-///
-/// Semantics:
-/// - `paused` / `pausedUntil` are per-address mappings.
-/// - `_transferShares` blocks if EITHER sender OR recipient is frozen.
-/// - `mintShares` / `burnShares` ALSO gate on the `_user` mapping entry
-///   (closes the prior C-1 bypass via LP deposit/withdraw).
+/// Unit + fuzz tests for the hybrid pause feature on EETH.
+/// Design:
+///   - global `paused` (bool)           : pause() / unpause()                      -> PAUSER_ROLE (strong)
+///   - per-user `pausedUntil[user]`     : pauseUntil(user)                         -> PAUSER_UNTIL_ROLE (weak)
+///                                      : extendPauseUntil(user, duration)         -> PAUSER_ROLE (strong)
+///                                      : cancelPauseUntil(user)                   -> PAUSER_ROLE (strong)
+/// All transfer / mint / burn paths require global !paused AND timer expired for the affected user(s).
 contract EETHPauseTest is TestSetup {
-    event Paused(address indexed user);
+    event Paused();
     event PausedUntil(address indexed user, uint64 pausedUntil);
-    event Unpaused(address indexed user);
+    event CancelledPauseUntil(address indexed user);
+    event Unpaused();
     event Transfer(address indexed from, address indexed to, uint256 value);
 
-    address pauser;       // holds EETH_PAUSER_ROLE (strong: pause + unpause)
-    address pauserUntil;  // holds EETH_PAUSER_UNTIL_ROLE (weak: 1-day timer)
-    address unauthorized; // no pause roles
+    address pauser;       // PAUSER_ROLE (strong)
+    address pauserUntil;  // PAUSER_UNTIL_ROLE (weak)
+    address unauthorized;
 
     uint64 constant ONE_DAY = 1 days;
 
@@ -52,22 +50,22 @@ contract EETHPauseTest is TestSetup {
     //                          ZERO-ADDRESS GUARDS
     // -------------------------------------------------------------------
 
-    function test_pause_rejectsZeroAddress() public {
-        vm.prank(pauser);
-        vm.expectRevert("No zero addresses");
-        eETHInstance.pause(address(0));
-    }
-
     function test_pauseUntil_rejectsZeroAddress() public {
         vm.prank(pauserUntil);
         vm.expectRevert("No zero addresses");
         eETHInstance.pauseUntil(address(0));
     }
 
-    function test_unpause_rejectsZeroAddress() public {
+    function test_extendPauseUntil_rejectsZeroAddress() public {
         vm.prank(pauser);
         vm.expectRevert("No zero addresses");
-        eETHInstance.unpause(address(0));
+        eETHInstance.extendPauseUntil(address(0), ONE_DAY);
+    }
+
+    function test_cancelPauseUntil_rejectsZeroAddress() public {
+        vm.prank(pauser);
+        vm.expectRevert("No zero addresses");
+        eETHInstance.cancelPauseUntil(address(0));
     }
 
     // -------------------------------------------------------------------
@@ -77,15 +75,15 @@ contract EETHPauseTest is TestSetup {
     function test_pause_onlyPauserRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pause(alice);
+        eETHInstance.pause();
 
         vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pause(alice);
+        eETHInstance.pause();
 
         vm.prank(pauser);
-        eETHInstance.pause(alice);
-        assertTrue(eETHInstance.paused(alice));
+        eETHInstance.pause();
+        assertTrue(eETHInstance.paused());
     }
 
     function test_pauseUntil_onlyPauserUntilRole() public {
@@ -102,293 +100,137 @@ contract EETHPauseTest is TestSetup {
         assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
     }
 
-    function test_unpause_onlyPauserRole() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
+    function test_extendPauseUntil_onlyPauserRole() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice); // arm the timer so extend has something to do
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.unpause(alice);
+        eETHInstance.extendPauseUntil(alice, 2 days);
 
         vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.unpause(alice);
+        eETHInstance.extendPauseUntil(alice, 2 days);
 
         vm.prank(pauser);
-        eETHInstance.unpause(alice);
-        assertFalse(eETHInstance.paused(alice));
+        eETHInstance.extendPauseUntil(alice, 2 days);
+        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 2 days);
+    }
+
+    function test_cancelPauseUntil_onlyPauserRole() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.cancelPauseUntil(alice);
+
+        vm.prank(pauserUntil);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.cancelPauseUntil(alice);
+
+        vm.prank(pauser);
+        eETHInstance.cancelPauseUntil(alice);
+        assertEq(eETHInstance.pausedUntil(alice), 0);
+    }
+
+    function test_unpause_onlyPauserRole() public {
+        vm.prank(pauser);
+        eETHInstance.pause();
+
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.unpause();
+
+        vm.prank(pauserUntil);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.unpause();
+
+        vm.prank(pauser);
+        eETHInstance.unpause();
+        assertFalse(eETHInstance.paused());
     }
 
     // -------------------------------------------------------------------
-    //                      PER-USER FREEZE SELECTIVITY
+    //                     GLOBAL PAUSE — TRANSFER / MINT / BURN
     // -------------------------------------------------------------------
 
-    function test_freeze_isPerUser_othersUnaffected() public {
+    function test_globalPause_blocksAllTransfers() public {
         vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(bob);
-        eETHInstance.transfer(chad, 1 ether);
-        vm.prank(chad);
-        eETHInstance.transfer(bob, 1 ether);
-    }
-
-    function test_freeze_blocksSender() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
+        eETHInstance.pause();
 
         vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
+        vm.expectRevert("PAUSED");
         eETHInstance.transfer(bob, 1 ether);
-    }
 
-    function test_freeze_blocksRecipient() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(bob);
-        vm.expectRevert("RECIPIENT PAUSED");
-        eETHInstance.transfer(alice, 1 ether);
-    }
-
-    function test_freeze_blocksSelfTransfer() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        eETHInstance.transfer(alice, 1 ether);
-    }
-
-    function test_freeze_blocksTransferFrom_viaSender() public {
+        // transferFrom also blocked
         vm.prank(alice);
         eETHInstance.approve(bob, 1 ether);
-
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
         vm.prank(bob);
-        vm.expectRevert("SENDER PAUSED");
+        vm.expectRevert("PAUSED");
         eETHInstance.transferFrom(alice, chad, 1 ether);
     }
 
-    function test_freeze_blocksTransferFrom_viaRecipient() public {
-        vm.prank(alice);
-        eETHInstance.approve(bob, 1 ether);
-
+    function test_globalPause_blocksMintShares() public {
         vm.prank(pauser);
-        eETHInstance.pause(chad);
+        eETHInstance.pause();
 
-        vm.prank(bob);
-        vm.expectRevert("RECIPIENT PAUSED");
-        eETHInstance.transferFrom(alice, chad, 1 ether);
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, 1 ether);
     }
 
-    function test_freeze_spenderNotChecked() public {
-        vm.prank(alice);
-        eETHInstance.approve(bob, 1 ether);
-
+    function test_globalPause_blocksBurnShares() public {
         vm.prank(pauser);
-        eETHInstance.pause(bob); // spender frozen — does NOT matter
+        eETHInstance.pause();
 
-        vm.prank(bob);
-        eETHInstance.transferFrom(alice, chad, 1 ether); // must succeed
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, 1 ether);
     }
 
-    function test_bothPartiesFrozen_sendErrorFiresFirst() public {
+    function test_globalPause_blocksLPDeposit() public {
         vm.prank(pauser);
-        eETHInstance.pause(alice);
-        vm.prank(pauser);
-        eETHInstance.pause(bob);
+        eETHInstance.pause();
 
         vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
+        vm.expectRevert("MINT PAUSED");
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    function test_globalUnpause_restoresTransfers() public {
+        vm.prank(pauser);
+        eETHInstance.pause();
+
+        vm.prank(pauser);
+        eETHInstance.unpause();
+
+        vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    function test_unfreeze_isPerUser() public {
+    /// @dev Documents M-2: unpause has no is-paused guard.
+    function test_unpause_noop_whenNotPaused() public {
+        assertFalse(eETHInstance.paused());
         vm.prank(pauser);
-        eETHInstance.pause(alice);
-        vm.prank(pauser);
-        eETHInstance.pause(bob);
+        eETHInstance.unpause();
+        assertFalse(eETHInstance.paused());
+    }
 
-        vm.prank(pauser);
-        eETHInstance.unpause(alice);
-
+    function test_globalPause_blocksEvenApprovedTransferFrom() public {
         vm.prank(alice);
-        eETHInstance.transfer(chad, 1 ether);
+        eETHInstance.approve(bob, 10 ether);
+
+        vm.prank(pauser);
+        eETHInstance.pause();
 
         vm.prank(bob);
-        vm.expectRevert("SENDER PAUSED");
-        eETHInstance.transfer(chad, 1 ether);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transferFrom(alice, chad, 1 ether);
     }
 
     // -------------------------------------------------------------------
-    //                     MINT / BURN SHARES FREEZE GATE
-    //         (user's new fix — previously bypassed, now blocked)
-    // -------------------------------------------------------------------
-
-    function test_mintShares_blockedWhenUserPaused() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("MINT PAUSED");
-        eETHInstance.mintShares(alice, 1 ether);
-    }
-
-    function test_mintShares_blockedWhenUserPauseUntilActive() public {
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("MINT PAUSED");
-        eETHInstance.mintShares(alice, 1 ether);
-    }
-
-    function test_mintShares_blockedAtPauseUntilBoundary() public {
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
-        vm.warp(expiry); // exactly at boundary — still frozen
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("MINT PAUSED");
-        eETHInstance.mintShares(alice, 1 ether);
-    }
-
-    function test_mintShares_worksAfterPauseUntilExpiry() public {
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
-
-        vm.warp(uint256(expiry) + 1);
-
-        uint256 sharesBefore = eETHInstance.shares(alice);
-        vm.prank(address(liquidityPoolInstance));
-        eETHInstance.mintShares(alice, 1 ether);
-        assertEq(eETHInstance.shares(alice), sharesBefore + 1 ether);
-    }
-
-    function test_mintShares_worksForNonFrozenUser() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice); // freeze alice, not bob
-
-        uint256 sharesBefore = eETHInstance.shares(bob);
-        vm.prank(address(liquidityPoolInstance));
-        eETHInstance.mintShares(bob, 1 ether);
-        assertEq(eETHInstance.shares(bob), sharesBefore + 1 ether);
-    }
-
-    function test_burnShares_blockedWhenUserPaused() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("BURN PAUSED");
-        eETHInstance.burnShares(alice, 1 ether);
-    }
-
-    function test_burnShares_blockedWhenUserPauseUntilActive() public {
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("BURN PAUSED");
-        eETHInstance.burnShares(alice, 1 ether);
-    }
-
-    function test_burnShares_blockedAtPauseUntilBoundary() public {
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
-        vm.warp(expiry);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("BURN PAUSED");
-        eETHInstance.burnShares(alice, 1 ether);
-    }
-
-    function test_burnShares_worksAfterPauseUntilExpiry() public {
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
-
-        vm.warp(uint256(expiry) + 1);
-
-        uint256 sharesBefore = eETHInstance.shares(alice);
-        vm.prank(address(liquidityPoolInstance));
-        eETHInstance.burnShares(alice, 1 ether);
-        assertEq(eETHInstance.shares(alice), sharesBefore - 1 ether);
-    }
-
-    function test_burnShares_worksForNonFrozenUser() public {
-        vm.prank(pauser);
-        eETHInstance.pause(bob);
-
-        uint256 sharesBefore = eETHInstance.shares(alice);
-        vm.prank(address(liquidityPoolInstance));
-        eETHInstance.burnShares(alice, 1 ether);
-        assertEq(eETHInstance.shares(alice), sharesBefore - 1 ether);
-    }
-
-    /// @dev mintShares check is first thing after onlyPoolContract — a non-LP caller
-    /// still sees the auth error, not the pause error.
-    function test_mintShares_revertsForNonLPCaller_evenWhenFrozen() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(bob);
-        vm.expectRevert("Only pool contract function");
-        eETHInstance.mintShares(alice, 1 ether);
-    }
-
-    function test_burnShares_revertsForNonLPCaller_evenWhenFrozen() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(bob);
-        vm.expectRevert("Incorrect Caller");
-        eETHInstance.burnShares(alice, 1 ether);
-    }
-
-    // -------------------------------------------------------------------
-    //          INTEGRATION: LP deposit/withdraw respect the freeze
-    // -------------------------------------------------------------------
-
-    function test_LPDeposit_blockedForFrozenDepositor() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("MINT PAUSED");
-        liquidityPoolInstance.deposit{value: 1 ether}();
-    }
-
-    function test_LPDeposit_blockedUnderPauseUntil() public {
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("MINT PAUSED");
-        liquidityPoolInstance.deposit{value: 1 ether}();
-    }
-
-    function test_LPDeposit_worksAfterPauseUntilExpiry() public {
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
-
-        vm.warp(uint256(expiry) + 1);
-
-        uint256 sharesBefore = eETHInstance.shares(alice);
-        vm.prank(alice);
-        liquidityPoolInstance.deposit{value: 1 ether}();
-        assertGt(eETHInstance.shares(alice), sharesBefore);
-    }
-
-    // -------------------------------------------------------------------
-    //                     pauseUntil TIMER SEMANTICS
+    //                     PER-USER TIMER — TRANSFER BLOCKING
     // -------------------------------------------------------------------
 
     function test_pauseUntil_blocksSender() public {
@@ -409,15 +251,54 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.transfer(alice, 1 ether);
     }
 
-    function test_pauseUntil_expiresAfterOneDay() public {
+    function test_pauseUntil_blocksSelfTransfer() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
-
-        vm.warp(uint256(expiry) + 1);
 
         vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(alice, 1 ether);
+    }
+
+    function test_pauseUntil_blocksMintShares() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, 1 ether);
+    }
+
+    function test_pauseUntil_blocksBurnShares() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, 1 ether);
+    }
+
+    function test_pauseUntil_blocksLPDepositForUser() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("MINT PAUSED");
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    function test_pauseUntil_isPerUser_othersUnaffected() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(bob);
+        eETHInstance.transfer(chad, 1 ether);
+        vm.prank(chad);
         eETHInstance.transfer(bob, 1 ether);
+
+        // bob can deposit
+        vm.prank(bob);
+        liquidityPoolInstance.deposit{value: 1 ether}();
     }
 
     function test_pauseUntil_blockedAtBoundary() public {
@@ -431,25 +312,34 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    function test_pauseUntil_timerIsPerUser() public {
+    function test_pauseUntil_expiresAfterOneDay() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        assertEq(eETHInstance.pausedUntil(bob), 0);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+
+        vm.warp(uint256(expiry) + 1);
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether);
     }
 
-    /// @dev Documents M-1.
-    function test_pauseUntil_silentNoOp_whilePaused() public {
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-        uint64 before = eETHInstance.pausedUntil(alice);
+    function test_pauseUntil_spenderCanRelayBetweenUnfrozenParties() public {
+        // Spender (bob) frozen on per-user timer, but alice → chad transferFrom must still work.
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
 
         vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
+        eETHInstance.pauseUntil(bob);
 
-        assertEq(eETHInstance.pausedUntil(alice), before);
-        assertTrue(eETHInstance.paused(alice));
+        vm.prank(bob);
+        eETHInstance.transferFrom(alice, chad, 1 ether);
     }
 
+    // -------------------------------------------------------------------
+    //                   pauseUntil — no-op while timer active
+    // -------------------------------------------------------------------
+
+    /// @dev Documents carry-over M-1: pauseUntil cannot be refreshed by the weak role.
     function test_pauseUntil_cannotExtend_whileTimerActive() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
@@ -460,7 +350,7 @@ contract EETHPauseTest is TestSetup {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
-        assertEq(eETHInstance.pausedUntil(alice), firstExpiry);
+        assertEq(eETHInstance.pausedUntil(alice), firstExpiry, "weak role cannot refresh (M-1)");
     }
 
     function test_pauseUntil_canRenew_afterExpiry() public {
@@ -474,34 +364,62 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.pauseUntil(alice);
 
         assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
-        assertGt(eETHInstance.pausedUntil(alice), firstExpiry);
     }
 
     // -------------------------------------------------------------------
-    //                          UNPAUSE SEMANTICS
+    //                         extendPauseUntil SEMANTICS
     // -------------------------------------------------------------------
 
-    function test_unpause_clearsBothFlags_whenFullyFrozen() public {
+    function test_extendPauseUntil_extendsLiveTimer() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        assertTrue(eETHInstance.paused(alice));
-        assertGt(eETHInstance.pausedUntil(alice), block.timestamp);
 
         vm.prank(pauser);
-        eETHInstance.unpause(alice);
+        eETHInstance.extendPauseUntil(alice, 7 days);
 
-        assertFalse(eETHInstance.paused(alice));
-        assertEq(eETHInstance.pausedUntil(alice), 0);
+        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 7 days);
 
+        vm.warp(block.timestamp + 1 days + 1); // past original 1-day expiry
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    /// @dev H-1 (HIGH): extendPauseUntil can SHORTEN a timer despite its name.
+    function test_SECURITY_extendPauseUntil_canShortenTimer() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice); // arms 1-day timer
+
+        // Admin calls extend with 1-hour duration → new expiry is EARLIER than original.
+        vm.prank(pauser);
+        eETHInstance.extendPauseUntil(alice, 1 hours);
+
+        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 1 hours);
+        assertLt(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY,
+                 "extend should not allow shortening (H-1)");
+    }
+
+    /// @dev H-1 corollary: duration=0 effectively releases the user next block.
+    function test_SECURITY_extendPauseUntil_withZeroDuration_effectivelyCancels() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        eETHInstance.extendPauseUntil(alice, 0);
+
+        // Current block — timer is at block.timestamp, require uses strict <, still paused.
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
+
+        // But any forward progress unfreezes.
+        vm.warp(block.timestamp + 1);
         vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    /// @dev Documents M-2: unpause after expiry does not clear pausedUntil.
-    function test_unpause_afterExpiry_leavesStaleTimer() public {
+    /// @dev M-1-new: extendPauseUntil silent no-op when timer already expired.
+    function test_extendPauseUntil_silentNoOp_whenTimerExpired() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
         uint64 expiry = eETHInstance.pausedUntil(alice);
@@ -509,32 +427,163 @@ contract EETHPauseTest is TestSetup {
         vm.warp(uint256(expiry) + 1);
 
         vm.prank(pauser);
-        eETHInstance.unpause(alice);
+        eETHInstance.extendPauseUntil(alice, 3 days);
 
-        assertEq(eETHInstance.pausedUntil(alice), expiry);
-        assertFalse(eETHInstance.paused(alice));
-
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
+        assertEq(eETHInstance.pausedUntil(alice), expiry, "no-op when timer expired (M-1-new)");
     }
 
-    /// @dev Documents M-2.
-    function test_unpause_noop_whenNeverPaused() public {
+    function test_extendPauseUntil_silentNoOp_whenNeverArmed() public {
         vm.prank(pauser);
-        eETHInstance.unpause(alice);
-        assertFalse(eETHInstance.paused(alice));
+        eETHInstance.extendPauseUntil(alice, 3 days);
         assertEq(eETHInstance.pausedUntil(alice), 0);
     }
 
+    function test_extendPauseUntil_emitsPausedUntil_whenActive() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        uint64 expected = uint64(block.timestamp) + 3 days;
+        vm.expectEmit(true, false, false, true);
+        emit PausedUntil(alice, expected);
+        vm.prank(pauser);
+        eETHInstance.extendPauseUntil(alice, 3 days);
+    }
+
+    function test_extendPauseUntil_doesNotEmit_whenExpired() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        vm.warp(block.timestamp + 2 days);
+
+        vm.recordLogs();
+        vm.prank(pauser);
+        eETHInstance.extendPauseUntil(alice, 3 days);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "no event on no-op");
+    }
+
+    function test_extendPauseUntil_onOtherUser_doesNotLeak() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        eETHInstance.extendPauseUntil(bob, 7 days); // bob was never paused → no-op
+
+        assertEq(eETHInstance.pausedUntil(bob), 0);
+    }
+
     // -------------------------------------------------------------------
-    //                           EVENT EMISSION
+    //                         cancelPauseUntil SEMANTICS
     // -------------------------------------------------------------------
 
-    function test_pause_emitsIndexedUser() public {
-        vm.expectEmit(true, false, false, true);
-        emit Paused(alice);
+    function test_cancelPauseUntil_clearsActiveTimer() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
         vm.prank(pauser);
-        eETHInstance.pause(alice);
+        eETHInstance.cancelPauseUntil(alice);
+
+        assertEq(eETHInstance.pausedUntil(alice), 0);
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether); // must succeed immediately
+    }
+
+    /// @dev M-2-new: cancelPauseUntil emits event even when there's nothing to cancel.
+    function test_cancelPauseUntil_emitsEvenWhenNeverArmed() public {
+        vm.expectEmit(true, false, false, true);
+        emit CancelledPauseUntil(alice);
+        vm.prank(pauser);
+        eETHInstance.cancelPauseUntil(alice);
+    }
+
+    function test_cancelPauseUntil_emitsEvenWhenAlreadyExpired() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        vm.warp(block.timestamp + 2 days);
+
+        vm.expectEmit(true, false, false, true);
+        emit CancelledPauseUntil(alice);
+        vm.prank(pauser);
+        eETHInstance.cancelPauseUntil(alice);
+
+        assertEq(eETHInstance.pausedUntil(alice), 0, "stale timer also cleared");
+    }
+
+    function test_cancelPauseUntil_isPerUser_doesNotTouchOthers() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(bob);
+
+        vm.prank(pauser);
+        eETHInstance.cancelPauseUntil(alice);
+
+        assertEq(eETHInstance.pausedUntil(alice), 0);
+        assertGt(eETHInstance.pausedUntil(bob), block.timestamp);
+    }
+
+    // -------------------------------------------------------------------
+    //                 GLOBAL ⨯ PER-USER INTERACTION
+    // -------------------------------------------------------------------
+
+    function test_globalPause_dominatesTimerCheck_inTransfer() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        eETHInstance.pause();
+
+        // Even bob (not timer-frozen) can't transfer — global wins, returns "PAUSED".
+        vm.prank(bob);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transfer(chad, 1 ether);
+    }
+
+    function test_globalUnpause_leavesPerUserTimerInEffect() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        eETHInstance.pause();
+        vm.prank(pauser);
+        eETHInstance.unpause();
+
+        // Bob can move again, alice is still locked by per-user timer.
+        vm.prank(bob);
+        eETHInstance.transfer(chad, 1 ether);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_pauseUntilWorksDuringGlobalPause_butTransfersStillBlocked() public {
+        vm.prank(pauser);
+        eETHInstance.pause();
+
+        // Weak role can still arm a per-user timer during global pause.
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        assertGt(eETHInstance.pausedUntil(alice), block.timestamp);
+    }
+
+    // -------------------------------------------------------------------
+    //                                EVENTS
+    // -------------------------------------------------------------------
+
+    function test_pause_emitsPaused() public {
+        vm.expectEmit(false, false, false, true);
+        emit Paused();
+        vm.prank(pauser);
+        eETHInstance.pause();
+    }
+
+    function test_unpause_emitsUnpaused() public {
+        vm.expectEmit(false, false, false, true);
+        emit Unpaused();
+        vm.prank(pauser);
+        eETHInstance.unpause();
     }
 
     function test_pauseUntil_emitsIndexedUserAndExpiry() public {
@@ -544,64 +593,73 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.pauseUntil(alice);
     }
 
-    function test_unpause_emitsIndexedUser() public {
-        vm.expectEmit(true, false, false, true);
-        emit Unpaused(alice);
-        vm.prank(pauser);
-        eETHInstance.unpause(alice);
-    }
-
     // -------------------------------------------------------------------
-    //                  NON-TRANSFER PATHS DURING FREEZE
+    //                   NON-TRANSFER PATHS DURING FREEZE
     // -------------------------------------------------------------------
 
-    function test_approve_notBlockedByFreeze() public {
+    function test_approve_worksDuringGlobalPause() public {
         vm.prank(pauser);
-        eETHInstance.pause(alice);
+        eETHInstance.pause();
 
         vm.prank(alice);
         eETHInstance.approve(bob, 1 ether);
         assertEq(eETHInstance.allowance(alice, bob), 1 ether);
     }
 
-    function test_permit_notBlockedByFreeze() public {
+    function test_approve_worksWhileUserPaused() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+        assertEq(eETHInstance.allowance(alice, bob), 1 ether);
+    }
+
+    function test_permit_worksDuringGlobalPause() public {
         ILiquidityPool.PermitInput memory p = createPermitInput(
             2, bob, 1 ether, eETHInstance.nonces(alice),
             type(uint256).max, eETHInstance.DOMAIN_SEPARATOR()
         );
 
         vm.prank(pauser);
-        eETHInstance.pause(alice);
+        eETHInstance.pause();
 
         eETHInstance.permit(alice, bob, 1 ether, type(uint256).max, p.v, p.r, p.s);
         assertEq(eETHInstance.allowance(alice, bob), 1 ether);
     }
 
     // -------------------------------------------------------------------
-    //                    INTERLEAVED / LIFECYCLE FLOWS
+    //                          LIFECYCLE SEQUENCES
     // -------------------------------------------------------------------
 
-    function test_sequence_pauseUntil_then_pause_locks() public {
+    function test_sequence_weakArms_then_strongExtends_then_strongCancels() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
         vm.prank(pauser);
-        eETHInstance.pause(alice);
+        eETHInstance.extendPauseUntil(alice, 3 days);
+        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 3 days);
 
-        vm.warp(block.timestamp + 2 days);
+        vm.prank(pauser);
+        eETHInstance.cancelPauseUntil(alice);
+        assertEq(eETHInstance.pausedUntil(alice), 0);
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether);
+    }
+
+    function test_sequence_globalPause_thenPerUserArm_thenUnpause_userStillFrozen() public {
+        vm.prank(pauser);
+        eETHInstance.pause();
+
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        eETHInstance.unpause();
 
         vm.prank(alice);
         vm.expectRevert("SENDER PAUSED");
-        eETHInstance.transfer(bob, 1 ether);
-
-        vm.prank(pauserUntil);
-        vm.expectRevert("IncorrectRole");
-        eETHInstance.unpause(alice);
-
-        vm.prank(pauser);
-        eETHInstance.unpause(alice);
-
-        vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether);
     }
 
@@ -623,7 +681,14 @@ contract EETHPauseTest is TestSetup {
         vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.pause(alice);
+        eETHInstance.pause();
+    }
+
+    function testFuzz_unpause_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.unpause();
     }
 
     function testFuzz_pauseUntil_revertsForNonPauserUntil(address caller) public {
@@ -633,11 +698,18 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.pauseUntil(alice);
     }
 
-    function testFuzz_unpause_revertsForNonPauser(address caller) public {
+    function testFuzz_extendPauseUntil_revertsForNonPauser(address caller) public {
         vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        eETHInstance.unpause(alice);
+        eETHInstance.extendPauseUntil(alice, ONE_DAY);
+    }
+
+    function testFuzz_cancelPauseUntil_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        eETHInstance.cancelPauseUntil(alice);
     }
 
     function testFuzz_pauseUntil_setsOneDayFromWarpedTimestamp(uint64 warpTo) public {
@@ -650,11 +722,34 @@ contract EETHPauseTest is TestSetup {
         assertEq(eETHInstance.pausedUntil(alice), warpTo + ONE_DAY);
     }
 
-    function testFuzz_senderFrozen_blocksAnyAmount(uint256 amount) public {
+    function testFuzz_extendPauseUntil_setsArbitraryDuration(uint64 duration) public {
+        duration = uint64(bound(uint256(duration), 1, 365 days));
+
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        eETHInstance.extendPauseUntil(alice, duration);
+
+        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + duration);
+    }
+
+    function testFuzz_globalPause_blocksTransferAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, eETHInstance.shares(alice));
 
         vm.prank(pauser);
-        eETHInstance.pause(alice);
+        eETHInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        eETHInstance.transfer(bob, amount);
+    }
+
+    function testFuzz_senderFrozen_blocksAnyAmount(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.shares(alice));
+
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
 
         vm.prank(alice);
         vm.expectRevert("SENDER PAUSED");
@@ -664,42 +759,56 @@ contract EETHPauseTest is TestSetup {
     function testFuzz_recipientFrozen_blocksAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, eETHInstance.shares(bob));
 
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
 
         vm.prank(bob);
         vm.expectRevert("RECIPIENT PAUSED");
         eETHInstance.transfer(alice, amount);
     }
 
-    function testFuzz_unfrozenUsers_unaffected(uint256 amount) public {
-        amount = bound(amount, 1, eETHInstance.shares(bob));
+    function testFuzz_globalPause_blocksMintShares(uint256 amount) public {
+        amount = bound(amount, 1, 1_000_000 ether);
 
         vm.prank(pauser);
-        eETHInstance.pause(alice);
+        eETHInstance.pause();
 
-        uint256 bobBefore = eETHInstance.shares(bob);
-        uint256 chadBefore = eETHInstance.shares(chad);
-
-        vm.prank(bob);
-        eETHInstance.transfer(chad, amount);
-
-        assertLe(eETHInstance.shares(bob), bobBefore);
-        assertGe(eETHInstance.shares(chad), chadBefore);
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, amount);
     }
 
-    function testFuzz_transferAtOrBeforeExpiry_blocksSender(uint64 delta) public {
-        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
+    function testFuzz_globalPause_blocksBurnShares(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.shares(alice));
+
+        vm.prank(pauser);
+        eETHInstance.pause();
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, amount);
+    }
+
+    function testFuzz_pauseUntil_blocksMintShares(uint256 amount) public {
+        amount = bound(amount, 1, 1_000_000 ether);
 
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
 
-        vm.warp(uint256(expiry) - delta);
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, amount);
+    }
 
-        vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        eETHInstance.transfer(bob, 1);
+    function testFuzz_pauseUntil_blocksBurnShares(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.shares(alice));
+
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, amount);
     }
 
     function testFuzz_transferWorksAfterExpiry(uint256 amount, uint64 extra) public {
@@ -721,69 +830,7 @@ contract EETHPauseTest is TestSetup {
         assertEq(eETHInstance.shares(bob), bobBefore + sharesMoved);
     }
 
-    function testFuzz_mintShares_blockedWhenPaused(uint256 amount) public {
-        amount = bound(amount, 1, 1_000_000 ether);
-
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("MINT PAUSED");
-        eETHInstance.mintShares(alice, amount);
-    }
-
-    function testFuzz_mintShares_blockedUnderPauseUntil(uint256 amount, uint64 delta) public {
-        amount = bound(amount, 1, 1_000_000 ether);
-        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
-
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
-        vm.warp(uint256(expiry) - delta);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("MINT PAUSED");
-        eETHInstance.mintShares(alice, amount);
-    }
-
-    function testFuzz_burnShares_blockedWhenPaused(uint256 amount) public {
-        amount = bound(amount, 1, eETHInstance.shares(alice));
-
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("BURN PAUSED");
-        eETHInstance.burnShares(alice, amount);
-    }
-
-    function testFuzz_burnShares_blockedUnderPauseUntil(uint256 amount, uint64 delta) public {
-        amount = bound(amount, 1, eETHInstance.shares(alice));
-        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
-
-        vm.prank(pauserUntil);
-        eETHInstance.pauseUntil(alice);
-        uint64 expiry = eETHInstance.pausedUntil(alice);
-        vm.warp(uint256(expiry) - delta);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert("BURN PAUSED");
-        eETHInstance.burnShares(alice, amount);
-    }
-
-    function testFuzz_independentUsers_freezingOneDoesNotTouchOther(address userA, address userB) public {
-        vm.assume(userA != address(0) && userB != address(0));
-        vm.assume(userA != userB);
-
-        vm.prank(pauser);
-        eETHInstance.pause(userA);
-
-        assertTrue(eETHInstance.paused(userA));
-        assertFalse(eETHInstance.paused(userB));
-        assertEq(eETHInstance.pausedUntil(userB), 0);
-    }
-
-    function testFuzz_pauseUntil_doesNotTouchOtherUser(address userA, address userB) public {
+    function testFuzz_independentUsers_timerIsolated(address userA, address userB) public {
         vm.assume(userA != address(0) && userB != address(0));
         vm.assume(userA != userB);
 
@@ -792,6 +839,5 @@ contract EETHPauseTest is TestSetup {
 
         assertGt(eETHInstance.pausedUntil(userA), block.timestamp);
         assertEq(eETHInstance.pausedUntil(userB), 0);
-        assertFalse(eETHInstance.paused(userB));
     }
 }

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -4,23 +4,24 @@ pragma solidity ^0.8.13;
 import "./TestSetup.sol";
 
 /// Unit + fuzz tests for the per-user FREEZE feature on EETH.
-/// Role model:
-///   EETH_PAUSER_ROLE         -> monitoring EOA   : pauseUntil(user) arms 1-day freeze
-///   EETH_EXTEND_PAUSER_ROLE  -> security council : pause(user) / unpause(user)
+/// Role model (post-rename):
+///   EETH_PAUSER_ROLE        -> security council : pause(user) / unpause(user) (strong)
+///   EETH_PAUSER_UNTIL_ROLE  -> monitoring EOA   : pauseUntil(user) arms 1-day freeze
 ///
-/// Semantics under test:
+/// Semantics:
 /// - `paused` / `pausedUntil` are per-address mappings.
 /// - `_transferShares` blocks if EITHER sender OR recipient is frozen.
-/// - `mintShares` / `burnShares` are NOT gated — documented as C-1 in the review.
+/// - `mintShares` / `burnShares` ALSO gate on the `_user` mapping entry
+///   (closes the prior C-1 bypass via LP deposit/withdraw).
 contract EETHPauseTest is TestSetup {
     event Paused(address indexed user);
     event PausedUntil(address indexed user, uint64 pausedUntil);
     event Unpaused(address indexed user);
     event Transfer(address indexed from, address indexed to, uint256 value);
 
-    address pauser;
-    address extendPauser;
-    address unauthorized;
+    address pauser;       // holds EETH_PAUSER_ROLE (strong: pause + unpause)
+    address pauserUntil;  // holds EETH_PAUSER_UNTIL_ROLE (weak: 1-day timer)
+    address unauthorized; // no pause roles
 
     uint64 constant ONE_DAY = 1 days;
 
@@ -28,12 +29,12 @@ contract EETHPauseTest is TestSetup {
         setUpTests();
 
         pauser = vm.addr(0xA11CE1);
-        extendPauser = vm.addr(0xA11CE2);
+        pauserUntil = vm.addr(0xA11CE2);
         unauthorized = vm.addr(0xA11CE3);
 
         vm.startPrank(owner);
         roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_ROLE(), pauser);
-        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_UNTIL_ROLE(), pauserUntil);
         vm.stopPrank();
 
         vm.deal(alice, 100 ether);
@@ -52,19 +53,19 @@ contract EETHPauseTest is TestSetup {
     // -------------------------------------------------------------------
 
     function test_pause_rejectsZeroAddress() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         vm.expectRevert("No zero addresses");
         eETHInstance.pause(address(0));
     }
 
     function test_pauseUntil_rejectsZeroAddress() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         vm.expectRevert("No zero addresses");
         eETHInstance.pauseUntil(address(0));
     }
 
     function test_unpause_rejectsZeroAddress() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         vm.expectRevert("No zero addresses");
         eETHInstance.unpause(address(0));
     }
@@ -73,47 +74,47 @@ contract EETHPauseTest is TestSetup {
     //                              ROLE GATING
     // -------------------------------------------------------------------
 
-    function test_pause_onlyExtendPauserRole() public {
+    function test_pause_onlyPauserRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
         eETHInstance.pause(alice);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
         eETHInstance.pause(alice);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
         assertTrue(eETHInstance.paused(alice));
     }
 
-    function test_pauseUntil_onlyPauserRole() public {
+    function test_pauseUntil_onlyPauserUntilRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
         eETHInstance.pauseUntil(alice);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         vm.expectRevert("IncorrectRole");
         eETHInstance.pauseUntil(alice);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
         assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
     }
 
-    function test_unpause_onlyExtendPauserRole() public {
-        vm.prank(extendPauser);
+    function test_unpause_onlyPauserRole() public {
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
         eETHInstance.unpause(alice);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
         eETHInstance.unpause(alice);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.unpause(alice);
         assertFalse(eETHInstance.paused(alice));
     }
@@ -123,20 +124,17 @@ contract EETHPauseTest is TestSetup {
     // -------------------------------------------------------------------
 
     function test_freeze_isPerUser_othersUnaffected() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
-        // bob -> chad must still succeed
         vm.prank(bob);
         eETHInstance.transfer(chad, 1 ether);
-
-        // chad -> bob must still succeed
         vm.prank(chad);
         eETHInstance.transfer(bob, 1 ether);
     }
 
     function test_freeze_blocksSender() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         vm.prank(alice);
@@ -145,7 +143,7 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_freeze_blocksRecipient() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         vm.prank(bob);
@@ -154,7 +152,7 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_freeze_blocksSelfTransfer() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         vm.prank(alice);
@@ -166,8 +164,8 @@ contract EETHPauseTest is TestSetup {
         vm.prank(alice);
         eETHInstance.approve(bob, 1 ether);
 
-        vm.prank(extendPauser);
-        eETHInstance.pause(alice); // owner (sender) frozen
+        vm.prank(pauser);
+        eETHInstance.pause(alice);
 
         vm.prank(bob);
         vm.expectRevert("SENDER PAUSED");
@@ -178,8 +176,8 @@ contract EETHPauseTest is TestSetup {
         vm.prank(alice);
         eETHInstance.approve(bob, 1 ether);
 
-        vm.prank(extendPauser);
-        eETHInstance.pause(chad); // recipient frozen
+        vm.prank(pauser);
+        eETHInstance.pause(chad);
 
         vm.prank(bob);
         vm.expectRevert("RECIPIENT PAUSED");
@@ -187,22 +185,20 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_freeze_spenderNotChecked() public {
-        // Spender (bob) being frozen should NOT block transferFrom between unfrozen parties.
-        // Only sender (alice) and recipient (chad) matter.
         vm.prank(alice);
         eETHInstance.approve(bob, 1 ether);
 
-        vm.prank(extendPauser);
-        eETHInstance.pause(bob);
+        vm.prank(pauser);
+        eETHInstance.pause(bob); // spender frozen — does NOT matter
 
         vm.prank(bob);
         eETHInstance.transferFrom(alice, chad, 1 ether); // must succeed
     }
 
     function test_bothPartiesFrozen_sendErrorFiresFirst() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(bob);
 
         vm.prank(alice);
@@ -211,23 +207,184 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_unfreeze_isPerUser() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(bob);
 
-        // Unfreeze only alice
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.unpause(alice);
 
-        // Alice can transfer to chad
         vm.prank(alice);
         eETHInstance.transfer(chad, 1 ether);
 
-        // Bob is still frozen
         vm.prank(bob);
         vm.expectRevert("SENDER PAUSED");
         eETHInstance.transfer(chad, 1 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //                     MINT / BURN SHARES FREEZE GATE
+    //         (user's new fix — previously bypassed, now blocked)
+    // -------------------------------------------------------------------
+
+    function test_mintShares_blockedWhenUserPaused() public {
+        vm.prank(pauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, 1 ether);
+    }
+
+    function test_mintShares_blockedWhenUserPauseUntilActive() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, 1 ether);
+    }
+
+    function test_mintShares_blockedAtPauseUntilBoundary() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+        vm.warp(expiry); // exactly at boundary — still frozen
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, 1 ether);
+    }
+
+    function test_mintShares_worksAfterPauseUntilExpiry() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+
+        vm.warp(uint256(expiry) + 1);
+
+        uint256 sharesBefore = eETHInstance.shares(alice);
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.mintShares(alice, 1 ether);
+        assertEq(eETHInstance.shares(alice), sharesBefore + 1 ether);
+    }
+
+    function test_mintShares_worksForNonFrozenUser() public {
+        vm.prank(pauser);
+        eETHInstance.pause(alice); // freeze alice, not bob
+
+        uint256 sharesBefore = eETHInstance.shares(bob);
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.mintShares(bob, 1 ether);
+        assertEq(eETHInstance.shares(bob), sharesBefore + 1 ether);
+    }
+
+    function test_burnShares_blockedWhenUserPaused() public {
+        vm.prank(pauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, 1 ether);
+    }
+
+    function test_burnShares_blockedWhenUserPauseUntilActive() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, 1 ether);
+    }
+
+    function test_burnShares_blockedAtPauseUntilBoundary() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+        vm.warp(expiry);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, 1 ether);
+    }
+
+    function test_burnShares_worksAfterPauseUntilExpiry() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+
+        vm.warp(uint256(expiry) + 1);
+
+        uint256 sharesBefore = eETHInstance.shares(alice);
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.burnShares(alice, 1 ether);
+        assertEq(eETHInstance.shares(alice), sharesBefore - 1 ether);
+    }
+
+    function test_burnShares_worksForNonFrozenUser() public {
+        vm.prank(pauser);
+        eETHInstance.pause(bob);
+
+        uint256 sharesBefore = eETHInstance.shares(alice);
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.burnShares(alice, 1 ether);
+        assertEq(eETHInstance.shares(alice), sharesBefore - 1 ether);
+    }
+
+    /// @dev mintShares check is first thing after onlyPoolContract — a non-LP caller
+    /// still sees the auth error, not the pause error.
+    function test_mintShares_revertsForNonLPCaller_evenWhenFrozen() public {
+        vm.prank(pauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(bob);
+        vm.expectRevert("Only pool contract function");
+        eETHInstance.mintShares(alice, 1 ether);
+    }
+
+    function test_burnShares_revertsForNonLPCaller_evenWhenFrozen() public {
+        vm.prank(pauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(bob);
+        vm.expectRevert("Incorrect Caller");
+        eETHInstance.burnShares(alice, 1 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //          INTEGRATION: LP deposit/withdraw respect the freeze
+    // -------------------------------------------------------------------
+
+    function test_LPDeposit_blockedForFrozenDepositor() public {
+        vm.prank(pauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("MINT PAUSED");
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    function test_LPDeposit_blockedUnderPauseUntil() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("MINT PAUSED");
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    function test_LPDeposit_worksAfterPauseUntilExpiry() public {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+
+        vm.warp(uint256(expiry) + 1);
+
+        uint256 sharesBefore = eETHInstance.shares(alice);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+        assertGt(eETHInstance.shares(alice), sharesBefore);
     }
 
     // -------------------------------------------------------------------
@@ -235,7 +392,7 @@ contract EETHPauseTest is TestSetup {
     // -------------------------------------------------------------------
 
     function test_pauseUntil_blocksSender() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
         vm.prank(alice);
@@ -244,7 +401,7 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_pauseUntil_blocksRecipient() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
         vm.prank(bob);
@@ -253,7 +410,7 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_pauseUntil_expiresAfterOneDay() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
         uint64 expiry = eETHInstance.pausedUntil(alice);
 
@@ -264,10 +421,10 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_pauseUntil_blockedAtBoundary() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
         uint64 expiry = eETHInstance.pausedUntil(alice);
-        vm.warp(expiry); // exactly at boundary — still frozen (require uses <)
+        vm.warp(expiry);
 
         vm.prank(alice);
         vm.expectRevert("SENDER PAUSED");
@@ -275,44 +432,45 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_pauseUntil_timerIsPerUser() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        assertEq(eETHInstance.pausedUntil(bob), 0, "bob timer untouched");
+        assertEq(eETHInstance.pausedUntil(bob), 0);
     }
 
+    /// @dev Documents M-1.
     function test_pauseUntil_silentNoOp_whilePaused() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
         uint64 before = eETHInstance.pausedUntil(alice);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
-        assertEq(eETHInstance.pausedUntil(alice), before, "no change while indefinitely paused (M-1)");
+        assertEq(eETHInstance.pausedUntil(alice), before);
         assertTrue(eETHInstance.paused(alice));
     }
 
     function test_pauseUntil_cannotExtend_whileTimerActive() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
         uint64 firstExpiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(block.timestamp + 12 hours);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
-        assertEq(eETHInstance.pausedUntil(alice), firstExpiry, "cannot extend live timer (M-1)");
+        assertEq(eETHInstance.pausedUntil(alice), firstExpiry);
     }
 
     function test_pauseUntil_canRenew_afterExpiry() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
         uint64 firstExpiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(uint256(firstExpiry) + 1);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
         assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
@@ -324,19 +482,19 @@ contract EETHPauseTest is TestSetup {
     // -------------------------------------------------------------------
 
     function test_unpause_clearsBothFlags_whenFullyFrozen() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         assertTrue(eETHInstance.paused(alice));
         assertGt(eETHInstance.pausedUntil(alice), block.timestamp);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.unpause(alice);
 
         assertFalse(eETHInstance.paused(alice));
-        assertEq(eETHInstance.pausedUntil(alice), 0, "timer cleared since it was active");
+        assertEq(eETHInstance.pausedUntil(alice), 0);
 
         vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether);
@@ -344,26 +502,25 @@ contract EETHPauseTest is TestSetup {
 
     /// @dev Documents M-2: unpause after expiry does not clear pausedUntil.
     function test_unpause_afterExpiry_leavesStaleTimer() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
         uint64 expiry = eETHInstance.pausedUntil(alice);
 
         vm.warp(uint256(expiry) + 1);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.unpause(alice);
 
-        assertEq(eETHInstance.pausedUntil(alice), expiry, "stale expiry remains (M-2)");
+        assertEq(eETHInstance.pausedUntil(alice), expiry);
         assertFalse(eETHInstance.paused(alice));
 
-        // Functionally still unfrozen (past timestamp).
         vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    /// @dev Documents M-2: unpause succeeds on never-paused user.
+    /// @dev Documents M-2.
     function test_unpause_noop_whenNeverPaused() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.unpause(alice);
         assertFalse(eETHInstance.paused(alice));
         assertEq(eETHInstance.pausedUntil(alice), 0);
@@ -376,21 +533,21 @@ contract EETHPauseTest is TestSetup {
     function test_pause_emitsIndexedUser() public {
         vm.expectEmit(true, false, false, true);
         emit Paused(alice);
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
     }
 
     function test_pauseUntil_emitsIndexedUserAndExpiry() public {
         vm.expectEmit(true, false, false, true);
         emit PausedUntil(alice, uint64(block.timestamp) + ONE_DAY);
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
     }
 
     function test_unpause_emitsIndexedUser() public {
         vm.expectEmit(true, false, false, true);
         emit Unpaused(alice);
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.unpause(alice);
     }
 
@@ -398,41 +555,8 @@ contract EETHPauseTest is TestSetup {
     //                  NON-TRANSFER PATHS DURING FREEZE
     // -------------------------------------------------------------------
 
-    /// @dev CRITICAL (C-1): LiquidityPool can still mint shares for a frozen user.
-    function test_mintShares_bypassesFreeze() public {
-        vm.prank(extendPauser);
-        eETHInstance.pause(alice);
-
-        uint256 sharesBefore = eETHInstance.shares(alice);
-        vm.prank(address(liquidityPoolInstance));
-        eETHInstance.mintShares(alice, 5 ether);
-        assertEq(eETHInstance.shares(alice), sharesBefore + 5 ether, "freeze did not stop mintShares (C-1)");
-    }
-
-    /// @dev CRITICAL (C-1): LiquidityPool can still burn shares for a frozen user.
-    function test_burnShares_bypassesFreeze() public {
-        vm.prank(extendPauser);
-        eETHInstance.pause(alice);
-
-        uint256 sharesBefore = eETHInstance.shares(alice);
-        vm.prank(address(liquidityPoolInstance));
-        eETHInstance.burnShares(alice, 1 ether);
-        assertEq(eETHInstance.shares(alice), sharesBefore - 1 ether, "freeze did not stop burnShares (C-1)");
-    }
-
-    /// @dev CRITICAL (C-1): A frozen user can still deposit via LP end-to-end.
-    function test_LPDeposit_bypassesFreezeOfDepositor() public {
-        vm.prank(extendPauser);
-        eETHInstance.pause(alice);
-
-        uint256 sharesBefore = eETHInstance.shares(alice);
-        vm.prank(alice);
-        liquidityPoolInstance.deposit{value: 1 ether}();
-        assertGt(eETHInstance.shares(alice), sharesBefore, "deposit path not blocked by freeze");
-    }
-
     function test_approve_notBlockedByFreeze() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         vm.prank(alice);
@@ -442,15 +566,11 @@ contract EETHPauseTest is TestSetup {
 
     function test_permit_notBlockedByFreeze() public {
         ILiquidityPool.PermitInput memory p = createPermitInput(
-            2, // alice pk
-            bob,
-            1 ether,
-            eETHInstance.nonces(alice),
-            type(uint256).max,
-            eETHInstance.DOMAIN_SEPARATOR()
+            2, bob, 1 ether, eETHInstance.nonces(alice),
+            type(uint256).max, eETHInstance.DOMAIN_SEPARATOR()
         );
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         eETHInstance.permit(alice, bob, 1 ether, type(uint256).max, p.v, p.r, p.s);
@@ -461,11 +581,11 @@ contract EETHPauseTest is TestSetup {
     //                    INTERLEAVED / LIFECYCLE FLOWS
     // -------------------------------------------------------------------
 
-    function test_sequence_pauseUntil_then_extendPauser_locks() public {
-        vm.prank(pauser);
+    function test_sequence_pauseUntil_then_pause_locks() public {
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         vm.warp(block.timestamp + 2 days);
@@ -474,11 +594,11 @@ contract EETHPauseTest is TestSetup {
         vm.expectRevert("SENDER PAUSED");
         eETHInstance.transfer(bob, 1 ether);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
         eETHInstance.unpause(alice);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.unpause(alice);
 
         vm.prank(alice);
@@ -486,11 +606,11 @@ contract EETHPauseTest is TestSetup {
     }
 
     function test_sequence_revokeRole_disablesPauser() public {
-        bytes32 role = eETHInstance.EETH_PAUSER_ROLE();
+        bytes32 role = eETHInstance.EETH_PAUSER_UNTIL_ROLE();
         vm.prank(owner);
-        roleRegistryInstance.revokeRole(role, pauser);
+        roleRegistryInstance.revokeRole(role, pauserUntil);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
         eETHInstance.pauseUntil(alice);
     }
@@ -499,22 +619,22 @@ contract EETHPauseTest is TestSetup {
     //                                FUZZING
     // -------------------------------------------------------------------
 
-    function testFuzz_pause_revertsForNonExtendPauser(address caller) public {
-        vm.assume(caller != extendPauser);
+    function testFuzz_pause_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
         eETHInstance.pause(alice);
     }
 
-    function testFuzz_pauseUntil_revertsForNonPauser(address caller) public {
-        vm.assume(caller != pauser);
+    function testFuzz_pauseUntil_revertsForNonPauserUntil(address caller) public {
+        vm.assume(caller != pauserUntil);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
         eETHInstance.pauseUntil(alice);
     }
 
-    function testFuzz_unpause_revertsForNonExtendPauser(address caller) public {
-        vm.assume(caller != extendPauser);
+    function testFuzz_unpause_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
         eETHInstance.unpause(alice);
@@ -524,7 +644,7 @@ contract EETHPauseTest is TestSetup {
         warpTo = uint64(bound(uint256(warpTo), block.timestamp + 1, type(uint64).max - ONE_DAY - 1));
         vm.warp(warpTo);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
         assertEq(eETHInstance.pausedUntil(alice), warpTo + ONE_DAY);
@@ -533,7 +653,7 @@ contract EETHPauseTest is TestSetup {
     function testFuzz_senderFrozen_blocksAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, eETHInstance.shares(alice));
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         vm.prank(alice);
@@ -544,7 +664,7 @@ contract EETHPauseTest is TestSetup {
     function testFuzz_recipientFrozen_blocksAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, eETHInstance.shares(bob));
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         vm.prank(bob);
@@ -555,8 +675,7 @@ contract EETHPauseTest is TestSetup {
     function testFuzz_unfrozenUsers_unaffected(uint256 amount) public {
         amount = bound(amount, 1, eETHInstance.shares(bob));
 
-        // Freeze a bystander
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
 
         uint256 bobBefore = eETHInstance.shares(bob);
@@ -565,7 +684,6 @@ contract EETHPauseTest is TestSetup {
         vm.prank(bob);
         eETHInstance.transfer(chad, amount);
 
-        // Share accounting preserved (allow wei-level rounding from shares/amount conversion)
         assertLe(eETHInstance.shares(bob), bobBefore);
         assertGe(eETHInstance.shares(chad), chadBefore);
     }
@@ -573,7 +691,7 @@ contract EETHPauseTest is TestSetup {
     function testFuzz_transferAtOrBeforeExpiry_blocksSender(uint64 delta) public {
         delta = uint64(bound(uint256(delta), 0, ONE_DAY));
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
         uint64 expiry = eETHInstance.pausedUntil(alice);
 
@@ -588,7 +706,7 @@ contract EETHPauseTest is TestSetup {
         amount = bound(amount, 1, eETHInstance.shares(alice));
         extra = uint64(bound(uint256(extra), 1, 365 days));
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
         vm.warp(uint256(eETHInstance.pausedUntil(alice)) + extra);
@@ -603,11 +721,61 @@ contract EETHPauseTest is TestSetup {
         assertEq(eETHInstance.shares(bob), bobBefore + sharesMoved);
     }
 
+    function testFuzz_mintShares_blockedWhenPaused(uint256 amount) public {
+        amount = bound(amount, 1, 1_000_000 ether);
+
+        vm.prank(pauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, amount);
+    }
+
+    function testFuzz_mintShares_blockedUnderPauseUntil(uint256 amount, uint64 delta) public {
+        amount = bound(amount, 1, 1_000_000 ether);
+        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
+
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+        vm.warp(uint256(expiry) - delta);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("MINT PAUSED");
+        eETHInstance.mintShares(alice, amount);
+    }
+
+    function testFuzz_burnShares_blockedWhenPaused(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.shares(alice));
+
+        vm.prank(pauser);
+        eETHInstance.pause(alice);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, amount);
+    }
+
+    function testFuzz_burnShares_blockedUnderPauseUntil(uint256 amount, uint64 delta) public {
+        amount = bound(amount, 1, eETHInstance.shares(alice));
+        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
+
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
+        uint64 expiry = eETHInstance.pausedUntil(alice);
+        vm.warp(uint256(expiry) - delta);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert("BURN PAUSED");
+        eETHInstance.burnShares(alice, amount);
+    }
+
     function testFuzz_independentUsers_freezingOneDoesNotTouchOther(address userA, address userB) public {
         vm.assume(userA != address(0) && userB != address(0));
         vm.assume(userA != userB);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         eETHInstance.pause(userA);
 
         assertTrue(eETHInstance.paused(userA));
@@ -619,7 +787,7 @@ contract EETHPauseTest is TestSetup {
         vm.assume(userA != address(0) && userB != address(0));
         vm.assume(userA != userB);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         eETHInstance.pauseUntil(userA);
 
         assertGt(eETHInstance.pausedUntil(userA), block.timestamp);

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -103,6 +103,7 @@ contract EETHPauseTest is TestSetup {
     function test_extendPauseUntil_onlyPauserRole() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice); // arm the timer so extend has something to do
+        uint256 armedAt = block.timestamp;
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
@@ -114,7 +115,8 @@ contract EETHPauseTest is TestSetup {
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 2 days);
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 2 days);
+        // Extension adds onto the existing deadline (armedAt + ONE_DAY), not block.timestamp.
+        assertEq(eETHInstance.pausedUntil(alice), armedAt + ONE_DAY + 2 days);
     }
 
     function test_cancelPauseUntil_onlyPauserRole() public {
@@ -373,11 +375,13 @@ contract EETHPauseTest is TestSetup {
     function test_extendPauseUntil_extendsLiveTimer() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 armedAt = block.timestamp;
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 7 days);
 
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 7 days);
+        // Adds onto the live (armedAt + ONE_DAY) deadline, not block.timestamp.
+        assertEq(eETHInstance.pausedUntil(alice), armedAt + ONE_DAY + 7 days);
 
         vm.warp(block.timestamp + 1 days + 1); // past original 1-day expiry
         vm.prank(alice);
@@ -385,37 +389,32 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    /// @dev H-1 (HIGH): extendPauseUntil can SHORTEN a timer despite its name.
-    function test_SECURITY_extendPauseUntil_canShortenTimer() public {
+    /// @dev I-02 regression: extendPauseUntil must never produce a shorter deadline than the existing one.
+    function test_extendPauseUntil_neverShortensTimer() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice); // arms 1-day timer
+        uint256 originalDeadline = eETHInstance.pausedUntil(alice);
 
-        // Admin calls extend with 1-hour duration → new expiry is EARLIER than original.
+        // Even a tiny duration must only ADD time, not reset the countdown.
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 1 hours);
 
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 1 hours);
-        assertLt(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY,
-                 "extend should not allow shortening (H-1)");
+        assertGt(eETHInstance.pausedUntil(alice), originalDeadline,
+                 "extension must move deadline forward, never shorten (I-02)");
+        assertEq(eETHInstance.pausedUntil(alice), originalDeadline + 1 hours);
     }
 
-    /// @dev H-1 corollary: duration=0 effectively releases the user next block.
-    function test_SECURITY_extendPauseUntil_withZeroDuration_effectivelyCancels() public {
+    /// @dev I-02 corollary: duration=0 is a no-op that preserves the original deadline.
+    function test_extendPauseUntil_withZeroDuration_isNoOp() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 originalDeadline = eETHInstance.pausedUntil(alice);
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 0);
 
-        // Current block — timer is at block.timestamp, require uses strict <, still paused.
-        vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        eETHInstance.transfer(bob, 1 ether);
-
-        // But any forward progress unfreezes.
-        vm.warp(block.timestamp + 1);
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
+        assertEq(eETHInstance.pausedUntil(alice), originalDeadline,
+                 "zero-duration extend must not alter the deadline");
     }
 
     /// @dev M-1-new: extendPauseUntil silent no-op when timer already expired.
@@ -442,7 +441,7 @@ contract EETHPauseTest is TestSetup {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
-        uint64 expected = uint64(block.timestamp) + 3 days;
+        uint64 expected = uint64(block.timestamp) + ONE_DAY + 3 days;
         vm.expectEmit(true, false, false, true);
         emit PausedUntil(alice, expected);
         vm.prank(pauser);
@@ -635,10 +634,11 @@ contract EETHPauseTest is TestSetup {
     function test_sequence_weakArms_then_strongExtends_then_strongCancels() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 armedAt = block.timestamp;
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 3 days);
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 3 days);
+        assertEq(eETHInstance.pausedUntil(alice), armedAt + ONE_DAY + 3 days);
 
         vm.prank(pauser);
         eETHInstance.cancelPauseUntil(alice);
@@ -727,11 +727,12 @@ contract EETHPauseTest is TestSetup {
 
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 originalDeadline = eETHInstance.pausedUntil(alice);
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, duration);
 
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + duration);
+        assertEq(eETHInstance.pausedUntil(alice), originalDeadline + duration);
     }
 
     function testFuzz_globalPause_blocksTransferAnyAmount(uint256 amount) public {

--- a/test/MembershipManagerPause.t.sol
+++ b/test/MembershipManagerPause.t.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "./TestSetup.sol";
+import "../src/MembershipManager.sol";
+
+/// Unit tests for the L-02 audit fix: paused users (per-user `pausedUntil` on EETH)
+/// must not be able to bypass the pause by routing through MembershipManager.
+contract MembershipManagerPauseTest is TestSetup {
+    address pauserUntil;
+
+    uint64 constant ONE_DAY = 1 days;
+
+    function setUp() public {
+        setUpTests();
+
+        pauserUntil = vm.addr(0xA11CE2);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_UNTIL_ROLE(), pauserUntil);
+        vm.stopPrank();
+
+        _upgradeMembershipManagerFromV0ToV1();
+
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+    }
+
+    function _wrapForUser(address user, uint256 amount) internal returns (uint256) {
+        vm.prank(user);
+        return membershipManagerV1Instance.wrapEth{value: amount}(amount, 0);
+    }
+
+    function _pauseUser(address user) internal {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(user);
+    }
+
+    // -------------------------------------------------------------------
+    //                       wrapEth blocked when paused
+    // -------------------------------------------------------------------
+
+    function test_wrapEth_revertsWhenUserPaused() public {
+        _pauseUser(alice);
+
+        vm.prank(alice);
+        vm.expectRevert(MembershipManager.UserPaused.selector);
+        membershipManagerV1Instance.wrapEth{value: 1 ether}(1 ether, 0);
+    }
+
+    function test_wrapEth_succeedsWhenNotPaused() public {
+        uint256 tokenId = _wrapForUser(alice, 1 ether);
+        assertGt(tokenId, 0);
+    }
+
+    function test_wrapEth_succeedsAfterPauseExpires() public {
+        _pauseUser(alice);
+        skip(ONE_DAY + 1);
+
+        // pause has expired; wrap should succeed
+        uint256 tokenId = _wrapForUser(alice, 1 ether);
+        assertGt(tokenId, 0);
+    }
+
+    // -------------------------------------------------------------------
+    //                  requestWithdraw blocked when paused
+    // -------------------------------------------------------------------
+
+    function test_requestWithdraw_revertsWhenUserPaused() public {
+        uint256 tokenId = _wrapForUser(alice, 2 ether);
+
+        _pauseUser(alice);
+
+        vm.prank(alice);
+        vm.expectRevert(MembershipManager.UserPaused.selector);
+        membershipManagerV1Instance.requestWithdraw(tokenId, 0.5 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //              requestWithdrawAndBurn blocked when paused
+    // -------------------------------------------------------------------
+
+    function test_requestWithdrawAndBurn_revertsWhenUserPaused() public {
+        uint256 tokenId = _wrapForUser(alice, 2 ether);
+
+        _pauseUser(alice);
+
+        vm.prank(alice);
+        vm.expectRevert(MembershipManager.UserPaused.selector);
+        membershipManagerV1Instance.requestWithdrawAndBurn(tokenId);
+    }
+
+    // -------------------------------------------------------------------
+    //          pause of one user does not affect other users
+    // -------------------------------------------------------------------
+
+    function test_pauseUntil_doesNotBlockOtherUsers() public {
+        _pauseUser(alice);
+
+        // bob is not paused, should be able to interact normally
+        uint256 bobToken = _wrapForUser(bob, 1 ether);
+        assertGt(bobToken, 0);
+    }
+}

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -608,28 +608,22 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         liquifierInstance = Liquifier(payable(liquifierProxy));
 
         // TODO - not sure what `name` and `versiona` are for
-        eETHImplementation = new EETH(address(roleRegistryInstance));
+        eETHImplementation = new EETH(address(roleRegistryInstance), address(liquidityPoolInstance));
         vm.expectRevert("Initializable: contract is already initialized");
-        eETHImplementation.initialize(payable(address(liquidityPoolInstance)));
+        eETHImplementation.initialize();
 
         eETHProxy = new UUPSProxy(address(eETHImplementation), "");
         eETHInstance = EETH(address(eETHProxy));
 
-        vm.expectRevert("No zero addresses");
-        eETHInstance.initialize(payable(address(0)));
-        eETHInstance.initialize(payable(address(liquidityPoolInstance)));
+        eETHInstance.initialize();
 
-        weEthImplementation = new WeETH(address(roleRegistryInstance));
+        weEthImplementation = new WeETH(address(eETHInstance), address(liquidityPoolInstance), address(roleRegistryInstance));
         vm.expectRevert("Initializable: contract is already initialized");
-        weEthImplementation.initialize(payable(address(liquidityPoolInstance)), address(eETHInstance));
+        weEthImplementation.initialize();
 
         weETHProxy = new UUPSProxy(address(weEthImplementation), "");
         weEthInstance = WeETH(address(weETHProxy));
-        vm.expectRevert("No zero addresses");
-        weEthInstance.initialize(address(0), address(eETHInstance));
-        vm.expectRevert("No zero addresses");
-        weEthInstance.initialize(payable(address(liquidityPoolInstance)), address(0));
-        weEthInstance.initialize(payable(address(liquidityPoolInstance)), address(eETHInstance));
+        weEthInstance.initialize();
 
         roleRegistryInstance.grantRole(eETHInstance.EETH_OPERATING_ADMIN_ROLE(), admin);
         roleRegistryInstance.grantRole(weEthInstance.WEETH_OPERATING_ADMIN_ROLE(), admin);
@@ -875,7 +869,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function _upgrade_weETH() internal {
-        address newWeETHImpl = address(new WeETH(address(roleRegistryInstance)));
+        address newWeETHImpl = address(new WeETH(address(eETHInstance), address(liquidityPoolInstance), address(roleRegistryInstance)));
         vm.prank(owner);
         weEthInstance.upgradeTo(newWeETHImpl);
     }

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -637,7 +637,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         eigenLayerEigenPodManager = new MockEigenPodManager();
         eigenLayerDelegationManager = new MockDelegationManager();
 
-        membershipNftImplementation = new MembershipNFT();
+        membershipNftImplementation = new MembershipNFT(address(eETHInstance));
         membershipNftProxy = new UUPSProxy(address(membershipNftImplementation), "");
         membershipNftInstance = MembershipNFT(payable(membershipNftProxy));
 

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -128,6 +128,7 @@ contract WeETHPauseTest is TestSetup {
     function test_extendPauseUntil_onlyPauserRole() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint256 armedAt = block.timestamp;
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
@@ -139,7 +140,8 @@ contract WeETHPauseTest is TestSetup {
 
         vm.prank(pauser);
         weEthInstance.extendPauseUntil(alice, 2 days);
-        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + 2 days);
+        // Extension adds onto the existing deadline (armedAt + ONE_DAY).
+        assertEq(weEthInstance.pausedUntil(alice), armedAt + ONE_DAY + 2 days);
     }
 
     function test_cancelPauseUntil_onlyPauserRole() public {
@@ -453,23 +455,26 @@ contract WeETHPauseTest is TestSetup {
     function test_extendPauseUntil_extendsLiveTimer() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint256 armedAt = block.timestamp;
 
         vm.prank(pauser);
         weEthInstance.extendPauseUntil(alice, 7 days);
 
-        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + 7 days);
+        assertEq(weEthInstance.pausedUntil(alice), armedAt + ONE_DAY + 7 days);
     }
 
-    /// @dev H-1 (HIGH): extendPauseUntil can shorten the timer.
-    function test_SECURITY_extendPauseUntil_canShortenTimer() public {
+    /// @dev I-02 regression: extendPauseUntil must never produce a shorter deadline than the existing one.
+    function test_extendPauseUntil_neverShortensTimer() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint256 originalDeadline = weEthInstance.pausedUntil(alice);
 
         vm.prank(pauser);
         weEthInstance.extendPauseUntil(alice, 1 hours);
 
-        assertLt(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY,
-                 "extend allowed to shorten (H-1)");
+        assertGt(weEthInstance.pausedUntil(alice), originalDeadline,
+                 "extension must move deadline forward, never shorten (I-02)");
+        assertEq(weEthInstance.pausedUntil(alice), originalDeadline + 1 hours);
     }
 
     function test_extendPauseUntil_silentNoOp_whenTimerExpired() public {
@@ -587,7 +592,7 @@ contract WeETHPauseTest is TestSetup {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
 
-        uint64 expected = uint64(block.timestamp) + 3 days;
+        uint64 expected = uint64(block.timestamp) + ONE_DAY + 3 days;
         vm.expectEmit(true, false, false, true);
         emit PausedUntil(alice, expected);
         vm.prank(pauser);
@@ -681,11 +686,12 @@ contract WeETHPauseTest is TestSetup {
 
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint256 originalDeadline = weEthInstance.pausedUntil(alice);
 
         vm.prank(pauser);
         weEthInstance.extendPauseUntil(alice, duration);
 
-        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + duration);
+        assertEq(weEthInstance.pausedUntil(alice), originalDeadline + duration);
     }
 
     function testFuzz_globalPause_blocksTransferAnyAmount(uint256 amount) public {

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -3,42 +3,45 @@ pragma solidity ^0.8.13;
 
 import "./TestSetup.sol";
 
-/// Unit + fuzz tests for the pause / pauseUntil / unpause feature on WeETH.
+/// Unit + fuzz tests for the per-user FREEZE feature on WeETH.
+/// Role model:
+///   WEETH_PAUSER_ROLE         -> monitoring EOA   : pauseUntil(user) arms 1-day freeze
+///   WEETH_EXTEND_PAUSER_ROLE  -> security council : pause(user) / unpause(user)
 ///
-/// Role gating (post H-1 fix, aligned with EETH):
-///   pause()      -> WEETH_EXTEND_PAUSER_ROLE  (security council multisig)
-///   pauseUntil() -> WEETH_PAUSER_ROLE         (monitoring EOA, 1-day timer)
-///   unpause()    -> WEETH_EXTEND_PAUSER_ROLE  (security council multisig)
+/// WeETH uses `_beforeTokenTransfer`, which fires on `_mint`/`_burn` too — so a freeze
+/// on either party blocks transfer, wrap (mint), and unwrap (burn).
 contract WeETHPauseTest is TestSetup {
-    // Re-declared events for vm.expectEmit.
-    event Paused();
-    event PausedUntil(uint64 pausedUntil);
-    event Unpaused();
+    event Paused(address indexed user);
+    event PausedUntil(address indexed user, uint64 pausedUntil);
+    event Unpaused(address indexed user);
 
-    address pauser;          // monitoring EOA (WEETH_PAUSER_ROLE) — pauseUntil only
-    address extendPauser;    // security council (WEETH_EXTEND_PAUSER_ROLE) — pause + unpause
-    address unauthorized;    // no weETH roles
+    address pauser;
+    address extendPauser;
+    address unauthorized;
 
     uint64 constant ONE_DAY = 1 days;
 
     function setUp() public {
         setUpTests();
 
-        pauser = vm.addr(0xB0B1);
-        extendPauser = vm.addr(0xB0B2);
-        unauthorized = vm.addr(0xB0B3);
+        pauser = vm.addr(0xB0B01);
+        extendPauser = vm.addr(0xB0B02);
+        unauthorized = vm.addr(0xB0B03);
 
         vm.startPrank(owner);
         roleRegistryInstance.grantRole(weEthInstance.WEETH_PAUSER_ROLE(), pauser);
         roleRegistryInstance.grantRole(weEthInstance.WEETH_EXTEND_PAUSER_ROLE(), extendPauser);
         vm.stopPrank();
 
-        // Give alice + bob eETH, then wrap some into weETH so we have weETH balances.
         vm.deal(alice, 100 ether);
         vm.deal(bob, 100 ether);
+        vm.deal(chad, 100 ether);
+
         vm.prank(alice);
         liquidityPoolInstance.deposit{value: 20 ether}();
         vm.prank(bob);
+        liquidityPoolInstance.deposit{value: 20 ether}();
+        vm.prank(chad);
         liquidityPoolInstance.deposit{value: 20 ether}();
 
         vm.prank(alice);
@@ -49,351 +52,438 @@ contract WeETHPauseTest is TestSetup {
         vm.prank(bob);
         eETHInstance.approve(address(weEthInstance), type(uint256).max);
         vm.prank(bob);
+        weEthInstance.wrap(10 ether);
+
+        vm.prank(chad);
+        eETHInstance.approve(address(weEthInstance), type(uint256).max);
+        vm.prank(chad);
         weEthInstance.wrap(10 ether);
     }
 
     // -------------------------------------------------------------------
-    //                     ROLE GATING (current source)
+    //                          ZERO-ADDRESS GUARDS
+    // -------------------------------------------------------------------
+
+    function test_pause_rejectsZeroAddress() public {
+        vm.prank(extendPauser);
+        vm.expectRevert("No zero addresses");
+        weEthInstance.pause(address(0));
+    }
+
+    function test_pauseUntil_rejectsZeroAddress() public {
+        vm.prank(pauser);
+        vm.expectRevert("No zero addresses");
+        weEthInstance.pauseUntil(address(0));
+    }
+
+    function test_unpause_rejectsZeroAddress() public {
+        vm.prank(extendPauser);
+        vm.expectRevert("No zero addresses");
+        weEthInstance.unpause(address(0));
+    }
+
+    // -------------------------------------------------------------------
+    //                               ROLE GATING
     // -------------------------------------------------------------------
 
     function test_pause_onlyExtendPauserRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
-        // pauser holds only WEETH_PAUSER_ROLE — cannot pause indefinitely
         vm.prank(pauser);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
         vm.prank(extendPauser);
-        weEthInstance.pause();
-        assertTrue(weEthInstance.paused());
+        weEthInstance.pause(alice);
+        assertTrue(weEthInstance.paused(alice));
     }
 
     function test_pauseUntil_onlyPauserRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pauseUntil();
+        weEthInstance.pauseUntil(alice);
 
         vm.prank(extendPauser);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pauseUntil();
+        weEthInstance.pauseUntil(alice);
 
         vm.prank(pauser);
-        weEthInstance.pauseUntil();
-        // NOTE: currently FAILS because src/WeETH.sol:113 writes `pausedUntil = 0`.
-        // Restore to `uint64(block.timestamp) + 1 days` to fix.
-        assertEq(weEthInstance.pausedUntil(), uint64(block.timestamp) + ONE_DAY);
+        weEthInstance.pauseUntil(alice);
+        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
     }
 
     function test_unpause_onlyExtendPauserRole() public {
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.unpause();
+        weEthInstance.unpause(alice);
 
-        // pauser holds only WEETH_PAUSER_ROLE — cannot unpause
         vm.prank(pauser);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.unpause();
+        weEthInstance.unpause(alice);
 
         vm.prank(extendPauser);
-        weEthInstance.unpause();
-        assertFalse(weEthInstance.paused());
+        weEthInstance.unpause(alice);
+        assertFalse(weEthInstance.paused(alice));
     }
 
     // -------------------------------------------------------------------
-    //            TRANSFER / MINT / BURN BLOCKING WHILE PAUSED
-    //    (WeETH uses _beforeTokenTransfer, so _mint and _burn also block)
+    //                      PER-USER FREEZE SELECTIVITY
     // -------------------------------------------------------------------
 
-    function test_transfer_blockedWhen_paused() public {
+    function test_freeze_isPerUser_othersUnaffected() public {
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
-        vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.prank(bob);
+        weEthInstance.transfer(chad, 1 ether);
+        vm.prank(chad);
         weEthInstance.transfer(bob, 1 ether);
     }
 
-    function test_transferFrom_blockedWhen_paused() public {
+    function test_freeze_blocksSender() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_freeze_blocksRecipient() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
+
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.transfer(alice, 1 ether);
+    }
+
+    function test_freeze_blocksSelfTransfer() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.transfer(alice, 1 ether);
+    }
+
+    function test_freeze_blocksTransferFrom_viaSender() public {
         vm.prank(alice);
         weEthInstance.approve(bob, 1 ether);
 
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
         vm.prank(bob);
-        vm.expectRevert("PAUSED");
-        weEthInstance.transferFrom(alice, bob, 1 ether);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.transferFrom(alice, chad, 1 ether);
     }
 
-    function test_wrap_blockedWhen_paused() public {
+    function test_freeze_blocksTransferFrom_viaRecipient() public {
+        vm.prank(alice);
+        weEthInstance.approve(bob, 1 ether);
+
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(chad);
+
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.transferFrom(alice, chad, 1 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //                  WRAP / UNWRAP UNDER FREEZE (WeETH side)
+    // -------------------------------------------------------------------
+
+    /// @dev Frozen on WeETH -> wrap fails at _mint's _beforeTokenTransfer (recipient check).
+    function test_wrap_blocked_whenCallerFrozenOnWeETH() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("RECIPIENT PAUSED");
         weEthInstance.wrap(1 ether);
     }
 
-    function test_wrapWithPermit_blockedWhen_paused() public {
+    /// @dev Frozen on WeETH -> unwrap fails at _burn's _beforeTokenTransfer (sender check).
+    function test_unwrap_blocked_whenCallerFrozenOnWeETH() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    function test_wrapWithPermit_blocked_whenCallerFrozenOnWeETH() public {
         ILiquidityPool.PermitInput memory p = createPermitInput(
-            2, // alice pk
-            address(weEthInstance),
-            1 ether,
-            eETHInstance.nonces(alice),
-            type(uint256).max,
-            eETHInstance.DOMAIN_SEPARATOR()
+            2, address(weEthInstance), 1 ether, eETHInstance.nonces(alice),
+            type(uint256).max, eETHInstance.DOMAIN_SEPARATOR()
         );
 
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("RECIPIENT PAUSED");
         weEthInstance.wrapWithPermit(1 ether, p);
     }
 
-    function test_unwrap_blockedWhen_paused() public {
-        vm.prank(extendPauser);
-        weEthInstance.pause();
-
-        vm.prank(alice);
-        vm.expectRevert("PAUSED");
-        weEthInstance.unwrap(1 ether);
-    }
-
-    function test_transfer_blockedWhen_pauseUntilActive() public {
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-
-        vm.prank(alice);
-        vm.expectRevert("PAUSED");
-        weEthInstance.transfer(bob, 1 ether);
-    }
-
-    function test_transfer_unblockedAfterPauseUntilExpiry() public {
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-        uint64 expiry = weEthInstance.pausedUntil();
-
-        vm.warp(uint256(expiry) + 1);
-
-        vm.prank(alice);
-        weEthInstance.transfer(bob, 1 ether);
-    }
-
-    function test_transfer_blockedAtBoundary() public {
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-        uint64 expiry = weEthInstance.pausedUntil();
-        vm.warp(expiry); // exactly pausedUntil
-
-        vm.prank(alice);
-        vm.expectRevert("PAUSED");
-        weEthInstance.transfer(bob, 1 ether);
-    }
-
     // -------------------------------------------------------------------
-    //                 CROSS-TOKEN COUPLING WITH eETH PAUSE
+    //       CROSS-TOKEN FREEZE — eETH freeze affects WeETH flows
     // -------------------------------------------------------------------
 
-    /// @dev When eETH is paused, weETH.unwrap reverts because unwrap calls eETH.transfer.
-    function test_eETHPause_blocks_weETH_unwrap_transitively() public {
+    /// @dev Frozen on eETH -> wrap fails at eETH.transferFrom (sender check on eETH side).
+    function test_wrap_blocked_whenCallerFrozenOnEETH() public {
         vm.startPrank(owner);
         roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
         vm.stopPrank();
 
         vm.prank(extendPauser);
-        eETHInstance.pause();
+        eETHInstance.pause(alice);
 
-        // weETH itself is not paused, but unwrap routes through eETH.transfer.
-        assertFalse(weEthInstance.paused());
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
-        weEthInstance.unwrap(1 ether);
-    }
-
-    /// @dev When eETH is paused, weETH.wrap reverts because wrap calls eETH.transferFrom.
-    function test_eETHPause_blocks_weETH_wrap_transitively() public {
-        vm.startPrank(owner);
-        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
-        vm.stopPrank();
-
-        vm.prank(extendPauser);
-        eETHInstance.pause();
-
-        assertFalse(weEthInstance.paused());
-        vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("SENDER PAUSED");
         weEthInstance.wrap(1 ether);
     }
 
-    /// @dev weETH-only pause does NOT prevent eETH transfers between users.
-    function test_weETHPause_doesNotBlock_eETHTransfer() public {
+    /// @dev Frozen on eETH -> unwrap fails at eETH.transfer (recipient check on eETH side).
+    function test_unwrap_blocked_whenCallerFrozenOnEETH() public {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        vm.stopPrank();
+
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        eETHInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    /// @dev Freezing WeETH on its own account on eETH bricks wrap for EVERYONE (C-2 hazard).
+    function test_SECURITY_freezingWeETHOnEETH_bricksWrapForAll() public {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        vm.stopPrank();
+
+        // Security council accidentally freezes the weETH contract's eETH account.
+        vm.prank(extendPauser);
+        eETHInstance.pause(address(weEthInstance));
+
+        // Bob (not frozen) can no longer wrap because eETH.transferFrom routes tokens
+        // TO address(weEthInstance), which is now frozen on eETH.
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.wrap(1 ether);
+    }
+
+    /// @dev Same hazard for unwrap.
+    function test_SECURITY_freezingWeETHOnEETH_bricksUnwrapForAll() public {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        vm.stopPrank();
+
+        vm.prank(extendPauser);
+        eETHInstance.pause(address(weEthInstance));
+
+        vm.prank(bob);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    /// @dev Freeze on weETH does NOT restrict user's eETH activity.
+    function test_weETHFreeze_doesNotTouchEETH() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
 
         vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether); // must succeed
     }
 
     // -------------------------------------------------------------------
-    //                        STATE / EVENT SEMANTICS
+    //                       TIMER SEMANTICS (WeETH)
     // -------------------------------------------------------------------
 
-    function test_pause_emitsPausedEvent() public {
-        vm.expectEmit(false, false, false, true);
-        emit Paused();
-        vm.prank(extendPauser);
-        weEthInstance.pause();
-    }
-
-    function test_pauseUntil_emitsPausedUntilEvent() public {
-        // NOTE: currently FAILS because src/WeETH.sol:113 emits PausedUntil(0)
-        // instead of PausedUntil(block.timestamp + 1 days).
-        vm.expectEmit(false, false, false, true);
-        emit PausedUntil(uint64(block.timestamp) + ONE_DAY);
+    function test_pauseUntil_expiresAfterOneDay() public {
         vm.prank(pauser);
-        weEthInstance.pauseUntil();
-    }
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
 
-    function test_unpause_emitsUnpausedEvent() public {
-        vm.expectEmit(false, false, false, true);
-        emit Unpaused();
-        vm.prank(extendPauser);
-        weEthInstance.unpause();
-    }
-
-    function test_pauseUntil_silentNoOp_whilePaused() public {
-        vm.prank(extendPauser);
-        weEthInstance.pause();
-        uint64 before = weEthInstance.pausedUntil();
-
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-
-        assertEq(weEthInstance.pausedUntil(), before);
-        assertTrue(weEthInstance.paused());
-    }
-
-    function test_pauseUntil_cannotExtend_whileTimerActive() public {
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-        uint64 firstExpiry = weEthInstance.pausedUntil();
-
-        vm.warp(block.timestamp + 6 hours);
-
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-
-        assertEq(weEthInstance.pausedUntil(), firstExpiry);
-    }
-
-    function test_pauseUntil_canRenew_afterExpiry() public {
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-        uint64 firstExpiry = weEthInstance.pausedUntil();
-
-        vm.warp(uint256(firstExpiry) + 1);
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-
-        assertGt(weEthInstance.pausedUntil(), firstExpiry);
-    }
-
-    function test_unpause_clearsBothFlags() public {
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-        vm.prank(extendPauser);
-        weEthInstance.pause();
-
-        assertTrue(weEthInstance.paused());
-        // NOTE: assertion on pausedUntil being in the future currently FAILS
-        // because pauseUntil writes 0. Restore the pause timer fix to make this pass.
-        assertGt(weEthInstance.pausedUntil(), block.timestamp);
-
-        vm.prank(extendPauser);
-        weEthInstance.unpause();
-
-        assertFalse(weEthInstance.paused());
-        assertLt(weEthInstance.pausedUntil(), block.timestamp);
+        vm.warp(uint256(expiry) + 1);
 
         vm.prank(alice);
         weEthInstance.transfer(bob, 1 ether);
     }
 
-    function test_unpause_whenPausedUntilAlreadyExpired_leavesStale() public {
+    function test_pauseUntil_blockedAtBoundary() public {
         vm.prank(pauser);
-        weEthInstance.pauseUntil();
-        uint64 expiry = weEthInstance.pausedUntil();
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
+        vm.warp(expiry);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_pauseUntil_silentNoOp_whilePaused() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
+        uint64 before = weEthInstance.pausedUntil(alice);
+
+        vm.prank(pauser);
+        weEthInstance.pauseUntil(alice);
+
+        assertEq(weEthInstance.pausedUntil(alice), before);
+        assertTrue(weEthInstance.paused(alice));
+    }
+
+    function test_pauseUntil_cannotExtend_whileTimerActive() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil(alice);
+        uint64 firstExpiry = weEthInstance.pausedUntil(alice);
+
+        vm.warp(block.timestamp + 6 hours);
+
+        vm.prank(pauser);
+        weEthInstance.pauseUntil(alice);
+
+        assertEq(weEthInstance.pausedUntil(alice), firstExpiry);
+    }
+
+    function test_pauseUntil_canRenew_afterExpiry() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil(alice);
+        uint64 firstExpiry = weEthInstance.pausedUntil(alice);
+
+        vm.warp(uint256(firstExpiry) + 1);
+        vm.prank(pauser);
+        weEthInstance.pauseUntil(alice);
+
+        assertGt(weEthInstance.pausedUntil(alice), firstExpiry);
+    }
+
+    // -------------------------------------------------------------------
+    //                            UNPAUSE SEMANTICS
+    // -------------------------------------------------------------------
+
+    function test_unpause_clearsBothFlags_whenFullyFrozen() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil(alice);
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
+
+        assertTrue(weEthInstance.paused(alice));
+        assertGt(weEthInstance.pausedUntil(alice), block.timestamp);
+
+        vm.prank(extendPauser);
+        weEthInstance.unpause(alice);
+
+        assertFalse(weEthInstance.paused(alice));
+        assertEq(weEthInstance.pausedUntil(alice), 0);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_unpause_afterExpiry_leavesStaleTimer() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
 
         vm.warp(uint256(expiry) + 1);
 
         vm.prank(extendPauser);
-        weEthInstance.unpause();
+        weEthInstance.unpause(alice);
 
-        assertEq(weEthInstance.pausedUntil(), expiry);
-        assertFalse(weEthInstance.paused());
+        assertEq(weEthInstance.pausedUntil(alice), expiry, "stale expiry remains (M-2)");
+        assertFalse(weEthInstance.paused(alice));
     }
 
     function test_unpause_noop_whenNeverPaused() public {
         vm.prank(extendPauser);
-        weEthInstance.unpause();
-        assertFalse(weEthInstance.paused());
-        assertEq(weEthInstance.pausedUntil(), 0);
+        weEthInstance.unpause(alice);
+        assertFalse(weEthInstance.paused(alice));
+        assertEq(weEthInstance.pausedUntil(alice), 0);
     }
 
     // -------------------------------------------------------------------
-    //                   NON-TRANSFER PATHS DURING PAUSE
+    //                              EVENTS
     // -------------------------------------------------------------------
 
-    function test_approve_notBlockedByPause() public {
+    function test_pause_emitsIndexedUser() public {
+        vm.expectEmit(true, false, false, true);
+        emit Paused(alice);
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
+    }
+
+    function test_pauseUntil_emitsIndexedUserAndExpiry() public {
+        vm.expectEmit(true, false, false, true);
+        emit PausedUntil(alice, uint64(block.timestamp) + ONE_DAY);
+        vm.prank(pauser);
+        weEthInstance.pauseUntil(alice);
+    }
+
+    function test_unpause_emitsIndexedUser() public {
+        vm.expectEmit(true, false, false, true);
+        emit Unpaused(alice);
+        vm.prank(extendPauser);
+        weEthInstance.unpause(alice);
+    }
+
+    // -------------------------------------------------------------------
+    //                     NON-TRANSFER PATHS DURING FREEZE
+    // -------------------------------------------------------------------
+
+    function test_approve_notBlockedByFreeze() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
 
         vm.prank(alice);
         weEthInstance.approve(bob, 1 ether);
         assertEq(weEthInstance.allowance(alice, bob), 1 ether);
     }
 
-    function test_getters_workWhilePaused() public {
+    function test_getters_workWhileFrozen() public {
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
-        // getRate, getEETHByWeETH, getWeETHByeETH are all view; must not revert.
         weEthInstance.getRate();
         weEthInstance.getEETHByWeETH(1 ether);
         weEthInstance.getWeETHByeETH(1 ether);
+        weEthInstance.balanceOf(alice);
     }
 
     // -------------------------------------------------------------------
-    //                             FUZZING
+    //                               FUZZING
     // -------------------------------------------------------------------
 
     function testFuzz_pause_revertsForNonExtendPauser(address caller) public {
         vm.assume(caller != extendPauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
     }
 
     function testFuzz_pauseUntil_revertsForNonPauser(address caller) public {
         vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pauseUntil();
+        weEthInstance.pauseUntil(alice);
     }
 
     function testFuzz_unpause_revertsForNonExtendPauser(address caller) public {
         vm.assume(caller != extendPauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.unpause();
+        weEthInstance.unpause(alice);
     }
 
     function testFuzz_pauseUntil_setsOneDayFromWarpedTimestamp(uint64 warpTo) public {
@@ -401,94 +491,79 @@ contract WeETHPauseTest is TestSetup {
         vm.warp(warpTo);
 
         vm.prank(pauser);
-        weEthInstance.pauseUntil();
+        weEthInstance.pauseUntil(alice);
 
-        assertEq(weEthInstance.pausedUntil(), warpTo + ONE_DAY);
+        assertEq(weEthInstance.pausedUntil(alice), warpTo + ONE_DAY);
     }
 
-    function testFuzz_transferBlockedWhenPaused(uint256 amount) public {
+    function testFuzz_senderFrozen_blocksAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(alice));
 
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("SENDER PAUSED");
         weEthInstance.transfer(bob, amount);
     }
 
-    function testFuzz_wrapBlockedWhenPaused(uint256 amount) public {
+    function testFuzz_recipientFrozen_blocksAnyAmount(uint256 amount) public {
+        amount = bound(amount, 1, weEthInstance.balanceOf(bob));
+
+        vm.prank(extendPauser);
+        weEthInstance.pause(alice);
+
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.transfer(alice, amount);
+    }
+
+    function testFuzz_wrapBlockedWhenFrozen(uint256 amount) public {
         amount = bound(amount, 1, eETHInstance.balanceOf(alice));
 
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("RECIPIENT PAUSED");
         weEthInstance.wrap(amount);
     }
 
-    function testFuzz_unwrapBlockedWhenPaused(uint256 amount) public {
+    function testFuzz_unwrapBlockedWhenFrozen(uint256 amount) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(alice));
 
         vm.prank(extendPauser);
-        weEthInstance.pause();
+        weEthInstance.pause(alice);
 
         vm.prank(alice);
-        vm.expectRevert("PAUSED");
+        vm.expectRevert("SENDER PAUSED");
         weEthInstance.unwrap(amount);
     }
 
-    function testFuzz_transferAtOrBeforeExpiry_blocks(uint64 delta) public {
-        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
-
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-        uint64 expiry = weEthInstance.pausedUntil();
-
-        vm.warp(uint256(expiry) - delta);
-
-        vm.prank(alice);
-        vm.expectRevert("PAUSED");
-        weEthInstance.transfer(bob, 1);
-    }
-
-    function testFuzz_transferWorksAfterExpiry(uint256 amount, uint64 extra) public {
-        amount = bound(amount, 1, weEthInstance.balanceOf(alice));
-        extra = uint64(bound(uint256(extra), 1, 365 days));
-
-        vm.prank(pauser);
-        weEthInstance.pauseUntil();
-
-        vm.warp(uint256(weEthInstance.pausedUntil()) + extra);
-
-        uint256 aliceBefore = weEthInstance.balanceOf(alice);
-        uint256 bobBefore = weEthInstance.balanceOf(bob);
-
-        vm.prank(alice);
-        weEthInstance.transfer(bob, amount);
-
-        assertEq(weEthInstance.balanceOf(alice), aliceBefore - amount);
-        assertEq(weEthInstance.balanceOf(bob), bobBefore + amount);
-    }
-
-    function testFuzz_unpauseClearsState(bool pauseFirst, bool pauseUntilFirst) public {
-        if (pauseUntilFirst) {
-            vm.prank(pauser);
-            weEthInstance.pauseUntil();
-        }
-        if (pauseFirst) {
-            vm.prank(extendPauser);
-            weEthInstance.pause();
-        }
+    function testFuzz_unfrozenUsers_unaffected(uint256 amount) public {
+        amount = bound(amount, 1, weEthInstance.balanceOf(bob));
 
         vm.prank(extendPauser);
-        weEthInstance.unpause();
+        weEthInstance.pause(alice);
 
-        assertFalse(weEthInstance.paused());
-        assertTrue(weEthInstance.pausedUntil() < block.timestamp || weEthInstance.pausedUntil() == 0);
+        uint256 bobBefore = weEthInstance.balanceOf(bob);
+        uint256 chadBefore = weEthInstance.balanceOf(chad);
 
-        vm.prank(alice);
-        weEthInstance.transfer(bob, 1);
+        vm.prank(bob);
+        weEthInstance.transfer(chad, amount);
+
+        assertEq(weEthInstance.balanceOf(bob), bobBefore - amount);
+        assertEq(weEthInstance.balanceOf(chad), chadBefore + amount);
+    }
+
+    function testFuzz_independentUsers_freezeIsolated(address userA, address userB) public {
+        vm.assume(userA != address(0) && userB != address(0));
+        vm.assume(userA != userB);
+
+        vm.prank(extendPauser);
+        weEthInstance.pause(userA);
+
+        assertTrue(weEthInstance.paused(userA));
+        assertFalse(weEthInstance.paused(userB));
     }
 }

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.13;
 import "./TestSetup.sol";
 
 /// Unit + fuzz tests for the per-user FREEZE feature on WeETH.
-/// Role model:
-///   WEETH_PAUSER_ROLE         -> monitoring EOA   : pauseUntil(user) arms 1-day freeze
-///   WEETH_EXTEND_PAUSER_ROLE  -> security council : pause(user) / unpause(user)
+/// Role model (post-rename):
+///   WEETH_PAUSER_ROLE        -> security council : pause(user) / unpause(user) (strong)
+///   WEETH_PAUSER_UNTIL_ROLE  -> monitoring EOA   : pauseUntil(user) arms 1-day freeze
 ///
 /// WeETH uses `_beforeTokenTransfer`, which fires on `_mint`/`_burn` too — so a freeze
 /// on either party blocks transfer, wrap (mint), and unwrap (burn).
@@ -15,8 +15,8 @@ contract WeETHPauseTest is TestSetup {
     event PausedUntil(address indexed user, uint64 pausedUntil);
     event Unpaused(address indexed user);
 
-    address pauser;
-    address extendPauser;
+    address pauser;        // WEETH_PAUSER_ROLE (strong)
+    address pauserUntil;   // WEETH_PAUSER_UNTIL_ROLE (weak)
     address unauthorized;
 
     uint64 constant ONE_DAY = 1 days;
@@ -25,12 +25,12 @@ contract WeETHPauseTest is TestSetup {
         setUpTests();
 
         pauser = vm.addr(0xB0B01);
-        extendPauser = vm.addr(0xB0B02);
+        pauserUntil = vm.addr(0xB0B02);
         unauthorized = vm.addr(0xB0B03);
 
         vm.startPrank(owner);
         roleRegistryInstance.grantRole(weEthInstance.WEETH_PAUSER_ROLE(), pauser);
-        roleRegistryInstance.grantRole(weEthInstance.WEETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        roleRegistryInstance.grantRole(weEthInstance.WEETH_PAUSER_UNTIL_ROLE(), pauserUntil);
         vm.stopPrank();
 
         vm.deal(alice, 100 ether);
@@ -60,24 +60,38 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrap(10 ether);
     }
 
+    /// @dev Shared helper — grants eETH pause role to a council address so tests can
+    /// exercise cross-token freeze interactions without repeating the dance.
+    function _grantEETHPauserRole(address to) internal {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_ROLE(), to);
+        vm.stopPrank();
+    }
+
+    function _grantEETHPauserUntilRole(address to) internal {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_UNTIL_ROLE(), to);
+        vm.stopPrank();
+    }
+
     // -------------------------------------------------------------------
     //                          ZERO-ADDRESS GUARDS
     // -------------------------------------------------------------------
 
     function test_pause_rejectsZeroAddress() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         vm.expectRevert("No zero addresses");
         weEthInstance.pause(address(0));
     }
 
     function test_pauseUntil_rejectsZeroAddress() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         vm.expectRevert("No zero addresses");
         weEthInstance.pauseUntil(address(0));
     }
 
     function test_unpause_rejectsZeroAddress() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         vm.expectRevert("No zero addresses");
         weEthInstance.unpause(address(0));
     }
@@ -86,57 +100,57 @@ contract WeETHPauseTest is TestSetup {
     //                               ROLE GATING
     // -------------------------------------------------------------------
 
-    function test_pause_onlyExtendPauserRole() public {
+    function test_pause_onlyPauserRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
         weEthInstance.pause(alice);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
         weEthInstance.pause(alice);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
         assertTrue(weEthInstance.paused(alice));
     }
 
-    function test_pauseUntil_onlyPauserRole() public {
+    function test_pauseUntil_onlyPauserUntilRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
         weEthInstance.pauseUntil(alice);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         vm.expectRevert("IncorrectRole");
         weEthInstance.pauseUntil(alice);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
     }
 
-    function test_unpause_onlyExtendPauserRole() public {
-        vm.prank(extendPauser);
+    function test_unpause_onlyPauserRole() public {
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
         weEthInstance.unpause(alice);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
         weEthInstance.unpause(alice);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.unpause(alice);
         assertFalse(weEthInstance.paused(alice));
     }
 
     // -------------------------------------------------------------------
-    //                      PER-USER FREEZE SELECTIVITY
+    //                     PER-USER FREEZE SELECTIVITY
     // -------------------------------------------------------------------
 
     function test_freeze_isPerUser_othersUnaffected() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(bob);
@@ -146,7 +160,7 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_freeze_blocksSender() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(alice);
@@ -155,7 +169,7 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_freeze_blocksRecipient() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(bob);
@@ -164,7 +178,7 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_freeze_blocksSelfTransfer() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(alice);
@@ -176,7 +190,7 @@ contract WeETHPauseTest is TestSetup {
         vm.prank(alice);
         weEthInstance.approve(bob, 1 ether);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(bob);
@@ -188,7 +202,7 @@ contract WeETHPauseTest is TestSetup {
         vm.prank(alice);
         weEthInstance.approve(bob, 1 ether);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(chad);
 
         vm.prank(bob);
@@ -197,12 +211,12 @@ contract WeETHPauseTest is TestSetup {
     }
 
     // -------------------------------------------------------------------
-    //                  WRAP / UNWRAP UNDER FREEZE (WeETH side)
+    //           WRAP UNDER FREEZE — weETH side (_beforeTokenTransfer)
     // -------------------------------------------------------------------
 
-    /// @dev Frozen on WeETH -> wrap fails at _mint's _beforeTokenTransfer (recipient check).
+    /// @dev pause() on WeETH -> wrap reverts at _mint's _beforeTokenTransfer.
     function test_wrap_blocked_whenCallerFrozenOnWeETH() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(alice);
@@ -210,14 +224,35 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrap(1 ether);
     }
 
-    /// @dev Frozen on WeETH -> unwrap fails at _burn's _beforeTokenTransfer (sender check).
-    function test_unwrap_blocked_whenCallerFrozenOnWeETH() public {
-        vm.prank(extendPauser);
-        weEthInstance.pause(alice);
+    /// @dev pauseUntil() on WeETH -> wrap reverts while timer active.
+    function test_wrap_blocked_underPauseUntil_onWeETH() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
 
         vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        weEthInstance.unwrap(1 ether);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.wrap(1 ether);
+    }
+
+    function test_wrap_blockedAtPauseUntilBoundary_onWeETH() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
+        vm.warp(expiry);
+
+        vm.prank(alice);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.wrap(1 ether);
+    }
+
+    function test_wrap_worksAfterPauseUntilExpiry_onWeETH() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
+        vm.warp(uint256(expiry) + 1);
+
+        vm.prank(alice);
+        weEthInstance.wrap(1 ether);
     }
 
     function test_wrapWithPermit_blocked_whenCallerFrozenOnWeETH() public {
@@ -226,7 +261,7 @@ contract WeETHPauseTest is TestSetup {
             type(uint256).max, eETHInstance.DOMAIN_SEPARATOR()
         );
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(alice);
@@ -234,62 +269,125 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrapWithPermit(1 ether, p);
     }
 
+    function test_wrapWithPermit_blocked_underPauseUntil_onWeETH() public {
+        ILiquidityPool.PermitInput memory p = createPermitInput(
+            2, address(weEthInstance), 1 ether, eETHInstance.nonces(alice),
+            type(uint256).max, eETHInstance.DOMAIN_SEPARATOR()
+        );
+
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.wrapWithPermit(1 ether, p);
+    }
+
     // -------------------------------------------------------------------
-    //       CROSS-TOKEN FREEZE — eETH freeze affects WeETH flows
+    //                        UNWRAP UNDER FREEZE — weETH side
     // -------------------------------------------------------------------
 
-    /// @dev Frozen on eETH -> wrap fails at eETH.transferFrom (sender check on eETH side).
+    function test_unwrap_blocked_whenCallerFrozenOnWeETH() public {
+        vm.prank(pauser);
+        weEthInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    function test_unwrap_blocked_underPauseUntil_onWeETH() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    function test_unwrap_blockedAtPauseUntilBoundary_onWeETH() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
+        vm.warp(expiry);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    function test_unwrap_worksAfterPauseUntilExpiry_onWeETH() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
+        vm.warp(uint256(expiry) + 1);
+
+        vm.prank(alice);
+        weEthInstance.unwrap(1 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //     CROSS-TOKEN FREEZE — freeze on eETH propagates to WeETH flows
+    // -------------------------------------------------------------------
+
     function test_wrap_blocked_whenCallerFrozenOnEETH() public {
-        vm.startPrank(owner);
-        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
-        vm.stopPrank();
-
-        vm.prank(extendPauser);
+        _grantEETHPauserRole(pauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
+
+        vm.prank(alice);
+        // wrap's eETH.transferFrom fails before weETH._mint runs, because mintShares
+        // routes through _transferShares (sender=alice is frozen on eETH).
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.wrap(1 ether);
+    }
+
+    function test_wrap_blocked_underPauseUntil_onEETH() public {
+        _grantEETHPauserUntilRole(pauserUntil);
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
 
         vm.prank(alice);
         vm.expectRevert("SENDER PAUSED");
         weEthInstance.wrap(1 ether);
     }
 
-    /// @dev Frozen on eETH -> unwrap fails at eETH.transfer (recipient check on eETH side).
     function test_unwrap_blocked_whenCallerFrozenOnEETH() public {
-        vm.startPrank(owner);
-        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
-        vm.stopPrank();
-
-        vm.prank(extendPauser);
+        _grantEETHPauserRole(pauser);
+        vm.prank(pauser);
         eETHInstance.pause(alice);
+
+        vm.prank(alice);
+        // weETH._burn succeeds (msg.sender frozen on eETH, not weETH), but the
+        // subsequent eETH.transfer(alice, ...) fails with recipient=alice frozen.
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    function test_unwrap_blocked_underPauseUntil_onEETH() public {
+        _grantEETHPauserUntilRole(pauserUntil);
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(alice);
 
         vm.prank(alice);
         vm.expectRevert("RECIPIENT PAUSED");
         weEthInstance.unwrap(1 ether);
     }
 
-    /// @dev Freezing WeETH on its own account on eETH bricks wrap for EVERYONE (C-2 hazard).
+    /// @dev C-2: freezing the WeETH contract's own eETH account bricks wrap for all.
     function test_SECURITY_freezingWeETHOnEETH_bricksWrapForAll() public {
-        vm.startPrank(owner);
-        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
-        vm.stopPrank();
-
-        // Security council accidentally freezes the weETH contract's eETH account.
-        vm.prank(extendPauser);
+        _grantEETHPauserRole(pauser);
+        vm.prank(pauser);
         eETHInstance.pause(address(weEthInstance));
 
-        // Bob (not frozen) can no longer wrap because eETH.transferFrom routes tokens
-        // TO address(weEthInstance), which is now frozen on eETH.
-        vm.prank(bob);
+        vm.prank(bob); // bob is NOT frozen on either token
         vm.expectRevert("RECIPIENT PAUSED");
         weEthInstance.wrap(1 ether);
     }
 
-    /// @dev Same hazard for unwrap.
     function test_SECURITY_freezingWeETHOnEETH_bricksUnwrapForAll() public {
-        vm.startPrank(owner);
-        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
-        vm.stopPrank();
-
-        vm.prank(extendPauser);
+        _grantEETHPauserRole(pauser);
+        vm.prank(pauser);
         eETHInstance.pause(address(weEthInstance));
 
         vm.prank(bob);
@@ -297,9 +395,8 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.unwrap(1 ether);
     }
 
-    /// @dev Freeze on weETH does NOT restrict user's eETH activity.
     function test_weETHFreeze_doesNotTouchEETH() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(alice);
@@ -311,7 +408,7 @@ contract WeETHPauseTest is TestSetup {
     // -------------------------------------------------------------------
 
     function test_pauseUntil_expiresAfterOneDay() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 expiry = weEthInstance.pausedUntil(alice);
 
@@ -322,7 +419,7 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_pauseUntil_blockedAtBoundary() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 expiry = weEthInstance.pausedUntil(alice);
         vm.warp(expiry);
@@ -333,11 +430,11 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_pauseUntil_silentNoOp_whilePaused() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
         uint64 before = weEthInstance.pausedUntil(alice);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
 
         assertEq(weEthInstance.pausedUntil(alice), before);
@@ -345,25 +442,25 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_pauseUntil_cannotExtend_whileTimerActive() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 firstExpiry = weEthInstance.pausedUntil(alice);
 
         vm.warp(block.timestamp + 6 hours);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
 
         assertEq(weEthInstance.pausedUntil(alice), firstExpiry);
     }
 
     function test_pauseUntil_canRenew_afterExpiry() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 firstExpiry = weEthInstance.pausedUntil(alice);
 
         vm.warp(uint256(firstExpiry) + 1);
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
 
         assertGt(weEthInstance.pausedUntil(alice), firstExpiry);
@@ -374,15 +471,15 @@ contract WeETHPauseTest is TestSetup {
     // -------------------------------------------------------------------
 
     function test_unpause_clearsBothFlags_whenFullyFrozen() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         assertTrue(weEthInstance.paused(alice));
         assertGt(weEthInstance.pausedUntil(alice), block.timestamp);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.unpause(alice);
 
         assertFalse(weEthInstance.paused(alice));
@@ -393,13 +490,13 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_unpause_afterExpiry_leavesStaleTimer() public {
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 expiry = weEthInstance.pausedUntil(alice);
 
         vm.warp(uint256(expiry) + 1);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.unpause(alice);
 
         assertEq(weEthInstance.pausedUntil(alice), expiry, "stale expiry remains (M-2)");
@@ -407,7 +504,7 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_unpause_noop_whenNeverPaused() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.unpause(alice);
         assertFalse(weEthInstance.paused(alice));
         assertEq(weEthInstance.pausedUntil(alice), 0);
@@ -420,21 +517,21 @@ contract WeETHPauseTest is TestSetup {
     function test_pause_emitsIndexedUser() public {
         vm.expectEmit(true, false, false, true);
         emit Paused(alice);
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
     }
 
     function test_pauseUntil_emitsIndexedUserAndExpiry() public {
         vm.expectEmit(true, false, false, true);
         emit PausedUntil(alice, uint64(block.timestamp) + ONE_DAY);
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
     }
 
     function test_unpause_emitsIndexedUser() public {
         vm.expectEmit(true, false, false, true);
         emit Unpaused(alice);
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.unpause(alice);
     }
 
@@ -443,7 +540,7 @@ contract WeETHPauseTest is TestSetup {
     // -------------------------------------------------------------------
 
     function test_approve_notBlockedByFreeze() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(alice);
@@ -452,7 +549,7 @@ contract WeETHPauseTest is TestSetup {
     }
 
     function test_getters_workWhileFrozen() public {
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         weEthInstance.getRate();
@@ -465,22 +562,22 @@ contract WeETHPauseTest is TestSetup {
     //                               FUZZING
     // -------------------------------------------------------------------
 
-    function testFuzz_pause_revertsForNonExtendPauser(address caller) public {
-        vm.assume(caller != extendPauser);
+    function testFuzz_pause_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
         weEthInstance.pause(alice);
     }
 
-    function testFuzz_pauseUntil_revertsForNonPauser(address caller) public {
-        vm.assume(caller != pauser);
+    function testFuzz_pauseUntil_revertsForNonPauserUntil(address caller) public {
+        vm.assume(caller != pauserUntil);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
         weEthInstance.pauseUntil(alice);
     }
 
-    function testFuzz_unpause_revertsForNonExtendPauser(address caller) public {
-        vm.assume(caller != extendPauser);
+    function testFuzz_unpause_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
         weEthInstance.unpause(alice);
@@ -490,7 +587,7 @@ contract WeETHPauseTest is TestSetup {
         warpTo = uint64(bound(uint256(warpTo), block.timestamp + 1, type(uint64).max - ONE_DAY - 1));
         vm.warp(warpTo);
 
-        vm.prank(pauser);
+        vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
 
         assertEq(weEthInstance.pausedUntil(alice), warpTo + ONE_DAY);
@@ -499,7 +596,7 @@ contract WeETHPauseTest is TestSetup {
     function testFuzz_senderFrozen_blocksAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(alice));
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(alice);
@@ -510,7 +607,7 @@ contract WeETHPauseTest is TestSetup {
     function testFuzz_recipientFrozen_blocksAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(bob));
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(bob);
@@ -518,10 +615,10 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.transfer(alice, amount);
     }
 
-    function testFuzz_wrapBlockedWhenFrozen(uint256 amount) public {
+    function testFuzz_wrapBlockedWhenFrozenOnWeETH(uint256 amount) public {
         amount = bound(amount, 1, eETHInstance.balanceOf(alice));
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         vm.prank(alice);
@@ -529,11 +626,39 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrap(amount);
     }
 
-    function testFuzz_unwrapBlockedWhenFrozen(uint256 amount) public {
+    function testFuzz_wrapBlockedUnderPauseUntil_onWeETH(uint256 amount, uint64 delta) public {
+        amount = bound(amount, 1, eETHInstance.balanceOf(alice));
+        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
+
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
+        vm.warp(uint256(expiry) - delta);
+
+        vm.prank(alice);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.wrap(amount);
+    }
+
+    function testFuzz_unwrapBlockedWhenFrozenOnWeETH(uint256 amount) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(alice));
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.unwrap(amount);
+    }
+
+    function testFuzz_unwrapBlockedUnderPauseUntil_onWeETH(uint256 amount, uint64 delta) public {
+        amount = bound(amount, 1, weEthInstance.balanceOf(alice));
+        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
+
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
+        vm.warp(uint256(expiry) - delta);
 
         vm.prank(alice);
         vm.expectRevert("SENDER PAUSED");
@@ -543,7 +668,7 @@ contract WeETHPauseTest is TestSetup {
     function testFuzz_unfrozenUsers_unaffected(uint256 amount) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(bob));
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(alice);
 
         uint256 bobBefore = weEthInstance.balanceOf(bob);
@@ -560,7 +685,7 @@ contract WeETHPauseTest is TestSetup {
         vm.assume(userA != address(0) && userB != address(0));
         vm.assume(userA != userB);
 
-        vm.prank(extendPauser);
+        vm.prank(pauser);
         weEthInstance.pause(userA);
 
         assertTrue(weEthInstance.paused(userA));

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -513,11 +513,30 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.transfer(bob, 1 ether);
     }
 
-    function test_cancelPauseUntil_emitsEvenWhenNeverArmed() public {
-        vm.expectEmit(true, false, false, true);
-        emit CancelledPauseUntil(alice);
+    /// @dev I-03 regression: cancelPauseUntil must not emit when the user was never paused.
+    function test_cancelPauseUntil_doesNotEmit_whenNeverArmed() public {
+        vm.recordLogs();
         vm.prank(pauser);
         weEthInstance.cancelPauseUntil(alice);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "no event when there is nothing to cancel (I-03)");
+        assertEq(weEthInstance.pausedUntil(alice), 0);
+    }
+
+    /// @dev I-03 regression: cancelPauseUntil is a no-op once the timer has already expired.
+    function test_cancelPauseUntil_isNoOp_whenExpired() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        uint256 staleDeadline = weEthInstance.pausedUntil(alice);
+        vm.warp(block.timestamp + 2 days);
+
+        vm.recordLogs();
+        vm.prank(pauser);
+        weEthInstance.cancelPauseUntil(alice);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "no event when timer already expired");
+        assertEq(weEthInstance.pausedUntil(alice), staleDeadline, "expired value is left as-is");
     }
 
     function test_cancelPauseUntil_isPerUser() public {

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -10,7 +10,7 @@ import "./TestSetup.sol";
 ///                                : cancelPauseUntil(user)                    -> PAUSER_ROLE (strong)
 contract WeETHPauseTest is TestSetup {
     event Paused();
-    event PausedUntil(address indexed user, uint64 pausedUntil);
+    event PausedUntil(address indexed user, uint256 pausedUntil);
     event CancelledPauseUntil(address indexed user);
     event Unpaused();
 
@@ -258,7 +258,7 @@ contract WeETHPauseTest is TestSetup {
     function test_wrap_blockedAtTimerBoundary_onWeETH() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
         vm.warp(expiry);
 
         vm.prank(alice);
@@ -269,7 +269,7 @@ contract WeETHPauseTest is TestSetup {
     function test_wrap_worksAfterTimerExpiry_onWeETH() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
         vm.warp(uint256(expiry) + 1);
 
         vm.prank(alice);
@@ -289,7 +289,7 @@ contract WeETHPauseTest is TestSetup {
     function test_unwrap_blockedAtTimerBoundary_onWeETH() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
         vm.warp(expiry);
 
         vm.prank(alice);
@@ -300,7 +300,7 @@ contract WeETHPauseTest is TestSetup {
     function test_unwrap_worksAfterTimerExpiry_onWeETH() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
         vm.warp(uint256(expiry) + 1);
 
         vm.prank(alice);
@@ -402,7 +402,7 @@ contract WeETHPauseTest is TestSetup {
     function test_pauseUntil_blockedAtBoundary() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
         vm.warp(expiry);
 
         vm.prank(alice);
@@ -413,7 +413,7 @@ contract WeETHPauseTest is TestSetup {
     function test_pauseUntil_expiresAfterOneDay() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
 
         vm.warp(uint256(expiry) + 1);
 
@@ -424,7 +424,7 @@ contract WeETHPauseTest is TestSetup {
     function test_pauseUntil_cannotExtend_whileTimerActive() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 firstExpiry = weEthInstance.pausedUntil(alice);
+        uint256 firstExpiry = weEthInstance.pausedUntil(alice);
 
         vm.warp(block.timestamp + 6 hours);
 
@@ -437,7 +437,7 @@ contract WeETHPauseTest is TestSetup {
     function test_pauseUntil_canRenew_afterExpiry() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 firstExpiry = weEthInstance.pausedUntil(alice);
+        uint256 firstExpiry = weEthInstance.pausedUntil(alice);
 
         vm.warp(uint256(firstExpiry) + 1);
         vm.prank(pauserUntil);
@@ -475,7 +475,7 @@ contract WeETHPauseTest is TestSetup {
     function test_extendPauseUntil_silentNoOp_whenTimerExpired() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
 
         vm.warp(uint256(expiry) + 1);
 
@@ -749,7 +749,7 @@ contract WeETHPauseTest is TestSetup {
 
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
         vm.warp(uint256(expiry) - delta);
 
         vm.prank(alice);
@@ -763,7 +763,7 @@ contract WeETHPauseTest is TestSetup {
 
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
+        uint256 expiry = weEthInstance.pausedUntil(alice);
         vm.warp(uint256(expiry) - delta);
 
         vm.prank(alice);

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "./TestSetup.sol";
+
+/// Unit + fuzz tests for the pause / pauseUntil / unpause feature on WeETH.
+///
+/// Role gating (post H-1 fix, aligned with EETH):
+///   pause()      -> WEETH_EXTEND_PAUSER_ROLE  (security council multisig)
+///   pauseUntil() -> WEETH_PAUSER_ROLE         (monitoring EOA, 1-day timer)
+///   unpause()    -> WEETH_EXTEND_PAUSER_ROLE  (security council multisig)
+contract WeETHPauseTest is TestSetup {
+    // Re-declared events for vm.expectEmit.
+    event Paused();
+    event PausedUntil(uint64 pausedUntil);
+    event Unpaused();
+
+    address pauser;          // monitoring EOA (WEETH_PAUSER_ROLE) — pauseUntil only
+    address extendPauser;    // security council (WEETH_EXTEND_PAUSER_ROLE) — pause + unpause
+    address unauthorized;    // no weETH roles
+
+    uint64 constant ONE_DAY = 1 days;
+
+    function setUp() public {
+        setUpTests();
+
+        pauser = vm.addr(0xB0B1);
+        extendPauser = vm.addr(0xB0B2);
+        unauthorized = vm.addr(0xB0B3);
+
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(weEthInstance.WEETH_PAUSER_ROLE(), pauser);
+        roleRegistryInstance.grantRole(weEthInstance.WEETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        vm.stopPrank();
+
+        // Give alice + bob eETH, then wrap some into weETH so we have weETH balances.
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 20 ether}();
+        vm.prank(bob);
+        liquidityPoolInstance.deposit{value: 20 ether}();
+
+        vm.prank(alice);
+        eETHInstance.approve(address(weEthInstance), type(uint256).max);
+        vm.prank(alice);
+        weEthInstance.wrap(10 ether);
+
+        vm.prank(bob);
+        eETHInstance.approve(address(weEthInstance), type(uint256).max);
+        vm.prank(bob);
+        weEthInstance.wrap(10 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //                     ROLE GATING (current source)
+    // -------------------------------------------------------------------
+
+    function test_pause_onlyExtendPauserRole() public {
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.pause();
+
+        // pauser holds only WEETH_PAUSER_ROLE — cannot pause indefinitely
+        vm.prank(pauser);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.pause();
+
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+        assertTrue(weEthInstance.paused());
+    }
+
+    function test_pauseUntil_onlyPauserRole() public {
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.pauseUntil();
+
+        vm.prank(extendPauser);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.pauseUntil();
+
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+        // NOTE: currently FAILS because src/WeETH.sol:113 writes `pausedUntil = 0`.
+        // Restore to `uint64(block.timestamp) + 1 days` to fix.
+        assertEq(weEthInstance.pausedUntil(), uint64(block.timestamp) + ONE_DAY);
+    }
+
+    function test_unpause_onlyExtendPauserRole() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.unpause();
+
+        // pauser holds only WEETH_PAUSER_ROLE — cannot unpause
+        vm.prank(pauser);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.unpause();
+
+        vm.prank(extendPauser);
+        weEthInstance.unpause();
+        assertFalse(weEthInstance.paused());
+    }
+
+    // -------------------------------------------------------------------
+    //            TRANSFER / MINT / BURN BLOCKING WHILE PAUSED
+    //    (WeETH uses _beforeTokenTransfer, so _mint and _burn also block)
+    // -------------------------------------------------------------------
+
+    function test_transfer_blockedWhen_paused() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_transferFrom_blockedWhen_paused() public {
+        vm.prank(alice);
+        weEthInstance.approve(bob, 1 ether);
+
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(bob);
+        vm.expectRevert("PAUSED");
+        weEthInstance.transferFrom(alice, bob, 1 ether);
+    }
+
+    function test_wrap_blockedWhen_paused() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.wrap(1 ether);
+    }
+
+    function test_wrapWithPermit_blockedWhen_paused() public {
+        ILiquidityPool.PermitInput memory p = createPermitInput(
+            2, // alice pk
+            address(weEthInstance),
+            1 ether,
+            eETHInstance.nonces(alice),
+            type(uint256).max,
+            eETHInstance.DOMAIN_SEPARATOR()
+        );
+
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.wrapWithPermit(1 ether, p);
+    }
+
+    function test_unwrap_blockedWhen_paused() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    function test_transfer_blockedWhen_pauseUntilActive() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_transfer_unblockedAfterPauseUntilExpiry() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+        uint64 expiry = weEthInstance.pausedUntil();
+
+        vm.warp(uint256(expiry) + 1);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_transfer_blockedAtBoundary() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+        uint64 expiry = weEthInstance.pausedUntil();
+        vm.warp(expiry); // exactly pausedUntil
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //                 CROSS-TOKEN COUPLING WITH eETH PAUSE
+    // -------------------------------------------------------------------
+
+    /// @dev When eETH is paused, weETH.unwrap reverts because unwrap calls eETH.transfer.
+    function test_eETHPause_blocks_weETH_unwrap_transitively() public {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        vm.stopPrank();
+
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        // weETH itself is not paused, but unwrap routes through eETH.transfer.
+        assertFalse(weEthInstance.paused());
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    /// @dev When eETH is paused, weETH.wrap reverts because wrap calls eETH.transferFrom.
+    function test_eETHPause_blocks_weETH_wrap_transitively() public {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_EXTEND_PAUSER_ROLE(), extendPauser);
+        vm.stopPrank();
+
+        vm.prank(extendPauser);
+        eETHInstance.pause();
+
+        assertFalse(weEthInstance.paused());
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.wrap(1 ether);
+    }
+
+    /// @dev weETH-only pause does NOT prevent eETH transfers between users.
+    function test_weETHPause_doesNotBlock_eETHTransfer() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 1 ether); // must succeed
+    }
+
+    // -------------------------------------------------------------------
+    //                        STATE / EVENT SEMANTICS
+    // -------------------------------------------------------------------
+
+    function test_pause_emitsPausedEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit Paused();
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+    }
+
+    function test_pauseUntil_emitsPausedUntilEvent() public {
+        // NOTE: currently FAILS because src/WeETH.sol:113 emits PausedUntil(0)
+        // instead of PausedUntil(block.timestamp + 1 days).
+        vm.expectEmit(false, false, false, true);
+        emit PausedUntil(uint64(block.timestamp) + ONE_DAY);
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+    }
+
+    function test_unpause_emitsUnpausedEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit Unpaused();
+        vm.prank(extendPauser);
+        weEthInstance.unpause();
+    }
+
+    function test_pauseUntil_silentNoOp_whilePaused() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+        uint64 before = weEthInstance.pausedUntil();
+
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+
+        assertEq(weEthInstance.pausedUntil(), before);
+        assertTrue(weEthInstance.paused());
+    }
+
+    function test_pauseUntil_cannotExtend_whileTimerActive() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+        uint64 firstExpiry = weEthInstance.pausedUntil();
+
+        vm.warp(block.timestamp + 6 hours);
+
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+
+        assertEq(weEthInstance.pausedUntil(), firstExpiry);
+    }
+
+    function test_pauseUntil_canRenew_afterExpiry() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+        uint64 firstExpiry = weEthInstance.pausedUntil();
+
+        vm.warp(uint256(firstExpiry) + 1);
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+
+        assertGt(weEthInstance.pausedUntil(), firstExpiry);
+    }
+
+    function test_unpause_clearsBothFlags() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        assertTrue(weEthInstance.paused());
+        // NOTE: assertion on pausedUntil being in the future currently FAILS
+        // because pauseUntil writes 0. Restore the pause timer fix to make this pass.
+        assertGt(weEthInstance.pausedUntil(), block.timestamp);
+
+        vm.prank(extendPauser);
+        weEthInstance.unpause();
+
+        assertFalse(weEthInstance.paused());
+        assertLt(weEthInstance.pausedUntil(), block.timestamp);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_unpause_whenPausedUntilAlreadyExpired_leavesStale() public {
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+        uint64 expiry = weEthInstance.pausedUntil();
+
+        vm.warp(uint256(expiry) + 1);
+
+        vm.prank(extendPauser);
+        weEthInstance.unpause();
+
+        assertEq(weEthInstance.pausedUntil(), expiry);
+        assertFalse(weEthInstance.paused());
+    }
+
+    function test_unpause_noop_whenNeverPaused() public {
+        vm.prank(extendPauser);
+        weEthInstance.unpause();
+        assertFalse(weEthInstance.paused());
+        assertEq(weEthInstance.pausedUntil(), 0);
+    }
+
+    // -------------------------------------------------------------------
+    //                   NON-TRANSFER PATHS DURING PAUSE
+    // -------------------------------------------------------------------
+
+    function test_approve_notBlockedByPause() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        weEthInstance.approve(bob, 1 ether);
+        assertEq(weEthInstance.allowance(alice, bob), 1 ether);
+    }
+
+    function test_getters_workWhilePaused() public {
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        // getRate, getEETHByWeETH, getWeETHByeETH are all view; must not revert.
+        weEthInstance.getRate();
+        weEthInstance.getEETHByWeETH(1 ether);
+        weEthInstance.getWeETHByeETH(1 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //                             FUZZING
+    // -------------------------------------------------------------------
+
+    function testFuzz_pause_revertsForNonExtendPauser(address caller) public {
+        vm.assume(caller != extendPauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.pause();
+    }
+
+    function testFuzz_pauseUntil_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.pauseUntil();
+    }
+
+    function testFuzz_unpause_revertsForNonExtendPauser(address caller) public {
+        vm.assume(caller != extendPauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.unpause();
+    }
+
+    function testFuzz_pauseUntil_setsOneDayFromWarpedTimestamp(uint64 warpTo) public {
+        warpTo = uint64(bound(uint256(warpTo), block.timestamp + 1, type(uint64).max - ONE_DAY - 1));
+        vm.warp(warpTo);
+
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+
+        assertEq(weEthInstance.pausedUntil(), warpTo + ONE_DAY);
+    }
+
+    function testFuzz_transferBlockedWhenPaused(uint256 amount) public {
+        amount = bound(amount, 1, weEthInstance.balanceOf(alice));
+
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.transfer(bob, amount);
+    }
+
+    function testFuzz_wrapBlockedWhenPaused(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.balanceOf(alice));
+
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.wrap(amount);
+    }
+
+    function testFuzz_unwrapBlockedWhenPaused(uint256 amount) public {
+        amount = bound(amount, 1, weEthInstance.balanceOf(alice));
+
+        vm.prank(extendPauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.unwrap(amount);
+    }
+
+    function testFuzz_transferAtOrBeforeExpiry_blocks(uint64 delta) public {
+        delta = uint64(bound(uint256(delta), 0, ONE_DAY));
+
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+        uint64 expiry = weEthInstance.pausedUntil();
+
+        vm.warp(uint256(expiry) - delta);
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.transfer(bob, 1);
+    }
+
+    function testFuzz_transferWorksAfterExpiry(uint256 amount, uint64 extra) public {
+        amount = bound(amount, 1, weEthInstance.balanceOf(alice));
+        extra = uint64(bound(uint256(extra), 1, 365 days));
+
+        vm.prank(pauser);
+        weEthInstance.pauseUntil();
+
+        vm.warp(uint256(weEthInstance.pausedUntil()) + extra);
+
+        uint256 aliceBefore = weEthInstance.balanceOf(alice);
+        uint256 bobBefore = weEthInstance.balanceOf(bob);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, amount);
+
+        assertEq(weEthInstance.balanceOf(alice), aliceBefore - amount);
+        assertEq(weEthInstance.balanceOf(bob), bobBefore + amount);
+    }
+
+    function testFuzz_unpauseClearsState(bool pauseFirst, bool pauseUntilFirst) public {
+        if (pauseUntilFirst) {
+            vm.prank(pauser);
+            weEthInstance.pauseUntil();
+        }
+        if (pauseFirst) {
+            vm.prank(extendPauser);
+            weEthInstance.pause();
+        }
+
+        vm.prank(extendPauser);
+        weEthInstance.unpause();
+
+        assertFalse(weEthInstance.paused());
+        assertTrue(weEthInstance.pausedUntil() < block.timestamp || weEthInstance.pausedUntil() == 0);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 1);
+    }
+}

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -3,20 +3,19 @@ pragma solidity ^0.8.13;
 
 import "./TestSetup.sol";
 
-/// Unit + fuzz tests for the per-user FREEZE feature on WeETH.
-/// Role model (post-rename):
-///   WEETH_PAUSER_ROLE        -> security council : pause(user) / unpause(user) (strong)
-///   WEETH_PAUSER_UNTIL_ROLE  -> monitoring EOA   : pauseUntil(user) arms 1-day freeze
-///
-/// WeETH uses `_beforeTokenTransfer`, which fires on `_mint`/`_burn` too — so a freeze
-/// on either party blocks transfer, wrap (mint), and unwrap (burn).
+/// Unit + fuzz tests for the hybrid pause feature on WeETH.
+/// - global `paused` (bool)       : pause() / unpause()                       -> PAUSER_ROLE (strong)
+/// - per-user `pausedUntil[u]`    : pauseUntil(user)                          -> PAUSER_UNTIL_ROLE (weak)
+///                                : extendPauseUntil(user, duration)          -> PAUSER_ROLE (strong)
+///                                : cancelPauseUntil(user)                    -> PAUSER_ROLE (strong)
 contract WeETHPauseTest is TestSetup {
-    event Paused(address indexed user);
+    event Paused();
     event PausedUntil(address indexed user, uint64 pausedUntil);
-    event Unpaused(address indexed user);
+    event CancelledPauseUntil(address indexed user);
+    event Unpaused();
 
-    address pauser;        // WEETH_PAUSER_ROLE (strong)
-    address pauserUntil;   // WEETH_PAUSER_UNTIL_ROLE (weak)
+    address pauser;
+    address pauserUntil;
     address unauthorized;
 
     uint64 constant ONE_DAY = 1 days;
@@ -60,8 +59,6 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrap(10 ether);
     }
 
-    /// @dev Shared helper — grants eETH pause role to a council address so tests can
-    /// exercise cross-token freeze interactions without repeating the dance.
     function _grantEETHPauserRole(address to) internal {
         vm.startPrank(owner);
         roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_ROLE(), to);
@@ -78,22 +75,22 @@ contract WeETHPauseTest is TestSetup {
     //                          ZERO-ADDRESS GUARDS
     // -------------------------------------------------------------------
 
-    function test_pause_rejectsZeroAddress() public {
-        vm.prank(pauser);
-        vm.expectRevert("No zero addresses");
-        weEthInstance.pause(address(0));
-    }
-
     function test_pauseUntil_rejectsZeroAddress() public {
         vm.prank(pauserUntil);
         vm.expectRevert("No zero addresses");
         weEthInstance.pauseUntil(address(0));
     }
 
-    function test_unpause_rejectsZeroAddress() public {
+    function test_extendPauseUntil_rejectsZeroAddress() public {
         vm.prank(pauser);
         vm.expectRevert("No zero addresses");
-        weEthInstance.unpause(address(0));
+        weEthInstance.extendPauseUntil(address(0), ONE_DAY);
+    }
+
+    function test_cancelPauseUntil_rejectsZeroAddress() public {
+        vm.prank(pauser);
+        vm.expectRevert("No zero addresses");
+        weEthInstance.cancelPauseUntil(address(0));
     }
 
     // -------------------------------------------------------------------
@@ -103,15 +100,15 @@ contract WeETHPauseTest is TestSetup {
     function test_pause_onlyPauserRole() public {
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
 
         vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
 
         vm.prank(pauser);
-        weEthInstance.pause(alice);
-        assertTrue(weEthInstance.paused(alice));
+        weEthInstance.pause();
+        assertTrue(weEthInstance.paused());
     }
 
     function test_pauseUntil_onlyPauserUntilRole() public {
@@ -128,113 +125,137 @@ contract WeETHPauseTest is TestSetup {
         assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY);
     }
 
-    function test_unpause_onlyPauserRole() public {
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
+    function test_extendPauseUntil_onlyPauserRole() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.unpause(alice);
+        weEthInstance.extendPauseUntil(alice, 2 days);
 
         vm.prank(pauserUntil);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.unpause(alice);
+        weEthInstance.extendPauseUntil(alice, 2 days);
 
         vm.prank(pauser);
-        weEthInstance.unpause(alice);
-        assertFalse(weEthInstance.paused(alice));
+        weEthInstance.extendPauseUntil(alice, 2 days);
+        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + 2 days);
+    }
+
+    function test_cancelPauseUntil_onlyPauserRole() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.cancelPauseUntil(alice);
+
+        vm.prank(pauserUntil);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.cancelPauseUntil(alice);
+
+        vm.prank(pauser);
+        weEthInstance.cancelPauseUntil(alice);
+        assertEq(weEthInstance.pausedUntil(alice), 0);
+    }
+
+    function test_unpause_onlyPauserRole() public {
+        vm.prank(pauser);
+        weEthInstance.pause();
+
+        vm.prank(unauthorized);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.unpause();
+
+        vm.prank(pauserUntil);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.unpause();
+
+        vm.prank(pauser);
+        weEthInstance.unpause();
+        assertFalse(weEthInstance.paused());
     }
 
     // -------------------------------------------------------------------
-    //                     PER-USER FREEZE SELECTIVITY
+    //                     GLOBAL PAUSE SEMANTICS
     // -------------------------------------------------------------------
 
-    function test_freeze_isPerUser_othersUnaffected() public {
+    function test_globalPause_blocksTransfer() public {
         vm.prank(pauser);
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
 
-        vm.prank(bob);
-        weEthInstance.transfer(chad, 1 ether);
-        vm.prank(chad);
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
         weEthInstance.transfer(bob, 1 ether);
     }
 
-    function test_freeze_blocksSender() public {
+    function test_globalPause_blocksWrap() public {
         vm.prank(pauser);
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
 
         vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        weEthInstance.transfer(bob, 1 ether);
-    }
-
-    function test_freeze_blocksRecipient() public {
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        vm.prank(bob);
-        vm.expectRevert("RECIPIENT PAUSED");
-        weEthInstance.transfer(alice, 1 ether);
-    }
-
-    function test_freeze_blocksSelfTransfer() public {
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        weEthInstance.transfer(alice, 1 ether);
-    }
-
-    function test_freeze_blocksTransferFrom_viaSender() public {
-        vm.prank(alice);
-        weEthInstance.approve(bob, 1 ether);
-
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        vm.prank(bob);
-        vm.expectRevert("SENDER PAUSED");
-        weEthInstance.transferFrom(alice, chad, 1 ether);
-    }
-
-    function test_freeze_blocksTransferFrom_viaRecipient() public {
-        vm.prank(alice);
-        weEthInstance.approve(bob, 1 ether);
-
-        vm.prank(pauser);
-        weEthInstance.pause(chad);
-
-        vm.prank(bob);
-        vm.expectRevert("RECIPIENT PAUSED");
-        weEthInstance.transferFrom(alice, chad, 1 ether);
-    }
-
-    // -------------------------------------------------------------------
-    //           WRAP UNDER FREEZE — weETH side (_beforeTokenTransfer)
-    // -------------------------------------------------------------------
-
-    /// @dev pause() on WeETH -> wrap reverts at _mint's _beforeTokenTransfer.
-    function test_wrap_blocked_whenCallerFrozenOnWeETH() public {
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("RECIPIENT PAUSED");
+        vm.expectRevert("PAUSED");
         weEthInstance.wrap(1 ether);
     }
 
-    /// @dev pauseUntil() on WeETH -> wrap reverts while timer active.
-    function test_wrap_blocked_underPauseUntil_onWeETH() public {
+    function test_globalPause_blocksUnwrap() public {
+        vm.prank(pauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.unwrap(1 ether);
+    }
+
+    function test_globalPause_blocksWrapWithPermit() public {
+        ILiquidityPool.PermitInput memory p = createPermitInput(
+            2, address(weEthInstance), 1 ether, eETHInstance.nonces(alice),
+            type(uint256).max, eETHInstance.DOMAIN_SEPARATOR()
+        );
+
+        vm.prank(pauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.wrapWithPermit(1 ether, p);
+    }
+
+    function test_globalUnpause_restoresFlow() public {
+        vm.prank(pauser);
+        weEthInstance.pause();
+
+        vm.prank(pauser);
+        weEthInstance.unpause();
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    /// @dev M-2 carry-over: unpause has no is-paused guard.
+    function test_unpause_noop_whenNotPaused() public {
+        assertFalse(weEthInstance.paused());
+        vm.prank(pauser);
+        weEthInstance.unpause();
+        assertFalse(weEthInstance.paused());
+    }
+
+    // -------------------------------------------------------------------
+    //                   WRAP / UNWRAP UNDER PER-USER TIMER
+    //              (WeETH side uses _beforeTokenTransfer on _mint/_burn)
+    // -------------------------------------------------------------------
+
+    function test_wrap_blockedWhenCallerOnWeETHTimer() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
 
         vm.prank(alice);
+        // _mint(alice, ...) triggers _beforeTokenTransfer(0, alice, ...); recipient check fires.
         vm.expectRevert("RECIPIENT PAUSED");
         weEthInstance.wrap(1 ether);
     }
 
-    function test_wrap_blockedAtPauseUntilBoundary_onWeETH() public {
+    function test_wrap_blockedAtTimerBoundary_onWeETH() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 expiry = weEthInstance.pausedUntil(alice);
@@ -245,7 +266,7 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrap(1 ether);
     }
 
-    function test_wrap_worksAfterPauseUntilExpiry_onWeETH() public {
+    function test_wrap_worksAfterTimerExpiry_onWeETH() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 expiry = weEthInstance.pausedUntil(alice);
@@ -255,57 +276,17 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrap(1 ether);
     }
 
-    function test_wrapWithPermit_blocked_whenCallerFrozenOnWeETH() public {
-        ILiquidityPool.PermitInput memory p = createPermitInput(
-            2, address(weEthInstance), 1 ether, eETHInstance.nonces(alice),
-            type(uint256).max, eETHInstance.DOMAIN_SEPARATOR()
-        );
-
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("RECIPIENT PAUSED");
-        weEthInstance.wrapWithPermit(1 ether, p);
-    }
-
-    function test_wrapWithPermit_blocked_underPauseUntil_onWeETH() public {
-        ILiquidityPool.PermitInput memory p = createPermitInput(
-            2, address(weEthInstance), 1 ether, eETHInstance.nonces(alice),
-            type(uint256).max, eETHInstance.DOMAIN_SEPARATOR()
-        );
-
+    function test_unwrap_blockedWhenCallerOnWeETHTimer() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
 
         vm.prank(alice);
-        vm.expectRevert("RECIPIENT PAUSED");
-        weEthInstance.wrapWithPermit(1 ether, p);
-    }
-
-    // -------------------------------------------------------------------
-    //                        UNWRAP UNDER FREEZE — weETH side
-    // -------------------------------------------------------------------
-
-    function test_unwrap_blocked_whenCallerFrozenOnWeETH() public {
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        vm.prank(alice);
+        // _burn(alice, ...) triggers _beforeTokenTransfer(alice, 0, ...); sender check fires.
         vm.expectRevert("SENDER PAUSED");
         weEthInstance.unwrap(1 ether);
     }
 
-    function test_unwrap_blocked_underPauseUntil_onWeETH() public {
-        vm.prank(pauserUntil);
-        weEthInstance.pauseUntil(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        weEthInstance.unwrap(1 ether);
-    }
-
-    function test_unwrap_blockedAtPauseUntilBoundary_onWeETH() public {
+    function test_unwrap_blockedAtTimerBoundary_onWeETH() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 expiry = weEthInstance.pausedUntil(alice);
@@ -316,7 +297,7 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.unwrap(1 ether);
     }
 
-    function test_unwrap_worksAfterPauseUntilExpiry_onWeETH() public {
+    function test_unwrap_worksAfterTimerExpiry_onWeETH() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 expiry = weEthInstance.pausedUntil(alice);
@@ -327,22 +308,10 @@ contract WeETHPauseTest is TestSetup {
     }
 
     // -------------------------------------------------------------------
-    //     CROSS-TOKEN FREEZE — freeze on eETH propagates to WeETH flows
+    //                 WRAP / UNWRAP UNDER CROSS-TOKEN TIMER (eETH side)
     // -------------------------------------------------------------------
 
-    function test_wrap_blocked_whenCallerFrozenOnEETH() public {
-        _grantEETHPauserRole(pauser);
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(alice);
-        // wrap's eETH.transferFrom fails before weETH._mint runs, because mintShares
-        // routes through _transferShares (sender=alice is frozen on eETH).
-        vm.expectRevert("SENDER PAUSED");
-        weEthInstance.wrap(1 ether);
-    }
-
-    function test_wrap_blocked_underPauseUntil_onEETH() public {
+    function test_wrap_blockedWhenCallerOnEETHTimer() public {
         _grantEETHPauserUntilRole(pauserUntil);
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
@@ -352,19 +321,7 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrap(1 ether);
     }
 
-    function test_unwrap_blocked_whenCallerFrozenOnEETH() public {
-        _grantEETHPauserRole(pauser);
-        vm.prank(pauser);
-        eETHInstance.pause(alice);
-
-        vm.prank(alice);
-        // weETH._burn succeeds (msg.sender frozen on eETH, not weETH), but the
-        // subsequent eETH.transfer(alice, ...) fails with recipient=alice frozen.
-        vm.expectRevert("RECIPIENT PAUSED");
-        weEthInstance.unwrap(1 ether);
-    }
-
-    function test_unwrap_blocked_underPauseUntil_onEETH() public {
+    function test_unwrap_blockedWhenCallerOnEETHTimer() public {
         _grantEETHPauserUntilRole(pauserUntil);
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
@@ -374,48 +331,72 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.unwrap(1 ether);
     }
 
-    /// @dev C-2: freezing the WeETH contract's own eETH account bricks wrap for all.
-    function test_SECURITY_freezingWeETHOnEETH_bricksWrapForAll() public {
-        _grantEETHPauserRole(pauser);
-        vm.prank(pauser);
-        eETHInstance.pause(address(weEthInstance));
+    function test_wrap_blockedWhenGlobalPausedOnEETH() public {
+        _grantEETHPauserRole(pauserUntil); // reuse the EOA; grant separate strong role on eETH
+        vm.prank(pauserUntil);
+        eETHInstance.pause();
 
-        vm.prank(bob); // bob is NOT frozen on either token
-        vm.expectRevert("RECIPIENT PAUSED");
+        vm.prank(alice);
+        // wrap path goes through eETH._transferShares which now reverts "PAUSED" (global).
+        vm.expectRevert("PAUSED");
         weEthInstance.wrap(1 ether);
     }
 
-    function test_SECURITY_freezingWeETHOnEETH_bricksUnwrapForAll() public {
-        _grantEETHPauserRole(pauser);
-        vm.prank(pauser);
-        eETHInstance.pause(address(weEthInstance));
+    function test_unwrap_blockedWhenGlobalPausedOnEETH() public {
+        _grantEETHPauserRole(pauserUntil);
+        vm.prank(pauserUntil);
+        eETHInstance.pause();
 
-        vm.prank(bob);
-        vm.expectRevert("SENDER PAUSED");
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
         weEthInstance.unwrap(1 ether);
     }
 
-    function test_weETHFreeze_doesNotTouchEETH() public {
+    function test_weETHFreeze_doesNotTouchEETHTransfers() public {
         vm.prank(pauser);
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
 
         vm.prank(alice);
         eETHInstance.transfer(bob, 1 ether); // must succeed
     }
 
     // -------------------------------------------------------------------
-    //                       TIMER SEMANTICS (WeETH)
+    //                     PER-USER TIMER BASIC TRANSFERS
     // -------------------------------------------------------------------
 
-    function test_pauseUntil_expiresAfterOneDay() public {
+    function test_pauseUntil_blocksSender() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        uint64 expiry = weEthInstance.pausedUntil(alice);
-
-        vm.warp(uint256(expiry) + 1);
 
         vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
         weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_pauseUntil_blocksRecipient() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(bob);
+        vm.expectRevert("RECIPIENT PAUSED");
+        weEthInstance.transfer(alice, 1 ether);
+    }
+
+    function test_pauseUntil_blocksSelfTransfer() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.transfer(alice, 1 ether);
+    }
+
+    function test_pauseUntil_isPerUser_othersUnaffected() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(bob);
+        weEthInstance.transfer(chad, 1 ether);
     }
 
     function test_pauseUntil_blockedAtBoundary() public {
@@ -429,16 +410,15 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.transfer(bob, 1 ether);
     }
 
-    function test_pauseUntil_silentNoOp_whilePaused() public {
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-        uint64 before = weEthInstance.pausedUntil(alice);
-
+    function test_pauseUntil_expiresAfterOneDay() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint64 expiry = weEthInstance.pausedUntil(alice);
 
-        assertEq(weEthInstance.pausedUntil(alice), before);
-        assertTrue(weEthInstance.paused(alice));
+        vm.warp(uint256(expiry) + 1);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 1 ether);
     }
 
     function test_pauseUntil_cannotExtend_whileTimerActive() public {
@@ -467,29 +447,32 @@ contract WeETHPauseTest is TestSetup {
     }
 
     // -------------------------------------------------------------------
-    //                            UNPAUSE SEMANTICS
+    //                        extendPauseUntil SEMANTICS
     // -------------------------------------------------------------------
 
-    function test_unpause_clearsBothFlags_whenFullyFrozen() public {
+    function test_extendPauseUntil_extendsLiveTimer() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        assertTrue(weEthInstance.paused(alice));
-        assertGt(weEthInstance.pausedUntil(alice), block.timestamp);
 
         vm.prank(pauser);
-        weEthInstance.unpause(alice);
+        weEthInstance.extendPauseUntil(alice, 7 days);
 
-        assertFalse(weEthInstance.paused(alice));
-        assertEq(weEthInstance.pausedUntil(alice), 0);
-
-        vm.prank(alice);
-        weEthInstance.transfer(bob, 1 ether);
+        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + 7 days);
     }
 
-    function test_unpause_afterExpiry_leavesStaleTimer() public {
+    /// @dev H-1 (HIGH): extendPauseUntil can shorten the timer.
+    function test_SECURITY_extendPauseUntil_canShortenTimer() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        weEthInstance.extendPauseUntil(alice, 1 hours);
+
+        assertLt(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY,
+                 "extend allowed to shorten (H-1)");
+    }
+
+    function test_extendPauseUntil_silentNoOp_whenTimerExpired() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
         uint64 expiry = weEthInstance.pausedUntil(alice);
@@ -497,28 +480,100 @@ contract WeETHPauseTest is TestSetup {
         vm.warp(uint256(expiry) + 1);
 
         vm.prank(pauser);
-        weEthInstance.unpause(alice);
+        weEthInstance.extendPauseUntil(alice, 3 days);
 
-        assertEq(weEthInstance.pausedUntil(alice), expiry, "stale expiry remains (M-2)");
-        assertFalse(weEthInstance.paused(alice));
+        assertEq(weEthInstance.pausedUntil(alice), expiry, "no-op on expired (M-1-new)");
     }
 
-    function test_unpause_noop_whenNeverPaused() public {
+    function test_extendPauseUntil_silentNoOp_whenNeverArmed() public {
         vm.prank(pauser);
-        weEthInstance.unpause(alice);
-        assertFalse(weEthInstance.paused(alice));
+        weEthInstance.extendPauseUntil(alice, 3 days);
         assertEq(weEthInstance.pausedUntil(alice), 0);
+    }
+
+    // -------------------------------------------------------------------
+    //                        cancelPauseUntil SEMANTICS
+    // -------------------------------------------------------------------
+
+    function test_cancelPauseUntil_clearsActiveTimer() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        weEthInstance.cancelPauseUntil(alice);
+
+        assertEq(weEthInstance.pausedUntil(alice), 0);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 1 ether);
+    }
+
+    function test_cancelPauseUntil_emitsEvenWhenNeverArmed() public {
+        vm.expectEmit(true, false, false, true);
+        emit CancelledPauseUntil(alice);
+        vm.prank(pauser);
+        weEthInstance.cancelPauseUntil(alice);
+    }
+
+    function test_cancelPauseUntil_isPerUser() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(bob);
+
+        vm.prank(pauser);
+        weEthInstance.cancelPauseUntil(alice);
+
+        assertEq(weEthInstance.pausedUntil(alice), 0);
+        assertGt(weEthInstance.pausedUntil(bob), block.timestamp);
+    }
+
+    // -------------------------------------------------------------------
+    //                       GLOBAL ⨯ PER-USER INTERACTION
+    // -------------------------------------------------------------------
+
+    function test_globalPause_dominatesTimer() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        weEthInstance.pause();
+
+        vm.prank(bob);
+        vm.expectRevert("PAUSED");
+        weEthInstance.transfer(chad, 1 ether);
+    }
+
+    function test_globalUnpause_leavesTimerInEffect() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        weEthInstance.pause();
+        vm.prank(pauser);
+        weEthInstance.unpause();
+
+        vm.prank(alice);
+        vm.expectRevert("SENDER PAUSED");
+        weEthInstance.transfer(bob, 1 ether);
     }
 
     // -------------------------------------------------------------------
     //                              EVENTS
     // -------------------------------------------------------------------
 
-    function test_pause_emitsIndexedUser() public {
-        vm.expectEmit(true, false, false, true);
-        emit Paused(alice);
+    function test_pause_emitsPaused() public {
+        vm.expectEmit(false, false, false, true);
+        emit Paused();
         vm.prank(pauser);
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
+    }
+
+    function test_unpause_emitsUnpaused() public {
+        vm.expectEmit(false, false, false, true);
+        emit Unpaused();
+        vm.prank(pauser);
+        weEthInstance.unpause();
     }
 
     function test_pauseUntil_emitsIndexedUserAndExpiry() public {
@@ -528,20 +583,34 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.pauseUntil(alice);
     }
 
-    function test_unpause_emitsIndexedUser() public {
+    function test_extendPauseUntil_emitsPausedUntil_whenActive() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        uint64 expected = uint64(block.timestamp) + 3 days;
         vm.expectEmit(true, false, false, true);
-        emit Unpaused(alice);
+        emit PausedUntil(alice, expected);
         vm.prank(pauser);
-        weEthInstance.unpause(alice);
+        weEthInstance.extendPauseUntil(alice, 3 days);
+    }
+
+    function test_cancelPauseUntil_emitsCancelledPauseUntil() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.expectEmit(true, false, false, true);
+        emit CancelledPauseUntil(alice);
+        vm.prank(pauser);
+        weEthInstance.cancelPauseUntil(alice);
     }
 
     // -------------------------------------------------------------------
     //                     NON-TRANSFER PATHS DURING FREEZE
     // -------------------------------------------------------------------
 
-    function test_approve_notBlockedByFreeze() public {
+    function test_approve_worksDuringGlobalPause() public {
         vm.prank(pauser);
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
 
         vm.prank(alice);
         weEthInstance.approve(bob, 1 ether);
@@ -550,7 +619,7 @@ contract WeETHPauseTest is TestSetup {
 
     function test_getters_workWhileFrozen() public {
         vm.prank(pauser);
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
 
         weEthInstance.getRate();
         weEthInstance.getEETHByWeETH(1 ether);
@@ -559,14 +628,21 @@ contract WeETHPauseTest is TestSetup {
     }
 
     // -------------------------------------------------------------------
-    //                               FUZZING
+    //                                FUZZING
     // -------------------------------------------------------------------
 
     function testFuzz_pause_revertsForNonPauser(address caller) public {
         vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
+    }
+
+    function testFuzz_unpause_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.unpause();
     }
 
     function testFuzz_pauseUntil_revertsForNonPauserUntil(address caller) public {
@@ -576,11 +652,18 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.pauseUntil(alice);
     }
 
-    function testFuzz_unpause_revertsForNonPauser(address caller) public {
+    function testFuzz_extendPauseUntil_revertsForNonPauser(address caller) public {
         vm.assume(caller != pauser);
         vm.prank(caller);
         vm.expectRevert("IncorrectRole");
-        weEthInstance.unpause(alice);
+        weEthInstance.extendPauseUntil(alice, ONE_DAY);
+    }
+
+    function testFuzz_cancelPauseUntil_revertsForNonPauser(address caller) public {
+        vm.assume(caller != pauser);
+        vm.prank(caller);
+        vm.expectRevert("IncorrectRole");
+        weEthInstance.cancelPauseUntil(alice);
     }
 
     function testFuzz_pauseUntil_setsOneDayFromWarpedTimestamp(uint64 warpTo) public {
@@ -593,37 +676,71 @@ contract WeETHPauseTest is TestSetup {
         assertEq(weEthInstance.pausedUntil(alice), warpTo + ONE_DAY);
     }
 
-    function testFuzz_senderFrozen_blocksAnyAmount(uint256 amount) public {
+    function testFuzz_extendPauseUntil_setsArbitraryDuration(uint64 duration) public {
+        duration = uint64(bound(uint256(duration), 1, 365 days));
+
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+
+        vm.prank(pauser);
+        weEthInstance.extendPauseUntil(alice, duration);
+
+        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + duration);
+    }
+
+    function testFuzz_globalPause_blocksTransferAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(alice));
 
         vm.prank(pauser);
-        weEthInstance.pause(alice);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.transfer(bob, amount);
+    }
+
+    function testFuzz_globalPause_blocksWrap(uint256 amount) public {
+        amount = bound(amount, 1, eETHInstance.balanceOf(alice));
+
+        vm.prank(pauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.wrap(amount);
+    }
+
+    function testFuzz_globalPause_blocksUnwrap(uint256 amount) public {
+        amount = bound(amount, 1, weEthInstance.balanceOf(alice));
+
+        vm.prank(pauser);
+        weEthInstance.pause();
+
+        vm.prank(alice);
+        vm.expectRevert("PAUSED");
+        weEthInstance.unwrap(amount);
+    }
+
+    function testFuzz_senderTimer_blocksAnyAmount(uint256 amount) public {
+        amount = bound(amount, 1, weEthInstance.balanceOf(alice));
+
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
 
         vm.prank(alice);
         vm.expectRevert("SENDER PAUSED");
         weEthInstance.transfer(bob, amount);
     }
 
-    function testFuzz_recipientFrozen_blocksAnyAmount(uint256 amount) public {
+    function testFuzz_recipientTimer_blocksAnyAmount(uint256 amount) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(bob));
 
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
 
         vm.prank(bob);
         vm.expectRevert("RECIPIENT PAUSED");
         weEthInstance.transfer(alice, amount);
-    }
-
-    function testFuzz_wrapBlockedWhenFrozenOnWeETH(uint256 amount) public {
-        amount = bound(amount, 1, eETHInstance.balanceOf(alice));
-
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("RECIPIENT PAUSED");
-        weEthInstance.wrap(amount);
     }
 
     function testFuzz_wrapBlockedUnderPauseUntil_onWeETH(uint256 amount, uint64 delta) public {
@@ -640,17 +757,6 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.wrap(amount);
     }
 
-    function testFuzz_unwrapBlockedWhenFrozenOnWeETH(uint256 amount) public {
-        amount = bound(amount, 1, weEthInstance.balanceOf(alice));
-
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        weEthInstance.unwrap(amount);
-    }
-
     function testFuzz_unwrapBlockedUnderPauseUntil_onWeETH(uint256 amount, uint64 delta) public {
         amount = bound(amount, 1, weEthInstance.balanceOf(alice));
         delta = uint64(bound(uint256(delta), 0, ONE_DAY));
@@ -665,30 +771,14 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.unwrap(amount);
     }
 
-    function testFuzz_unfrozenUsers_unaffected(uint256 amount) public {
-        amount = bound(amount, 1, weEthInstance.balanceOf(bob));
-
-        vm.prank(pauser);
-        weEthInstance.pause(alice);
-
-        uint256 bobBefore = weEthInstance.balanceOf(bob);
-        uint256 chadBefore = weEthInstance.balanceOf(chad);
-
-        vm.prank(bob);
-        weEthInstance.transfer(chad, amount);
-
-        assertEq(weEthInstance.balanceOf(bob), bobBefore - amount);
-        assertEq(weEthInstance.balanceOf(chad), chadBefore + amount);
-    }
-
-    function testFuzz_independentUsers_freezeIsolated(address userA, address userB) public {
+    function testFuzz_independentUsers_timerIsolated(address userA, address userB) public {
         vm.assume(userA != address(0) && userB != address(0));
         vm.assume(userA != userB);
 
-        vm.prank(pauser);
-        weEthInstance.pause(userA);
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(userA);
 
-        assertTrue(weEthInstance.paused(userA));
-        assertFalse(weEthInstance.paused(userB));
+        assertGt(weEthInstance.pausedUntil(userA), block.timestamp);
+        assertEq(weEthInstance.pausedUntil(userB), 0);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes core `eETH`/`weETH` mint/burn/transfer paths and introduces new upgrade-safe storage layout changes (immutables + deprecated slots) that could impact token movement if misconfigured.
> 
> **Overview**
> Adds a **hybrid pause system** to `EETH` and `WeETH`: a global `paused` flag plus a per-user `pausedUntil` timer, both role-gated (`*_PAUSER_ROLE` and `*_PAUSER_UNTIL_ROLE`) with new events and helper `isPausedUntil` getters.
> 
> Enforces these pause checks across **token movement and supply changes**: `eETH` now blocks share transfers, minting, and burning when globally paused or when either party is time-paused; `weETH` blocks transfers/mints/burns via `_beforeTokenTransfer` and exposes matching pause APIs.
> 
> Hardens related flows by preventing paused users from interacting via `MembershipManager` (wrap/withdraw paths) and `MembershipNFT` transfers, updates `IeETH`/`IWeETH` interfaces accordingly, adjusts constructors/initializers to use immutable dependencies with deprecated storage fields for upgrade compatibility, and adds extensive new tests covering pause semantics and role gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0188cc89101484a2e976cbdbc074f29281d6a9d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->