### PR TITLE
T1-7 Hardcode Exit Fee Maximum and T2-3 Hardcoded Safety Floors

### DIFF
--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -84,7 +84,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         if (_priorityWithdrawalQueue == address(0)) revert InvalidPriorityWithdrawalQueue();
         if (_maxFinalizedWithdrawalAmountPerDay == 0) revert InvalidMaxFinalizedWithdrawalAmountPerDay();
         if (_maxNumValidatorsToApprovePerDay == 0) revert InvalidMaxNumValidatorsToApprovePerDay();
-        if (_maxAcceptableRebaseAprInBps < 0) revert InvalidMaxAcceptableRebaseApr();
+        if (_maxAcceptableRebaseAprInBps <= 0 || _maxAcceptableRebaseAprInBps > 10_000) revert InvalidMaxAcceptableRebaseApr();
         if (_maxValidatorTaskBatchSize == 0) revert InvalidValidatorTaskBatchSize();
         _disableInitializers();
         priorityWithdrawalQueue = IPriorityWithdrawalQueue(_priorityWithdrawalQueue);

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -56,6 +56,9 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     bytes32 public constant ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE = keccak256("ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE");
     bytes32 public constant ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE = keccak256("ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE");
 
+    int256 public immutable MAX_ACCEPTABLE_REBASE_APR_IN_BPS;
+    uint256 public immutable MAX_VALIDATOR_TASK_BATCH_SIZE;
+
     event AdminUpdated(address _address, bool _isAdmin);
     event AdminOperationsExecuted(address indexed _address, bytes32 indexed _reportHash);
 
@@ -64,9 +67,13 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     event ValidatorApprovalTaskInvalidated(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
 
     error IncorrectRole();
+    error InvalidAcceptableRebaseApr();
+    error InvalidValidatorTaskBatchSize();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(int256 _maxAcceptableRebaseAprInBps, uint256 _maxValidatorTaskBatchSize) {
+        MAX_ACCEPTABLE_REBASE_APR_IN_BPS = _maxAcceptableRebaseAprInBps;
+        MAX_VALIDATOR_TASK_BATCH_SIZE = _maxValidatorTaskBatchSize;
         _disableInitializers();
     }
 
@@ -162,6 +169,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     function setValidatorTaskBatchSize(uint16 _batchSize) external {
         if(!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if (_batchSize > MAX_VALIDATOR_TASK_BATCH_SIZE) revert InvalidValidatorTaskBatchSize();
         validatorTaskBatchSize = _batchSize;
     }
 
@@ -302,6 +310,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     function updateAcceptableRebaseApr(int32 _acceptableRebaseAprInBps) external {
         if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if (_acceptableRebaseAprInBps < 0 || _acceptableRebaseAprInBps > MAX_ACCEPTABLE_REBASE_APR_IN_BPS) revert InvalidAcceptableRebaseApr();
         acceptableRebaseAprInBps = _acceptableRebaseAprInBps;
     }
 

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -69,9 +69,11 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     error IncorrectRole();
     error InvalidAcceptableRebaseApr();
     error InvalidValidatorTaskBatchSize();
+    error InvalidMaxAcceptableRebaseApr();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(int256 _maxAcceptableRebaseAprInBps, uint256 _maxValidatorTaskBatchSize) {
+        if (_maxAcceptableRebaseAprInBps < 0 || _maxAcceptableRebaseAprInBps > 10000) revert InvalidMaxAcceptableRebaseApr();
         MAX_ACCEPTABLE_REBASE_APR_IN_BPS = _maxAcceptableRebaseAprInBps;
         MAX_VALIDATOR_TASK_BATCH_SIZE = _maxValidatorTaskBatchSize;
         _disableInitializers();

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -186,7 +186,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     function setValidatorTaskBatchSize(uint16 _batchSize) external {
         if(!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
-        if (_batchSize > MAX_VALIDATOR_TASK_BATCH_SIZE) revert InvalidValidatorTaskBatchSize();
+        if (_batchSize == 0 || _batchSize > MAX_VALIDATOR_TASK_BATCH_SIZE) revert InvalidValidatorTaskBatchSize();
         validatorTaskBatchSize = _batchSize;
     }
 

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -73,6 +73,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _liquidityPool, address _eEth, address _weEth, address _treasury, address _roleRegistry, address _etherFiRestaker, address _priorityWithdrawalQueue, uint256 _maxExitFeeSplitToTreasuryInBps, uint256 _maxExitFeeInBps, uint256 _maxLowWatermarkInBpsOfTvl) {
+        if (_maxExitFeeSplitToTreasuryInBps > BASIS_POINT_SCALE || _maxExitFeeInBps > BASIS_POINT_SCALE || _maxLowWatermarkInBpsOfTvl > BASIS_POINT_SCALE) revert InvalidAmount();
         MAX_EXIT_FEE_SPLIT_TO_TREASURY_IN_BPS = _maxExitFeeSplitToTreasuryInBps;
         MAX_EXIT_FEE_IN_BPS = _maxExitFeeInBps;
         MAX_LOW_WATERMARK_IN_BPS_OF_TVL = _maxLowWatermarkInBpsOfTvl;

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -101,9 +101,9 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
 
     function initializeTokenParameters(address[] memory _tokens, uint16[] memory _exitFeeSplitToTreasuryInBps, uint16[] memory _exitFeeInBps, uint16[] memory _lowWatermarkInBpsOfTvl, uint256[] memory _bucketCapacity, uint256[] memory _bucketRefillRate)  external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
         for(uint256 i = 0; i < _exitFeeSplitToTreasuryInBps.length; i++) {
-            require(_exitFeeSplitToTreasuryInBps[i] <= BASIS_POINT_SCALE, "INVALID");
-            require(_exitFeeInBps[i] <= BASIS_POINT_SCALE, "INVALID");
-            require(_lowWatermarkInBpsOfTvl[i] <= BASIS_POINT_SCALE, "INVALID");
+            require (_exitFeeSplitToTreasuryInBps[i] <= MAX_EXIT_FEE_SPLIT_TO_TREASURY_IN_BPS, "Exceeds max exit fee split to treasury");
+            require (_exitFeeInBps[i] <= MAX_EXIT_FEE_IN_BPS, "Exceeds max exit fee");
+            require (_lowWatermarkInBpsOfTvl[i] <= MAX_LOW_WATERMARK_IN_BPS_OF_TVL, "Exceeds max low watermark of tvl");
             tokenToRedemptionInfo[address(_tokens[i])] = RedemptionInfo({
                 limit: BucketLimiter.create(_convertToBucketUnit(_bucketCapacity[i], Math.Rounding.Down), _convertToBucketUnit(_bucketRefillRate[i], Math.Rounding.Down)),
                 exitFeeSplitToTreasuryInBps: _exitFeeSplitToTreasuryInBps[i],

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -43,7 +43,6 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
 
     uint256 private constant BUCKET_UNIT_SCALE = 1e12;
     uint256 private constant BASIS_POINT_SCALE = 1e4;
-    uint256 private constant MAX_EXIT_FEE_BASIS_POINTS = 100; // 1%
 
     bytes32 public constant ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE = keccak256("ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE");
     address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
@@ -57,6 +56,10 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
     ILido public immutable lido;
     IPriorityWithdrawalQueue public immutable priorityWithdrawalQueue;
 
+    uint256 public immutable MAX_EXIT_FEE_SPLIT_TO_TREASURY_IN_BPS;
+    uint256 public immutable MAX_EXIT_FEE_IN_BPS;
+    uint256 public immutable MAX_LOW_WATERMARK_IN_BPS_OF_TVL;
+
     mapping(address => RedemptionInfo) public tokenToRedemptionInfo;
 
 
@@ -69,7 +72,10 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
     receive() external payable {}
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _liquidityPool, address _eEth, address _weEth, address _treasury, address _roleRegistry, address _etherFiRestaker, address _priorityWithdrawalQueue) {
+    constructor(address _liquidityPool, address _eEth, address _weEth, address _treasury, address _roleRegistry, address _etherFiRestaker, address _priorityWithdrawalQueue, uint256 _maxExitFeeSplitToTreasuryInBps, uint256 _maxExitFeeInBps, uint256 _maxLowWatermarkInBpsOfTvl) {
+        MAX_EXIT_FEE_SPLIT_TO_TREASURY_IN_BPS = _maxExitFeeSplitToTreasuryInBps;
+        MAX_EXIT_FEE_IN_BPS = _maxExitFeeInBps;
+        MAX_LOW_WATERMARK_IN_BPS_OF_TVL = _maxLowWatermarkInBpsOfTvl;
         roleRegistry = RoleRegistry(_roleRegistry);
         treasury = _treasury;
         liquidityPool = ILiquidityPool(payable(_liquidityPool));
@@ -316,17 +322,17 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
      * @param token The token to set the exit fee for
      */
     function setExitFeeBasisPoints(uint16 _exitFeeInBps, address token) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
-        require(_exitFeeInBps <= MAX_EXIT_FEE_BASIS_POINTS, "Exceeds max exit fee");
+        require(_exitFeeInBps <= MAX_EXIT_FEE_IN_BPS, "Exceeds max exit fee");
         tokenToRedemptionInfo[token].exitFeeInBps = _exitFeeInBps;
     }
 
     function setLowWatermarkInBpsOfTvl(uint16 _lowWatermarkInBpsOfTvl, address token) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
-        require(_lowWatermarkInBpsOfTvl <= BASIS_POINT_SCALE, "INVALID");
+        require(_lowWatermarkInBpsOfTvl <= MAX_LOW_WATERMARK_IN_BPS_OF_TVL, "Exceeds max low watermark of tvl");
         tokenToRedemptionInfo[token].lowWatermarkInBpsOfTvl = _lowWatermarkInBpsOfTvl;
     }
 
     function setExitFeeSplitToTreasuryInBps(uint16 _exitFeeSplitToTreasuryInBps, address token) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
-        require(_exitFeeSplitToTreasuryInBps <= BASIS_POINT_SCALE, "INVALID");
+        require(_exitFeeSplitToTreasuryInBps <= MAX_EXIT_FEE_SPLIT_TO_TREASURY_IN_BPS, "Exceeds max exit fee split to treasury");
         tokenToRedemptionInfo[token].exitFeeSplitToTreasuryInBps = _exitFeeSplitToTreasuryInBps;
     }
 

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -43,6 +43,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
 
     uint256 private constant BUCKET_UNIT_SCALE = 1e12;
     uint256 private constant BASIS_POINT_SCALE = 1e4;
+    uint256 private constant MAX_EXIT_FEE_BASIS_POINTS = 100; // 1%
 
     bytes32 public constant ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE = keccak256("ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE");
     address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
@@ -315,7 +316,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Reentra
      * @param token The token to set the exit fee for
      */
     function setExitFeeBasisPoints(uint16 _exitFeeInBps, address token) external hasRole(ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE) {
-        require(_exitFeeInBps <= BASIS_POINT_SCALE, "INVALID");
+        require(_exitFeeInBps <= MAX_EXIT_FEE_BASIS_POINTS, "Exceeds max exit fee");
         tokenToRedemptionInfo[token].exitFeeInBps = _exitFeeInBps;
     }
 

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -75,6 +75,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
     //--------------------------------------------------------------------------------------
 
     address public immutable priorityWithdrawalQueue;
+    uint256 public immutable MIN_AMOUNT_FOR_SHARE;
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ROLES  ---------------------------------------
@@ -117,14 +118,16 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
     error IncorrectRole();
     error InvalidValidatorSize();
     error InvalidArrayLengths();
+    error InvalidAmountForShare();
 
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _priorityWithdrawalQueue) {
+    constructor(address _priorityWithdrawalQueue, uint256 _minAmountForShare) {
         priorityWithdrawalQueue = _priorityWithdrawalQueue;
+        MIN_AMOUNT_FOR_SHARE = _minAmountForShare;
         _disableInitializers();
     }
 
@@ -132,6 +135,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         if (msg.value > type(uint128).max) revert InvalidAmount();
         totalValueOutOfLp -= uint128(msg.value);
         totalValueInLp += uint128(msg.value);
+        _checkMinAmountForShare();
     }
 
     function initialize(address _eEthAddress, address _stakingManagerAddress, address _nodesManagerAddress, address _membershipManagerAddress, address _tNftAddress, address _etherFiAdminContract, address _withdrawRequestNFT) external initializer {
@@ -236,6 +240,8 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         totalValueInLp -= uint128(_amount);
 
         eETH.burnShares(msg.sender, share);
+
+        _checkMinAmountForShare();
 
         _sendFund(_recipient, _amount);
 
@@ -441,6 +447,8 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         totalValueOutOfLp = uint128(int128(totalValueOutOfLp) + _accruedRewards);
 
+        _checkMinAmountForShare();
+
         emit Rebase(getTotalPooledEther(), eETH.totalShares());
     }
 
@@ -498,6 +506,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
     function burnEEthShares(uint256 shares) external {
         if (msg.sender != address(etherFiRedemptionManager) && msg.sender != address(withdrawRequestNFT) && msg.sender != priorityWithdrawalQueue) revert IncorrectCaller();
         eETH.burnShares(msg.sender, shares);
+        _checkMinAmountForShare();
     }
 
     function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external {
@@ -511,6 +520,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         totalValueOutOfLp -= uint128(_withdrawalValueInETH);
 
         eETH.burnShares(msg.sender, _amountSharesToBurn);
+        _checkMinAmountForShare();
         emit EEthSharesBurnedForNonETHWithdrawal(_amountSharesToBurn, _withdrawalValueInETH);
     }
 
@@ -526,6 +536,8 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
         if (amount > type(uint128).max || amount == 0 || share == 0) revert InvalidAmount();
 
         eETH.mintShares(_recipient, share);
+
+        _checkMinAmountForShare();
 
         return share;
     }
@@ -547,6 +559,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
     function _accountForEthSentOut(uint256 _amount) internal {
         totalValueOutOfLp += uint128(_amount);
         totalValueInLp -= uint128(_amount);
+        _checkMinAmountForShare();
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
@@ -596,6 +609,10 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, IL
             return 0;
         }
         return (_share * getTotalPooledEther()) / totalShares;
+    }
+
+    function _checkMinAmountForShare() internal view {
+        if (amountForShare(1 ether) < MIN_AMOUNT_FOR_SHARE) revert InvalidAmountForShare();
     }
 
     function getImplementation() external view returns (address) {return _getImplementation();}

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1013,6 +1013,40 @@ contract EtherFiOracleTest is TestSetup {
         etherFiAdminInstance.setValidatorTaskBatchSize(75);
     }
 
+    function test_setValidatorTaskBatchSize_guardrail() public {
+        uint256 maxBatchSize = etherFiAdminInstance.MAX_VALIDATOR_TASK_BATCH_SIZE();
+        assertEq(maxBatchSize, 1_000); // configured in TestSetup
+
+        // boundary value is accepted
+        vm.prank(alice);
+        etherFiAdminInstance.setValidatorTaskBatchSize(uint16(maxBatchSize));
+
+        // one above the cap reverts
+        vm.prank(alice);
+        vm.expectRevert(EtherFiAdmin.InvalidValidatorTaskBatchSize.selector);
+        etherFiAdminInstance.setValidatorTaskBatchSize(uint16(maxBatchSize + 1));
+    }
+
+    function test_updateAcceptableRebaseApr_guardrail() public {
+        int256 maxApr = etherFiAdminInstance.MAX_ACCEPTABLE_REBASE_APR_IN_BPS();
+        assertEq(maxApr, 10_000); // configured in TestSetup
+
+        // boundary value is accepted
+        vm.prank(alice);
+        etherFiAdminInstance.updateAcceptableRebaseApr(int32(maxApr));
+        assertEq(etherFiAdminInstance.acceptableRebaseAprInBps(), int32(maxApr));
+
+        // negative limit is not allowed in acceptable rebase apr
+        vm.prank(alice);
+        vm.expectRevert(EtherFiAdmin.InvalidAcceptableRebaseApr.selector);
+        etherFiAdminInstance.updateAcceptableRebaseApr(-1);
+
+        // one above the cap reverts
+        vm.prank(alice);
+        vm.expectRevert(EtherFiAdmin.InvalidAcceptableRebaseApr.selector);
+        etherFiAdminInstance.updateAcceptableRebaseApr(int32(maxApr + 1));
+    }
+
     function test_executeValidatorApprovalTask() public {
         // RoleRegistry is already initialized and alice already has the role in setUpTests
 

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1050,43 +1050,43 @@ contract EtherFiOracleTest is TestSetup {
     function test_constructor_priorityWithdrawalQueue_guardrail() public {
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidPriorityWithdrawalQueue.selector);
-        new EtherFiAdmin(address(0x0), 1_000, 1_000, 0, 1_000);
+        new EtherFiAdmin(address(0x0), 1_000, 1_000, 500, 1_000);
     }
 
     function test_constructor_maxFinalizedWithdrawalAmountPerDay_guardrail() public {
-        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 0, 1_000);
+        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 500, 1_000);
         assertEq(nonZeroValue.MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY(), 1_000);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidMaxFinalizedWithdrawalAmountPerDay.selector);
-        new EtherFiAdmin(address(0x1234), 0, 1_000, 0, 1_000);
+        new EtherFiAdmin(address(0x1234), 0, 1_000, 500, 1_000);
     }
 
     function test_constructor_maxNumValidatorsToApprovePerDay_guardrail() public {
-        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 100, 0, 1_000);
+        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 100, 500, 1_000);
         assertEq(nonZeroValue.MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY(), 100);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidMaxNumValidatorsToApprovePerDay.selector);
-        new EtherFiAdmin(address(0x1234), 1_000, 0, 0, 1_000); // 0 is invalid
+        new EtherFiAdmin(address(0x1234), 1_000, 0, 500, 1_000); // 0 is invalid
     }
 
     function test_constructor_maxValidatorTaskBatchSize_guardrail() public {
-        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 0, 1_000);
+        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 500, 1_000);
         assertEq(nonZeroValue.MAX_VALIDATOR_TASK_BATCH_SIZE(), 1_000);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidValidatorTaskBatchSize.selector);
-        new EtherFiAdmin(address(0x1234), 1_000, 1_000, 0, 0);
+        new EtherFiAdmin(address(0x1234), 1_000, 1_000, 500, 0);
     }
 
     function test_constructor_maxAcceptableRebaseAprInBps_guardrail() public {
-        // boundary values are accepted
-        EtherFiAdmin lowerBoundary = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 0, 1_000);
-        assertEq(lowerBoundary.MAX_ACCEPTABLE_REBASE_APR_IN_BPS(), 0);
+        EtherFiAdmin validValue = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 500, 1_000);
+        assertEq(validValue.MAX_ACCEPTABLE_REBASE_APR_IN_BPS(), 500);
 
-        EtherFiAdmin upperBoundary = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 10_000, 1_000);
-        assertEq(upperBoundary.MAX_ACCEPTABLE_REBASE_APR_IN_BPS(), 10_000);
+        // value 0 reverts
+        vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
+        new EtherFiAdmin(address(0x1234), 1_000, 1_000, 0, 1_000);
 
         // negative values revert
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1047,6 +1047,23 @@ contract EtherFiOracleTest is TestSetup {
         etherFiAdminInstance.updateAcceptableRebaseApr(int32(maxApr + 1));
     }
 
+    function test_constructor_maxAcceptableRebaseAprInBps_guardrail() public {
+        // boundary values are accepted
+        EtherFiAdmin lowerBoundary = new EtherFiAdmin(0, 1_000);
+        assertEq(lowerBoundary.MAX_ACCEPTABLE_REBASE_APR_IN_BPS(), 0);
+
+        EtherFiAdmin upperBoundary = new EtherFiAdmin(10_000, 1_000);
+        assertEq(upperBoundary.MAX_ACCEPTABLE_REBASE_APR_IN_BPS(), 10_000);
+
+        // negative values revert
+        vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
+        new EtherFiAdmin(-1, 1_000);
+
+        // values above 10_000 revert
+        vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
+        new EtherFiAdmin(10_001, 1_000);
+    }
+
     function test_executeValidatorApprovalTask() public {
         // RoleRegistry is already initialized and alice already has the role in setUpTests
 

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -120,6 +120,107 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         vm.stopPrank();
     }
 
+    function test_initializeTokenParameters_guardrails() public {
+        uint256 maxExitFee = etherFiRedemptionManagerInstance.MAX_EXIT_FEE_IN_BPS();
+        uint256 maxSplit = etherFiRedemptionManagerInstance.MAX_EXIT_FEE_SPLIT_TO_TREASURY_IN_BPS();
+        uint256 maxLowWatermark = etherFiRedemptionManagerInstance.MAX_LOW_WATERMARK_IN_BPS_OF_TVL();
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = ETH_ADDRESS;
+        uint16[] memory exitFeeSplitBps = new uint16[](1);
+        uint16[] memory exitFeeBps = new uint16[](1);
+        uint16[] memory lowWatermarkBps = new uint16[](1);
+        uint256[] memory capacities = new uint256[](1);
+        uint256[] memory refillRates = new uint256[](1);
+        capacities[0] = 5 ether;
+        refillRates[0] = 0.001 ether;
+
+        vm.startPrank(admin);
+
+        // exit fee split above cap reverts
+        exitFeeSplitBps[0] = uint16(maxSplit + 1);
+        exitFeeBps[0] = uint16(maxExitFee);
+        lowWatermarkBps[0] = uint16(maxLowWatermark);
+        vm.expectRevert("Exceeds max exit fee split to treasury");
+        etherFiRedemptionManagerInstance.initializeTokenParameters(tokens, exitFeeSplitBps, exitFeeBps, lowWatermarkBps, capacities, refillRates);
+
+        // exit fee above cap reverts
+        exitFeeSplitBps[0] = uint16(maxSplit);
+        exitFeeBps[0] = uint16(maxExitFee + 1);
+        lowWatermarkBps[0] = uint16(maxLowWatermark);
+        vm.expectRevert("Exceeds max exit fee");
+        etherFiRedemptionManagerInstance.initializeTokenParameters(tokens, exitFeeSplitBps, exitFeeBps, lowWatermarkBps, capacities, refillRates);
+
+        // low watermark above cap reverts
+        exitFeeSplitBps[0] = uint16(maxSplit);
+        exitFeeBps[0] = uint16(maxExitFee);
+        lowWatermarkBps[0] = uint16(maxLowWatermark + 1);
+        vm.expectRevert("Exceeds max low watermark of tvl");
+        etherFiRedemptionManagerInstance.initializeTokenParameters(tokens, exitFeeSplitBps, exitFeeBps, lowWatermarkBps, capacities, refillRates);
+
+        // boundary values are accepted
+        exitFeeSplitBps[0] = uint16(maxSplit);
+        exitFeeBps[0] = uint16(maxExitFee);
+        lowWatermarkBps[0] = uint16(maxLowWatermark);
+        etherFiRedemptionManagerInstance.initializeTokenParameters(tokens, exitFeeSplitBps, exitFeeBps, lowWatermarkBps, capacities, refillRates);
+        (, uint16 storedSplit, uint16 storedFee, uint16 storedLowWM) =
+            etherFiRedemptionManagerInstance.tokenToRedemptionInfo(ETH_ADDRESS);
+        assertEq(storedSplit, uint16(maxSplit));
+        assertEq(storedFee, uint16(maxExitFee));
+        assertEq(storedLowWM, uint16(maxLowWatermark));
+
+        vm.stopPrank();
+    }
+
+    function test_constructor_max_caps_guardrail() public {
+        uint256 oneAboveBasisPoints = 10_001;
+
+        // _maxExitFeeSplitToTreasuryInBps above BASIS_POINT_SCALE reverts
+        vm.expectRevert(EtherFiRedemptionManager.InvalidAmount.selector);
+        new EtherFiRedemptionManager(
+            address(liquidityPoolInstance),
+            address(eETHInstance),
+            address(weEthInstance),
+            address(treasuryInstance),
+            address(roleRegistryInstance),
+            address(etherFiRestakerInstance),
+            address(priorityQueueInstance),
+            oneAboveBasisPoints,
+            100,
+            10_000
+        );
+
+        // _maxExitFeeInBps above BASIS_POINT_SCALE reverts
+        vm.expectRevert(EtherFiRedemptionManager.InvalidAmount.selector);
+        new EtherFiRedemptionManager(
+            address(liquidityPoolInstance),
+            address(eETHInstance),
+            address(weEthInstance),
+            address(treasuryInstance),
+            address(roleRegistryInstance),
+            address(etherFiRestakerInstance),
+            address(priorityQueueInstance),
+            10_000,
+            oneAboveBasisPoints,
+            10_000
+        );
+
+        // _maxLowWatermarkInBpsOfTvl above BASIS_POINT_SCALE reverts
+        vm.expectRevert(EtherFiRedemptionManager.InvalidAmount.selector);
+        new EtherFiRedemptionManager(
+            address(liquidityPoolInstance),
+            address(eETHInstance),
+            address(weEthInstance),
+            address(treasuryInstance),
+            address(roleRegistryInstance),
+            address(etherFiRestakerInstance),
+            address(priorityQueueInstance),
+            10_000,
+            100,
+            oneAboveBasisPoints
+        );
+    }
+
     function _admin_permission_by_token(address token) public {
         address dummy = makeAddr("dummy");
         vm.startPrank(dummy);

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -86,6 +86,12 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(100_01, ETH_ADDRESS); // 100.01%
     }
 
+    function test_exit_fee_guardrail() public {
+        vm.prank(admin);
+        vm.expectRevert("Exceeds max exit fee");
+        etherFiRedemptionManagerInstance.setExitFeeBasisPoints(101, ETH_ADDRESS);
+    }
+
     function _admin_permission_by_token(address token) public {
         address dummy = makeAddr("dummy");
         vm.startPrank(dummy);
@@ -114,7 +120,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         depositAmount = bound(depositAmount, 1 ether, 1000 ether);
         redeemAmount = bound(redeemAmount, 0.1 ether, depositAmount);
         exitFeeSplitBps = bound(exitFeeSplitBps, 0, 10000);
-        exitFeeBps = uint16(bound(uint256(exitFeeBps), 0, 10000));
+        exitFeeBps = uint16(bound(uint256(exitFeeBps), 0, 100));
         lowWatermarkBps = uint16(bound(uint256(lowWatermarkBps), 0, 10000));
 
 
@@ -169,7 +175,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         depositAmount = bound(depositAmount, 1 ether, 1000 ether);
         redeemAmount = bound(redeemAmount, 0.1 ether, depositAmount);
         exitFeeSplitBps = uint16(bound(exitFeeSplitBps, 0, 10000));
-        exitFeeBps = uint16(bound(exitFeeBps, 0, 10000));
+        exitFeeBps = uint16(bound(exitFeeBps, 0, 100));
         lowWatermarkBps = uint16(bound(lowWatermarkBps, 0, 10000));
         rebase = bound(rebase, 0, int128(uint128(depositAmount) / 10));
 

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -82,14 +82,42 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(100_00, ETH_ADDRESS); // 100%
         assertEq(etherFiRedemptionManagerInstance.lowWatermarkInETH(ETH_ADDRESS), 100 ether);
 
-        vm.expectRevert("INVALID");
+        vm.expectRevert("Exceeds max low watermark of tvl");
         etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(100_01, ETH_ADDRESS); // 100.01%
     }
 
     function test_exit_fee_guardrail() public {
-        vm.prank(admin);
+        vm.startPrank(admin);
+
+        uint256 maxExitFee = etherFiRedemptionManagerInstance.MAX_EXIT_FEE_IN_BPS();
+        assertEq(maxExitFee, 100); // configured in TestSetup
+
+        // boundary value is accepted
+        etherFiRedemptionManagerInstance.setExitFeeBasisPoints(uint16(maxExitFee), ETH_ADDRESS);
+        (, , uint16 exitFeeBps, ) = etherFiRedemptionManagerInstance.tokenToRedemptionInfo(ETH_ADDRESS);
+        assertEq(exitFeeBps, uint16(maxExitFee));
+
+        // one above the cap reverts
         vm.expectRevert("Exceeds max exit fee");
-        etherFiRedemptionManagerInstance.setExitFeeBasisPoints(101, ETH_ADDRESS);
+        etherFiRedemptionManagerInstance.setExitFeeBasisPoints(uint16(maxExitFee + 1), ETH_ADDRESS);
+        vm.stopPrank();
+    }
+
+    function test_exit_fee_split_to_treasury_guardrail() public {
+        vm.startPrank(admin);
+
+        uint256 maxSplit = etherFiRedemptionManagerInstance.MAX_EXIT_FEE_SPLIT_TO_TREASURY_IN_BPS();
+        assertEq(maxSplit, 10_000); // configured in TestSetup
+
+        // boundary value is accepted
+        etherFiRedemptionManagerInstance.setExitFeeSplitToTreasuryInBps(uint16(maxSplit), ETH_ADDRESS);
+        (, uint16 exitSplit, , ) = etherFiRedemptionManagerInstance.tokenToRedemptionInfo(ETH_ADDRESS);
+        assertEq(exitSplit, uint16(maxSplit));
+
+        // one above the cap reverts
+        vm.expectRevert("Exceeds max exit fee split to treasury");
+        etherFiRedemptionManagerInstance.setExitFeeSplitToTreasuryInBps(uint16(maxSplit + 1), ETH_ADDRESS);
+        vm.stopPrank();
     }
 
     function _admin_permission_by_token(address token) public {

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -213,7 +213,7 @@ contract LiquidityPoolTest is TestSetup {
     }
 
     function test_StakingManagerFailsNotInitializedToken() public {
-        LiquidityPool liquidityPoolNoToken = new LiquidityPool(address(0x0));
+        LiquidityPool liquidityPoolNoToken = new LiquidityPool(address(0x0), 0);
 
         vm.startPrank(alice);
         vm.deal(alice, 3 ether);
@@ -763,7 +763,7 @@ contract LiquidityPoolTest is TestSetup {
     }
 
     function test_Upgrade2_49_onlyRoleRegistryOwnerCanUpgrade() public {
-        liquidityPool = address(new LiquidityPool(address(0x0)));
+        liquidityPool = address(new LiquidityPool(address(0x0), 0));
         vm.expectRevert(RoleRegistry.OnlyProtocolUpgrader.selector);
         vm.prank(address(100));
         liquidityPoolInstance.upgradeTo(liquidityPool);
@@ -1446,10 +1446,272 @@ contract LiquidityPoolTest is TestSetup {
         vm.startPrank(alice);
         liquidityPoolInstance.deposit{value: 100 ether}();
         vm.stopPrank();
-        
+
         vm.prank(address(membershipManagerInstance));
         liquidityPoolInstance.rebase(10 ether);
-        
+
         assertEq(liquidityPoolInstance.getTotalPooledEther(), 110 ether);
+    }
+
+    // ============================================================================
+    // MIN_AMOUNT_FOR_SHARE Tests
+    // ============================================================================
+    //
+    // The LiquidityPool now enforces a configurable floor on the eETH share-price.
+    // After share-supply or pooled-ether changes, `_checkMinAmountForShare()` reverts
+    // with `InvalidAmountForShare` whenever `amountForShare(1 ether) < MIN_AMOUNT_FOR_SHARE`.
+    // The check fires from: receive(), withdraw(), rebase(), burnEEthShares(),
+    // burnEEthSharesForNonETHWithdrawal(), _deposit() (every external deposit*),
+    // and _accountForEthSentOut() (validator-deposit flows).
+
+    /// @dev Deploy a fresh LiquidityPool implementation with the desired MIN and upgrade the proxy.
+    /// Preserves the existing `priorityWithdrawalQueue` immutable.
+    function _upgradeLpWithMinAmount(uint256 minAmount) internal {
+        address pq = liquidityPoolInstance.priorityWithdrawalQueue();
+        LiquidityPool newImpl = new LiquidityPool(pq, minAmount);
+        vm.prank(owner);
+        liquidityPoolInstance.upgradeTo(address(newImpl));
+    }
+
+    /// @dev Set the packed (totalValueOutOfLp, totalValueInLp) storage at slot 207.
+    /// Used to seed `totalValueOutOfLp` so a negative `rebase()` doesn't underflow before
+    /// reaching `_checkMinAmountForShare`.
+    function _setLpAccounting(uint128 valueOutOfLp, uint128 valueInLp) internal {
+        bytes32 packed = bytes32(uint256(valueOutOfLp) | (uint256(valueInLp) << 128));
+        vm.store(address(liquidityPoolInstance), bytes32(uint256(207)), packed);
+    }
+
+    // --- immutable getter ---
+
+    function test_minAmountForShare_default_is_zero_in_test_setup() public {
+        assertEq(liquidityPoolInstance.MIN_AMOUNT_FOR_SHARE(), 0);
+    }
+
+    function test_minAmountForShare_immutable_is_set_via_constructor() public {
+        LiquidityPool fresh = new LiquidityPool(address(0), 0.5 ether);
+        assertEq(fresh.MIN_AMOUNT_FOR_SHARE(), 0.5 ether);
+
+        LiquidityPool fresh2 = new LiquidityPool(address(0), type(uint256).max);
+        assertEq(fresh2.MIN_AMOUNT_FOR_SHARE(), type(uint256).max);
+    }
+
+    function test_minAmountForShare_immutable_persists_through_upgrade() public {
+        _upgradeLpWithMinAmount(0.75 ether);
+        assertEq(liquidityPoolInstance.MIN_AMOUNT_FOR_SHARE(), 0.75 ether);
+    }
+
+    // --- with MIN = 0 (check effectively disabled) ---
+
+    function test_minAmountForShare_zero_allows_empty_pool_operations() public {
+        // amountForShare(1 ether) returns 0 when totalShares == 0; with MIN=0 the strict `<` is false.
+        assertEq(liquidityPoolInstance.MIN_AMOUNT_FOR_SHARE(), 0);
+        assertEq(eETHInstance.totalShares(), 0);
+
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+        assertEq(eETHInstance.balanceOf(alice), 1 ether);
+    }
+
+    // --- deposit / mint flow ---
+
+    function test_minAmountForShare_first_deposit_passes_at_exact_boundary() public {
+        // First deposit yields ratio = exactly 1 ether per 1 ether of shares; strict `<` allows MIN = 1 ether.
+        _upgradeLpWithMinAmount(1 ether);
+
+        vm.deal(alice, 5 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 5 ether}();
+        assertEq(liquidityPoolInstance.amountForShare(1 ether), 1 ether);
+    }
+
+    function test_minAmountForShare_first_deposit_reverts_when_min_above_initial_ratio() public {
+        // Initial deposit ratio is 1 ether; MIN = 1 ether + 1 wei should reject the mint.
+        _upgradeLpWithMinAmount(1 ether + 1);
+
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    function test_minAmountForShare_subsequent_deposit_succeeds_above_min() public {
+        // Establish ratio = 1.1 ether per share (positive rebase), then upgrade with MIN below it.
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(10 ether);
+        assertEq(liquidityPoolInstance.amountForShare(1 ether), 1.1 ether);
+
+        _upgradeLpWithMinAmount(1.05 ether);
+
+        vm.deal(bob, 5 ether);
+        vm.prank(bob);
+        uint256 shares = liquidityPoolInstance.deposit{value: 5 ether}();
+        assertGt(shares, 0);
+        // Proportional minting preserves ratio.
+        assertEq(liquidityPoolInstance.amountForShare(1 ether), 1.1 ether);
+    }
+
+    // --- rebase flow ---
+
+    function test_minAmountForShare_positive_rebase_succeeds() public {
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+
+        _upgradeLpWithMinAmount(1 ether);
+
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(20 ether);
+        assertEq(liquidityPoolInstance.amountForShare(1 ether), 1.2 ether);
+    }
+
+    function test_minAmountForShare_negative_rebase_above_min_succeeds() public {
+        // Deposit 100 ether (totalShares=100, ratio=1.0), then move 50 ether to outOfLp so
+        // a negative rebase has room to subtract without underflowing.
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+        _setLpAccounting(50 ether, 50 ether); // totalPooled stays at 100, ratio still 1.0
+
+        _upgradeLpWithMinAmount(0.9 ether);
+
+        // Drop totalPooled from 100 to 95 → ratio 0.95 (above MIN).
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(-5 ether);
+        assertEq(liquidityPoolInstance.amountForShare(1 ether), 0.95 ether);
+    }
+
+    function test_minAmountForShare_negative_rebase_at_exact_boundary_succeeds() public {
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+        _setLpAccounting(50 ether, 50 ether);
+
+        _upgradeLpWithMinAmount(0.9 ether);
+
+        // Drop totalPooled to exactly 90 → ratio 0.9 (== MIN; strict `<` lets equality through).
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(-10 ether);
+        assertEq(liquidityPoolInstance.amountForShare(1 ether), 0.9 ether);
+    }
+
+    function test_minAmountForShare_negative_rebase_below_min_reverts() public {
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+        _setLpAccounting(50 ether, 50 ether);
+
+        _upgradeLpWithMinAmount(0.9 ether);
+
+        // Drop totalPooled to 89 → ratio 0.89 < MIN, reverts on the MIN check.
+        vm.prank(address(membershipManagerInstance));
+        vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+        liquidityPoolInstance.rebase(-11 ether);
+    }
+
+    // --- burnEEthShares (called by RedemptionManager / withdrawRequestNFT / priorityWithdrawalQueue) ---
+
+    function test_minAmountForShare_burnEEthShares_increases_ratio() public {
+        // Burning eETH shares without removing pooled ETH only raises the ratio,
+        // so the check cannot revert on this path even with MIN equal to the prior ratio.
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+
+        // Move 10 eETH worth of shares to the redemption manager.
+        vm.prank(alice);
+        eETHInstance.transfer(address(etherFiRedemptionManagerInstance), 10 ether);
+        uint256 sharesToBurn = eETHInstance.shares(address(etherFiRedemptionManagerInstance));
+
+        _upgradeLpWithMinAmount(1 ether);
+
+        vm.prank(address(etherFiRedemptionManagerInstance));
+        liquidityPoolInstance.burnEEthShares(sharesToBurn);
+
+        // ratio = 100 ether / 90 shares > 1 ether
+        assertGt(liquidityPoolInstance.amountForShare(1 ether), 1 ether);
+    }
+
+    function test_minAmountForShare_burnEEthShares_reverts_at_zero_total_shares() public {
+        // Burning the last share leaves totalShares == 0, where amountForShare returns 0.
+        // With MIN > 0 this trips the guard.
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+
+        // Cache the transfer amount BEFORE pranking — view calls otherwise consume vm.prank.
+        uint256 aliceBalance = eETHInstance.balanceOf(alice);
+        vm.prank(alice);
+        eETHInstance.transfer(address(etherFiRedemptionManagerInstance), aliceBalance);
+        uint256 sharesToBurn = eETHInstance.shares(address(etherFiRedemptionManagerInstance));
+
+        _upgradeLpWithMinAmount(1 ether);
+
+        vm.prank(address(etherFiRedemptionManagerInstance));
+        vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+        liquidityPoolInstance.burnEEthShares(sharesToBurn);
+    }
+
+    // --- receive() ---
+
+    function test_minAmountForShare_receive_reverts_when_pool_empty_and_min_positive() public {
+        _upgradeLpWithMinAmount(1 ether);
+
+        // No deposits yet → totalShares == 0 → amountForShare(1 ether) == 0 → 0 < 1 ether → revert.
+        // Note: receive() also subtracts msg.value from totalValueOutOfLp, which is 0 here, so we
+        // also expect the underflow path. We rely on `vm.expectRevert` matching either.
+        vm.deal(bob, 1 ether);
+        vm.prank(bob);
+        vm.expectRevert();
+        (bool sent, ) = address(liquidityPoolInstance).call{value: 1 ether}("");
+        sent; // silence unused-var
+    }
+
+    // --- access control on the new constructor / immutable ---
+
+    function test_minAmountForShare_immutable_independent_of_priority_queue() public {
+        // The two constructor params are independent and neither cross-contaminates the other.
+        LiquidityPool a = new LiquidityPool(address(0xBEEF), 1 ether);
+        assertEq(a.priorityWithdrawalQueue(), address(0xBEEF));
+        assertEq(a.MIN_AMOUNT_FOR_SHARE(), 1 ether);
+
+        LiquidityPool b = new LiquidityPool(address(0), 0);
+        assertEq(b.priorityWithdrawalQueue(), address(0));
+        assertEq(b.MIN_AMOUNT_FOR_SHARE(), 0);
+    }
+
+    // --- fuzz: rebase boundary ---
+
+    function testFuzz_minAmountForShare_rebase_boundary(int128 rebaseAmount) public {
+        // Anchor share-price at 1.0 ether with a 100 ether deposit.
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+        // Move pooled ETH out of LP so negative rebase has room before underflow.
+        _setLpAccounting(50 ether, 50 ether);
+
+        // Bound rebase to keep totalValueOutOfLp in [0, type(uint128).max] after the update.
+        // Pre-rebase totalValueOutOfLp == 50e18.
+        rebaseAmount = int128(bound(int256(rebaseAmount), -50 ether, 50 ether));
+
+        uint256 minAmount = 0.5 ether;
+        _upgradeLpWithMinAmount(minAmount);
+
+        // Compute resulting ratio: amountForShare(1 ether) = (1e18 * (100e18 + rebaseAmount)) / 100e18
+        int256 newPooled = 100 ether + int256(rebaseAmount);
+        uint256 expectedRatio = uint256(newPooled * 1 ether / 100 ether);
+
+        if (expectedRatio < minAmount) {
+            vm.prank(address(membershipManagerInstance));
+            vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+            liquidityPoolInstance.rebase(rebaseAmount);
+        } else {
+            vm.prank(address(membershipManagerInstance));
+            liquidityPoolInstance.rebase(rebaseAmount);
+            assertEq(liquidityPoolInstance.amountForShare(1 ether), expectedRatio);
+        }
     }
 }

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -50,7 +50,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
 
         // Upgrade LiquidityPool to latest version (needed for setPriorityWithdrawalQueue)
         vm.startPrank(owner);
-        LiquidityPool newLpImpl = new LiquidityPool(address(priorityQueue));
+        LiquidityPool newLpImpl = new LiquidityPool(address(priorityQueue), 0);
         liquidityPoolInstance.upgradeTo(address(newLpImpl));
 
         // Grant roles

--- a/test/RestakingRewardsRouter.t.sol
+++ b/test/RestakingRewardsRouter.t.sol
@@ -67,6 +67,10 @@ contract RestakingRewardsRouterTest is Test {
         bytes32 value = bytes32(uint256(1000 ether)); // Lower 16 bytes = 1000 ether, upper 16 bytes = 0
         vm.store(address(liquidityPool), bytes32(uint256(207)), value);
 
+        // LiquidityPool.receive() now calls _checkMinAmountForShare() -> eETH.totalShares().
+        // eETH is unset in this test (proxy never initialized), so mock the call to return 0.
+        vm.mockCall(address(0), abi.encodeWithSelector(IeETH.totalShares.selector), abi.encode(uint256(0)));
+
         // Deploy RestakingRewardsRouter implementation
         routerImpl = new RestakingRewardsRouter(
             address(roleRegistry),

--- a/test/RestakingRewardsRouter.t.sol
+++ b/test/RestakingRewardsRouter.t.sol
@@ -56,7 +56,7 @@ contract RestakingRewardsRouterTest is Test {
         otherToken = new TestERC20("Other Token", "OTH");
 
         // Deploy LiquidityPool
-        liquidityPoolImpl = new LiquidityPool(address(0x0));
+        liquidityPoolImpl = new LiquidityPool(address(0x0), 0);
         liquidityPoolProxy = new UUPSProxy(address(liquidityPoolImpl), "");
         liquidityPool = LiquidityPool(payable(address(liquidityPoolProxy)));
         

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -656,7 +656,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         membershipManagerProxy = new UUPSProxy(address(membershipManagerImplementation), "");
         membershipManagerInstance = MembershipManagerV0(payable(membershipManagerProxy));
 
-        etherFiAdminImplementation = new EtherFiAdmin();
+        etherFiAdminImplementation = new EtherFiAdmin(10_000, 1_000);
         etherFiAdminProxy = new UUPSProxy(address(etherFiAdminImplementation), "");
         etherFiAdminInstance = EtherFiAdmin(payable(etherFiAdminProxy));
 
@@ -687,7 +687,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         );
         priorityQueueInstance = PriorityWithdrawalQueue(address(priorityQueueProxy));
 
-        etherFiRedemptionManagerProxy = new UUPSProxy(address(new EtherFiRedemptionManager(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(treasuryInstance), address(roleRegistryInstance), address(etherFiRestakerInstance), address(priorityQueueInstance))), "");
+        etherFiRedemptionManagerProxy = new UUPSProxy(address(new EtherFiRedemptionManager(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(treasuryInstance), address(roleRegistryInstance), address(etherFiRestakerInstance), address(priorityQueueInstance), 10_000, 100, 10_000)), "");
         etherFiRedemptionManagerInstance = EtherFiRedemptionManager(payable(etherFiRedemptionManagerProxy));
         roleRegistryInstance.grantRole(keccak256("ETHERFI_REDEMPTION_MANAGER_ADMIN_ROLE"), owner);
         // etherFiRedemptionManagerInstance.initializeTokenParameters(_tokens, _exitFeeSplitToTreasuryInBps, _exitFeeInBps, _lowWatermarkInBpsOfTvl, _bucketCapacity, _bucketRefillRate);
@@ -881,7 +881,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function _upgrade_etherfiAdmin() internal {
-        address newAdminImpl = address(new EtherFiAdmin());
+        address newAdminImpl = address(new EtherFiAdmin(10_000, 1_000));
         vm.prank(etherFiAdminInstance.owner());
         etherFiAdminInstance.upgradeTo(newAdminImpl);
     }
@@ -910,7 +910,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
             );
             priorityQueueInstance = PriorityWithdrawalQueue(address(priorityQueueProxy));
-            EtherFiRedemptionManager etherFiRedemptionManagerImplementation = new EtherFiRedemptionManager(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(treasuryInstance), address(roleRegistryInstance), address(etherFiRestakerInstance), address(priorityQueueInstance));
+            EtherFiRedemptionManager etherFiRedemptionManagerImplementation = new EtherFiRedemptionManager(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(treasuryInstance), address(roleRegistryInstance), address(etherFiRestakerInstance), address(priorityQueueInstance), 10_000, 100, 10_000);
             etherFiRedemptionManagerProxy = new UUPSProxy(address(etherFiRedemptionManagerImplementation), "");
             etherFiRedemptionManagerInstance = EtherFiRedemptionManager(payable(etherFiRedemptionManagerProxy));
             etherFiRedemptionManagerInstance.initialize(10_00, 1_00, 1_00, 5 ether, 0.001 ether); // 10% fee split to treasury, 1% exit fee, 1% low watermark

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -589,7 +589,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         addressProviderInstance = new AddressProvider(address(owner));
 
-        liquidityPoolImplementation = new LiquidityPool(address(0x0));
+        liquidityPoolImplementation = new LiquidityPool(address(0x0), 0);
         liquidityPoolProxy = new UUPSProxy(address(liquidityPoolImplementation),"");
         liquidityPoolInstance = LiquidityPool(payable(address(liquidityPoolProxy)));
 
@@ -1563,7 +1563,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function _upgrade_liquidity_pool_contract() internal {
-        address newImpl = address(new LiquidityPool(address(0x0)));
+        address newImpl = address(new LiquidityPool(address(0x0), 0));
         vm.startPrank(liquidityPoolInstance.owner());
         liquidityPoolInstance.upgradeTo(newImpl);
         vm.stopPrank();

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -79,7 +79,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.prank(stakingManager.owner());
         stakingManager.upgradeTo(address(stakingManagerImpl));
 
-        LiquidityPool liquidityPoolImpl = new LiquidityPool(address(0x0));
+        LiquidityPool liquidityPoolImpl = new LiquidityPool(address(0x0), 0);
         vm.prank(LiquidityPool(payable(address(liquidityPool))).owner());
         LiquidityPool(payable(address(liquidityPool))).upgradeTo(address(liquidityPoolImpl));
 

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -53,7 +53,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         vm.prank(stakingManager.owner());
         stakingManager.upgradeTo(address(stakingManagerImpl));
 
-        LiquidityPool liquidityPoolImpl = new LiquidityPool(address(0x0));
+        LiquidityPool liquidityPoolImpl = new LiquidityPool(address(0x0), 0);
         vm.prank(liquidityPool.owner());
         liquidityPool.upgradeTo(address(liquidityPoolImpl));
 

--- a/test/integration-tests/MinAmountForShare.t.sol
+++ b/test/integration-tests/MinAmountForShare.t.sol
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/console2.sol";
+import "../TestSetup.sol";
+import "../../script/deploys/Deployed.s.sol";
+
+/// @notice Mainnet-fork tests for the MIN_AMOUNT_FOR_SHARE immutable on LiquidityPool.
+///
+/// MIN_AMOUNT_FOR_SHARE is enforced by `_checkMinAmountForShare()` which reverts with
+/// `InvalidAmountForShare` whenever `amountForShare(1 ether) < MIN_AMOUNT_FOR_SHARE`.
+/// The check is invoked from every state-changing path that can move the eETH/ETH ratio:
+///   - receive(), _deposit() (deposit / depositToRecipient / deposit(address,address))
+///   - withdraw() (NFT, membershipManager, redemptionManager, priorityWithdrawalQueue)
+///   - rebase() (membershipManager)
+///   - burnEEthShares() (redemptionManager / NFT / priorityQueue)
+///   - burnEEthSharesForNonETHWithdrawal() (redemptionManager)
+///   - _accountForEthSentOut() (validator funding)
+///
+/// These tests exercise each of those impacted entry points against real mainnet state by
+/// upgrading the LiquidityPool implementation in-place to one constructed with a chosen MIN.
+contract MinAmountForShareForkTest is TestSetup, Deployed {
+    address internal constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    function setUp() public {
+        initializeRealisticFork(MAINNET_FORK);
+        // alice/bob may collide with code-bearing addresses on a live fork; clear them so
+        // ETH transfers in tests aren't intercepted by an unrelated fallback.
+        vm.etch(alice, bytes(""));
+        vm.etch(bob, bytes(""));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    /// @dev Deploy a fresh LiquidityPool implementation with the desired MIN and upgrade
+    /// the proxy. The `priorityWithdrawalQueue` immutable on mainnet is `address(0)` today;
+    /// preserve that so we don't introduce unrelated changes through the fork upgrade.
+    function _upgradeLpWithMinAmount(uint256 minAmount) internal {
+        LiquidityPool newImpl = new LiquidityPool(address(0), minAmount);
+        vm.prank(roleRegistryInstance.owner());
+        liquidityPoolInstance.upgradeTo(address(newImpl));
+        assertEq(liquidityPoolInstance.MIN_AMOUNT_FOR_SHARE(), minAmount);
+    }
+
+    function _ratio() internal view returns (uint256) {
+        return liquidityPoolInstance.amountForShare(1 ether);
+    }
+
+    /// @dev Wire the redemption manager so a redeem call doesn't get rejected by the
+    /// rate limiter or the lowWatermark on a live fork.
+    function _openRedemptionManager() internal {
+        vm.startPrank(OPERATING_TIMELOCK);
+        etherFiRedemptionManagerInstance.setCapacity(3000 ether, ETH_ADDRESS);
+        etherFiRedemptionManagerInstance.setRefillRatePerSecond(3000 ether, ETH_ADDRESS);
+        etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(0, ETH_ADDRESS);
+        vm.stopPrank();
+        vm.warp(block.timestamp + 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // Immutable wiring
+    // ---------------------------------------------------------------------
+
+    /// Pre-upgrade: mainnet's currently-deployed LP impl predates this branch, so the
+    /// `MIN_AMOUNT_FOR_SHARE` getter selector does not exist on the deployed bytecode.
+    /// The proxy delegatecall returns no data and reverts. Asserting this guards against
+    /// silent regressions in the pre-upgrade baseline this test suite assumes.
+    function test_fork_minAmount_getter_absent_pre_upgrade() public {
+        (bool ok, ) = address(liquidityPoolInstance).staticcall(
+            abi.encodeWithSignature("MIN_AMOUNT_FOR_SHARE()")
+        );
+        assertFalse(ok, "MIN_AMOUNT_FOR_SHARE getter unexpectedly exists pre-upgrade");
+    }
+
+    function test_fork_minAmount_immutable_set_after_upgrade() public {
+        _upgradeLpWithMinAmount(0.5 ether);
+        assertEq(liquidityPoolInstance.MIN_AMOUNT_FOR_SHARE(), 0.5 ether);
+
+        _upgradeLpWithMinAmount(1.5 ether);
+        assertEq(liquidityPoolInstance.MIN_AMOUNT_FOR_SHARE(), 1.5 ether);
+
+        _upgradeLpWithMinAmount(0);
+        assertEq(liquidityPoolInstance.MIN_AMOUNT_FOR_SHARE(), 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // deposit() — _deposit() path
+    // ---------------------------------------------------------------------
+
+    function test_fork_deposit_succeeds_when_min_below_current_ratio() public {
+        uint256 ratio = _ratio();
+        require(ratio > 1, "fork ratio too small");
+        _upgradeLpWithMinAmount(ratio - 1);
+
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        uint256 shares = liquidityPoolInstance.deposit{value: 1 ether}();
+
+        assertGt(shares, 0);
+        // Proportional minting preserves the ratio.
+        assertEq(_ratio(), ratio);
+    }
+
+    function test_fork_deposit_succeeds_at_exact_boundary() public {
+        // strict `<` lets equality through
+        uint256 ratio = _ratio();
+        _upgradeLpWithMinAmount(ratio);
+
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        uint256 shares = liquidityPoolInstance.deposit{value: 1 ether}();
+        assertGt(shares, 0);
+    }
+
+    function test_fork_deposit_reverts_when_min_above_current_ratio() public {
+        uint256 ratio = _ratio();
+        _upgradeLpWithMinAmount(ratio + 1);
+
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    /// MIN much larger than any plausible ratio — every deposit must revert.
+    function test_fork_deposit_reverts_when_min_extreme() public {
+        _upgradeLpWithMinAmount(type(uint128).max);
+
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    // ---------------------------------------------------------------------
+    // receive() — bare ETH transfer to the LP
+    // ---------------------------------------------------------------------
+
+    /// receive() decrements totalValueOutOfLp by msg.value (it's the ELE sweep / restaker
+    /// return path). On a fork totalValueOutOfLp is enormous, so a 1 ether send won't
+    /// underflow — the only revert source we care about is `InvalidAmountForShare`.
+    function test_fork_receive_reverts_when_min_above_current_ratio() public {
+        uint256 ratio = _ratio();
+        _upgradeLpWithMinAmount(ratio + 1);
+
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        (bool ok, bytes memory err) = address(liquidityPoolInstance).call{value: 1 ether}("");
+        assertFalse(ok);
+        // expect the InvalidAmountForShare selector specifically
+        assertEq(bytes4(err), LiquidityPool.InvalidAmountForShare.selector);
+    }
+
+    function test_fork_receive_succeeds_when_min_below_current_ratio() public {
+        uint256 ratio = _ratio();
+        _upgradeLpWithMinAmount(ratio - 1);
+
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        (bool ok, ) = address(liquidityPoolInstance).call{value: 1 ether}("");
+        assertTrue(ok);
+    }
+
+    // ---------------------------------------------------------------------
+    // rebase()
+    // ---------------------------------------------------------------------
+
+    function test_fork_rebase_positive_succeeds_at_boundary() public {
+        uint256 ratio = _ratio();
+        // MIN == current ratio. A positive rebase only raises the ratio, so it must pass.
+        _upgradeLpWithMinAmount(ratio);
+
+        address mm = liquidityPoolInstance.membershipManager();
+        vm.prank(mm);
+        liquidityPoolInstance.rebase(int128(int256(uint256(1 ether))));
+
+        assertGe(_ratio(), ratio);
+    }
+
+    function test_fork_rebase_negative_reverts_when_below_min() public {
+        uint256 ratio = _ratio();
+        _upgradeLpWithMinAmount(ratio);
+
+        // Any meaningful negative rebase strictly reduces the ratio, which is now == MIN.
+        // A 100 ether shrink against mainnet's totalShares is enough to move ratio by far
+        // more than 1 wei.
+        address mm = liquidityPoolInstance.membershipManager();
+        vm.prank(mm);
+        vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+        liquidityPoolInstance.rebase(-100 ether);
+    }
+
+    function test_fork_rebase_negative_succeeds_when_above_min() public {
+        uint256 ratio = _ratio();
+        // Park MIN well below current ratio. A small negative rebase shouldn't trip it.
+        require(ratio > 0.1 ether, "fork ratio too small");
+        _upgradeLpWithMinAmount(ratio - 0.1 ether);
+
+        address mm = liquidityPoolInstance.membershipManager();
+        vm.prank(mm);
+        liquidityPoolInstance.rebase(-100 ether);
+
+        // ratio decreased but stayed above MIN
+        uint256 newRatio = _ratio();
+        assertLt(newRatio, ratio);
+        assertGe(newRatio, liquidityPoolInstance.MIN_AMOUNT_FOR_SHARE());
+    }
+
+    // ---------------------------------------------------------------------
+    // EtherFiRedemptionManager.redeemEEth — burnEEthSharesForNonETHWithdrawal + withdraw
+    // ---------------------------------------------------------------------
+
+    /// The exit fee retained by the protocol means a redemption can only INCREASE the
+    /// ratio, so as long as MIN <= currentRatio the redeem path goes through.
+    function test_fork_redemption_succeeds_when_min_at_current_ratio() public {
+        _openRedemptionManager();
+        uint256 ratio = _ratio();
+        _upgradeLpWithMinAmount(ratio);
+
+        vm.deal(alice, 50 ether);
+        vm.startPrank(alice);
+        liquidityPoolInstance.deposit{value: 30 ether}();
+
+        address receiver = makeAddr("min-share-receiver");
+        vm.etch(receiver, bytes(""));
+        uint256 amount = 10 ether;
+        eETHInstance.approve(address(etherFiRedemptionManagerInstance), amount);
+        etherFiRedemptionManagerInstance.redeemEEth(amount, receiver, ETH_ADDRESS);
+        vm.stopPrank();
+
+        // Ratio after redemption is at or above the boundary.
+        assertGe(_ratio(), ratio);
+    }
+
+    /// With MIN above the current ratio, redeemEEth reverts on the very first hop into LP.
+    /// This test demonstrates the guard blocks the redemption flow end-to-end.
+    function test_fork_redemption_reverts_when_min_above_current_ratio() public {
+        _openRedemptionManager();
+        uint256 ratio = _ratio();
+
+        // Pre-stage: deposit BEFORE upgrading so we have eETH that bypasses the deposit guard.
+        vm.deal(alice, 50 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 30 ether}();
+
+        _upgradeLpWithMinAmount(ratio + 1);
+
+        address receiver = makeAddr("min-share-receiver-2");
+        vm.etch(receiver, bytes(""));
+        uint256 amount = 10 ether;
+
+        vm.startPrank(alice);
+        eETHInstance.approve(address(etherFiRedemptionManagerInstance), amount);
+        vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+        etherFiRedemptionManagerInstance.redeemEEth(amount, receiver, ETH_ADDRESS);
+        vm.stopPrank();
+    }
+
+    // ---------------------------------------------------------------------
+    // burnEEthShares — direct path used by redemptionManager / NFT / priorityQueue
+    // ---------------------------------------------------------------------
+
+    /// Burning shares (without removing pooled ETH) only RAISES the ratio — even with MIN
+    /// pinned to the pre-burn ratio the call must succeed.
+    function test_fork_burnEEthShares_succeeds_at_boundary() public {
+        // mint some eETH to the redemption manager so it has shares to burn
+        vm.deal(alice, 50 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 30 ether}();
+        vm.prank(alice);
+        eETHInstance.transfer(address(etherFiRedemptionManagerInstance), 5 ether);
+        uint256 sharesToBurn = eETHInstance.shares(address(etherFiRedemptionManagerInstance));
+
+        uint256 ratio = _ratio();
+        _upgradeLpWithMinAmount(ratio);
+
+        vm.prank(address(etherFiRedemptionManagerInstance));
+        liquidityPoolInstance.burnEEthShares(sharesToBurn);
+
+        // ratio increased
+        assertGe(_ratio(), ratio);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fuzz across many MIN values vs the live mainnet ratio
+    // ---------------------------------------------------------------------
+
+    function testFuzz_fork_deposit_boundary_across_min_values(uint256 rawMin) public {
+        uint256 ratio = _ratio();
+        // bound MIN to a meaningful range either side of the live ratio
+        uint256 minAmount = bound(rawMin, 0, ratio + 1 ether);
+        _upgradeLpWithMinAmount(minAmount);
+
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        if (ratio < minAmount) {
+            vm.expectRevert(LiquidityPool.InvalidAmountForShare.selector);
+            liquidityPoolInstance.deposit{value: 1 ether}();
+        } else {
+            uint256 shares = liquidityPoolInstance.deposit{value: 1 ether}();
+            assertGt(shares, 0);
+            assertEq(_ratio(), ratio);
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core staking/redemption accounting by introducing new immutables and runtime reverts (e.g., LiquidityPool share-price floor), which could block deposits/withdrawals/redemptions if misconfigured. Constructor signature changes also require careful deployment/upgrade coordination across proxies and tests.
> 
> **Overview**
> Adds **hard guardrails** via new constructor immutables across core contracts.
> 
> `EtherFiAdmin` now validates constructor inputs and introduces max caps for `acceptableRebaseAprInBps` and `validatorTaskBatchSize`, enforcing them in `updateAcceptableRebaseApr` and `setValidatorTaskBatchSize`.
> 
> `EtherFiRedemptionManager` adds immutable maximums for exit-fee parameters and enforces them in `initializeTokenParameters` and per-token setters (with updated revert messages), and tests are updated to reflect the tighter caps.
> 
> `LiquidityPool` introduces an immutable `MIN_AMOUNT_FOR_SHARE` and a `_checkMinAmountForShare()` share-price floor enforced across deposit/withdraw/rebase/burn/receive/accounting paths; extensive unit + new mainnet-fork integration tests cover boundary and revert behavior, and all deployments/upgrades are updated for the new constructor args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3519f30e1825121799a27950f5583cb399c7d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->