### PR TITLE
yash/audit-fixes/pause-transfers

### DIFF
--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -154,11 +154,11 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         }
     }
 
-    function extendPauseUntil(address _user, uint64 _duration) external {
+    function extendPauseUntil(address _user, uint256 _duration) external {
         require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
-            pausedUntil[_user] = block.timestamp + _duration;
+            pausedUntil[_user] += _duration;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -266,6 +266,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         return liquidityPool.getTotalEtherClaimOf(_user);
     }
 
+    function isPausedUntil(address _user) external view returns (bool) {
+        return pausedUntil[_user] >= block.timestamp;
+    }
+
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -166,8 +166,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
     function cancelPauseUntil(address _user) external {
         require(roleRegistry.hasRole(EETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
-        delete pausedUntil[_user];
-        emit CancelledPauseUntil(_user);
+        if (pausedUntil[_user] >= block.timestamp) {
+            delete pausedUntil[_user];
+            emit CancelledPauseUntil(_user);
+        }
     }
 
     function unpause() external {

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -202,6 +202,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     /// @return uint256 ID of the withdraw request NFT
     function requestWithdraw(uint256 _tokenId, uint256 _amount) external whenNotPaused returns (uint256) {
         _requireTokenOwner(_tokenId);
+        _requireUserNotPaused();
 
         // prevent transfers for several blocks after a withdrawal to prevent frontrunning
         membershipNFT.incrementLock(_tokenId, withdrawalLockBlocks);
@@ -228,6 +229,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     /// @return uint256 ID of the withdraw request NFT
     function requestWithdrawAndBurn(uint256 _tokenId) external whenNotPaused returns (uint256) {
         _requireTokenOwner(_tokenId);
+        _requireUserNotPaused();
 
         // Claim all staking rewards before burn
         _claimStakingRewards(_tokenId);
@@ -457,6 +459,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     }
 
     function _wrapEth(uint256 _amount, uint256 _amountForPoints, address _referral) internal returns (uint256) {
+        _requireUserNotPaused();
         liquidityPool.deposit{value: _amount + _amountForPoints}(msg.sender, _referral);
         uint256 tokenId = _mintMembershipNFT(msg.sender, _amount, _amountForPoints, 0, 0);
         _emitNftUpdateEvent(tokenId);
@@ -602,6 +605,11 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         _incrementTierDeposit(tier, amount);
         
         token.vaultShare = tierData[tier].rewardsGlobalIndex;
+    }
+
+    error UserPaused();
+    function _requireUserNotPaused() internal view {
+        if (eETH.isPausedUntil(msg.sender)) revert UserPaused();
     }
 
 

--- a/src/MembershipNFT.sol
+++ b/src/MembershipNFT.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./interfaces/IMembershipManager.sol";
 import "./interfaces/IMembershipNFT.sol";
 import "./interfaces/ILiquidityPool.sol";
+import "./interfaces/IeETH.sol";
 
 import "forge-std/console.sol";
 
@@ -34,6 +35,7 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     mapping(address => bool) public admins;
 
     ILiquidityPool public liquidityPool;
+    IeETH public immutable eETH;
 
     event MerkleUpdated(bytes32, bytes32);
     event MintingPaused(bool isPaused);
@@ -44,10 +46,12 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     error InvalidEAPRollover();
     error RequireTokenUnlocked();
     error OnlyMembershipManagerContract();
+    error UserPaused();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _eETH) {
         _disableInitializers();
+        eETH = IeETH(_eETH);
     }
 
     function initialize(string calldata _metadataURI, address _membershipManagerInstance) external initializer {
@@ -147,6 +151,8 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
         if (_from == address(0x00) || _to == address(0x00)) {
             return;
         }
+
+        if (eETH.isPausedUntil(_from) || eETH.isPausedUntil(_to)) revert UserPaused();
 
         // prevent transfers if token is locked
         for (uint256 x; x < _ids.length; ++x) {

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -202,4 +202,8 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
+
+    function isPausedUntil(address _user) external view returns (bool) {
+        return pausedUntil[_user] >= block.timestamp;
+    }
 }

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -118,11 +118,11 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         }
     }
 
-    function extendPauseUntil(address _user, uint64 _duration) external {
+    function extendPauseUntil(address _user, uint256 _duration) external {
         require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
         if (pausedUntil[_user] >= block.timestamp) {
-            pausedUntil[_user] = block.timestamp + _duration;
+            pausedUntil[_user] += _duration;
             emit PausedUntil(_user, pausedUntil[_user]);
         }
     }

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -130,8 +130,10 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     function cancelPauseUntil(address _user) external {
         require(roleRegistry.hasRole(WEETH_PAUSER_ROLE, msg.sender), "IncorrectRole");
         require(_user != address(0), "No zero addresses");
-        delete pausedUntil[_user];
-        emit CancelledPauseUntil(_user);
+        if (pausedUntil[_user] >= block.timestamp) {
+            delete pausedUntil[_user];
+            emit CancelledPauseUntil(_user);
+        }
     }
 
     function unpause() external {

--- a/src/interfaces/IWeETH.sol
+++ b/src/interfaces/IWeETH.sol
@@ -42,7 +42,7 @@ interface IWeETH is IERC20Upgradeable {
 
     function pause() external;
     function pauseUntil(address _user) external;
-    function extendPauseUntil(address _user, uint64 _duration) external;
+    function extendPauseUntil(address _user, uint256 _duration) external;
     function cancelPauseUntil(address _user) external;
     function unpause() external;
 

--- a/src/interfaces/IWeETH.sol
+++ b/src/interfaces/IWeETH.sol
@@ -21,6 +21,10 @@ interface IWeETH is IERC20Upgradeable {
     function whitelistedSpender(address spender) external view returns (bool);
     function blacklistedRecipient(address recipient) external view returns (bool);
 
+    function paused() external view returns (bool);
+    function pausedUntil(address _user) external view returns (uint256);
+    function isPausedUntil(address _user) external view returns (bool);
+
     // STATE-CHANGING FUNCTIONS
     function initialize() external;
     function wrap(uint256 _eETHAmount) external returns (uint256);
@@ -35,6 +39,12 @@ interface IWeETH is IERC20Upgradeable {
         bytes32 r,
         bytes32 s
     ) external;
+
+    function pause() external;
+    function pauseUntil(address _user) external;
+    function extendPauseUntil(address _user, uint64 _duration) external;
+    function cancelPauseUntil(address _user) external;
+    function unpause() external;
 
     function setWhitelistedSpender(address[] calldata _spenders, bool _isWhitelisted) external;
     function setBlacklistedRecipient(address[] calldata _recipients, bool _isBlacklisted) external;

--- a/src/interfaces/IeETH.sol
+++ b/src/interfaces/IeETH.sol
@@ -19,6 +19,10 @@ interface IeETH {
     function shares(address _user) external view returns (uint256);
     function balanceOf(address _user) external view returns (uint256);
 
+    function paused() external view returns (bool);
+    function pausedUntil(address _user) external view returns (uint256);
+    function isPausedUntil(address _user) external view returns (bool);
+
     function initialize() external;
     function mintShares(address _user, uint256 _share) external;
     function burnShares(address _user, uint256 _share) external;
@@ -27,6 +31,12 @@ interface IeETH {
     function approve(address _spender, uint256 _amount) external returns (bool);
     function increaseAllowance(address _spender, uint256 _increaseAmount) external returns (bool);
     function decreaseAllowance(address _spender, uint256 _decreaseAmount) external returns (bool);
+
+    function pause() external;
+    function pauseUntil(address _user) external;
+    function extendPauseUntil(address _user, uint64 _duration) external;
+    function cancelPauseUntil(address _user) external;
+    function unpause() external;
 
     function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
 }

--- a/src/interfaces/IeETH.sol
+++ b/src/interfaces/IeETH.sol
@@ -34,7 +34,7 @@ interface IeETH {
 
     function pause() external;
     function pauseUntil(address _user) external;
-    function extendPauseUntil(address _user, uint64 _duration) external;
+    function extendPauseUntil(address _user, uint256 _duration) external;
     function cancelPauseUntil(address _user) external;
     function unpause() external;
 

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -487,25 +487,31 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.transfer(bob, 1 ether); // must succeed immediately
     }
 
-    /// @dev M-2-new: cancelPauseUntil emits event even when there's nothing to cancel.
-    function test_cancelPauseUntil_emitsEvenWhenNeverArmed() public {
-        vm.expectEmit(true, false, false, true);
-        emit CancelledPauseUntil(alice);
+    /// @dev I-03 regression: cancelPauseUntil must not emit when the user was never paused.
+    function test_cancelPauseUntil_doesNotEmit_whenNeverArmed() public {
+        vm.recordLogs();
         vm.prank(pauser);
         eETHInstance.cancelPauseUntil(alice);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "no event when there is nothing to cancel (I-03)");
+        assertEq(eETHInstance.pausedUntil(alice), 0);
     }
 
-    function test_cancelPauseUntil_emitsEvenWhenAlreadyExpired() public {
+    /// @dev I-03 regression: cancelPauseUntil is a no-op once the timer has already expired.
+    /// The stale value is harmless (transfer checks treat past timestamps as unpaused).
+    function test_cancelPauseUntil_isNoOp_whenExpired() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 staleDeadline = eETHInstance.pausedUntil(alice);
         vm.warp(block.timestamp + 2 days);
 
-        vm.expectEmit(true, false, false, true);
-        emit CancelledPauseUntil(alice);
+        vm.recordLogs();
         vm.prank(pauser);
         eETHInstance.cancelPauseUntil(alice);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        assertEq(eETHInstance.pausedUntil(alice), 0, "stale timer also cleared");
+        assertEq(logs.length, 0, "no event when timer already expired");
+        assertEq(eETHInstance.pausedUntil(alice), staleDeadline, "expired value is left as-is");
     }
 
     function test_cancelPauseUntil_isPerUser_doesNotTouchOthers() public {

--- a/test/EETHPause.t.sol
+++ b/test/EETHPause.t.sol
@@ -103,6 +103,7 @@ contract EETHPauseTest is TestSetup {
     function test_extendPauseUntil_onlyPauserRole() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice); // arm the timer so extend has something to do
+        uint256 armedAt = block.timestamp;
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
@@ -114,7 +115,8 @@ contract EETHPauseTest is TestSetup {
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 2 days);
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 2 days);
+        // Extension adds onto the existing deadline (armedAt + ONE_DAY), not block.timestamp.
+        assertEq(eETHInstance.pausedUntil(alice), armedAt + ONE_DAY + 2 days);
     }
 
     function test_cancelPauseUntil_onlyPauserRole() public {
@@ -373,11 +375,13 @@ contract EETHPauseTest is TestSetup {
     function test_extendPauseUntil_extendsLiveTimer() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 armedAt = block.timestamp;
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 7 days);
 
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 7 days);
+        // Adds onto the live (armedAt + ONE_DAY) deadline, not block.timestamp.
+        assertEq(eETHInstance.pausedUntil(alice), armedAt + ONE_DAY + 7 days);
 
         vm.warp(block.timestamp + 1 days + 1); // past original 1-day expiry
         vm.prank(alice);
@@ -385,37 +389,32 @@ contract EETHPauseTest is TestSetup {
         eETHInstance.transfer(bob, 1 ether);
     }
 
-    /// @dev H-1 (HIGH): extendPauseUntil can SHORTEN a timer despite its name.
-    function test_SECURITY_extendPauseUntil_canShortenTimer() public {
+    /// @dev I-02 regression: extendPauseUntil must never produce a shorter deadline than the existing one.
+    function test_extendPauseUntil_neverShortensTimer() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice); // arms 1-day timer
+        uint256 originalDeadline = eETHInstance.pausedUntil(alice);
 
-        // Admin calls extend with 1-hour duration → new expiry is EARLIER than original.
+        // Even a tiny duration must only ADD time, not reset the countdown.
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 1 hours);
 
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 1 hours);
-        assertLt(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY,
-                 "extend should not allow shortening (H-1)");
+        assertGt(eETHInstance.pausedUntil(alice), originalDeadline,
+                 "extension must move deadline forward, never shorten (I-02)");
+        assertEq(eETHInstance.pausedUntil(alice), originalDeadline + 1 hours);
     }
 
-    /// @dev H-1 corollary: duration=0 effectively releases the user next block.
-    function test_SECURITY_extendPauseUntil_withZeroDuration_effectivelyCancels() public {
+    /// @dev I-02 corollary: duration=0 is a no-op that preserves the original deadline.
+    function test_extendPauseUntil_withZeroDuration_isNoOp() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 originalDeadline = eETHInstance.pausedUntil(alice);
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 0);
 
-        // Current block — timer is at block.timestamp, require uses strict <, still paused.
-        vm.prank(alice);
-        vm.expectRevert("SENDER PAUSED");
-        eETHInstance.transfer(bob, 1 ether);
-
-        // But any forward progress unfreezes.
-        vm.warp(block.timestamp + 1);
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
+        assertEq(eETHInstance.pausedUntil(alice), originalDeadline,
+                 "zero-duration extend must not alter the deadline");
     }
 
     /// @dev M-1-new: extendPauseUntil silent no-op when timer already expired.
@@ -442,7 +441,7 @@ contract EETHPauseTest is TestSetup {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
 
-        uint64 expected = uint64(block.timestamp) + 3 days;
+        uint64 expected = uint64(block.timestamp) + ONE_DAY + 3 days;
         vm.expectEmit(true, false, false, true);
         emit PausedUntil(alice, expected);
         vm.prank(pauser);
@@ -635,10 +634,11 @@ contract EETHPauseTest is TestSetup {
     function test_sequence_weakArms_then_strongExtends_then_strongCancels() public {
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 armedAt = block.timestamp;
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, 3 days);
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + 3 days);
+        assertEq(eETHInstance.pausedUntil(alice), armedAt + ONE_DAY + 3 days);
 
         vm.prank(pauser);
         eETHInstance.cancelPauseUntil(alice);
@@ -727,11 +727,12 @@ contract EETHPauseTest is TestSetup {
 
         vm.prank(pauserUntil);
         eETHInstance.pauseUntil(alice);
+        uint256 originalDeadline = eETHInstance.pausedUntil(alice);
 
         vm.prank(pauser);
         eETHInstance.extendPauseUntil(alice, duration);
 
-        assertEq(eETHInstance.pausedUntil(alice), uint64(block.timestamp) + duration);
+        assertEq(eETHInstance.pausedUntil(alice), originalDeadline + duration);
     }
 
     function testFuzz_globalPause_blocksTransferAnyAmount(uint256 amount) public {

--- a/test/MembershipManagerPause.t.sol
+++ b/test/MembershipManagerPause.t.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "./TestSetup.sol";
+import "../src/MembershipManager.sol";
+
+/// Unit tests for the L-02 audit fix: paused users (per-user `pausedUntil` on EETH)
+/// must not be able to bypass the pause by routing through MembershipManager.
+contract MembershipManagerPauseTest is TestSetup {
+    address pauserUntil;
+
+    uint64 constant ONE_DAY = 1 days;
+
+    function setUp() public {
+        setUpTests();
+
+        pauserUntil = vm.addr(0xA11CE2);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(eETHInstance.EETH_PAUSER_UNTIL_ROLE(), pauserUntil);
+        vm.stopPrank();
+
+        _upgradeMembershipManagerFromV0ToV1();
+
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+    }
+
+    function _wrapForUser(address user, uint256 amount) internal returns (uint256) {
+        vm.prank(user);
+        return membershipManagerV1Instance.wrapEth{value: amount}(amount, 0);
+    }
+
+    function _pauseUser(address user) internal {
+        vm.prank(pauserUntil);
+        eETHInstance.pauseUntil(user);
+    }
+
+    // -------------------------------------------------------------------
+    //                       wrapEth blocked when paused
+    // -------------------------------------------------------------------
+
+    function test_wrapEth_revertsWhenUserPaused() public {
+        _pauseUser(alice);
+
+        vm.prank(alice);
+        vm.expectRevert(MembershipManager.UserPaused.selector);
+        membershipManagerV1Instance.wrapEth{value: 1 ether}(1 ether, 0);
+    }
+
+    function test_wrapEth_succeedsWhenNotPaused() public {
+        uint256 tokenId = _wrapForUser(alice, 1 ether);
+        assertGt(tokenId, 0);
+    }
+
+    function test_wrapEth_succeedsAfterPauseExpires() public {
+        _pauseUser(alice);
+        skip(ONE_DAY + 1);
+
+        // pause has expired; wrap should succeed
+        uint256 tokenId = _wrapForUser(alice, 1 ether);
+        assertGt(tokenId, 0);
+    }
+
+    // -------------------------------------------------------------------
+    //                  requestWithdraw blocked when paused
+    // -------------------------------------------------------------------
+
+    function test_requestWithdraw_revertsWhenUserPaused() public {
+        uint256 tokenId = _wrapForUser(alice, 2 ether);
+
+        _pauseUser(alice);
+
+        vm.prank(alice);
+        vm.expectRevert(MembershipManager.UserPaused.selector);
+        membershipManagerV1Instance.requestWithdraw(tokenId, 0.5 ether);
+    }
+
+    // -------------------------------------------------------------------
+    //              requestWithdrawAndBurn blocked when paused
+    // -------------------------------------------------------------------
+
+    function test_requestWithdrawAndBurn_revertsWhenUserPaused() public {
+        uint256 tokenId = _wrapForUser(alice, 2 ether);
+
+        _pauseUser(alice);
+
+        vm.prank(alice);
+        vm.expectRevert(MembershipManager.UserPaused.selector);
+        membershipManagerV1Instance.requestWithdrawAndBurn(tokenId);
+    }
+
+    // -------------------------------------------------------------------
+    //          pause of one user does not affect other users
+    // -------------------------------------------------------------------
+
+    function test_pauseUntil_doesNotBlockOtherUsers() public {
+        _pauseUser(alice);
+
+        // bob is not paused, should be able to interact normally
+        uint256 bobToken = _wrapForUser(bob, 1 ether);
+        assertGt(bobToken, 0);
+    }
+}

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -637,7 +637,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         eigenLayerEigenPodManager = new MockEigenPodManager();
         eigenLayerDelegationManager = new MockDelegationManager();
 
-        membershipNftImplementation = new MembershipNFT();
+        membershipNftImplementation = new MembershipNFT(address(eETHInstance));
         membershipNftProxy = new UUPSProxy(address(membershipNftImplementation), "");
         membershipNftInstance = MembershipNFT(payable(membershipNftProxy));
 

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -128,6 +128,7 @@ contract WeETHPauseTest is TestSetup {
     function test_extendPauseUntil_onlyPauserRole() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint256 armedAt = block.timestamp;
 
         vm.prank(unauthorized);
         vm.expectRevert("IncorrectRole");
@@ -139,7 +140,8 @@ contract WeETHPauseTest is TestSetup {
 
         vm.prank(pauser);
         weEthInstance.extendPauseUntil(alice, 2 days);
-        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + 2 days);
+        // Extension adds onto the existing deadline (armedAt + ONE_DAY).
+        assertEq(weEthInstance.pausedUntil(alice), armedAt + ONE_DAY + 2 days);
     }
 
     function test_cancelPauseUntil_onlyPauserRole() public {
@@ -453,23 +455,26 @@ contract WeETHPauseTest is TestSetup {
     function test_extendPauseUntil_extendsLiveTimer() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint256 armedAt = block.timestamp;
 
         vm.prank(pauser);
         weEthInstance.extendPauseUntil(alice, 7 days);
 
-        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + 7 days);
+        assertEq(weEthInstance.pausedUntil(alice), armedAt + ONE_DAY + 7 days);
     }
 
-    /// @dev H-1 (HIGH): extendPauseUntil can shorten the timer.
-    function test_SECURITY_extendPauseUntil_canShortenTimer() public {
+    /// @dev I-02 regression: extendPauseUntil must never produce a shorter deadline than the existing one.
+    function test_extendPauseUntil_neverShortensTimer() public {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint256 originalDeadline = weEthInstance.pausedUntil(alice);
 
         vm.prank(pauser);
         weEthInstance.extendPauseUntil(alice, 1 hours);
 
-        assertLt(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + ONE_DAY,
-                 "extend allowed to shorten (H-1)");
+        assertGt(weEthInstance.pausedUntil(alice), originalDeadline,
+                 "extension must move deadline forward, never shorten (I-02)");
+        assertEq(weEthInstance.pausedUntil(alice), originalDeadline + 1 hours);
     }
 
     function test_extendPauseUntil_silentNoOp_whenTimerExpired() public {
@@ -587,7 +592,7 @@ contract WeETHPauseTest is TestSetup {
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
 
-        uint64 expected = uint64(block.timestamp) + 3 days;
+        uint64 expected = uint64(block.timestamp) + ONE_DAY + 3 days;
         vm.expectEmit(true, false, false, true);
         emit PausedUntil(alice, expected);
         vm.prank(pauser);
@@ -681,11 +686,12 @@ contract WeETHPauseTest is TestSetup {
 
         vm.prank(pauserUntil);
         weEthInstance.pauseUntil(alice);
+        uint256 originalDeadline = weEthInstance.pausedUntil(alice);
 
         vm.prank(pauser);
         weEthInstance.extendPauseUntil(alice, duration);
 
-        assertEq(weEthInstance.pausedUntil(alice), uint64(block.timestamp) + duration);
+        assertEq(weEthInstance.pausedUntil(alice), originalDeadline + duration);
     }
 
     function testFuzz_globalPause_blocksTransferAnyAmount(uint256 amount) public {

--- a/test/WeETHPause.t.sol
+++ b/test/WeETHPause.t.sol
@@ -513,11 +513,30 @@ contract WeETHPauseTest is TestSetup {
         weEthInstance.transfer(bob, 1 ether);
     }
 
-    function test_cancelPauseUntil_emitsEvenWhenNeverArmed() public {
-        vm.expectEmit(true, false, false, true);
-        emit CancelledPauseUntil(alice);
+    /// @dev I-03 regression: cancelPauseUntil must not emit when the user was never paused.
+    function test_cancelPauseUntil_doesNotEmit_whenNeverArmed() public {
+        vm.recordLogs();
         vm.prank(pauser);
         weEthInstance.cancelPauseUntil(alice);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "no event when there is nothing to cancel (I-03)");
+        assertEq(weEthInstance.pausedUntil(alice), 0);
+    }
+
+    /// @dev I-03 regression: cancelPauseUntil is a no-op once the timer has already expired.
+    function test_cancelPauseUntil_isNoOp_whenExpired() public {
+        vm.prank(pauserUntil);
+        weEthInstance.pauseUntil(alice);
+        uint256 staleDeadline = weEthInstance.pausedUntil(alice);
+        vm.warp(block.timestamp + 2 days);
+
+        vm.recordLogs();
+        vm.prank(pauser);
+        weEthInstance.cancelPauseUntil(alice);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "no event when timer already expired");
+        assertEq(weEthInstance.pausedUntil(alice), staleDeadline, "expired value is left as-is");
     }
 
     function test_cancelPauseUntil_isPerUser() public {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes pause/unpause semantics on core token and membership withdrawal/mint paths, which could unintentionally block user operations if misconfigured or if integrations depended on the prior timestamp-reset behavior.
> 
> **Overview**
> Fixes per-user pause mechanics on `EETH` and `WeETH` so `extendPauseUntil` truly *extends* an active pause (adds to the existing deadline) and `cancelPauseUntil` becomes a no-op (no state change/event) when the pause is already inactive/expired; both also widen `_duration` to `uint256` and add `isPausedUntil()` convenience getters.
> 
> Closes pause bypasses by enforcing the per-user pause in `MembershipManager` (`wrapEth`, `requestWithdraw`, `requestWithdrawAndBurn`) and in `MembershipNFT` transfers (reverting if either sender or receiver is paused), updating interfaces/test setup accordingly and adding targeted regression tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b0b98b174770750ef716029f080f660c9623500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->