### PR TITLE
yash/feat/check-execute-task

### DIFF
--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -190,32 +190,20 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         validatorTaskBatchSize = _batchSize;
     }
 
-    function canExecuteTasks(IEtherFiOracle.OracleReport calldata _report) external view returns (bool) {
+    function canExecuteTasks(IEtherFiOracle.OracleReport calldata _report) external view returns (bool _isValid) {
         bytes32 reportHash = etherFiOracle.generateReportHash(_report);
-        uint32 current_slot = etherFiOracle.computeSlotAtTimestamp(block.timestamp);
-
-        if (!etherFiOracle.isConsensusReached(reportHash)) return false;
-        if (slotForNextReportToProcess() != _report.refSlotFrom) return false;
-        if (blockForNextReportToProcess() != _report.refBlockFrom) return false;
-        if (current_slot < postReportWaitTimeInSlots + etherFiOracle.getConsensusSlot(reportHash)) return false;
-        return true;
+        (_isValid,) = _validateReport(_report, reportHash);
     }
 
     function executeTasks(IEtherFiOracle.OracleReport calldata _report) external {
         bytes32 reportHash = etherFiOracle.generateReportHash(_report);
-        uint32 current_slot = etherFiOracle.computeSlotAtTimestamp(block.timestamp);
-        require(etherFiOracle.isConsensusReached(reportHash), "EtherFiAdmin: report didn't reach consensus");
-        require(slotForNextReportToProcess() == _report.refSlotFrom, "EtherFiAdmin: report has wrong `refSlotFrom`");
-        require(blockForNextReportToProcess() == _report.refBlockFrom, "EtherFiAdmin: report has wrong `refBlockFrom`");
-        require(current_slot >= postReportWaitTimeInSlots + etherFiOracle.getConsensusSlot(reportHash), "EtherFiAdmin: report is too fresh");
+        (bool _isValid, string memory _error) = _validateReport(_report, reportHash);
+        require(_isValid, _error);
 
-        uint256 elapsedTime = (_report.refSlotTo - lastHandledReportRefSlot) * 12 seconds;
-        require(elapsedTime > 0, "EtherFiAdmin: report spans zero slots");
-
-        _handleAccruedRewards(_report, elapsedTime);
+        _handleAccruedRewards(_report);
         _handleProtocolFees(_report);
-        _handleValidators(reportHash, elapsedTime, _report);
-        _handleWithdrawals(_report, elapsedTime);
+        _handleValidators(reportHash, _report);
+        _handleWithdrawals(_report);
 
         lastHandledReportRefSlot = _report.refSlotTo;
         lastHandledReportRefBlock = _report.refBlockTo;
@@ -249,44 +237,24 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     //protocol owns the eth that was distributed to NO and treasury in eigenpods and etherfinodes 
     function _handleProtocolFees(IEtherFiOracle.OracleReport calldata _report) internal { 
-        require(_report.protocolFees >= 0, "EtherFiAdmin: protocol fees can't be negative");
         if(_report.protocolFees == 0) {
             return;
         }
-        int128 totalRewards = _report.protocolFees + _report.accruedRewards;
-        // protocol fees are less than 20% of total rewards
-        require( _report.protocolFees * 5 <= totalRewards, "EtherFiAdmin: protocol fees exceed 20% total rewards");
-
         liquidityPool.payProtocolFees(uint128(_report.protocolFees));
     }
 
-    function _handleAccruedRewards(IEtherFiOracle.OracleReport calldata _report, uint256 elapsedTime) internal {
+    function _handleAccruedRewards(IEtherFiOracle.OracleReport calldata _report) internal {
         if (_report.accruedRewards == 0) {
             return;
         }
 
-        // This guard will be removed in future versions
-        // Ensure that the new TVL didnt' change too much
-        // Check if the absolute change (increment, decrement) in TVL is beyond the threshold variable
-        // - 5% APR = 0.0137% per day
-        // - 10% APR = 0.0274% per day
-        int256 currentTVL = int128(uint128(liquidityPool.getTotalPooledEther()));
-        int256 apr;
-        if (currentTVL > 0) {
-            apr = 10000 * (_report.accruedRewards * 365 days) / (currentTVL * int256(elapsedTime));
-        }
-        int256 absApr = (apr > 0) ? apr : - apr;
-        require(absApr <= acceptableRebaseAprInBps, "EtherFiAdmin: TVL changed too much");
-
         membershipManager.rebase(_report.accruedRewards);
     }
 
-    function _enqueueValidatorApprovalTask(bytes32 _reportHash, uint256 elapsedTime, IEtherFiOracle.OracleReport calldata _report) internal {
+    function _enqueueValidatorApprovalTask(bytes32 _reportHash, IEtherFiOracle.OracleReport calldata _report) internal {
         if(_report.validatorsToApprove.length == 0) {
             return;
         }
-        uint256 numValidatorsToApprovePerDay = (_report.validatorsToApprove.length * 1 days) / elapsedTime;
-        require(numValidatorsToApprovePerDay <= MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY, "EtherFiAdmin: number of validators to approve exceeds max");
 
         uint256 numBatches = (_report.validatorsToApprove.length + validatorTaskBatchSize - 1) / validatorTaskBatchSize;
 
@@ -305,20 +273,60 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         }
     }
 
-    function _handleValidators(bytes32 _reportHash, uint256 elapsedTime, IEtherFiOracle.OracleReport calldata _report) internal {
-        _enqueueValidatorApprovalTask(_reportHash, elapsedTime, _report);
+    function _handleValidators(bytes32 _reportHash, IEtherFiOracle.OracleReport calldata _report) internal {
+        _enqueueValidatorApprovalTask(_reportHash, _report);
     }
 
-    function _handleWithdrawals(IEtherFiOracle.OracleReport calldata _report, uint256 elapsedTime) internal {
-        uint256 finalizedWithdrawalAmountPerDay = (_report.finalizedWithdrawalAmount * 1 days) / elapsedTime;
-        require(finalizedWithdrawalAmountPerDay <= MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY, "EtherFiAdmin: finalized withdrawal amount exceeds max");
-
+    function _handleWithdrawals(IEtherFiOracle.OracleReport calldata _report) internal {
         for (uint256 i = 0; i < _report.withdrawalRequestsToInvalidate.length; i++) {
             withdrawRequestNft.invalidateRequest(_report.withdrawalRequestsToInvalidate[i]);
         }
         withdrawRequestNft.finalizeRequests(_report.lastFinalizedWithdrawalRequestId);
-        require(_report.finalizedWithdrawalAmount + liquidityPool.ethAmountLockedForWithdrawal() + priorityWithdrawalQueue.ethAmountLockedForPriorityWithdrawal() <= address(liquidityPool).balance, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
         liquidityPool.addEthAmountLockedForWithdrawal(_report.finalizedWithdrawalAmount);
+    }
+
+    function _validateReport(IEtherFiOracle.OracleReport calldata _report, bytes32 _reportHash) internal view returns (bool, string memory) {
+        uint32 current_slot = etherFiOracle.computeSlotAtTimestamp(block.timestamp);
+        if (!etherFiOracle.isConsensusReached(_reportHash)) return (false, "EtherFiAdmin: report didn't reach consensus");
+        if (slotForNextReportToProcess() != _report.refSlotFrom) return (false, "EtherFiAdmin: report has wrong `refSlotFrom`");
+        if (blockForNextReportToProcess() != _report.refBlockFrom) return (false, "EtherFiAdmin: report has wrong `refBlockFrom`");
+        if (current_slot < postReportWaitTimeInSlots + etherFiOracle.getConsensusSlot(_reportHash)) return (false, "EtherFiAdmin: report is too fresh");
+
+        uint256 elapsedTime = (_report.refSlotTo - lastHandledReportRefSlot) * 12 seconds;
+        if (elapsedTime == 0) return (false, "EtherFiAdmin: report spans zero slots");
+
+        // validate accrued rewards
+        int256 currentTVL = int128(uint128(liquidityPool.getTotalPooledEther()));
+
+        // This guard will be removed in future versions
+        // Ensure that the new TVL didnt' change too much
+        // Check if the absolute change (increment, decrement) in TVL is beyond the threshold variable
+        // - 5% APR = 0.0137% per day
+        // - 10% APR = 0.0274% per day
+        int256 apr;
+        if (currentTVL > 0) {
+            apr = 10000 * (_report.accruedRewards * 365 days) / (currentTVL * int256(elapsedTime));
+        }
+        int256 absApr = (apr > 0) ? apr : - apr;
+        if (absApr > acceptableRebaseAprInBps) return (false, "EtherFiAdmin: TVL changed too much");
+
+        // validate protocol fees
+        if (_report.protocolFees < 0) return (false, "EtherFiAdmin: protocol fees can't be negative");
+        int128 totalRewards = _report.protocolFees + _report.accruedRewards;
+        // protocol fees are less than 20% of total rewards
+        if (_report.protocolFees > 0 && _report.protocolFees * 5 > totalRewards) return (false, "EtherFiAdmin: protocol fees exceed 20% total rewards");
+
+        // validate approvals
+        uint256 numValidatorsToApprovePerDay = (_report.validatorsToApprove.length * 1 days) / elapsedTime;
+        if (numValidatorsToApprovePerDay > MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY) return (false, "EtherFiAdmin: number of validators to approve exceeds max");
+
+        // validate withdrawals
+        uint256 finalizedWithdrawalAmountPerDay = (_report.finalizedWithdrawalAmount * 1 days) / elapsedTime;
+        if (finalizedWithdrawalAmountPerDay > MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY) return (false, "EtherFiAdmin: finalized withdrawal amount exceeds max");
+        if (_report.finalizedWithdrawalAmount + liquidityPool.ethAmountLockedForWithdrawal() + priorityWithdrawalQueue.ethAmountLockedForPriorityWithdrawal() > address(liquidityPool).balance) return (false, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
+
+        // report is valid
+        return (true, "");
     }
 
     function slotForNextReportToProcess() public view returns (uint32) {

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -54,12 +54,15 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     RoleRegistry public roleRegistry;
 
+    uint256 public maxFinalizedWithdrawalAmountPerDay;
+    uint256 public maxNumValidatorsToApprovePerDay;
+
     bytes32 public constant ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE = keccak256("ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE");
     bytes32 public constant ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE = keccak256("ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE");
 
     IPriorityWithdrawalQueue public immutable priorityWithdrawalQueue;
-    uint256 public immutable MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY;
-    uint256 public immutable MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY;
+    uint256 public constant MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY = 100_000 ether;
+    uint256 public constant MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY = 500;
 
     int256 public immutable MAX_ACCEPTABLE_REBASE_APR_IN_BPS;
     uint256 public immutable MAX_VALIDATOR_TASK_BATCH_SIZE;
@@ -80,18 +83,14 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     error InvalidMaxAcceptableRebaseApr();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _priorityWithdrawalQueue, uint256 _maxFinalizedWithdrawalAmountPerDay, uint256 _maxNumValidatorsToApprovePerDay, int256 _maxAcceptableRebaseAprInBps, uint256 _maxValidatorTaskBatchSize) {
+    constructor(address _priorityWithdrawalQueue, int256 _maxAcceptableRebaseAprInBps, uint256 _maxValidatorTaskBatchSize) {
         if (_priorityWithdrawalQueue == address(0)) revert InvalidPriorityWithdrawalQueue();
-        if (_maxFinalizedWithdrawalAmountPerDay == 0) revert InvalidMaxFinalizedWithdrawalAmountPerDay();
-        if (_maxNumValidatorsToApprovePerDay == 0) revert InvalidMaxNumValidatorsToApprovePerDay();
         if (_maxAcceptableRebaseAprInBps <= 0 || _maxAcceptableRebaseAprInBps > 10_000) revert InvalidMaxAcceptableRebaseApr();
         if (_maxValidatorTaskBatchSize == 0) revert InvalidValidatorTaskBatchSize();
-        _disableInitializers();
         priorityWithdrawalQueue = IPriorityWithdrawalQueue(_priorityWithdrawalQueue);
-        MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY = _maxFinalizedWithdrawalAmountPerDay;
-        MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY = _maxNumValidatorsToApprovePerDay;
         MAX_ACCEPTABLE_REBASE_APR_IN_BPS = _maxAcceptableRebaseAprInBps;
         MAX_VALIDATOR_TASK_BATCH_SIZE = _maxValidatorTaskBatchSize;
+        _disableInitializers();
     }
 
     function initialize(
@@ -318,11 +317,11 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
         // validate approvals
         uint256 numValidatorsToApprovePerDay = (_report.validatorsToApprove.length * 1 days) / elapsedTime;
-        if (numValidatorsToApprovePerDay > MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY) return (false, "EtherFiAdmin: number of validators to approve exceeds max");
+        if (numValidatorsToApprovePerDay > maxNumValidatorsToApprovePerDay) return (false, "EtherFiAdmin: number of validators to approve exceeds max");
 
         // validate withdrawals
         uint256 finalizedWithdrawalAmountPerDay = (_report.finalizedWithdrawalAmount * 1 days) / elapsedTime;
-        if (finalizedWithdrawalAmountPerDay > MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY) return (false, "EtherFiAdmin: finalized withdrawal amount exceeds max");
+        if (finalizedWithdrawalAmountPerDay > maxFinalizedWithdrawalAmountPerDay) return (false, "EtherFiAdmin: finalized withdrawal amount exceeds max");
         if (_report.finalizedWithdrawalAmount > address(liquidityPool).balance) return (false, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
 
         // report is valid
@@ -335,6 +334,18 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     function blockForNextReportToProcess() public view returns (uint32) {
         return (lastHandledReportRefBlock == 0) ? 0 : lastHandledReportRefBlock + 1;
+    }
+
+    function updateMaxFinalizedWithdrawalAmountPerDay(uint256 _maxFinalizedWithdrawalAmountPerDay) external {
+        if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if (_maxFinalizedWithdrawalAmountPerDay == 0 || _maxFinalizedWithdrawalAmountPerDay > MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY) revert InvalidMaxFinalizedWithdrawalAmountPerDay();
+        maxFinalizedWithdrawalAmountPerDay = _maxFinalizedWithdrawalAmountPerDay;
+    }
+
+    function updateMaxNumValidatorsToApprovePerDay(uint256 _maxNumValidatorsToApprovePerDay) external {
+        if (!roleRegistry.hasRole(ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
+        if (_maxNumValidatorsToApprovePerDay > MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY) revert InvalidMaxNumValidatorsToApprovePerDay();
+        maxNumValidatorsToApprovePerDay = _maxNumValidatorsToApprovePerDay;
     }
 
     function updateAcceptableRebaseApr(int32 _acceptableRebaseAprInBps) external {

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1618,4 +1618,245 @@ contract EtherFiOracleTest is TestSetup {
         _moveClock(1 days / 12);
         _executeAdminTasks(report, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
     }
+
+    // =====================================================================
+    // canExecuteTasks unit tests
+    //
+    // canExecuteTasks and executeTasks share _validateReport. Each test
+    // exercises one gate: where the gate trips, canExecuteTasks must return
+    // false AND executeTasks must revert with the matching string. Any
+    // future drift between the two functions should fail one of these tests.
+    // =====================================================================
+
+    // Submit `_report` so it reaches consensus and clear any post-report
+    // wait time. Does NOT call executeTasks.
+    function _submitForConsensus(IEtherFiOracle.OracleReport memory _report) internal {
+        _initReportBlockStamp(_report);
+
+        uint32 currentSlot = etherFiOracleInstance.computeSlotAtTimestamp(block.timestamp);
+        uint32 currentEpoch = (currentSlot / 32);
+        uint32 reportEpoch = (_report.refSlotTo / 32) + 3;
+        if (currentEpoch < reportEpoch) {
+            uint32 numSlotsToMove = 32 * (reportEpoch - currentEpoch);
+            _moveClock(int256(int32(numSlotsToMove)));
+        }
+
+        vm.prank(alice);
+        etherFiOracleInstance.submitReport(_report);
+        vm.prank(bob);
+        etherFiOracleInstance.submitReport(_report);
+
+        int256 offset = int256(int16(etherFiAdminInstance.postReportWaitTimeInSlots()));
+        if (offset > 2 * 32) offset -= 2 * 32;
+        if (offset > 0) _moveClock(offset);
+    }
+
+    function test_canExecuteTasks_falseWhenNoConsensus() public {
+        _moveClock(1024 + 2 * slotsPerEpoch);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        _initReportBlockStamp(report);
+
+        // No submission, so no consensus on the hash.
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: report didn't reach consensus");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    // After a successful execute, slotForNextReportToProcess() advances past
+    // the report's refSlotFrom. The same report can no longer be executed,
+    // and the refSlotFrom gate is what trips. (refBlockFrom is structurally
+    // symmetric — checked by the same once-stale-always-stale relationship.)
+    function test_canExecuteTasks_falseWhenWrongRefSlotFrom() public {
+        IEtherFiOracle.OracleReport memory firstReport = _emptyOracleReport();
+        _executeAdminTasks(firstReport);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(firstReport), false);
+
+        vm.expectRevert("EtherFiAdmin: report has wrong `refSlotFrom`");
+        etherFiAdminInstance.executeTasks(firstReport);
+    }
+
+    function test_canExecuteTasks_falseWhenTooFresh() public {
+        vm.prank(alice);
+        etherFiAdminInstance.updatePostReportWaitTimeInSlots(10);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        _initReportBlockStamp(report);
+
+        _moveClock(1024 + 2 * slotsPerEpoch);
+
+        vm.prank(alice);
+        etherFiOracleInstance.submitReport(report);
+        vm.prank(bob);
+        etherFiOracleInstance.submitReport(report);
+
+        // Consensus reached this same block; wait window of 10 slots not yet elapsed.
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: report is too fresh");
+        etherFiAdminInstance.executeTasks(report);
+
+        // Once the wait elapses, the gate flips.
+        _moveClock(11);
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+    }
+
+    function test_canExecuteTasks_falseWhenAprAboveCap() public {
+        // Tighten the cap so any non-zero rebase trips it.
+        vm.prank(alice);
+        etherFiAdminInstance.updateAcceptableRebaseApr(0);
+
+        // TVL > 0 so the APR formula is non-trivial.
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.accruedRewards = 0.01 ether;
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: TVL changed too much");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    // The APR check uses absApr, so a negative rebase of equal magnitude
+    // must trip the same gate.
+    function test_canExecuteTasks_falseWhenNegativeAprAboveCap() public {
+        vm.prank(alice);
+        etherFiAdminInstance.updateAcceptableRebaseApr(0);
+
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.accruedRewards = -0.01 ether;
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: TVL changed too much");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    function test_canExecuteTasks_falseWhenProtocolFeesNegative() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.protocolFees = -1;
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: protocol fees can't be negative");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    // Regression pin: protocolFees == 0 with a negative accruedRewards must
+    // pass validation. An earlier refactor accidentally extended the 20%
+    // rule to protocolFees == 0, which would have rejected this case
+    // (5*0 > 0 + ar when ar < 0). We only assert the validation gate here;
+    // the downstream rebase path is exercised by the existing
+    // test_huge_negative_rebaes.
+    function test_canExecuteTasks_trueWhenZeroFeesAndNegativeRewards() public {
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.protocolFees = 0;
+        report.accruedRewards = -1 wei;
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+    }
+
+    // 5*pf == pf+ar -> 4*pf == ar, i.e. fees are exactly 20% of total
+    // rewards. The gate is `pf*5 > totalRewards` (strict), so equality
+    // passes.
+    function test_canExecuteTasks_trueAtTwentyPercentBoundary() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.accruedRewards = 4 ether;
+        report.protocolFees = 1 ether; // 5*1 == 1+4
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+    }
+
+    function test_canExecuteTasks_falseWhenFeesExceedTwentyPercent() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        // 5*pf > pf+ar : pick pf=2, ar=4 -> 10 > 6.
+        report.accruedRewards = 4 ether;
+        report.protocolFees = 2 ether;
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: protocol fees exceed 20% total rewards");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    function test_canExecuteTasks_falseWhenValidatorRateAboveCap() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.validatorsToApprove = new uint256[](400); // > 200/day cap
+        for (uint256 i = 0; i < 400; i++) {
+            report.validatorsToApprove[i] = i + 1;
+        }
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: number of validators to approve exceeds max");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    function test_canExecuteTasks_falseWhenWithdrawalRateAboveCap() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.finalizedWithdrawalAmount = 20000 ether; // > 10000 ether/day cap
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: finalized withdrawal amount exceeds max");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    function test_canExecuteTasks_falseWhenFinalizedExceedsLpLiquidity() public {
+        vm.deal(alice, 5 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 5 ether}();
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.finalizedWithdrawalAmount = 6 ether; // 6 > LP balance (5)
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    function test_canExecuteTasks_trueOnHappyPath() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+
+        etherFiAdminInstance.executeTasks(report);
+
+        // After execution the same report no longer matches the cursor.
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+    }
 }

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -10,6 +10,11 @@ contract EtherFiOracleTest is TestSetup {
 
         // Timestamp = 1, BlockNumber = 0
         vm.roll(0);
+
+        vm.prank(alice);
+        etherFiAdminInstance.updateMaxFinalizedWithdrawalAmountPerDay(10_000 ether);
+        vm.prank(alice);
+        etherFiAdminInstance.updateMaxNumValidatorsToApprovePerDay(200);
     }
 
     function test_addCommitteeMember() public {
@@ -1052,51 +1057,33 @@ contract EtherFiOracleTest is TestSetup {
     function test_constructor_priorityWithdrawalQueue_guardrail() public {
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidPriorityWithdrawalQueue.selector);
-        new EtherFiAdmin(address(0x0), 1_000, 1_000, 500, 1_000);
-    }
-
-    function test_constructor_maxFinalizedWithdrawalAmountPerDay_guardrail() public {
-        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 500, 1_000);
-        assertEq(nonZeroValue.MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY(), 1_000);
-
-        // value 0 reverts
-        vm.expectRevert(EtherFiAdmin.InvalidMaxFinalizedWithdrawalAmountPerDay.selector);
-        new EtherFiAdmin(address(0x1234), 0, 1_000, 500, 1_000);
-    }
-
-    function test_constructor_maxNumValidatorsToApprovePerDay_guardrail() public {
-        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 100, 500, 1_000);
-        assertEq(nonZeroValue.MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY(), 100);
-
-        // value 0 reverts
-        vm.expectRevert(EtherFiAdmin.InvalidMaxNumValidatorsToApprovePerDay.selector);
-        new EtherFiAdmin(address(0x1234), 1_000, 0, 500, 1_000); // 0 is invalid
+        new EtherFiAdmin(address(0x0), 500, 1_000);
     }
 
     function test_constructor_maxValidatorTaskBatchSize_guardrail() public {
-        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 500, 1_000);
+        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 500, 1_000);
         assertEq(nonZeroValue.MAX_VALIDATOR_TASK_BATCH_SIZE(), 1_000);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidValidatorTaskBatchSize.selector);
-        new EtherFiAdmin(address(0x1234), 1_000, 1_000, 500, 0);
+        new EtherFiAdmin(address(0x1234), 500, 0);
     }
 
     function test_constructor_maxAcceptableRebaseAprInBps_guardrail() public {
-        EtherFiAdmin validValue = new EtherFiAdmin(address(0x1234), 1_000, 1_000, 500, 1_000);
+        EtherFiAdmin validValue = new EtherFiAdmin(address(0x1234), 500, 1_000);
         assertEq(validValue.MAX_ACCEPTABLE_REBASE_APR_IN_BPS(), 500);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(address(0x1234), 1_000, 1_000, 0, 1_000);
+        new EtherFiAdmin(address(0x1234), 0, 1_000);
 
         // negative values revert
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(address(0x1234), 1_000, 1_000, -1, 1_000);
+        new EtherFiAdmin(address(0x1234), -1, 1_000);
 
         // values above 10_000 revert
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(address(0x1234), 1_000, 1_000, 10_001, 1_000);
+        new EtherFiAdmin(address(0x1234), 10_001, 1_000);
     }
 
     function test_executeValidatorApprovalTask() public {

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -717,7 +717,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         );
         priorityQueueInstance = PriorityWithdrawalQueue(payable(address(priorityQueueProxy)));
 
-        etherFiAdminImplementation = new EtherFiAdmin(address(priorityQueueInstance), 10000 ether, 200, 10_000, 1_000);
+        etherFiAdminImplementation = new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000);
         etherFiAdminProxy = new UUPSProxy(address(etherFiAdminImplementation), "");
         etherFiAdminInstance = EtherFiAdmin(payable(etherFiAdminProxy));
 
@@ -936,7 +936,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function _upgrade_etherfiAdmin() internal {
-        address newAdminImpl = address(new EtherFiAdmin(address(priorityQueueInstance), 10000 ether, 200, 10_000, 1_000));
+        address newAdminImpl = address(new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000));
         vm.prank(etherFiAdminInstance.owner());
         etherFiAdminInstance.upgradeTo(newAdminImpl);
     }

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -401,6 +401,10 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.assume(recipient != address(0) && recipient != address(liquidityPoolInstance));
         // Filter out contracts that don't implement IERC721Receiver - only allow EOAs
         vm.assume(recipient.code.length == 0);
+        // Filter out precompile addresses (0x01..0xff). They have no code so the
+        // line above lets them through, but the low-level ETH transfer inside
+        // claimWithdraw fails against them -> SendFail.
+        vm.assume(uint160(recipient) > 0xff);
 
         // Setup initial balance for recipient
         vm.deal(recipient, depositAmount);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the validation gates for `executeTasks`/`canExecuteTasks`, including protocol-fee, rebase APR, validator-approval, and withdrawal-rate limits; incorrect configuration or logic could block report processing or allow higher-than-intended throughput.
> 
> **Overview**
> Refactors `EtherFiAdmin` so `canExecuteTasks` and `executeTasks` share a single `_validateReport` path that returns consistent revert reasons, and moves key guardrails (consensus/freshness sequencing, APR sanity check, protocol-fee bounds, validator-approval rate, withdrawal rate, and LP-liquidity check) into that function.
> 
> Replaces constructor-passed daily caps with admin-updatable storage params (`maxFinalizedWithdrawalAmountPerDay`, `maxNumValidatorsToApprovePerDay`) bounded by new hard constants, and adds role-gated setters for both. Updates test setup/constructor expectations and adds extensive unit coverage to ensure `canExecuteTasks` returns `false` exactly when `executeTasks` would revert with the matching error string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35410424d86282cd21e3118b2e88b691a40b29b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->