### PR TITLE
yash/feat/min-max-withdraw-request

### DIFF
--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -34,6 +34,7 @@ contract PriorityWithdrawalQueue is
     //--------------------------------------------------------------------------------------
 
     uint96 public constant MIN_AMOUNT = 0.01 ether;
+    uint96 public constant MAX_AMOUNT = 1000 ether;
     uint256 private constant _BASIS_POINT_SCALE = 1e4;
 
     //--------------------------------------------------------------------------------------
@@ -191,7 +192,7 @@ contract PriorityWithdrawalQueue is
         uint96 amountOfEEth,
         uint96 amountWithFee
     ) external whenNotPaused onlyWhitelisted nonReentrant returns (bytes32 requestId) {
-        if (amountOfEEth < MIN_AMOUNT) revert InvalidAmount();
+        if (amountOfEEth < MIN_AMOUNT || amountOfEEth > MAX_AMOUNT) revert InvalidAmount();
         (uint256 lpEthBefore, uint256 queueEEthSharesBefore) = _snapshotBalances();
 
         IERC20(address(eETH)).safeTransferFrom(msg.sender, address(this), amountOfEEth);
@@ -205,7 +206,7 @@ contract PriorityWithdrawalQueue is
         uint96 amountWithFee,
         PermitInput calldata permit
     ) external whenNotPaused onlyWhitelisted nonReentrant returns (bytes32 requestId) {
-        if (amountOfEEth < MIN_AMOUNT) revert InvalidAmount();
+        if (amountOfEEth < MIN_AMOUNT || amountOfEEth > MAX_AMOUNT) revert InvalidAmount();
         (uint256 lpEthBefore, uint256 queueEEthSharesBefore) = _snapshotBalances();
 
         try eETH.permit(msg.sender, address(this), permit.value, permit.deadline, permit.v, permit.r, permit.s) {} catch {
@@ -234,7 +235,7 @@ contract PriorityWithdrawalQueue is
         IERC20(address(weETH)).safeTransferFrom(msg.sender, address(this), weEthAmount);
         uint96 eEthAmount = uint96(weETH.unwrap(weEthAmount));
 
-        if (eEthAmount < MIN_AMOUNT) revert InvalidAmount();
+        if (eEthAmount < MIN_AMOUNT || eEthAmount > MAX_AMOUNT) revert InvalidAmount();
 
         (requestId,) = _queueWithdrawRequest(msg.sender, eEthAmount, amountWithFee);
         _verifyRequestPostConditions(lpEthBefore, queueEEthSharesBefore, eEthAmount);
@@ -261,7 +262,7 @@ contract PriorityWithdrawalQueue is
         IERC20(address(weETH)).safeTransferFrom(msg.sender, address(this), weEthAmount);
         uint96 eEthAmount = uint96(weETH.unwrap(weEthAmount));
 
-        if (eEthAmount < MIN_AMOUNT) revert InvalidAmount();
+        if (eEthAmount < MIN_AMOUNT || eEthAmount > MAX_AMOUNT) revert InvalidAmount();
 
         (requestId,) = _queueWithdrawRequest(msg.sender, eEthAmount, amountWithFee);
         _verifyRequestPostConditions(lpEthBefore, queueEEthSharesBefore, eEthAmount);

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -22,6 +22,8 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     using SafeERC20 for IERC20;
 
     uint256 private constant BASIS_POINT_SCALE = 1e4;
+    uint256 public constant MIN_WITHDRAW_AMOUNT = 0.01 ether;
+    uint256 public constant MAX_WITHDRAW_AMOUNT = 1000 ether;
     // this treasury address is set to ethfi buyback wallet address
     address public immutable treasury;
     
@@ -62,6 +64,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     event Unpaused(address account);
 
     error IncorrectRole();
+    error InvalidWithdrawalAmount();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _treasury) {
@@ -109,6 +112,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @param fee fee to be subtracted from amount when recipient calls claimWithdraw
     /// @return uint256 id of the withdraw request
     function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient, uint256 fee) external payable onlyLiquidityPool whenNotPaused returns (uint256) {
+        if (amountOfEEth < MIN_WITHDRAW_AMOUNT || amountOfEEth > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         uint256 requestId = nextRequestId++;
         uint32 feeGwei = uint32(fee / 1 gwei);
 

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -1684,11 +1684,204 @@ contract PriorityWithdrawalQueueTest is TestSetup {
     function test_revert_amountTooSmall() public {
         vm.startPrank(vipUser);
         eETHInstance.approve(address(priorityQueue), 0.001 ether);
-        
+
         // Default minimum amount is 0.01 ether
         vm.expectRevert(PriorityWithdrawalQueue.InvalidAmount.selector);
         priorityQueue.requestWithdraw(0.001 ether, 0);
         vm.stopPrank();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------  MIN / MAX AMOUNT BOUNDARY TESTS  -----------------------------
+    //--------------------------------------------------------------------------------------
+
+    /// @dev Top up vipUser's eETH so they can request a withdrawal at MAX_AMOUNT.
+    function _topUpVipUserEEth(uint96 target) internal {
+        uint256 current = eETHInstance.balanceOf(vipUser);
+        if (current >= target) return;
+        uint256 needed = uint256(target) - current + 1 ether; // small buffer for rebases
+        vm.deal(vipUser, vipUser.balance + needed);
+        vm.prank(vipUser);
+        liquidityPoolInstance.deposit{value: needed}();
+    }
+
+    function test_requestWithdraw_atMin_succeeds() public {
+        uint96 amt = priorityQueue.MIN_AMOUNT();
+
+        vm.startPrank(vipUser);
+        eETHInstance.approve(address(priorityQueue), amt);
+        bytes32 requestId = priorityQueue.requestWithdraw(amt, amt);
+        vm.stopPrank();
+
+        assertTrue(priorityQueue.requestExists(requestId), "MIN_AMOUNT request should be created");
+    }
+
+    function test_requestWithdraw_belowMin_reverts() public {
+        uint96 amt = priorityQueue.MIN_AMOUNT() - 1;
+
+        vm.startPrank(vipUser);
+        eETHInstance.approve(address(priorityQueue), amt);
+        vm.expectRevert(PriorityWithdrawalQueue.InvalidAmount.selector);
+        priorityQueue.requestWithdraw(amt, amt);
+        vm.stopPrank();
+    }
+
+    function test_requestWithdraw_atMax_succeeds() public {
+        uint96 amt = priorityQueue.MAX_AMOUNT();
+        _topUpVipUserEEth(amt);
+
+        vm.startPrank(vipUser);
+        eETHInstance.approve(address(priorityQueue), amt);
+        bytes32 requestId = priorityQueue.requestWithdraw(amt, amt);
+        vm.stopPrank();
+
+        assertTrue(priorityQueue.requestExists(requestId), "MAX_AMOUNT request should be created");
+    }
+
+    function test_requestWithdraw_aboveMax_reverts() public {
+        uint96 amt = priorityQueue.MAX_AMOUNT() + 1;
+        _topUpVipUserEEth(amt);
+
+        vm.startPrank(vipUser);
+        eETHInstance.approve(address(priorityQueue), amt);
+        vm.expectRevert(PriorityWithdrawalQueue.InvalidAmount.selector);
+        priorityQueue.requestWithdraw(amt, amt);
+        vm.stopPrank();
+    }
+
+    function test_requestWithdrawWithPermit_atMin_succeeds() public {
+        uint256 userPrivKey = 999;
+        address permitUser = vm.addr(userPrivKey);
+        uint96 amt = priorityQueue.MIN_AMOUNT();
+
+        vm.prank(alice);
+        priorityQueue.addToWhitelist(permitUser);
+        vm.deal(permitUser, 1 ether);
+        vm.prank(permitUser);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+
+        IPriorityWithdrawalQueue.PermitInput memory permit = _createEEthPermitInput(
+            userPrivKey,
+            address(priorityQueue),
+            amt,
+            eETHInstance.nonces(permitUser),
+            block.timestamp + 1 hours
+        );
+
+        vm.prank(permitUser);
+        bytes32 requestId = priorityQueue.requestWithdrawWithPermit(amt, amt, permit);
+        assertTrue(priorityQueue.requestExists(requestId), "MIN_AMOUNT permit request should be created");
+    }
+
+    function test_requestWithdrawWithPermit_belowMin_reverts() public {
+        uint256 userPrivKey = 999;
+        address permitUser = vm.addr(userPrivKey);
+        uint96 amt = priorityQueue.MIN_AMOUNT() - 1;
+
+        vm.prank(alice);
+        priorityQueue.addToWhitelist(permitUser);
+        vm.deal(permitUser, 1 ether);
+        vm.prank(permitUser);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+
+        IPriorityWithdrawalQueue.PermitInput memory permit = _createEEthPermitInput(
+            userPrivKey,
+            address(priorityQueue),
+            amt,
+            eETHInstance.nonces(permitUser),
+            block.timestamp + 1 hours
+        );
+
+        vm.prank(permitUser);
+        vm.expectRevert(PriorityWithdrawalQueue.InvalidAmount.selector);
+        priorityQueue.requestWithdrawWithPermit(amt, amt, permit);
+    }
+
+    function test_requestWithdrawWithPermit_aboveMax_reverts() public {
+        uint256 userPrivKey = 999;
+        address permitUser = vm.addr(userPrivKey);
+        uint96 amt = priorityQueue.MAX_AMOUNT() + 1;
+
+        vm.prank(alice);
+        priorityQueue.addToWhitelist(permitUser);
+        vm.deal(permitUser, uint256(amt) + 1 ether);
+        vm.prank(permitUser);
+        liquidityPoolInstance.deposit{value: uint256(amt) + 1 ether}();
+
+        IPriorityWithdrawalQueue.PermitInput memory permit = _createEEthPermitInput(
+            userPrivKey,
+            address(priorityQueue),
+            amt,
+            eETHInstance.nonces(permitUser),
+            block.timestamp + 1 hours
+        );
+
+        vm.prank(permitUser);
+        vm.expectRevert(PriorityWithdrawalQueue.InvalidAmount.selector);
+        priorityQueue.requestWithdrawWithPermit(amt, amt, permit);
+    }
+
+    function test_requestWithdrawWithWeETH_atMin_succeeds() public {
+        // wrap → unwrap can round down by a few wei on mainnet fork (weETH rate > 1).
+        // Pad the eETH amount so the unwrapped value is comfortably above MIN_AMOUNT.
+        uint96 eEthAmount = priorityQueue.MIN_AMOUNT() + 0.05 ether;
+        vm.startPrank(vipUser);
+        eETHInstance.approve(address(weEthInstance), eEthAmount);
+        uint256 weEthMinted = weEthInstance.wrap(eEthAmount);
+        IERC20(address(weEthInstance)).approve(address(priorityQueue), weEthMinted);
+
+        // amountWithFee must be > 0 and <= unwrapped eETH; MIN_AMOUNT is the smallest safe value.
+        bytes32 requestId = priorityQueue.requestWithdrawWithWeETH(uint96(weEthMinted), priorityQueue.MIN_AMOUNT());
+        vm.stopPrank();
+
+        assertTrue(priorityQueue.requestExists(requestId), "weETH MIN_AMOUNT request should be created");
+    }
+
+    function test_requestWithdrawWithWeETH_aboveMax_reverts() public {
+        // The unwrap value must exceed MAX_AMOUNT. Pad above the boundary so rounding can't mask the revert.
+        uint96 eEthAmount = priorityQueue.MAX_AMOUNT() + 1 ether;
+        _topUpVipUserEEth(eEthAmount);
+
+        vm.startPrank(vipUser);
+        eETHInstance.approve(address(weEthInstance), eEthAmount);
+        uint256 weEthMinted = weEthInstance.wrap(eEthAmount);
+        IERC20(address(weEthInstance)).approve(address(priorityQueue), weEthMinted);
+
+        vm.expectRevert(PriorityWithdrawalQueue.InvalidAmount.selector);
+        priorityQueue.requestWithdrawWithWeETH(uint96(weEthMinted), 0);
+        vm.stopPrank();
+    }
+
+    function test_requestWithdrawWithWeETHAndPermit_aboveMax_reverts() public {
+        uint256 userPrivKey = 555;
+        address permitUser = vm.addr(userPrivKey);
+
+        vm.prank(alice);
+        priorityQueue.addToWhitelist(permitUser);
+        vm.deal(permitUser, uint256(priorityQueue.MAX_AMOUNT()) + 5 ether);
+        vm.startPrank(permitUser);
+        liquidityPoolInstance.deposit{value: uint256(priorityQueue.MAX_AMOUNT()) + 5 ether}();
+
+        uint96 eEthAmount = priorityQueue.MAX_AMOUNT() + 1 ether;
+        eETHInstance.approve(address(weEthInstance), eEthAmount);
+        uint256 weEthMinted = weEthInstance.wrap(eEthAmount);
+
+        IPriorityWithdrawalQueue.PermitInput memory permit = _createWeEthPermitInput(
+            userPrivKey,
+            address(priorityQueue),
+            weEthMinted,
+            weEthInstance.nonces(permitUser),
+            block.timestamp + 1 hours
+        );
+
+        vm.expectRevert(PriorityWithdrawalQueue.InvalidAmount.selector);
+        priorityQueue.requestWithdrawWithWeETHAndPermit(uint96(weEthMinted), 0, permit);
+        vm.stopPrank();
+    }
+
+    function test_constants_minMaxValues() public view {
+        assertEq(priorityQueue.MIN_AMOUNT(), 0.01 ether, "MIN_AMOUNT mismatch");
+        assertEq(priorityQueue.MAX_AMOUNT(), 1000 ether, "MAX_AMOUNT mismatch");
     }
 
     function test_revert_requestNotFound() public {

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -245,7 +245,11 @@ contract WithdrawRequestNFTTest is TestSetup {
         
     }
 
-    function test_SD_6() public {
+    // Sub-wei rounding scenario from the original SD-6 report. The MIN_WITHDRAW_AMOUNT
+    // gate now blocks any request smaller than 0.01 ether, so the rounding path is
+    // unreachable from the public API. Pin the new behavior: the legacy 9-wei request
+    // reverts with InvalidWithdrawalAmount before any state is touched.
+    function test_SD_6_requestBelowMinReverts() public {
         vm.deal(bob, 98);
 
         vm.startPrank(bob);
@@ -253,44 +257,12 @@ contract WithdrawRequestNFTTest is TestSetup {
         eETHInstance.approve(address(liquidityPoolInstance), 98);
         vm.stopPrank();
 
-        assertEq(eETHInstance.totalShares(), 98);
-        assertEq(liquidityPoolInstance.getTotalPooledEther(), 98);
         vm.prank(address(membershipManagerInstance));
         liquidityPoolInstance.rebase(2);
-        assertEq(eETHInstance.totalShares(), 98);
-        assertEq(liquidityPoolInstance.getTotalPooledEther(), 100);
-
-        assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), 0);
-        vm.prank(bob);
-        // Withdraw request for 9 wei eETH amount (= 8.82 wei eETH share)
-        // 8 wei eETH share is transfered to `withdrawRequestNFT` contract
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 9);
-        assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), 8);
-        // Within `LP.requestWithdraw`
-        // - `share` is calculated by `sharesForAmount` as (9 * 98) / 100 = 8.82 ---> (rounded down to) 8
-
-
-        _finalizeWithdrawalRequest(requestId);
-
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
-        // Within `claimWithdraw`,
-        // - `request.amountOfEEth` is 9
-        // - `amountForShares` is (8 * 100) / 98 = 8.16 ---> (rounded down to) 8
-        // - `amountToTransfer` is min(9, 8) = 8
-        // Therefore, it calls `LP.withdraw(.., 8)`
-
-        // Within `LP.withdraw`, 
-        // - `share` is calculated by 'sharesForWithdrawalAmount' as (8 * 98 + 100 - 1) / 100 = 8.83 ---> (rounded down to) 8
-
-        // As a result, bob received 8 wei ETH which is 1 wei less than 9 wei.
-        assertEq(bob.balance, 8);
-        assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), 0);
-
-        // We burnt 8 wei eETH share which is worth of 8.16 wei eETH amount.
-        // We processed the withdrawal of 8 wei ETH. 
-        // --> The rest 0.16 wei ETH is effectively distributed to the other eETH holders.
+        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, 9);
     }
 
 
@@ -364,9 +336,9 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     function testFuzz_RequestWithdraw(uint96 depositAmount, uint96 withdrawAmount, address recipient) public {
-        // Assume valid conditions
+        // Assume valid conditions — withdraw amount must satisfy [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT].
         vm.assume(depositAmount >= 1 ether && depositAmount <= 1000 ether);
-        vm.assume(withdrawAmount > 0 && withdrawAmount <= depositAmount);
+        vm.assume(withdrawAmount >= withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT() && withdrawAmount <= depositAmount);
         vm.assume(recipient != address(0) && recipient != address(liquidityPoolInstance));
         // Filter out contracts that don't implement IERC721Receiver - only allow EOAs
         vm.assume(recipient.code.length == 0);
@@ -396,11 +368,14 @@ contract WithdrawRequestNFTTest is TestSetup {
         assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), withdrawAmount, "Incorrect contract eETH balance");
         assertEq(withdrawRequestNFTInstance.nextRequestId(), requestId + 1, "Incorrect next request ID");
 
-        if (eETHInstance.balanceOf(bob) > 0) {
+        uint256 minAmount = withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT();
+        uint256 maxAmount = withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT();
+        if (eETHInstance.balanceOf(bob) >= minAmount) {
             uint256 reqAmount = eETHInstance.balanceOf(bob);
+            if (reqAmount > maxAmount) reqAmount = maxAmount;
             vm.startPrank(bob);
             eETHInstance.approve(address(liquidityPoolInstance), reqAmount);
-            uint256 requestId2 = liquidityPoolInstance.requestWithdraw(recipient, reqAmount);    
+            uint256 requestId2 = liquidityPoolInstance.requestWithdraw(recipient, reqAmount);
             vm.stopPrank();
             assertEq(requestId2, requestId + 1, "Incorrect next request ID");
         }
@@ -413,11 +388,16 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint16 remainderSplitBps,
         address recipient
     ) public {
-        // Assume valid conditions
-        vm.assume(depositAmount >= 1 ether && depositAmount <= 1e6 ether);
-        vm.assume(withdrawAmount > 0 && withdrawAmount <= depositAmount);
-        vm.assume(rebaseAmount >= 0.5 ether && rebaseAmount <= depositAmount);
-        vm.assume(remainderSplitBps <= 10000);
+        // Bound to valid ranges. withdrawAmount is bounded against the new
+        // [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT] gate; without bound() the cascading
+        // vm.assume calls hit forge's input-rejection cap at low probability.
+        depositAmount = uint96(bound(depositAmount, 1 ether, 1e6 ether));
+        uint96 maxWithdraw = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT());
+        uint96 minWithdraw = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT());
+        uint96 withdrawCeil = depositAmount < maxWithdraw ? depositAmount : maxWithdraw;
+        withdrawAmount = uint96(bound(withdrawAmount, minWithdraw, withdrawCeil));
+        rebaseAmount = uint96(bound(rebaseAmount, 0.5 ether, depositAmount));
+        remainderSplitBps = uint16(bound(remainderSplitBps, 0, 10000));
         vm.assume(recipient != address(0) && recipient != address(liquidityPoolInstance));
         // Filter out contracts that don't implement IERC721Receiver - only allow EOAs
         vm.assume(recipient.code.length == 0);
@@ -531,9 +511,9 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     function testFuzz_InvalidateRequest(uint96 depositAmount, uint96 withdrawAmount, address recipient) public {
-        // Assume valid conditions
+        // Assume valid conditions — withdraw amount must satisfy [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT].
         vm.assume(depositAmount >= 1 ether && depositAmount <= 1000 ether);
-        vm.assume(withdrawAmount > 0 && withdrawAmount <= depositAmount);
+        vm.assume(withdrawAmount >= withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT() && withdrawAmount <= depositAmount);
         vm.assume(recipient != address(0) && recipient != address(liquidityPoolInstance) && recipient != alice && recipient != admin && recipient != (address(etherFiAdminInstance)) && recipient != roleRegistryInstance.owner());
         // Filter out contracts that don't implement IERC721Receiver - only allow EOAs
         vm.assume(recipient.code.length == 0);
@@ -1573,6 +1553,98 @@ contract WithdrawRequestNFTTest is TestSetup {
     /// @dev Off-by-one: the token at EXACTLY lastFinalizedRequestId is finalized
     ///      and therefore must NOT be invalidatable. The next token (id + 1) is
     ///      not finalized and must still be invalidatable.
+    //--------------------------------------------------------------------------------------
+    //----------------------  MIN / MAX WITHDRAW AMOUNT TESTS  -----------------------------
+    //--------------------------------------------------------------------------------------
+
+    function test_constants_minMaxWithdrawAmount() public view {
+        assertEq(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT(), 0.01 ether, "MIN_WITHDRAW_AMOUNT mismatch");
+        assertEq(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT(), 1000 ether, "MAX_WITHDRAW_AMOUNT mismatch");
+    }
+
+    function test_requestWithdraw_atMin_succeeds() public {
+        uint96 amt = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT());
+
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), amt);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.stopPrank();
+
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
+        assertEq(request.amountOfEEth, amt, "MIN_WITHDRAW_AMOUNT request should be created");
+    }
+
+    function test_requestWithdraw_belowMin_reverts() public {
+        uint96 amt = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT()) - 1;
+
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), amt);
+        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.stopPrank();
+    }
+
+    function test_requestWithdraw_atMax_succeeds() public {
+        uint96 amt = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT());
+
+        vm.deal(bob, uint256(amt) + 1 ether);
+        vm.startPrank(bob);
+        liquidityPoolInstance.deposit{value: uint256(amt) + 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), amt);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.stopPrank();
+
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
+        assertEq(request.amountOfEEth, amt, "MAX_WITHDRAW_AMOUNT request should be created");
+    }
+
+    function test_requestWithdraw_aboveMax_reverts() public {
+        uint96 amt = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT()) + 1;
+
+        vm.deal(bob, uint256(amt) + 1 ether);
+        vm.startPrank(bob);
+        liquidityPoolInstance.deposit{value: uint256(amt) + 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), amt);
+        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.stopPrank();
+    }
+
+    /// @dev Direct call (bypassing LP) hits the gate first.
+    function test_requestWithdraw_direct_belowMin_reverts() public {
+        uint96 amt = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT()) - 1;
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
+        withdrawRequestNFTInstance.requestWithdraw(amt, amt, bob, 0);
+    }
+
+    function test_requestWithdraw_direct_aboveMax_reverts() public {
+        uint96 amt = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT()) + 1;
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
+        withdrawRequestNFTInstance.requestWithdraw(amt, amt, bob, 0);
+    }
+
+    function test_requestWithdraw_direct_atMin_succeeds() public {
+        uint96 amt = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT());
+
+        vm.prank(address(liquidityPoolInstance));
+        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(amt, amt, bob, 0);
+        assertEq(withdrawRequestNFTInstance.getRequest(requestId).amountOfEEth, amt);
+    }
+
+    function test_requestWithdraw_direct_atMax_succeeds() public {
+        uint96 amt = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT());
+
+        vm.prank(address(liquidityPoolInstance));
+        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(amt, amt, bob, 0);
+        assertEq(withdrawRequestNFTInstance.getRequest(requestId).amountOfEEth, amt);
+    }
+
     function test_invalidateRequest_boundary_atLastFinalizedRequestId() public {
         uint256 r1 = _requestFor(bob, 1 ether);
         uint256 r2 = _requestFor(bob, 1 ether);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes withdrawal request validation in two core contracts, which can affect user-facing behavior and any integrations that submit very large withdrawals. Logic change is simple (constant bounds) but touches critical withdrawal entrypoints.
> 
> **Overview**
> Adds an upper bound of `1000 ether` for withdrawal requests across both the `PriorityWithdrawalQueue` and `WithdrawRequestNFT` flows, rejecting requests outside `[0.01 ether, 1000 ether]` (new `MAX_AMOUNT` / `MAX_WITHDRAW_AMOUNT`).
> 
> Updates and expands test coverage to assert min/max boundary behavior for eETH, weETH, and permit-based requests, and replaces the prior SD-6 sub-wei rounding test with an expectation that such tiny requests now revert (`InvalidWithdrawalAmount`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961b91f70a40e49d4a71a98af428487dd370745b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->