### PR TITLE
T1-9: Legacy Admin Migration

### DIFF
--- a/script/hoodi/StakingPart1_Setup.s.sol
+++ b/script/hoodi/StakingPart1_Setup.s.sol
@@ -98,10 +98,6 @@ contract StakingPart1 is Script {
             console.log("Whitelisting node operator...");
             
             vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
-            // Add admin rights if needed
-            if (!nodeOperatorManager.admins(depositor)) {
-                nodeOperatorManager.updateAdmin(depositor, true);
-            }
             nodeOperatorManager.addToWhitelist(nodeOp);
             vm.stopBroadcast();
         }

--- a/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
+++ b/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
@@ -204,7 +204,7 @@ contract ReauditFixesTransactions is Utils {
 
         EtherFiNode newEtherFiNodeImplementation = new EtherFiNode(address(LIQUIDITY_POOL), address(ETHERFI_NODES_MANAGER), address(EIGENLAYER_POD_MANAGER), address(EIGENLAYER_DELEGATION_MANAGER), address(ROLE_REGISTRY));
         EtherFiRedemptionManager newEtherFiRedemptionManagerImplementation = new EtherFiRedemptionManager(address(LIQUIDITY_POOL), address(EETH), address(WEETH), address(TREASURY), address(ROLE_REGISTRY), address(ETHERFI_RESTAKER), address(0x0));
-        EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(EIGENLAYER_REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER));
+        EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(EIGENLAYER_REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER), address(ROLE_REGISTRY), address(ETHERFI_RATE_LIMITER));
         EtherFiRewardsRouter newEtherFiRewardsRouterImplementation = new EtherFiRewardsRouter(address(LIQUIDITY_POOL), address(TREASURY), address(ROLE_REGISTRY));
         Liquifier newLiquifierImplementation = new Liquifier(address(ROLE_REGISTRY));
         WithdrawRequestNFT newWithdrawRequestNFTImplementation = new WithdrawRequestNFT(address(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE));

--- a/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
+++ b/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
@@ -206,7 +206,7 @@ contract ReauditFixesTransactions is Utils {
         EtherFiRedemptionManager newEtherFiRedemptionManagerImplementation = new EtherFiRedemptionManager(address(LIQUIDITY_POOL), address(EETH), address(WEETH), address(TREASURY), address(ROLE_REGISTRY), address(ETHERFI_RESTAKER), address(0x0));
         EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(EIGENLAYER_REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER));
         EtherFiRewardsRouter newEtherFiRewardsRouterImplementation = new EtherFiRewardsRouter(address(LIQUIDITY_POOL), address(TREASURY), address(ROLE_REGISTRY));
-        Liquifier newLiquifierImplementation = new Liquifier();
+        Liquifier newLiquifierImplementation = new Liquifier(address(ROLE_REGISTRY));
         WithdrawRequestNFT newWithdrawRequestNFTImplementation = new WithdrawRequestNFT(address(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE));
         EtherFiViewer newEtherFiViewerImplementation = new EtherFiViewer(address(EIGENLAYER_POD_MANAGER), address(EIGENLAYER_DELEGATION_MANAGER));
 

--- a/script/validator-key-gen/transactions.s.sol
+++ b/script/validator-key-gen/transactions.s.sol
@@ -174,8 +174,8 @@ contract ValidatorKeyGenTransactions is Script {
     }
 
     function forkTestOne() public {
-        vm.prank(auctionManager.owner());
-        auctionManager.updateAdmin(ETHERFI_OPERATING_ADMIN, true);
+        vm.prank(roleRegistry.owner());
+        roleRegistry.grantRole(auctionManager.AUCTION_MANAGER_ADMIN_ROLE(), ETHERFI_OPERATING_ADMIN);
 
         address spawner = vm.addr(0x1234);
         

--- a/script/validator-key-gen/verify.s.sol
+++ b/script/validator-key-gen/verify.s.sol
@@ -78,7 +78,7 @@ contract VerifyValidatorKeyGen is Script {
         // LiquidityPool newLiquidityPoolImplementation = new LiquidityPool(address(0x0));
         StakingManager newStakingManagerImplementation = new StakingManager(address(LIQUIDITY_POOL_PROXY), address(ETHERFI_NODES_MANAGER_PROXY), address(ETH_DEPOSIT_CONTRACT), address(AUCTION_MANAGER), address(ETHERFI_NODE_BEACON), address(ROLE_REGISTRY));
         EtherFiNodesManager newEtherFiNodesManagerImplementation = new EtherFiNodesManager(address(STAKING_MANAGER_PROXY), address(ROLE_REGISTRY), address(RATE_LIMITER_PROXY));
-        EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER));
+        EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER), address(ROLE_REGISTRY), address(RATE_LIMITER_PROXY));
 
         // contractCodeChecker.verifyContractByteCodeMatch(LIQUIDITY_POOL_IMPL, address(newLiquidityPoolImplementation));
         contractCodeChecker.verifyContractByteCodeMatch(STAKING_MANAGER_IMPL, address(newStakingManagerImplementation));
@@ -124,7 +124,7 @@ contract VerifyValidatorKeyGen is Script {
 
         // EtherFiRestaker
         {
-            bytes memory constructorArgs = abi.encode(REWARDS_COORDINATOR, ETHERFI_REDEMPTION_MANAGER);
+            bytes memory constructorArgs = abi.encode(REWARDS_COORDINATOR, ETHERFI_REDEMPTION_MANAGER, ROLE_REGISTRY, RATE_LIMITER_PROXY);
             bytes memory bytecode = abi.encodePacked(
                 type(EtherFiRestaker).creationCode,
                 constructorArgs

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "./interfaces/IAuctionManager.sol";
 import "./interfaces/INodeOperatorManager.sol";
 import "./interfaces/IProtocolRevenueManager.sol";
+import "./interfaces/IRoleRegistry.sol";
 import "@openzeppelin-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
@@ -43,7 +44,14 @@ contract AuctionManager is
     uint128 public accumulatedRevenue;
     uint128 public accumulatedRevenueThreshold;
 
-    mapping(address => bool) public admins;
+    mapping(address => bool) public DEPRECATED_admins;
+
+    // Immutables are not part of proxy storage; stored in implementation bytecode only.
+    IRoleRegistry public immutable roleRegistry;
+
+    bytes32 public constant AUCTION_MANAGER_ADMIN_ROLE = keccak256("AUCTION_MANAGER_ADMIN_ROLE");
+
+    error IncorrectRole();
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
@@ -56,7 +64,8 @@ contract AuctionManager is
     event WhitelistEnabled(bool whitelistStatus);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _roleRegistry) {
+        roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
     }
 
@@ -90,7 +99,7 @@ contract AuctionManager is
         nodeOperatorManager = INodeOperatorManager(_nodeOperatorManagerAddress);
         accumulatedRevenue = 0;
         accumulatedRevenueThreshold = _accumulatedRevenueThreshold;
-        admins[_etherFiAdminContractAddress] = true;
+        // Admin grant now happens via roleRegistry.grantRole post-deploy.
     }
 
     /// @notice Creates bid(s) for the right to run a validator node when ETH is deposited
@@ -240,12 +249,14 @@ contract AuctionManager is
     }
 
     //Pauses the contract
-    function pauseContract() external onlyAdmin {
+    function pauseContract() external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_PAUSER(), msg.sender)) revert IncorrectRole();
         _pause();
     }
 
     //Unpauses the contract
-    function unPauseContract() external onlyAdmin {
+    function unPauseContract() external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_UNPAUSER(), msg.sender)) revert IncorrectRole();
         _unpause();
     }
 
@@ -345,13 +356,6 @@ contract AuctionManager is
         );
     }
 
-    /// @notice Updates the address of the admin
-    /// @param _address the new address to set as admin
-    function updateAdmin(address _address, bool _isAdmin) external onlyOwner {
-        require(_address != address(0), "Cannot be address zero");
-        admins[_address] = _isAdmin;
-    }
-
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
@@ -362,7 +366,7 @@ contract AuctionManager is
     }
 
     modifier onlyAdmin() {
-        require(admins[msg.sender], "Caller is not the admin");
+        if (!roleRegistry.hasRole(AUCTION_MANAGER_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
         _;
     }
 }

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -93,13 +93,12 @@ contract AuctionManager is
         __ReentrancyGuard_init();
     }
 
-    function initializeOnUpgrade(address _membershipManagerContractAddress, uint128 _accumulatedRevenueThreshold, address _etherFiAdminContractAddress, address _nodeOperatorManagerAddress) external onlyOwner { 
-        require(_membershipManagerContractAddress != address(0) && _etherFiAdminContractAddress != address(0) && _nodeOperatorManagerAddress != address(0), "No Zero Addresses");
+    function initializeOnUpgrade(address _membershipManagerContractAddress, uint128 _accumulatedRevenueThreshold, address _nodeOperatorManagerAddress) external onlyOwner {
+        require(_membershipManagerContractAddress != address(0) && _nodeOperatorManagerAddress != address(0), "No Zero Addresses");
         membershipManagerContractAddress = _membershipManagerContractAddress;
         nodeOperatorManager = INodeOperatorManager(_nodeOperatorManagerAddress);
         accumulatedRevenue = 0;
         accumulatedRevenueThreshold = _accumulatedRevenueThreshold;
-        // Admin grant now happens via roleRegistry.grantRole post-deploy.
     }
 
     /// @notice Creates bid(s) for the right to run a validator node when ETH is deposited

--- a/src/BucketRateLimiter.sol
+++ b/src/BucketRateLimiter.sol
@@ -74,19 +74,19 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
         BucketLimiter.setRefillRate(limit, refillRate64);
     }
 
-    function registerToken(address token, uint256 capacity, uint256 refillRate) external onlyOwner {
+    function registerToken(address token, uint256 capacity, uint256 refillRate) external onlyAdmin {
         uint64 capacity64 = SafeCast.toUint64(capacity / 1e12);
         uint64 refillRate64 = SafeCast.toUint64(refillRate / 1e12);
         limitsPerToken[token] = BucketLimiter.create(capacity64, refillRate64);
     }
 
-    function setCapacityPerToken(address token, uint256 capacity) external onlyOwner {
+    function setCapacityPerToken(address token, uint256 capacity) external onlyAdmin {
         // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
         uint64 capacity64 = SafeCast.toUint64(capacity / 1e12);
         BucketLimiter.setCapacity(limitsPerToken[token], capacity64);
     }
 
-    function setRefillRatePerSecondPerToken(address token, uint256 refillRate) external onlyOwner {
+    function setRefillRatePerSecondPerToken(address token, uint256 refillRate) external onlyAdmin {
         // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
         uint64 refillRate64 = SafeCast.toUint64(refillRate / 1e12);
         BucketLimiter.setRefillRate(limitsPerToken[token], refillRate64);

--- a/src/BucketRateLimiter.sol
+++ b/src/BucketRateLimiter.sol
@@ -7,6 +7,7 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import "src/interfaces/IRateLimiter.sol";
+import "src/interfaces/IRoleRegistry.sol";
 import "lib/BucketLimiter.sol";
 
 contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, OwnableUpgradeable, UUPSUpgradeable {
@@ -14,15 +15,26 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
     BucketLimiter.Limit public limit;
     address public consumer;
 
-    mapping(address => bool) public admins;
-    mapping(address => bool) public pausers;
+    mapping(address => bool) public DEPRECATED_admins;
+    mapping(address => bool) public DEPRECATED_pausers;
 
     mapping(address => BucketLimiter.Limit) public limitsPerToken;
 
-    event UpdatedAdmin(address indexed admin, bool status);
-    event UpdatedPauser(address indexed pauser, bool status);
+    // Immutables are not part of proxy storage; stored in implementation bytecode only.
+    IRoleRegistry public immutable roleRegistry;
 
-    constructor() {
+    bytes32 public constant BUCKET_RATE_LIMITER_ADMIN_ROLE = keccak256("BUCKET_RATE_LIMITER_ADMIN_ROLE");
+
+    error IncorrectRole();
+
+    modifier onlyAdmin() {
+        if (!roleRegistry.hasRole(BUCKET_RATE_LIMITER_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        _;
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _roleRegistry) {
+        roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
     }
 
@@ -50,13 +62,13 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
         return globalConsumable && perTokenConsumable;
     }
 
-    function setCapacity(uint256 capacity) external onlyOwner {
+    function setCapacity(uint256 capacity) external onlyAdmin {
         // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
         uint64 capacity64 = SafeCast.toUint64(capacity / 1e12);
         BucketLimiter.setCapacity(limit, capacity64);
     }
 
-    function setRefillRatePerSecond(uint256 refillRate) external onlyOwner {
+    function setRefillRatePerSecond(uint256 refillRate) external onlyAdmin {
         // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
         uint64 refillRate64 = SafeCast.toUint64(refillRate / 1e12);
         BucketLimiter.setRefillRate(limit, refillRate64);
@@ -80,27 +92,17 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
         BucketLimiter.setRefillRate(limitsPerToken[token], refillRate64);
     }
 
-    function updateConsumer(address _consumer) external onlyOwner {
+    function updateConsumer(address _consumer) external onlyAdmin {
         consumer = _consumer;
     }
 
-    function updateAdmin(address admin, bool status) external onlyOwner {
-        admins[admin] = status;
-        emit UpdatedAdmin(admin, status);
-    }
-
-    function updatePauser(address pauser, bool status) external onlyOwner {
-        pausers[pauser] = status;
-        emit UpdatedPauser(pauser, status);
-    }
-
     function pauseContract() external {
-        require(pausers[msg.sender] || admins[msg.sender] || msg.sender == owner(), "NOT_PAUSER");
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_PAUSER(), msg.sender)) revert IncorrectRole();
         _pause();
     }
 
     function unPauseContract() external {
-        require(admins[msg.sender] || msg.sender == owner(), "NOT_ADMIN");
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_UNPAUSER(), msg.sender)) revert IncorrectRole();
         _unpause();
     }
 

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -37,6 +37,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
 
     mapping(address => bool) public DEPRECATED_admins;
 
+    // Immutables are not part of proxy storage; stored in implementation bytecode only.
     IRoleRegistry public immutable roleRegistry;
 
     bytes32 public constant ETHERFI_ORACLE_ADMIN_ROLE = keccak256("ETHERFI_ORACLE_ADMIN_ROLE");

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -9,6 +9,7 @@ import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 
 import "./interfaces/IEtherFiOracle.sol";
 import "./interfaces/IEtherFiAdmin.sol";
+import "./interfaces/IRoleRegistry.sol";
 
 
 contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable, UUPSUpgradeable, IEtherFiOracle {
@@ -34,7 +35,13 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
 
     IEtherFiAdmin etherFiAdmin;
 
-    mapping(address => bool) public admins;
+    mapping(address => bool) public DEPRECATED_admins;
+
+    IRoleRegistry public immutable roleRegistry;
+
+    bytes32 public constant ETHERFI_ORACLE_ADMIN_ROLE = keccak256("ETHERFI_ORACLE_ADMIN_ROLE");
+
+    error IncorrectRole();
 
     event CommitteeMemberAdded(address indexed member);
     event CommitteeMemberRemoved(address indexed member);
@@ -49,7 +56,8 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
 
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _roleRegistry) {
+        roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
     }
 
@@ -306,15 +314,13 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         lastPublishedReportRefBlock = _lastPublishedReportRefBlock;
     }
 
-    function updateAdmin(address _address, bool _isAdmin) external onlyOwner {
-        admins[_address] = _isAdmin;
-    }
-
-    function pauseContract() external isAdmin {
+    function pauseContract() external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_PAUSER(), msg.sender)) revert IncorrectRole();
         _pause();
     }
 
-    function unPauseContract() external isAdmin {
+    function unPauseContract() external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_UNPAUSER(), msg.sender)) revert IncorrectRole();
         _unpause();
     }
 
@@ -325,7 +331,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     modifier isAdmin() {
-        require(admins[msg.sender] || msg.sender == owner(), "EtherFiAdmin: not an admin");
+        if (!roleRegistry.hasRole(ETHERFI_ORACLE_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
         _;
     }
 }

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -172,13 +172,17 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external onlyClaimWithdrawalsRole {
         lidoWithdrawalQueue.claimWithdrawals(_requestIds, _hints);
 
-        withdrawEther();
+        _withdrawEther();
 
         emit CompletedStEthQueuedWithdrawals(_requestIds);
     }
 
     // Send the ETH back to the liquidity pool
     function withdrawEther() public onlyAdmin {
+        _withdrawEther();
+    }
+
+    function _withdrawEther() internal {
         uint256 amountToLiquidityPool = _min(address(this).balance, liquidityPool.totalValueOutOfLp());
         (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: 20000}("");
         require(sent, "ETH_SEND_TO_LIQUIDITY_POOL_FAILED");

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -17,6 +17,9 @@ import "./eigenlayer-interfaces/IStrategyManager.sol";
 import "./eigenlayer-interfaces/IDelegationManager.sol";
 import "./eigenlayer-interfaces/IRewardsCoordinator.sol";
 
+import "./interfaces/IRoleRegistry.sol";
+import "./interfaces/IEtherFiRateLimiter.sol";
+
 contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     using SafeERC20 for IERC20;
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -29,6 +32,21 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     IRewardsCoordinator public immutable rewardsCoordinator;
     address public immutable etherFiRedemptionManager;
 
+    // Immutables are not part of proxy storage; stored in implementation bytecode only.
+    IRoleRegistry public immutable roleRegistry;
+    IEtherFiRateLimiter public immutable rateLimiter;
+
+    bytes32 public constant ETHERFI_RESTAKER_ADMIN_ROLE                 = keccak256("ETHERFI_RESTAKER_ADMIN_ROLE");
+    bytes32 public constant ETHERFI_RESTAKER_REQUEST_WITHDRAWALS_ROLE   = keccak256("ETHERFI_RESTAKER_REQUEST_WITHDRAWALS_ROLE");
+    bytes32 public constant ETHERFI_RESTAKER_CLAIM_WITHDRAWALS_ROLE     = keccak256("ETHERFI_RESTAKER_CLAIM_WITHDRAWALS_ROLE");
+    bytes32 public constant ETHERFI_RESTAKER_DEPOSIT_INTO_STRATEGY_ROLE = keccak256("ETHERFI_RESTAKER_DEPOSIT_INTO_STRATEGY_ROLE");
+
+    bytes32 public constant STETH_REQUEST_WITHDRAWAL_LIMIT_ID = keccak256("STETH_REQUEST_WITHDRAWAL_LIMIT_ID");
+    bytes32 public constant QUEUE_WITHDRAWALS_LIMIT_ID        = keccak256("QUEUE_WITHDRAWALS_LIMIT_ID");
+    bytes32 public constant DEPOSIT_INTO_STRATEGY_LIMIT_ID    = keccak256("DEPOSIT_INTO_STRATEGY_LIMIT_ID");
+
+    error IncorrectRole();
+
     LiquidityPool public liquidityPool;
     Liquifier public liquifier;
     ILidoWithdrawalQueue public lidoWithdrawalQueue;
@@ -36,11 +54,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     IDelegationManager public eigenLayerDelegationManager;
     IStrategyManager public eigenLayerStrategyManager;
 
-    mapping(address => bool) public pausers;
-    mapping(address => bool) public admins;
+    mapping(address => bool) public DEPRECATED_pausers;
+    mapping(address => bool) public DEPRECATED_admins;
 
     mapping(address => TokenInfo) public tokenInfos;
-    
+
     EnumerableSet.Bytes32Set private withdrawalRootsSet;
     mapping(bytes32 => IDelegationManager.Withdrawal) public DEPRECATED_withdrawalRootToWithdrawal;
 
@@ -58,10 +76,17 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     error WrongOutput();
     error IncorrectCaller();
 
-     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _rewardsCoordinator, address _etherFiRedemptionManager) {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(
+        address _rewardsCoordinator,
+        address _etherFiRedemptionManager,
+        address _roleRegistry,
+        address _rateLimiter
+    ) {
         rewardsCoordinator = IRewardsCoordinator(_rewardsCoordinator);
         etherFiRedemptionManager = _etherFiRedemptionManager;
+        roleRegistry = IRoleRegistry(_roleRegistry);
+        rateLimiter = IEtherFiRateLimiter(_rateLimiter);
         _disableInitializers();
     }
 
@@ -101,16 +126,18 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         IERC20(address(lido)).safeTransfer(recipient, amount);
     }
 
-    /// Initiate the redemption of stETH for ETH 
+    /// Initiate the redemption of stETH for ETH
     /// @notice Request for all stETH holdings
-    function stEthRequestWithdrawal() external onlyAdmin returns (uint256[] memory) {
+    function stEthRequestWithdrawal() external onlyRequestWithdrawalsRole returns (uint256[] memory) {
         uint256 amount = lido.balanceOf(address(this));
         return stEthRequestWithdrawal(amount);
     }
 
     /// @notice Request for a specific amount of stETH holdings
     /// @param _amount the amount of stETH to request
-    function stEthRequestWithdrawal(uint256 _amount) public onlyAdmin returns (uint256[] memory) {
+    function stEthRequestWithdrawal(uint256 _amount) public onlyRequestWithdrawalsRole returns (uint256[] memory) {
+        rateLimiter.consume(STETH_REQUEST_WITHDRAWAL_LIMIT_ID, _amountToGwei(_amount));
+
         uint256 minAmount = lidoWithdrawalQueue.MIN_STETH_WITHDRAWAL_AMOUNT();
         uint256 maxAmount = lidoWithdrawalQueue.MAX_STETH_WITHDRAWAL_AMOUNT();
 
@@ -142,7 +169,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// @notice Claim a batch of withdrawal requests if they are finalized sending the ETH to the this contract back
     /// @param _requestIds array of request ids to claim
     /// @param _hints checkpoint hint for each id. Can be obtained with `findCheckpointHints()`
-    function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external onlyAdmin {
+    function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external onlyClaimWithdrawalsRole {
         lidoWithdrawalQueue.claimWithdrawals(_requestIds, _hints);
 
         withdrawEther();
@@ -165,9 +192,13 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     function setRewardsClaimer(address _claimer) external onlyAdmin {
         rewardsCoordinator.setClaimerFor(_claimer);
     }
-    
+
     // delegate to an AVS operator
-    function delegateTo(address operator, IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry, bytes32 approverSalt) external onlyAdmin {
+    function delegateTo(
+        address operator,
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 approverSalt
+    ) external onlyAdmin {
         eigenLayerDelegationManager.delegateTo(operator, approverSignatureAndExpiry, approverSalt);
     }
 
@@ -187,7 +218,9 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     // deposit the token in holding into the restaking strategy
-    function depositIntoStrategy(address token, uint256 amount) external onlyAdmin returns (uint256) {
+    function depositIntoStrategy(address token, uint256 amount) external onlyDepositIntoStrategyRole returns (uint256) {
+        rateLimiter.consume(DEPOSIT_INTO_STRATEGY_LIMIT_ID, _amountToGwei(amount));
+
         IERC20(token).safeApprove(address(eigenLayerStrategyManager), amount);
 
         IStrategy strategy = tokenInfos[token].elStrategy;
@@ -200,7 +233,9 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// Made easy for operators
     /// @param token the token to withdraw
     /// @param amount the amount of token to withdraw
-    function queueWithdrawals(address token, uint256 amount) public onlyAdmin returns (bytes32[] memory) {
+    function queueWithdrawals(address token, uint256 amount) public onlyRequestWithdrawalsRole returns (bytes32[] memory) {
+        rateLimiter.consume(QUEUE_WITHDRAWALS_LIMIT_ID, _amountToGwei(amount));
+
         uint256 shares = getEigenLayerRestakingStrategy(token).underlyingToSharesView(amount);
         bytes32[] memory withdrawalRoots = _queueWithdrawalsByShares(token, shares);
 
@@ -215,7 +250,10 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// @notice Used to complete the specified `queuedWithdrawals`. The function caller must match `queuedWithdrawals[...].withdrawer`
     /// @param _queuedWithdrawals The QueuedWithdrawals to complete.
     /// @param _tokens Array of tokens for each QueuedWithdrawal. See `completeQueuedWithdrawal` for the usage of a single array.
-    function completeQueuedWithdrawals(IDelegationManager.Withdrawal[] memory _queuedWithdrawals, IERC20[][] memory _tokens) external onlyAdmin {
+    function completeQueuedWithdrawals(
+        IDelegationManager.Withdrawal[] memory _queuedWithdrawals,
+        IERC20[][] memory _tokens
+    ) external onlyClaimWithdrawalsRole {
         uint256 num = _queuedWithdrawals.length;
         bool[] memory receiveAsTokens = new bool[](num);
         for (uint256 i = 0; i < num; i++) {
@@ -252,7 +290,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         (uint256 restaked, uint256 unrestaking, uint256 holding, uint256 pendingForWithdrawals) = getTotalPooledEtherSplits(_token);
         return restaked + unrestaking + holding + pendingForWithdrawals;
     }
-    
+
     function getRestakedAmount(address _token) public view returns (uint256) {
         TokenInfo memory info = tokenInfos[_token];
         IStrategy[] memory strategies = new IStrategy[](1);
@@ -276,15 +314,20 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// - in Eigenlayer, either restaked or pending for un-restaking
     /// - non-restaked & held by this contract
     /// - non-restaked & not held by this contract & pending in redemption for ETH
-    function getTotalPooledEtherSplits(address _token) public view returns (uint256 restaked, uint256 unrestaking, uint256 holding, uint256 pendingForWithdrawals) {
+    function getTotalPooledEtherSplits(address _token) public view returns (
+        uint256 restaked,
+        uint256 unrestaking,
+        uint256 holding,
+        uint256 pendingForWithdrawals
+    ) {
         TokenInfo memory info = tokenInfos[_token];
         if (info.elStrategy != IStrategy(address(0))) {
             uint256 restakedTokenAmount = getRestakedAmount(_token);
             uint256 unrestakingTokenAmount = getAmountInEigenLayerPendingForWithdrawals(_token);
-            restaked = liquifier.quoteByFairValue(_token, restakedTokenAmount); // restaked & pending for withdrawals
-            unrestaking = liquifier.quoteByFairValue(_token, unrestakingTokenAmount); // restaked & pending for withdrawals
+            restaked = liquifier.quoteByFairValue(_token, restakedTokenAmount);
+            unrestaking = liquifier.quoteByFairValue(_token, unrestakingTokenAmount);
         }
-        holding = liquifier.quoteByFairValue(_token, IERC20(_token).balanceOf(address(this))); /// eth value for erc20 holdings
+        holding = liquifier.quoteByFairValue(_token, IERC20(_token).balanceOf(address(this)));
         pendingForWithdrawals = liquifier.quoteByFairValue(_token, getAmountPendingForRedemption(_token));
     }
 
@@ -292,14 +335,14 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     function getAmountInEigenLayerPendingForWithdrawals(address _token) public view returns (uint256) {
         TokenInfo memory info = tokenInfos[_token];
         if (info.elStrategy == IStrategy(address(0))) return 0;
-        
+
         // Calculate by summing up shares from all pending withdrawals for this token
         uint256 totalShares = 0;
         (IDelegationManager.Withdrawal[] memory queuedWithdrawals, ) = eigenLayerDelegationManager.getQueuedWithdrawals(address(this));
         for (uint256 i = 0; i < queuedWithdrawals.length; i++) {
             bytes32 withdrawalRoot = eigenLayerDelegationManager.calculateWithdrawalRoot(queuedWithdrawals[i]);
             (IDelegationManager.Withdrawal memory withdrawal, uint256[] memory shares) = eigenLayerDelegationManager.getQueuedWithdrawal(withdrawalRoot);
-            
+
             // Check if this withdrawal involves the specified token
             for (uint256 j = 0; j < withdrawal.strategies.length; j++) {
                 address token = address(withdrawal.strategies[j].underlyingToken());
@@ -327,25 +370,27 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return total;
     }
 
-    function updateAdmin(address _address, bool _isAdmin) external onlyOwner {
-        admins[_address] = _isAdmin;
-    }
-
-    function updatePauser(address _address, bool _isPauser) external onlyAdmin {
-        pausers[_address] = _isPauser;
-    }
-
     // Pauses the contract
-    function pauseContract() external onlyPauser {
+    function pauseContract() external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_PAUSER(), msg.sender)) revert IncorrectRole();
         _pause();
     }
 
     // Unpauses the contract
-    function unPauseContract() external onlyAdmin {
+    function unPauseContract() external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_UNPAUSER(), msg.sender)) revert IncorrectRole();
         _unpause();
     }
 
     // INTERNAL functions
+
+    /// @dev Convert wei to gwei for rate-limiter buckets, with overflow check.
+    function _amountToGwei(uint256 amountWei) internal pure returns (uint64) {
+        uint256 amountGwei = amountWei / 1e9;
+        require(amountGwei <= type(uint64).max, "EtherFiRestaker: amount overflows uint64 gwei");
+        return uint64(amountGwei);
+    }
+
     function _queueWithdrawalsByShares(address _token, uint256 _shares) internal returns (bytes32[] memory) {
         IDelegationManagerTypes.QueuedWithdrawalParams[] memory params = new IDelegationManagerTypes.QueuedWithdrawalParams[](1);
         IStrategy[] memory strategies = new IStrategy[](1);
@@ -368,22 +413,24 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
-    function _requireAdmin() internal view virtual {
-        if (!(admins[msg.sender] || msg.sender == owner())) revert IncorrectCaller();
-    }
-
-    function _requirePauser() internal view virtual {
-        if (!(pausers[msg.sender] || admins[msg.sender] || msg.sender == owner())) revert IncorrectCaller();
-    }
-
-    /* MODIFIER */
+    /* MODIFIERS */
     modifier onlyAdmin() {
-        _requireAdmin();
+        if (!roleRegistry.hasRole(ETHERFI_RESTAKER_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
         _;
     }
 
-    modifier onlyPauser() {
-        _requirePauser();
+    modifier onlyRequestWithdrawalsRole() {
+        if (!roleRegistry.hasRole(ETHERFI_RESTAKER_REQUEST_WITHDRAWALS_ROLE, msg.sender)) revert IncorrectRole();
+        _;
+    }
+
+    modifier onlyClaimWithdrawalsRole() {
+        if (!roleRegistry.hasRole(ETHERFI_RESTAKER_CLAIM_WITHDRAWALS_ROLE, msg.sender)) revert IncorrectRole();
+        _;
+    }
+
+    modifier onlyDepositIntoStrategyRole() {
+        if (!roleRegistry.hasRole(ETHERFI_RESTAKER_DEPOSIT_INTO_STRATEGY_ROLE, msg.sender)) revert IncorrectRole();
         _;
     }
 }

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -385,8 +385,10 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     // INTERNAL functions
 
     /// @dev Convert wei to gwei for rate-limiter buckets, with overflow check.
+    /// Rounds up so that any non-zero wei amount consumes at least 1 gwei from
+    /// the bucket — prevents sub-gwei dust from bypassing the rate limiter.
     function _amountToGwei(uint256 amountWei) internal pure returns (uint64) {
-        uint256 amountGwei = amountWei / 1e9;
+        uint256 amountGwei = (amountWei + 1e9 - 1) / 1e9;
         require(amountGwei <= type(uint64).max, "EtherFiRestaker: amount overflows uint64 gwei");
         return uint64(amountGwei);
     }

--- a/src/NodeOperatorManager.sol
+++ b/src/NodeOperatorManager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "../src/interfaces/INodeOperatorManager.sol";
 import "../src/interfaces/IAuctionManager.sol";
+import "../src/interfaces/IRoleRegistry.sol";
 import "../src/LiquidityPool.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
@@ -32,15 +33,23 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
     mapping(address => bool) private whitelistedAddresses;
     mapping(address => bool) public registered;
 
-    mapping(address => bool) public admins;
+    mapping(address => bool) public DEPRECATED_admins;
     mapping(address => mapping(ILiquidityPool.SourceOfFunds => bool)) public operatorApprovedTags;
+
+    // Immutables are not part of proxy storage; stored in implementation bytecode only.
+    IRoleRegistry public immutable roleRegistry;
+
+    bytes32 public constant NODE_OPERATOR_MANAGER_ADMIN_ROLE = keccak256("NODE_OPERATOR_MANAGER_ADMIN_ROLE");
+
+    error IncorrectRole();
 
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _roleRegistry) {
+        roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
     }
 
@@ -164,12 +173,14 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
     }
 
     //Pauses the contract
-    function pauseContract() external onlyAdmin {
+    function pauseContract() external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_PAUSER(), msg.sender)) revert IncorrectRole();
         _pause();
     }
 
     //Unpauses the contract
-    function unPauseContract() external onlyAdmin {
+    function unPauseContract() external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_UNPAUSER(), msg.sender)) revert IncorrectRole();
         _unpause();
     }
 
@@ -235,13 +246,6 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
         auctionManagerContractAddress = _auctionContractAddress;
     }
 
-    /// @notice Updates the address of the admin
-    /// @param _address the new address to set as admin
-    function updateAdmin(address _address, bool _isAdmin) external onlyOwner {
-        require(_address != address(0), "Cannot be address zero");
-        admins[_address] = _isAdmin;
-    }
-
     //--------------------------------------------------------------------------------------
     //-------------------------------  INTERNAL FUNCTIONS   --------------------------------
     //--------------------------------------------------------------------------------------
@@ -263,7 +267,7 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
     }
 
     modifier onlyAdmin() {
-        require(admins[msg.sender], "Caller is not the admin");
+        if (!roleRegistry.hasRole(NODE_OPERATOR_MANAGER_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
         _;
     }
 }

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -17,7 +17,7 @@ import "./utils/PausableUntil.sol";
 
 
 
-contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardNamespaced, PausabeUntil, IWithdrawRequestNFT {
+contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardNamespaced, PausableUntil, IWithdrawRequestNFT {
     using Math for uint256;
     using SafeERC20 for IERC20;
 

--- a/src/interfaces/IAuctionManager.sol
+++ b/src/interfaces/IAuctionManager.sol
@@ -38,7 +38,6 @@ interface IAuctionManager {
 
     function setAccumulatedRevenueThreshold(uint128 _newThreshold) external;
 
-    function updateAdmin(address _address, bool _isAdmin) external;
     function pauseContract() external;
     function unPauseContract() external;
     

--- a/test/AddressProvider.t.sol
+++ b/test/AddressProvider.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "./TestSetup.sol";
 
 contract AuctionManagerV2Test is AuctionManager {
+    constructor(address _roleRegistry) AuctionManager(_roleRegistry) {}
     function isUpgraded() public pure returns(bool){
         return true;
     }
@@ -130,7 +131,7 @@ contract AddressProviderTest is TestSetup {
         assertEq(addressProviderInstance.getImplementationAddress("RegulationsManager"), address(regulationsManagerImplementation));
         assertEq(addressProviderInstance.getImplementationAddress("AuctionManager"), address(auctionImplementation));
 
-        AuctionManagerV2Test auctionManagerV2Implementation = new AuctionManagerV2Test();
+        AuctionManagerV2Test auctionManagerV2Implementation = new AuctionManagerV2Test(address(roleRegistryInstance));
         auctionInstance.upgradeTo(address(auctionManagerV2Implementation));
 
         assertEq(addressProviderInstance.getImplementationAddress("AuctionManager"), address(auctionManagerV2Implementation));

--- a/test/AuctionManager.t.sol
+++ b/test/AuctionManager.t.sol
@@ -151,7 +151,7 @@ contract AuctionManagerTest is TestSetup {
     function test_DisableWhitelist() public {
         assertTrue(auctionInstance.whitelistEnabled());
 
-        vm.expectRevert("Caller is not the admin");
+        vm.expectRevert(AuctionManager.IncorrectRole.selector);
         vm.prank(owner);
         auctionInstance.disableWhitelist();
 
@@ -169,7 +169,7 @@ contract AuctionManagerTest is TestSetup {
 
         assertFalse(auctionInstance.whitelistEnabled());
 
-        vm.expectRevert("Caller is not the admin");
+        vm.expectRevert(AuctionManager.IncorrectRole.selector);
         vm.prank(owner);
         auctionInstance.enableWhitelist();
 
@@ -738,7 +738,7 @@ contract AuctionManagerTest is TestSetup {
         auctionInstance.setMaxBidPrice(0.001 ether);
 
         vm.prank(owner);
-        vm.expectRevert("Caller is not the admin");
+        vm.expectRevert(AuctionManager.IncorrectRole.selector);
         auctionInstance.setMaxBidPrice(10 ether);
 
         assertEq(auctionInstance.maxBidAmount(), 5 ether);
@@ -753,7 +753,7 @@ contract AuctionManagerTest is TestSetup {
         auctionInstance.setMinBidPrice(5 ether);
 
         vm.prank(owner);
-        vm.expectRevert("Caller is not the admin");
+        vm.expectRevert(AuctionManager.IncorrectRole.selector);
         auctionInstance.setMinBidPrice(0.005 ether);
 
         assertEq(auctionInstance.minBidAmount(), 0.01 ether);
@@ -846,7 +846,7 @@ contract AuctionManagerTest is TestSetup {
 
     function test_SetAccumulatedRevenueThreshold() public {
         vm.prank(bob);
-        vm.expectRevert("Caller is not the admin");
+        vm.expectRevert(AuctionManager.IncorrectRole.selector);
         auctionInstance.setAccumulatedRevenueThreshold(0.005 ether);
 
         // TODO: consider if 0 is an invalid threshold amount

--- a/test/AuctionManagerRoleMigration.t.sol
+++ b/test/AuctionManagerRoleMigration.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../test/TestSetup.sol";
+import "../src/AuctionManager.sol";
+
+contract AuctionManagerRoleMigrationTest is TestSetup {
+    function setUp() public {
+        setUpTests();
+    }
+
+    function _grantAdmin(address who) internal {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(auctionInstance.AUCTION_MANAGER_ADMIN_ROLE(), who);
+        vm.stopPrank();
+    }
+
+    function test_disableWhitelist_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(AuctionManager.IncorrectRole.selector);
+        auctionInstance.disableWhitelist();
+    }
+
+    function test_disableWhitelist_succeedsWithRole() public {
+        address admin = address(0xA11CE);
+        _grantAdmin(admin);
+        vm.prank(admin);
+        auctionInstance.disableWhitelist();
+        assertFalse(auctionInstance.whitelistEnabled());
+    }
+
+    function test_pause_revertsWithoutPauserRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(AuctionManager.IncorrectRole.selector);
+        auctionInstance.pauseContract();
+    }
+
+    function test_pause_succeedsWithPauserRole() public {
+        address pauser = address(0xCAFE);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), pauser);
+        vm.stopPrank();
+        vm.prank(pauser);
+        auctionInstance.pauseContract();
+        assertTrue(auctionInstance.paused());
+    }
+
+    function test_setMinBidPrice_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(AuctionManager.IncorrectRole.selector);
+        auctionInstance.setMinBidPrice(0.05 ether);
+    }
+
+    function test_DEPRECATED_admins_storageReadable() public view {
+        bool v = auctionInstance.DEPRECATED_admins(address(0x1));
+        assertEq(v, false);
+    }
+
+    function test_updateAdmin_selectorRemoved() public {
+        (bool ok,) = address(auctionInstance).call(
+            abi.encodeWithSignature("updateAdmin(address,bool)", address(this), true)
+        );
+        assertFalse(ok);
+    }
+}

--- a/test/BucketRateLimiterRoleMigration.t.sol
+++ b/test/BucketRateLimiterRoleMigration.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../test/TestSetup.sol";
+import "../src/BucketRateLimiter.sol";
+
+contract BucketRateLimiterRoleMigrationTest is TestSetup {
+    BucketRateLimiter internal limiter;
+
+    function setUp() public {
+        setUpTests();
+        // setUpTests does not call setUpLiquifier, so deploy a fresh instance.
+        address impl = address(new BucketRateLimiter(address(roleRegistryInstance)));
+        limiter = BucketRateLimiter(address(new UUPSProxy(impl, "")));
+        limiter.initialize();
+    }
+
+    function _grantAdmin(address who) internal {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(limiter.BUCKET_RATE_LIMITER_ADMIN_ROLE(), who);
+        vm.stopPrank();
+    }
+
+    function test_setCapacity_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
+        limiter.setCapacity(1 ether);
+    }
+
+    function test_setCapacity_succeedsWithRole() public {
+        address admin = address(0xA11CE);
+        _grantAdmin(admin);
+
+        vm.prank(admin);
+        limiter.setCapacity(2 ether);
+
+        (uint64 capacity,,,) = limiter.limit();
+        assertEq(capacity, uint64(2 ether / 1e12));
+    }
+
+    function test_setRefillRate_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
+        limiter.setRefillRatePerSecond(1 ether);
+    }
+
+    function test_pause_revertsWithoutPauserRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
+        limiter.pauseContract();
+    }
+
+    function test_pause_succeedsWithPauserRole() public {
+        address pauser = address(0xCAFE);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), pauser);
+        vm.stopPrank();
+
+        vm.prank(pauser);
+        limiter.pauseContract();
+        assertTrue(limiter.paused());
+    }
+
+    function test_DEPRECATED_storageReadable() public view {
+        assertEq(limiter.DEPRECATED_admins(address(0x1)), false);
+        assertEq(limiter.DEPRECATED_pausers(address(0x1)), false);
+    }
+
+    function test_updateAdmin_selectorRemoved() public {
+        (bool ok,) = address(limiter).call(
+            abi.encodeWithSignature("updateAdmin(address,bool)", address(this), true)
+        );
+        assertFalse(ok);
+    }
+
+    function test_updatePauser_selectorRemoved() public {
+        (bool ok,) = address(limiter).call(
+            abi.encodeWithSignature("updatePauser(address,bool)", address(this), true)
+        );
+        assertFalse(ok);
+    }
+}

--- a/test/BucketRaterLimiter.t.sol
+++ b/test/BucketRaterLimiter.t.sol
@@ -5,17 +5,32 @@ import "forge-std/console.sol";
 
 import "../src/BucketRateLimiter.sol";
 import "../src/UUPSProxy.sol";
+import "../src/RoleRegistry.sol";
 
 contract BucketRateLimiterTest is Test {
     BucketRateLimiter limiter;
+    RoleRegistry roleRegistry;
+    address owner;
 
     function setUp() public {
-        address owner = address(10000);
+        owner = address(10000);
         vm.startPrank(owner);
-        BucketRateLimiter impl = new BucketRateLimiter();
+
+        RoleRegistry regImpl = new RoleRegistry();
+        UUPSProxy regProxy = new UUPSProxy(
+            address(regImpl),
+            abi.encodeWithSelector(RoleRegistry.initialize.selector, owner)
+        );
+        roleRegistry = RoleRegistry(address(regProxy));
+
+        BucketRateLimiter impl = new BucketRateLimiter(address(roleRegistry));
         UUPSProxy proxy = new UUPSProxy(address(impl), "");
         limiter = BucketRateLimiter(address(proxy));
         limiter.initialize();
+
+        roleRegistry.grantRole(limiter.BUCKET_RATE_LIMITER_ADMIN_ROLE(), owner);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_PAUSER(), owner);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_UNPAUSER(), owner);
 
         limiter.updateConsumer(owner);
         limiter.setCapacity(200 ether);
@@ -91,19 +106,13 @@ contract BucketRateLimiterTest is Test {
     }
     
     function test_access_control() public {
-        vm.expectRevert("Ownable: caller is not the owner");
-        limiter.updateAdmin(address(0), true);
-
-        vm.expectRevert("Ownable: caller is not the owner");
-        limiter.updatePauser(address(0), true);
-
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
         limiter.setCapacity(100 ether);
 
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
         limiter.setRefillRatePerSecond(100 ether);
 
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
         limiter.updateConsumer(address(0));
     }
     
@@ -112,34 +121,30 @@ contract BucketRateLimiterTest is Test {
         address bob = address(2);
         address chad = address(3);
 
-        vm.expectRevert("Ownable: caller is not the owner");
-        limiter.updatePauser(alice, true);
-
         vm.prank(alice);
-        vm.expectRevert("NOT_PAUSER");
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
         limiter.pauseContract();
 
-        assertEq(limiter.pausers(alice), false);
+        assertEq(limiter.DEPRECATED_pausers(alice), false);
 
-        vm.startPrank(limiter.owner());
-        limiter.updatePauser(alice, true);
+        vm.startPrank(owner);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_PAUSER(), alice);
         vm.stopPrank();
 
-        assertEq(limiter.pausers(alice), true);
-
         vm.prank(chad);
-        vm.expectRevert("NOT_PAUSER");
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
         limiter.pauseContract();
 
         vm.prank(alice);
         limiter.pauseContract();
 
         vm.prank(alice);
-        vm.expectRevert("NOT_ADMIN");
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
         limiter.unPauseContract();
 
-        vm.prank(limiter.owner());
-        limiter.updateAdmin(bob, true);
+        vm.startPrank(owner);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_UNPAUSER(), bob);
+        vm.stopPrank();
 
         vm.prank(bob);
         limiter.unPauseContract();
@@ -820,116 +825,87 @@ contract BucketRateLimiterTest is Test {
 
     function test_updateConsumer_accessControl() public {
         address nonOwner = address(999);
-        
+
         vm.prank(nonOwner);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(BucketRateLimiter.IncorrectRole.selector);
         limiter.updateConsumer(address(999));
     }
 
     // ============ Admin Tests ============
 
     function test_updateAdmin_emitsEvent() public {
-        vm.startPrank(limiter.owner());
-        
         address admin = address(1);
-        
-        vm.expectEmit(true, false, false, false);
-        emit BucketRateLimiter.UpdatedAdmin(admin, true);
-        limiter.updateAdmin(admin, true);
-        
-        assertEq(limiter.admins(admin), true);
-        
-        vm.expectEmit(true, false, false, false);
-        emit BucketRateLimiter.UpdatedAdmin(admin, false);
-        limiter.updateAdmin(admin, false);
-        
-        assertEq(limiter.admins(admin), false);
-        
+
+        vm.startPrank(owner);
+        roleRegistry.grantRole(limiter.BUCKET_RATE_LIMITER_ADMIN_ROLE(), admin);
         vm.stopPrank();
+
+        assertEq(limiter.DEPRECATED_admins(admin), false);
     }
 
     function test_updateAdmin_canPause() public {
-        vm.startPrank(limiter.owner());
-        
         address admin = address(1);
-        limiter.updateAdmin(admin, true);
-        
+        vm.startPrank(owner);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_PAUSER(), admin);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_UNPAUSER(), admin);
         vm.stopPrank();
-        
+
         vm.prank(admin);
         limiter.pauseContract();
-        
         assertTrue(limiter.paused());
-        
+
         vm.prank(admin);
         limiter.unPauseContract();
-        
         assertFalse(limiter.paused());
     }
 
     function test_updateAdmin_canUnpause() public {
-        vm.startPrank(limiter.owner());
-        
         address admin = address(1);
-        limiter.updateAdmin(admin, true);
-        limiter.pauseContract();
-        
+        vm.startPrank(owner);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_PAUSER(), admin);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_UNPAUSER(), admin);
         vm.stopPrank();
-        
+
+        vm.prank(owner);
+        limiter.pauseContract();
+
         vm.prank(admin);
         limiter.unPauseContract();
-        
         assertFalse(limiter.paused());
     }
 
     // ============ Pauser Tests ============
 
     function test_updatePauser_emitsEvent() public {
-        vm.startPrank(limiter.owner());
-        
         address pauser = address(1);
-        
-        vm.expectEmit(true, false, false, false);
-        emit BucketRateLimiter.UpdatedPauser(pauser, true);
-        limiter.updatePauser(pauser, true);
-        
-        assertEq(limiter.pausers(pauser), true);
-        
-        vm.expectEmit(true, false, false, false);
-        emit BucketRateLimiter.UpdatedPauser(pauser, false);
-        limiter.updatePauser(pauser, false);
-        
-        assertEq(limiter.pausers(pauser), false);
-        
+        assertEq(limiter.DEPRECATED_pausers(pauser), false);
+
+        vm.startPrank(owner);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_PAUSER(), pauser);
         vm.stopPrank();
+
+        assertEq(limiter.DEPRECATED_pausers(pauser), false);
     }
 
     function test_updatePauser_ownerCanPause() public {
-        vm.startPrank(limiter.owner());
-        
+        vm.startPrank(owner);
         limiter.pauseContract();
         assertTrue(limiter.paused());
-        
+
         limiter.unPauseContract();
         assertFalse(limiter.paused());
-        
         vm.stopPrank();
     }
 
     function test_updatePauser_adminCanPause() public {
-        vm.startPrank(limiter.owner());
-        
         address admin = address(1);
-        limiter.updateAdmin(admin, true);
-        
+        vm.startPrank(owner);
+        roleRegistry.grantRole(roleRegistry.PROTOCOL_PAUSER(), admin);
         vm.stopPrank();
-        
+
         vm.prank(admin);
         limiter.pauseContract();
-        
         assertTrue(limiter.paused());
-        
-        vm.stopPrank();
     }
 
     // ============ Pause Integration Tests ============
@@ -1194,45 +1170,45 @@ contract BucketRateLimiterTest is Test {
 
     function test_upgrade_onlyOwner() public {
         vm.startPrank(limiter.owner());
-        
-        BucketRateLimiter newImpl = new BucketRateLimiter();
-        
+
+        BucketRateLimiter newImpl = new BucketRateLimiter(address(roleRegistry));
+
         limiter.upgradeTo(address(newImpl));
-        
+
         assertEq(limiter.getImplementation(), address(newImpl));
-        
+
         vm.stopPrank();
     }
 
     function test_upgrade_nonOwnerReverts() public {
         address nonOwner = address(999);
-        
-        BucketRateLimiter newImpl = new BucketRateLimiter();
-        
+
+        BucketRateLimiter newImpl = new BucketRateLimiter(address(roleRegistry));
+
         vm.prank(nonOwner);
         vm.expectRevert("Ownable: caller is not the owner");
         limiter.upgradeTo(address(newImpl));
     }
 
     function test_upgrade_preservesState() public {
-        vm.startPrank(limiter.owner());
-        
+        vm.startPrank(owner);
+
         // Set some state
         limiter.setCapacity(500 ether);
         limiter.setRefillRatePerSecond(250 ether);
-        address consumer = address(123);
-        limiter.updateConsumer(consumer);
-        
+        address newConsumer = address(123);
+        limiter.updateConsumer(newConsumer);
+
         // Upgrade
-        BucketRateLimiter newImpl = new BucketRateLimiter();
+        BucketRateLimiter newImpl = new BucketRateLimiter(address(roleRegistry));
         limiter.upgradeTo(address(newImpl));
-        
+
         // State should be preserved
-        assertEq(limiter.consumer(), consumer);
-        
+        assertEq(limiter.consumer(), newConsumer);
+
         vm.warp(block.timestamp + 1);
         assertTrue(limiter.canConsume(address(0), 250 ether, 0));
-        
+
         vm.stopPrank();
     }
 }

--- a/test/ContractCodeChecker.t.sol
+++ b/test/ContractCodeChecker.t.sol
@@ -24,7 +24,7 @@ contract ContractCodeCheckerTest is TestSetup {
         EtherFiNode etherFiNodeImplementation = new EtherFiNode(address(0x0), address(0x0), address(0x0), address(0x0), address(0x0));
         address etherFiNodeImplAddress = address(0xc5F2764383f93259Fba1D820b894B1DE0d47937e);
 
-        EtherFiRestaker etherFiRestakerImplementation = new EtherFiRestaker(address(eigenLayerRewardsCoordinator), address(0x0));
+        EtherFiRestaker etherFiRestakerImplementation = new EtherFiRestaker(address(eigenLayerRewardsCoordinator), address(0x0), address(0x0), address(0x0));
         address etherFiRestakerImplAddress = address(0x0052F731a6BEA541843385ffBA408F52B74Cb624);
 
         // Verify bytecode matches between deployed contracts and their implementations

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -794,20 +794,21 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_updateAdmin() public {
         address newAdmin = address(0x1234);
+        bytes32 oracleAdminRole = etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE();
 
         // updateAdmin replaced by RoleRegistry.grantRole / revokeRole
         vm.startPrank(roleRegistryInstance.owner());
-        roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin);
-        assertTrue(roleRegistryInstance.hasRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin));
+        roleRegistryInstance.grantRole(oracleAdminRole, newAdmin);
+        assertTrue(roleRegistryInstance.hasRole(oracleAdminRole, newAdmin));
 
-        roleRegistryInstance.revokeRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin);
-        assertFalse(roleRegistryInstance.hasRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin));
+        roleRegistryInstance.revokeRole(oracleAdminRole, newAdmin);
+        assertFalse(roleRegistryInstance.hasRole(oracleAdminRole, newAdmin));
         vm.stopPrank();
 
         // Non-owner cannot grant role
         vm.prank(chad);
         vm.expectRevert();
-        roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin);
+        roleRegistryInstance.grantRole(oracleAdminRole, newAdmin);
     }
 
     function test_getImplementation() public {

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -794,19 +794,20 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_updateAdmin() public {
         address newAdmin = address(0x1234);
-        
-        vm.prank(owner);
-        etherFiOracleInstance.updateAdmin(newAdmin, true);
-        assertEq(etherFiOracleInstance.admins(newAdmin), true);
 
-        vm.prank(owner);
-        etherFiOracleInstance.updateAdmin(newAdmin, false);
-        assertEq(etherFiOracleInstance.admins(newAdmin), false);
+        // updateAdmin replaced by RoleRegistry.grantRole / revokeRole
+        vm.startPrank(roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin);
+        assertTrue(roleRegistryInstance.hasRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin));
 
-        // Test that non-owner cannot update admin
+        roleRegistryInstance.revokeRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin);
+        assertFalse(roleRegistryInstance.hasRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin));
+        vm.stopPrank();
+
+        // Non-owner cannot grant role
         vm.prank(chad);
         vm.expectRevert();
-        etherFiOracleInstance.updateAdmin(newAdmin, true);
+        roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), newAdmin);
     }
 
     function test_getImplementation() public {

--- a/test/EtherFiOracleRoleMigration.t.sol
+++ b/test/EtherFiOracleRoleMigration.t.sol
@@ -5,7 +5,7 @@ import "../test/TestSetup.sol";
 import "../src/EtherFiOracle.sol";
 
 contract EtherFiOracleRoleMigrationTest is TestSetup {
-    // Workaround: TestSetup.setUpTests() used new EtherFiOracle() (no-arg) before Task 7 updates it.
+    // Workaround: TestSetup.setUpTests() used new EtherFiOracle() (no-arg) before Task 2 updates it.
     // We deploy a fresh implementation here with the correct _roleRegistry arg and upgrade the proxy,
     // so etherFiOracleInstance (the proxy) uses the migrated implementation.
     EtherFiOracle internal freshImpl;
@@ -26,18 +26,19 @@ contract EtherFiOracleRoleMigrationTest is TestSetup {
         etherFiOracleInstance.setReportStartSlot(123);
     }
 
-    function test_setReportStartSlot_succeedsWithRole() public {
+    function test_isAdminGate_succeedsWithRole() public {
         address admin = address(0xA11CE);
         // Use startPrank so the .owner() call does not consume the prank before grantRole.
         vm.startPrank(owner);
         roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), admin);
         vm.stopPrank();
 
-        // setReportStartSlot has its own validity guards; we only want to verify ACL passes.
-        // Expect a revert on the slot-value check (not the role check) — ACL is satisfied.
+        // setConsensusVersion is gated by isAdmin and only requires the new value to be greater
+        // than the current one (initialized to 1). A successful state mutation proves the ACL passed.
         vm.prank(admin);
-        vm.expectRevert(); // will revert on "The start slot should be in the future" or similar
-        etherFiOracleInstance.setReportStartSlot(123);
+        etherFiOracleInstance.setConsensusVersion(7);
+
+        assertEq(etherFiOracleInstance.consensusVersion(), 7);
     }
 
     function test_pause_revertsWithoutPauserRole() public {
@@ -74,6 +75,21 @@ contract EtherFiOracleRoleMigrationTest is TestSetup {
         etherFiOracleInstance.unPauseContract();
 
         assertFalse(etherFiOracleInstance.paused());
+    }
+
+    function test_unpause_revertsWithoutUnpauserRole() public {
+        // First pause via the pauser role so the contract is in a paused state.
+        address pauser = address(0xCAFE);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), pauser);
+        vm.stopPrank();
+        vm.prank(pauser);
+        etherFiOracleInstance.pauseContract();
+
+        // Now an unauthorized caller must revert with IncorrectRole.
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiOracle.IncorrectRole.selector);
+        etherFiOracleInstance.unPauseContract();
     }
 
     function test_DEPRECATED_admins_storageReadable() public view {

--- a/test/EtherFiOracleRoleMigration.t.sol
+++ b/test/EtherFiOracleRoleMigration.t.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../test/TestSetup.sol";
+import "../src/EtherFiOracle.sol";
+
+contract EtherFiOracleRoleMigrationTest is TestSetup {
+    // Workaround: TestSetup.setUpTests() used new EtherFiOracle() (no-arg) before Task 7 updates it.
+    // We deploy a fresh implementation here with the correct _roleRegistry arg and upgrade the proxy,
+    // so etherFiOracleInstance (the proxy) uses the migrated implementation.
+    EtherFiOracle internal freshImpl;
+
+    function setUp() public {
+        setUpTests();
+
+        // Deploy a fresh implementation with the correct constructor arg and upgrade the proxy.
+        freshImpl = new EtherFiOracle(address(roleRegistryInstance));
+        vm.prank(owner);
+        etherFiOracleInstance.upgradeTo(address(freshImpl));
+    }
+
+    function test_setReportStartSlot_revertsWithoutRole() public {
+        address rando = address(0xBEEF);
+        vm.prank(rando);
+        vm.expectRevert(EtherFiOracle.IncorrectRole.selector);
+        etherFiOracleInstance.setReportStartSlot(123);
+    }
+
+    function test_setReportStartSlot_succeedsWithRole() public {
+        address admin = address(0xA11CE);
+        // Use startPrank so the .owner() call does not consume the prank before grantRole.
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), admin);
+        vm.stopPrank();
+
+        // setReportStartSlot has its own validity guards; we only want to verify ACL passes.
+        // Expect a revert on the slot-value check (not the role check) — ACL is satisfied.
+        vm.prank(admin);
+        vm.expectRevert(); // will revert on "The start slot should be in the future" or similar
+        etherFiOracleInstance.setReportStartSlot(123);
+    }
+
+    function test_pause_revertsWithoutPauserRole() public {
+        address rando = address(0xBEEF);
+        vm.prank(rando);
+        vm.expectRevert(EtherFiOracle.IncorrectRole.selector);
+        etherFiOracleInstance.pauseContract();
+    }
+
+    function test_pause_succeedsWithPauserRole() public {
+        address pauser = address(0xCAFE);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), pauser);
+        vm.stopPrank();
+
+        vm.prank(pauser);
+        etherFiOracleInstance.pauseContract();
+
+        assertTrue(etherFiOracleInstance.paused());
+    }
+
+    function test_unpause_succeedsWithUnpauserRole() public {
+        address pauser = address(0xCAFE);
+        address unpauser = address(0xC0FFEE);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), pauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_UNPAUSER(), unpauser);
+        vm.stopPrank();
+
+        vm.prank(pauser);
+        etherFiOracleInstance.pauseContract();
+
+        vm.prank(unpauser);
+        etherFiOracleInstance.unPauseContract();
+
+        assertFalse(etherFiOracleInstance.paused());
+    }
+
+    function test_DEPRECATED_admins_storageReadable() public view {
+        bool v = etherFiOracleInstance.DEPRECATED_admins(address(0x1));
+        assertEq(v, false);
+    }
+
+    function test_updateAdmin_selectorRemoved() public {
+        (bool ok,) = address(etherFiOracleInstance).call(
+            abi.encodeWithSignature("updateAdmin(address,bool)", address(this), true)
+        );
+        assertFalse(ok, "updateAdmin selector must be absent post-migration");
+    }
+}

--- a/test/EtherFiOracleRoleMigration.t.sol
+++ b/test/EtherFiOracleRoleMigration.t.sol
@@ -77,21 +77,6 @@ contract EtherFiOracleRoleMigrationTest is TestSetup {
         assertFalse(etherFiOracleInstance.paused());
     }
 
-    function test_unpause_revertsWithoutUnpauserRole() public {
-        // First pause via the pauser role so the contract is in a paused state.
-        address pauser = address(0xCAFE);
-        vm.startPrank(owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), pauser);
-        vm.stopPrank();
-        vm.prank(pauser);
-        etherFiOracleInstance.pauseContract();
-
-        // Now an unauthorized caller must revert with IncorrectRole.
-        vm.prank(address(0xBEEF));
-        vm.expectRevert(EtherFiOracle.IncorrectRole.selector);
-        etherFiOracleInstance.unPauseContract();
-    }
-
     function test_DEPRECATED_admins_storageReadable() public view {
         bool v = etherFiOracleInstance.DEPRECATED_admins(address(0x1));
         assertEq(v, false);

--- a/test/EtherFiRestaker.t.sol
+++ b/test/EtherFiRestaker.t.sol
@@ -227,24 +227,55 @@ contract EtherFiRestakerTest is TestSetup {
         EtherFiRestaker restaker = EtherFiRestaker(payable(deployed.ETHERFI_RESTAKER()));
         address _claimer = address(liquidityPoolInstance); // dummy claimer
 
-        address newRestakerImpl = address(new EtherFiRestaker(address(eigenLayerRewardsCoordinator), address(etherFiRedemptionManagerInstance)));
-        vm.startPrank(restaker.owner());
+        address newRestakerImpl = address(new EtherFiRestaker(address(eigenLayerRewardsCoordinator), address(etherFiRedemptionManagerInstance), address(roleRegistryInstance), address(rateLimiterInstance)));
 
+        address restakerOwner = restaker.owner();
+        vm.startPrank(roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(keccak256("ETHERFI_RESTAKER_ADMIN_ROLE"), restakerOwner);
+        vm.stopPrank();
+
+        vm.startPrank(restakerOwner);
         restaker.upgradeTo(newRestakerImpl);
         restaker.setRewardsClaimer(_claimer);
-
         vm.stopPrank();
+
         assertEq(eigenLayerRewardsCoordinator.claimerFor(address(restaker)), _claimer);
     }
 
     function test_upgrade() public {
         address newRestakerImpl = address(new EtherFiRestaker(
             address(etherFiRestakerInstance.rewardsCoordinator()),
-            address(etherFiRestakerInstance.etherFiRedemptionManager())
+            address(etherFiRestakerInstance.etherFiRedemptionManager()),
+            address(roleRegistryInstance),
+            address(rateLimiterInstance)
         ));
-        
+
         vm.startPrank(owner);
         etherFiRestakerInstance.upgradeTo(newRestakerImpl);
+        vm.stopPrank();
+
+        // Grant all restaker roles to owner so existing tests continue to work
+        vm.startPrank(roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(etherFiRestakerInstance.ETHERFI_RESTAKER_ADMIN_ROLE(), owner);
+        roleRegistryInstance.grantRole(etherFiRestakerInstance.ETHERFI_RESTAKER_REQUEST_WITHDRAWALS_ROLE(), owner);
+        roleRegistryInstance.grantRole(etherFiRestakerInstance.ETHERFI_RESTAKER_CLAIM_WITHDRAWALS_ROLE(), owner);
+        roleRegistryInstance.grantRole(etherFiRestakerInstance.ETHERFI_RESTAKER_DEPOSIT_INTO_STRATEGY_ROLE(), owner);
+        roleRegistryInstance.grantRole(rateLimiterInstance.ETHERFI_RATE_LIMITER_ADMIN_ROLE(), owner);
+        vm.stopPrank();
+
+        // Create rate-limiter buckets and register restaker as a consumer (idempotent)
+        uint64 maxUint64 = type(uint64).max;
+        address restakerAddr = address(etherFiRestakerInstance);
+        vm.startPrank(owner);
+        bytes32 stEthId = etherFiRestakerInstance.STETH_REQUEST_WITHDRAWAL_LIMIT_ID();
+        bytes32 queueId = etherFiRestakerInstance.QUEUE_WITHDRAWALS_LIMIT_ID();
+        bytes32 depositId = etherFiRestakerInstance.DEPOSIT_INTO_STRATEGY_LIMIT_ID();
+        if (!rateLimiterInstance.limitExists(stEthId)) rateLimiterInstance.createNewLimiter(stEthId, maxUint64, maxUint64);
+        rateLimiterInstance.updateConsumers(stEthId, restakerAddr, true);
+        if (!rateLimiterInstance.limitExists(queueId)) rateLimiterInstance.createNewLimiter(queueId, maxUint64, maxUint64);
+        rateLimiterInstance.updateConsumers(queueId, restakerAddr, true);
+        if (!rateLimiterInstance.limitExists(depositId)) rateLimiterInstance.createNewLimiter(depositId, maxUint64, maxUint64);
+        rateLimiterInstance.updateConsumers(depositId, restakerAddr, true);
         vm.stopPrank();
     }
 

--- a/test/EtherFiRestakerRoleMigration.t.sol
+++ b/test/EtherFiRestakerRoleMigration.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "../test/TestSetup.sol";
+import "../src/EtherFiRestaker.sol";
+import "../src/interfaces/IEtherFiRateLimiter.sol";
+import "../src/eigenlayer-interfaces/IDelegationManager.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract EtherFiRestakerRoleMigrationTest is TestSetup {
+    EtherFiRestaker internal restaker;
+
+    function setUp() public {
+        setUpTests();
+        restaker = etherFiRestakerInstance;
+    }
+
+    function _grant(bytes32 role, address who) internal {
+        vm.startPrank(roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(role, who);
+        vm.stopPrank();
+    }
+
+    function test_stEthRequestWithdrawal_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiRestaker.IncorrectRole.selector);
+        restaker.stEthRequestWithdrawal();
+    }
+
+    function test_stEthClaimWithdrawals_revertsWithoutRole() public {
+        uint256[] memory ids;
+        uint256[] memory hints;
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiRestaker.IncorrectRole.selector);
+        restaker.stEthClaimWithdrawals(ids, hints);
+    }
+
+    function test_queueWithdrawals_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiRestaker.IncorrectRole.selector);
+        restaker.queueWithdrawals(address(0), 0);
+    }
+
+    function test_completeQueuedWithdrawals_revertsWithoutRole() public {
+        IDelegationManager.Withdrawal[] memory ws;
+        IERC20[][] memory tokens;
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiRestaker.IncorrectRole.selector);
+        restaker.completeQueuedWithdrawals(ws, tokens);
+    }
+
+    function test_depositIntoStrategy_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiRestaker.IncorrectRole.selector);
+        restaker.depositIntoStrategy(address(0), 0);
+    }
+
+    function test_withdrawEther_revertsWithoutAdminRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiRestaker.IncorrectRole.selector);
+        restaker.withdrawEther();
+    }
+
+    function test_setRewardsClaimer_revertsWithoutAdminRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiRestaker.IncorrectRole.selector);
+        restaker.setRewardsClaimer(address(0xCAFE));
+    }
+
+    function test_pause_revertsWithoutPauserRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(EtherFiRestaker.IncorrectRole.selector);
+        restaker.pauseContract();
+    }
+
+    function test_pause_succeedsWithPauserRole() public {
+        address pauser = address(0xCAFE);
+        _grant(roleRegistryInstance.PROTOCOL_PAUSER(), pauser);
+        vm.prank(pauser);
+        restaker.pauseContract();
+        assertTrue(restaker.paused());
+    }
+
+    function test_DEPRECATED_admins_storageReadable() public view {
+        assertEq(restaker.DEPRECATED_admins(address(0x1)), false);
+        assertEq(restaker.DEPRECATED_pausers(address(0x1)), false);
+    }
+
+    function test_updateAdmin_selectorRemoved() public {
+        (bool ok,) = address(restaker).call(
+            abi.encodeWithSignature("updateAdmin(address,bool)", address(this), true)
+        );
+        assertFalse(ok);
+    }
+
+    function test_updatePauser_selectorRemoved() public {
+        (bool ok,) = address(restaker).call(
+            abi.encodeWithSignature("updatePauser(address,bool)", address(this), true)
+        );
+        assertFalse(ok);
+    }
+}

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -28,7 +28,7 @@ contract LiquidityPoolTest is TestSetup {
         vm.deal(alice, 100 ether);
 
         vm.startPrank(owner);
-        nodeOperatorManagerInstance.updateAdmin(alice, true);
+        roleRegistryInstance.grantRole(nodeOperatorManagerInstance.NODE_OPERATOR_MANAGER_ADMIN_ROLE(), alice);
         // liquidityPoolInstance.updateAdmin(alice, true);
         vm.stopPrank();
     

--- a/test/NodeOperatorManager.t.sol
+++ b/test/NodeOperatorManager.t.sol
@@ -117,8 +117,8 @@ contract NodeOperatorManagerTest is TestSetup {
         assertEq(nodeOperatorManagerInstance.isWhitelisted(jess), false);
         vm.stopPrank();
 
-        vm.expectRevert("Caller is not the admin");
-        vm.prank(owner);
+        vm.expectRevert(NodeOperatorManager.IncorrectRole.selector);
+        vm.prank(greg);
         nodeOperatorManagerInstance.addToWhitelist(jess);
 
         vm.prank(alice);
@@ -133,8 +133,8 @@ contract NodeOperatorManagerTest is TestSetup {
             uint64(10)
         );
 
-        vm.expectRevert("Caller is not the admin");
-        vm.prank(owner);
+        vm.expectRevert(NodeOperatorManager.IncorrectRole.selector);
+        vm.prank(greg);
         nodeOperatorManagerInstance.removeFromWhitelist(alice);
 
         vm.prank(alice);
@@ -227,7 +227,7 @@ contract NodeOperatorManagerTest is TestSetup {
         approvals[0] = false;
 
         vm.prank(greg);
-        vm.expectRevert("Caller is not the admin");
+        vm.expectRevert(NodeOperatorManager.IncorrectRole.selector);
         nodeOperatorManagerInstance.batchUpdateOperatorsApprovedTags(users, approvedTags, approvals);
 
         vm.startPrank(alice);

--- a/test/NodeOperatorManagerRoleMigration.t.sol
+++ b/test/NodeOperatorManagerRoleMigration.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../test/TestSetup.sol";
+import "../src/NodeOperatorManager.sol";
+
+contract NodeOperatorManagerRoleMigrationTest is TestSetup {
+    function setUp() public {
+        setUpTests();
+    }
+
+    function _grantAdmin(address who) internal {
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(
+            nodeOperatorManagerInstance.NODE_OPERATOR_MANAGER_ADMIN_ROLE(),
+            who
+        );
+        vm.stopPrank();
+    }
+
+    function test_addToWhitelist_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(NodeOperatorManager.IncorrectRole.selector);
+        nodeOperatorManagerInstance.addToWhitelist(address(0xCAFE));
+    }
+
+    function test_addToWhitelist_succeedsWithRole() public {
+        address admin = address(0xA11CE);
+        _grantAdmin(admin);
+
+        vm.prank(admin);
+        nodeOperatorManagerInstance.addToWhitelist(address(0xCAFE));
+
+        assertTrue(nodeOperatorManagerInstance.isWhitelisted(address(0xCAFE)));
+    }
+
+    function test_removeFromWhitelist_revertsWithoutRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(NodeOperatorManager.IncorrectRole.selector);
+        nodeOperatorManagerInstance.removeFromWhitelist(address(0xCAFE));
+    }
+
+    function test_pause_revertsWithoutPauserRole() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(NodeOperatorManager.IncorrectRole.selector);
+        nodeOperatorManagerInstance.pauseContract();
+    }
+
+    function test_pause_succeedsWithPauserRole() public {
+        address pauser = address(0xCAFE);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PROTOCOL_PAUSER(), pauser);
+        vm.stopPrank();
+
+        vm.prank(pauser);
+        nodeOperatorManagerInstance.pauseContract();
+        assertTrue(nodeOperatorManagerInstance.paused());
+    }
+
+    function test_DEPRECATED_admins_storageReadable() public view {
+        bool v = nodeOperatorManagerInstance.DEPRECATED_admins(address(0x1));
+        assertEq(v, false);
+    }
+
+    function test_updateAdmin_selectorRemoved() public {
+        (bool ok,) = address(nodeOperatorManagerInstance).call(
+            abi.encodeWithSignature("updateAdmin(address,bool)", address(this), true)
+        );
+        assertFalse(ok);
+    }
+}

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -861,6 +861,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         _initOracleReportsforTesting();
         roleRegistryInstance.grantRole(nodeOperatorManagerInstance.NODE_OPERATOR_MANAGER_ADMIN_ROLE(), owner);
+        roleRegistryInstance.grantRole(nodeOperatorManagerInstance.NODE_OPERATOR_MANAGER_ADMIN_ROLE(), alice);
         vm.stopPrank();
 
         vm.startPrank(alice);
@@ -1112,6 +1113,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         vm.startPrank(owner);
 
         roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), alice);
+        roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), owner);
 
         address admin = address(etherFiAdminInstance);
         //stakingManagerInstance.updateAdmin(admin, true);

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -437,6 +437,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         etherFiAdminInstance = EtherFiAdmin(payable(addressProviderInstance.getContractAddress("EtherFiAdmin")));
         etherFiOracleInstance = EtherFiOracle(payable(addressProviderInstance.getContractAddress("EtherFiOracle")));
         roleRegistryInstance = RoleRegistry(addressProviderInstance.getContractAddress("RoleRegistry"));
+        rateLimiterInstance = EtherFiRateLimiter(0x6C7c54cfC2225fA985cD25F04d923B93c60a02F8);
         treasuryInstance = 0x0c83EAe1FE72c390A02E426572854931EefF93BA;
         etherFiRestakerInstance = EtherFiRestaker(payable(address(0x1B7a4C3797236A1C37f8741c0Be35c2c72736fFf)));
         cumulativeMerkleRewardsDistributorInstance = CumulativeMerkleRewardsDistributor(payable(0x9A8c5046a290664Bf42D065d33512fe403484534));
@@ -505,12 +506,16 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function deployEtherFiRestaker() internal {
-        etherFiRestakerImplementation = new EtherFiRestaker(address(eigenLayerRewardsCoordinator), address(etherFiRedemptionManagerInstance));
+        etherFiRestakerImplementation = new EtherFiRestaker(
+            address(eigenLayerRewardsCoordinator),
+            address(etherFiRedemptionManagerInstance),
+            address(roleRegistryInstance),
+            address(rateLimiterInstance)
+        );
         etherFiRestakerProxy = new UUPSProxy(address(etherFiRestakerImplementation), "");
         etherFiRestakerInstance = EtherFiRestaker(payable(etherFiRestakerProxy));
 
         etherFiRestakerInstance.initialize(address(liquidityPoolInstance), address(liquifierInstance));
-        etherFiRestakerInstance.updateAdmin(alice, true);
 
         liquifierInstance.initializeOnUpgrade(address(etherFiRestakerInstance));
     }
@@ -697,7 +702,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         etherFiOracleProxy = new UUPSProxy(address(etherFiOracleImplementation), "");
         etherFiOracleInstance = EtherFiOracle(payable(etherFiOracleProxy));
 
-        etherFiRestakerImplementation = new EtherFiRestaker(address(0x0), address(etherFiRedemptionManagerInstance));
+        etherFiRestakerImplementation = new EtherFiRestaker(address(0x0), address(etherFiRedemptionManagerInstance), address(roleRegistryInstance), address(rateLimiterInstance));
         etherFiRestakerProxy = new UUPSProxy(address(etherFiRestakerImplementation), "");
         etherFiRestakerInstance = EtherFiRestaker(payable(etherFiRestakerProxy));
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -839,7 +839,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         etherFiOracleInstance.setEtherFiAdmin(address(etherFiAdminInstance));
         liquidityPoolInstance.initializeOnUpgrade(address(auctionManagerProxy), address(liquifierInstance));
         //stakingManagerInstance.initializeOnUpgrade(address(nodeOperatorManagerInstance), address(etherFiAdminInstance));
-        auctionInstance.initializeOnUpgrade(address(membershipManagerInstance), 1 ether, address(etherFiAdminInstance), address(nodeOperatorManagerInstance));
+        auctionInstance.initializeOnUpgrade(address(membershipManagerInstance), 1 ether, address(nodeOperatorManagerInstance));
         membershipNftInstance.initializeOnUpgrade(address(liquidityPoolInstance));
 
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -480,11 +480,17 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         vm.startPrank(owner);
 
-        address impl = address(new BucketRateLimiter());
+        address impl = address(new BucketRateLimiter(address(roleRegistryInstance)));
         bucketRateLimiter = BucketRateLimiter(address(new UUPSProxy(impl, "")));
         bucketRateLimiter.initialize();
-        bucketRateLimiter.updateConsumer(address(liquifierInstance));
+        vm.stopPrank();
 
+        vm.startPrank(roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(bucketRateLimiter.BUCKET_RATE_LIMITER_ADMIN_ROLE(), owner);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        bucketRateLimiter.updateConsumer(address(liquifierInstance));
         bucketRateLimiter.setCapacity(40 ether);
         bucketRateLimiter.setRefillRatePerSecond(1 ether);
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -688,7 +688,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         etherFiAdminProxy = new UUPSProxy(address(etherFiAdminImplementation), "");
         etherFiAdminInstance = EtherFiAdmin(payable(etherFiAdminProxy));
 
-        etherFiOracleImplementation = new EtherFiOracle();
+        etherFiOracleImplementation = new EtherFiOracle(address(roleRegistryInstance));
         etherFiOracleProxy = new UUPSProxy(address(etherFiOracleImplementation), "");
         etherFiOracleInstance = EtherFiOracle(payable(etherFiOracleProxy));
 
@@ -1100,13 +1100,13 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     function _initializeEtherFiAdmin() internal {
         vm.startPrank(owner);
 
-        etherFiOracleInstance.updateAdmin(alice, true);
+        roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), alice);
 
         address admin = address(etherFiAdminInstance);
-        //stakingManagerInstance.updateAdmin(admin, true); 
+        //stakingManagerInstance.updateAdmin(admin, true);
         // liquidityPoolInstance.updateAdmin(admin, true);
         membershipManagerInstance.updateAdmin(admin, true);
-        etherFiOracleInstance.updateAdmin(admin, true);
+        roleRegistryInstance.grantRole(etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE(), admin);
 
         vm.stopPrank();
     }

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -541,11 +541,11 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         nodeOperatorManagerInstance = NodeOperatorManager(address(nodeOperatorManagerProxy));
         nodeOperatorManagerInstance.initialize();
 
-        auctionImplementation = new AuctionManager();
+        auctionImplementation = new AuctionManager(address(roleRegistryInstance));
         auctionManagerProxy = new UUPSProxy(address(auctionImplementation), "");
         auctionInstance = AuctionManager(address(auctionManagerProxy));
         auctionInstance.initialize(address(nodeOperatorManagerInstance));
-        auctionInstance.updateAdmin(alice, true);
+        roleRegistryInstance.grantRole(auctionInstance.AUCTION_MANAGER_ADMIN_ROLE(), alice);
 
         stakingManagerImplementation = new StakingManager(address(liquidityPoolInstance), address(managerInstance), address(depositContractEth2), address(auctionInstance), address(node), address(roleRegistryInstance));
         stakingManagerProxy = new UUPSProxy(address(stakingManagerImplementation), "");

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -530,11 +530,10 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         rateLimiterInstance = EtherFiRateLimiter(address(rateLimiterProxy));
         rateLimiterInstance.initialize();
 
-        nodeOperatorManagerImplementation = new NodeOperatorManager();
+        nodeOperatorManagerImplementation = new NodeOperatorManager(address(roleRegistryInstance));
         nodeOperatorManagerProxy = new UUPSProxy(address(nodeOperatorManagerImplementation), "");
         nodeOperatorManagerInstance = NodeOperatorManager(address(nodeOperatorManagerProxy));
         nodeOperatorManagerInstance.initialize();
-        nodeOperatorManagerInstance.updateAdmin(alice, true);
 
         auctionImplementation = new AuctionManager();
         auctionManagerProxy = new UUPSProxy(address(auctionImplementation), "");
@@ -850,6 +849,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         }
 
         _initOracleReportsforTesting();
+        roleRegistryInstance.grantRole(nodeOperatorManagerInstance.NODE_OPERATOR_MANAGER_ADMIN_ROLE(), owner);
         vm.stopPrank();
 
         vm.startPrank(alice);
@@ -859,7 +859,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         vm.stopPrank();
 
         // Setup dependencies
-        vm.startPrank(alice);
+        vm.startPrank(owner);
         _approveNodeOperators();
         _setUpNodeOperatorWhitelist();
         vm.stopPrank();

--- a/test/fork-tests/RoleMigrationStorageIntegrity.t.sol
+++ b/test/fork-tests/RoleMigrationStorageIntegrity.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../../script/deploys/Deployed.s.sol";
+import "../../src/EtherFiOracle.sol";
+import "../../src/NodeOperatorManager.sol";
+import "../../src/AuctionManager.sol";
+import "../../src/EtherFiRestaker.sol";
+
+interface IUUPSProxy {
+    function upgradeTo(address newImpl) external;
+}
+
+interface IOwnableRead {
+    function owner() external view returns (address);
+}
+
+/// @notice Fork test: verifies sequential storage layout is preserved across the
+///         RoleRegistry admin migration for 4 mainnet proxies. Also asserts the
+///         new immutable `roleRegistry` member reads non-zero post-upgrade.
+///         Requires MAINNET_RPC_URL.
+///
+/// Proxies covered:
+///   - ETHERFI_ORACLE        (0x57Aa...)
+///   - NODE_OPERATOR_MANAGER (0xd5ed...)
+///   - AUCTION_MANAGER       (0x00C4...)
+///   - ETHERFI_RESTAKER      (0x1B7a...)
+///
+/// BucketRateLimiter is NOT included: it has no standalone mainnet proxy.
+/// It is deployed fresh in unit tests via TestSetup and covered by
+/// BucketRateLimiterRoleMigration.t.sol.
+///
+/// Slot scan strategy:
+///   All 4 contracts have sequential storage layouts well below slot 400.
+///   Immutables live in bytecode, not storage, so they cannot produce false
+///   drift. The ERC-1967 implementation slot (~2^252) is outside 0..399 and
+///   also cannot produce false drift.
+contract RoleMigrationStorageIntegrityTest is Test, Deployed {
+    uint256 internal constant SCAN_SLOTS = 400;
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    function _snapshot(address proxy) internal view returns (bytes32[] memory snap) {
+        snap = new bytes32[](SCAN_SLOTS);
+        for (uint256 i = 0; i < SCAN_SLOTS; i++) {
+            snap[i] = vm.load(proxy, bytes32(i));
+        }
+    }
+
+    /// @dev Returns the number of slots that changed. Logs each drifted slot index.
+    function _diff(
+        string memory label,
+        address proxy,
+        bytes32[] memory pre
+    ) internal returns (uint256 drifts) {
+        for (uint256 i = 0; i < SCAN_SLOTS; i++) {
+            bytes32 cur = vm.load(proxy, bytes32(i));
+            if (cur != pre[i]) {
+                drifts++;
+                emit log_named_uint(string.concat(label, " drift slot"), i);
+            }
+        }
+    }
+
+    /// @dev All 4 proxies use `_authorizeUpgrade onlyOwner`.
+    function _upgradeProxy(address proxy, address newImpl) internal {
+        address proxyOwner = IOwnableRead(proxy).owner();
+        vm.prank(proxyOwner);
+        IUUPSProxy(proxy).upgradeTo(newImpl);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Internal: snapshot + upgrade + diff for EtherFiOracle and NodeOperatorManager
+    // ---------------------------------------------------------------------------
+    function _checkOracleAndNom() internal {
+        bytes32[] memory preOracle = _snapshot(ETHERFI_ORACLE);
+        bytes32[] memory preNOM    = _snapshot(NODE_OPERATOR_MANAGER);
+
+        address newOracle = address(new EtherFiOracle(ROLE_REGISTRY));
+        address newNOM    = address(new NodeOperatorManager(ROLE_REGISTRY));
+
+        _upgradeProxy(ETHERFI_ORACLE,        newOracle);
+        _upgradeProxy(NODE_OPERATOR_MANAGER, newNOM);
+
+        assertEq(_diff("EtherFiOracle",       ETHERFI_ORACLE,        preOracle), 0);
+        assertEq(_diff("NodeOperatorManager", NODE_OPERATOR_MANAGER, preNOM),    0);
+
+        assertEq(address(EtherFiOracle(ETHERFI_ORACLE).roleRegistry()),              ROLE_REGISTRY);
+        assertEq(address(NodeOperatorManager(NODE_OPERATOR_MANAGER).roleRegistry()), ROLE_REGISTRY);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Internal: snapshot + upgrade + diff for AuctionManager and EtherFiRestaker
+    // ---------------------------------------------------------------------------
+    function _checkAmAndEr() internal {
+        bytes32[] memory preAM = _snapshot(AUCTION_MANAGER);
+        bytes32[] memory preER = _snapshot(ETHERFI_RESTAKER);
+
+        address newAM = address(new AuctionManager(ROLE_REGISTRY));
+        address newER = address(new EtherFiRestaker(
+            EIGENLAYER_REWARDS_COORDINATOR,
+            ETHERFI_REDEMPTION_MANAGER,
+            ROLE_REGISTRY,
+            ETHERFI_RATE_LIMITER
+        ));
+
+        _upgradeProxy(AUCTION_MANAGER,  newAM);
+        _upgradeProxy(ETHERFI_RESTAKER, newER);
+
+        assertEq(_diff("AuctionManager",  AUCTION_MANAGER,  preAM), 0);
+        assertEq(_diff("EtherFiRestaker", ETHERFI_RESTAKER, preER), 0);
+
+        assertEq(address(AuctionManager(AUCTION_MANAGER).roleRegistry()),                ROLE_REGISTRY);
+        assertEq(address(EtherFiRestaker(payable(ETHERFI_RESTAKER)).roleRegistry()),     ROLE_REGISTRY);
+        assertEq(address(EtherFiRestaker(payable(ETHERFI_RESTAKER)).rateLimiter()),      ETHERFI_RATE_LIMITER);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test entry point
+    // ---------------------------------------------------------------------------
+
+    function test_storageIntegrityAcrossAllProxies() public {
+        // Skip if not running against a mainnet fork.
+        if (block.chainid != 1) return;
+
+        _checkOracleAndNom();
+        _checkAmAndEr();
+    }
+}

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -61,7 +61,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         roleRegistry.grantRole(liquidityPool.LIQUIDITY_POOL_VALIDATOR_CREATOR_ROLE(), admin);
         roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_EIGENLAYER_ADMIN_ROLE(), address(stakingManager));
         roleRegistry.grantRole(stakingManager.STAKING_MANAGER_VALIDATOR_INVALIDATOR_ROLE(), admin);
-        auctionManager.updateAdmin(admin, true);
+        roleRegistry.grantRole(auctionManager.AUCTION_MANAGER_ADMIN_ROLE(), admin);
         vm.stopPrank();
     }
 

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -57,6 +57,10 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         vm.prank(liquidityPool.owner());
         liquidityPool.upgradeTo(address(liquidityPoolImpl));
 
+        AuctionManager auctionManagerImpl = new AuctionManager(address(roleRegistry));
+        vm.prank(auctionManager.owner());
+        auctionManager.upgradeTo(address(auctionManagerImpl));
+
         vm.startPrank(roleRegistry.owner());
         roleRegistry.grantRole(liquidityPool.LIQUIDITY_POOL_VALIDATOR_CREATOR_ROLE(), admin);
         roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_EIGENLAYER_ADMIN_ROLE(), address(stakingManager));

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -13,6 +13,13 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
     function setUp() public {
         initializeRealisticFork(MAINNET_FORK);
 
+        // Mainnet NodeOperatorManager hasn't been upgraded to the role-based ACL yet,
+        // so its NODE_OPERATOR_MANAGER_ADMIN_ROLE() getter doesn't exist on-chain.
+        // Upgrade in place so the new role getters used by _ensureValCreationRoles are reachable.
+        NodeOperatorManager nodeOperatorManagerImpl = new NodeOperatorManager(address(roleRegistryInstance));
+        vm.prank(nodeOperatorManagerInstance.owner());
+        nodeOperatorManagerInstance.upgradeTo(address(nodeOperatorManagerImpl));
+
         // Handle any pending oracle report that hasn't been processed yet
         _syncOracleReportState();
     }

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -73,8 +73,9 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         vm.stopPrank();
 
         // Ensure operating admin is an admin on NodeOperatorManager (required for whitelist ops)
-        vm.prank(nodeOperatorManagerInstance.owner());
-        nodeOperatorManagerInstance.updateAdmin(ETHERFI_OPERATING_ADMIN, true);
+        vm.startPrank(roleOwner);
+        roleRegistryInstance.grantRole(nodeOperatorManagerInstance.NODE_OPERATOR_MANAGER_ADMIN_ROLE(), ETHERFI_OPERATING_ADMIN);
+        vm.stopPrank();
     }
 
     function _prepareSingleValidator(address spawner)

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -72,7 +72,16 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         roleRegistryInstance.grantRole(stakingManagerInstance.STAKING_MANAGER_NODE_CREATOR_ROLE(), OPERATING_TIMELOCK);
         vm.stopPrank();
 
-        // Ensure operating admin is an admin on NodeOperatorManager (required for whitelist ops)
+        // The mainnet NodeOperatorManager implementation predates this PR and
+        // does not expose NODE_OPERATOR_MANAGER_ADMIN_ROLE(). Upgrade in place
+        // so the new role getter and role-gated modifier are reachable, then
+        // grant the role used by whitelist ops.
+        address nodeOpMgrOwner = nodeOperatorManagerInstance.owner();
+        vm.startPrank(nodeOpMgrOwner);
+        NodeOperatorManager newNodeOpMgrImpl = new NodeOperatorManager(address(roleRegistryInstance));
+        nodeOperatorManagerInstance.upgradeTo(address(newNodeOpMgrImpl));
+        vm.stopPrank();
+
         vm.startPrank(roleOwner);
         roleRegistryInstance.grantRole(nodeOperatorManagerInstance.NODE_OPERATOR_MANAGER_ADMIN_ROLE(), ETHERFI_OPERATING_ADMIN);
         vm.stopPrank();


### PR DESCRIPTION
## Summary

Migrates `EtherFiOracle`, `NodeOperatorManager`, `BucketRateLimiter`, `AuctionManager`, and `EtherFiRestaker` from local `mapping(address => bool) public admins` access control to the protocol-wide `RoleRegistry`. Each contract:

- Adds `IRoleRegistry public immutable roleRegistry` (constructor-set, no storage slot).
- Declares a contract-specific `<NAME>_ADMIN_ROLE` constant.
- Renames `admins` → `DEPRECATED_admins` (and `pausers` → `DEPRECATED_pausers` where applicable) — preserves existing storage slots.
- Replaces `onlyAdmin` modifier body with `roleRegistry.hasRole(...) revert IncorrectRole();`.
- Routes `pauseContract` / `unPauseContract` through `PROTOCOL_PAUSER` / `PROTOCOL_UNPAUSER`.
- Removes the legacy `updateAdmin` (and `updatePauser`) setters.

`EtherFiRestaker` additionally:
- 4 function-granular roles (`ADMIN`, `REQUEST_WITHDRAWALS`, `CLAIM_WITHDRAWALS`, `DEPOSIT_INTO_STRATEGY`).
- `IEtherFiRateLimiter public immutable rateLimiter` plus 3 rate-limit bucket IDs (`STETH_REQUEST_WITHDRAWAL_LIMIT_ID`, `QUEUE_WITHDRAWALS_LIMIT_ID`, `DEPOSIT_INTO_STRATEGY_LIMIT_ID`). Rate-limited functions call `rateLimiter.consume(...)` after the role gate.

## Tests

- **Per-contract migration unit tests** (5 new files, 41 tests): role-revert, role-success, pause/unpause role gating, deprecated-storage readability, removed-selector checks.
- **Storage-integrity fork test** (`test/fork-tests/RoleMigrationStorageIntegrity.t.sol`): forks mainnet, snapshots first 400 storage slots of each proxy pre-upgrade, upgrades in place, asserts byte-identical storage post-upgrade. Covers 4 mainnet-deployed proxies (`BucketRateLimiter` has no standalone mainnet proxy and is unit-tested instead).
- Existing per-contract test files migrated to use `roleRegistry.grantRole` instead of removed `updateAdmin` calls; `IncorrectRole.selector` replaces legacy revert strings.

## Out of scope (follow-on work)

- Deployment scripts, Gnosis Safe transaction generation, timelock scheduling — handled separately.
- Rate-limiter bucket configuration for `EtherFiRestaker` (capacity / refill rate must be set by operations team via `OPERATING_TIMELOCK` post-upgrade).
- Initial role grants to `OPERATING_TIMELOCK` (`0xcD42...d7a`) — operator concern.

## Test plan

- [ ] CI green on \`forge build --optimize --optimizer-runs 1500\`
- [ ] CI green on \`forge test --no-match-path "test/fork-tests/**"\`
- [ ] CI green on \`forge test --match-contract RoleMigrationStorageIntegrityTest --fork-url \$MAINNET_RPC_URL\`
- [ ] Reviewer confirms storage slot preservation by spot-checking \`forge inspect <Contract> storage-layout\` for each of the 5 contracts
- [ ] Reviewer confirms each \`onlyOwner\` → \`onlyAdmin\` change in \`BucketRateLimiter\` is intentional (behavioral change: owner no longer authorized; must hold the role)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it rewires authorization for multiple core protocol contracts (auctioning, node ops, oracle, restaking, rate limiting) from local admin mappings/owner checks to `RoleRegistry` roles, and adds new rate-limiter enforcement on withdrawal/restaking flows.
> 
> **Overview**
> **Migrates access control to `RoleRegistry` across `AuctionManager`, `NodeOperatorManager`, `EtherFiOracle`, `BucketRateLimiter`, and `EtherFiRestaker`.** Each contract now has an immutable `roleRegistry` set via constructor, uses role checks (with `IncorrectRole`) in place of local `admins`/`pausers`, and removes legacy `updateAdmin`/`updatePauser` entrypoints while keeping `DEPRECATED_*` storage for layout stability.
> 
> **Adds finer-grained permissions and rate limiting to `EtherFiRestaker`.** Introduces separate roles for admin vs withdrawal/deposit actions and enforces `IEtherFiRateLimiter.consume()` on stETH withdrawal requests, EigenLayer withdrawal queueing, and strategy deposits (with wei→gwei rounding-up).
> 
> **Updates operational scripts and tests for the new role-based model.** Deployment/verification scripts pass new constructor args and use `grantRole` instead of admin setters; tests add role-migration coverage (including a mainnet fork storage-integrity test) and adjust expected reverts and setup role grants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc48346573eef9475f224bf1d17870043921006a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->