### PR TITLE
T1-6: Permissionless executeTasks()

### DIFF
--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -177,8 +177,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function executeTasks(IEtherFiOracle.OracleReport calldata _report) external {
-        if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE, msg.sender)) revert IncorrectRole();
-
         bytes32 reportHash = etherFiOracle.generateReportHash(_report);
         uint32 current_slot = etherFiOracle.computeSlotAtTimestamp(block.timestamp);
         require(etherFiOracle.isConsensusReached(reportHash), "EtherFiAdmin: report didn't reach consensus");

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1347,7 +1347,7 @@ contract EtherFiOracleTest is TestSetup {
         etherFiOracleInstance.submitReport(wrongReport);
     }
 
-    function test_executeTasks_insufficientRole() public {
+    function test_executeTasks_permissionless() public {
         vm.prank(owner);
         etherFiOracleInstance.setQuorumSize(1);
 
@@ -1361,9 +1361,16 @@ contract EtherFiOracleTest is TestSetup {
 
         _moveClock(int256(uint256(etherFiAdminInstance.postReportWaitTimeInSlots()) + 1));
 
+        // chad has no roles; executeTasks is permissionless once consensus is reached
+        // and the report passes the freshness/sequencing checks.
+        assertFalse(roleRegistryInstance.hasRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE(), chad));
+        assertFalse(roleRegistryInstance.hasRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), chad));
+
         vm.prank(chad);
-        vm.expectRevert(EtherFiAdmin.IncorrectRole.selector);
         etherFiAdminInstance.executeTasks(report);
+
+        assertEq(etherFiAdminInstance.lastHandledReportRefSlot(), report.refSlotTo);
+        assertEq(etherFiAdminInstance.lastHandledReportRefBlock(), report.refBlockTo);
     }
 
     function test_pause_unPause_edgeCases() public {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Removes role gating from `EtherFiAdmin.executeTasks`, allowing any account to trigger state-changing reward/fee/validator/withdrawal processing once oracle consensus and sequencing/freshness checks pass. This increases operational exposure (griefing/DoS via public callers) and should be reviewed for reentrancy, gas, and trust assumptions around report validity.
> 
> **Overview**
> `EtherFiAdmin.executeTasks` is now **permissionless**: the executor role check was removed so any caller can process an oracle report once consensus is reached and the report passes the existing sequencing (`refSlotFrom`/`refBlockFrom`) and freshness wait checks.
> 
> Tests were updated to reflect this behavior by renaming the insufficient-role test to `test_executeTasks_permissionless` and asserting a role-less address can execute tasks and advance `lastHandledReportRefSlot`/`lastHandledReportRefBlock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a05fa6672951171b64b72c119c6b2c4f46746c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->