### PR TITLE
yash/fix/syko-review

### DIFF
--- a/.github/workflows/run-forge-tests.yaml
+++ b/.github/workflows/run-forge-tests.yaml
@@ -30,6 +30,7 @@ jobs:
         run: forge test -vvv
         env:
           MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+          OP_RPC_URL: ${{ secrets.OP_RPC_URL }}
           SCROLL_RPC_URL: ${{ secrets.SCROLL_RPC_URL }}
           HISTORICAL_PROOF_812_WITHDRAWAL_RPC_URL: ${{ secrets.HISTORICAL_PROOF_812_WITHDRAWAL_RPC_URL }}
           HISTORICAL_PROOF_RPC_URL: ${{ secrets.HISTORICAL_PROOF_RPC_URL }}

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -231,6 +231,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
     
     function registerToken(address _token, address _target, bool _isWhitelisted, uint16 _discountInBasisPoints, uint32 _timeBoundCapInEther, uint32 _totalCapInEther, bool _isL2Eth) external onlyOwner {
+        if (_discountInBasisPoints < MIN_DISCOUNT_RATE_IN_BPS || _discountInBasisPoints > BASIS_POINT_SCALE) revert InvalidDiscountRate();
         if (tokenInfos[_token].timeBoundCapClockStartTime != 0) revert AlreadyRegistered();
         if (_isL2Eth) {
             if (_token == address(0) || _target != address(0)) revert();

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -99,7 +99,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
 
     uint256 public immutable MIN_DISCOUNT_RATE_IN_BPS;
     uint256 public immutable STALE_PRICE_WINDOW;
-    uint256 public immutable MAX_PRICE_DEVIATION_In_BPS;
+    uint256 public immutable MAX_PRICE_DEVIATION_IN_BPS;
 
     event Liquified(address _user, uint256 _toEEthAmount, address _fromToken, bool _isRestaked);
     // This event is deprecated. will be removed in the next release.
@@ -136,7 +136,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         stEthPriceFeed = AggregatorV3Interface(_stEthPriceFeed);
         MIN_DISCOUNT_RATE_IN_BPS = _minDiscountInBasisPoints;
         STALE_PRICE_WINDOW = _stalePriceWindow;
-        MAX_PRICE_DEVIATION_In_BPS = _maxPriceDeviationInBps;
+        MAX_PRICE_DEVIATION_IN_BPS = _maxPriceDeviationInBps;
         _disableInitializers();
     }
 
@@ -319,7 +319,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
                 if (updatedAt + STALE_PRICE_WINDOW >= block.timestamp) {
                     uint256 pricefeedValue = (uint256(answer) * _amount) / 1e18;
                     uint256 deviation = pricefeedValue > _marketValue ? pricefeedValue - _marketValue : _marketValue - pricefeedValue;
-                    if (deviation * BASIS_POINT_SCALE / _marketValue > MAX_PRICE_DEVIATION_In_BPS) revert InvalidStEthPrice();
+                    if (deviation * BASIS_POINT_SCALE / _marketValue > MAX_PRICE_DEVIATION_IN_BPS) revert InvalidStEthPrice();
                 }
             } else {
                 _marketValue = _amount; /// 1:1 from stETH to eETH

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -313,7 +313,14 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
 
         if (_token == address(lido)) {
             if (quoteStEthWithCurve) {
+                // check market value from curve pool, stETH price is on avrage always lower than ETH (this is essentially the capital efficiency of the protocol)
+                // if stETH price is temporarily larger than underlying ETH value, we set market value as 1:1 
                 _marketValue = _min(_amount, ICurvePoolQuoter1(address(stEth_Eth_Pool)).get_dy(1, 0, _amount));
+
+                // We also validate against chainlink price feed to ensure there's no significant price deviation 
+                // If price feed is stale, we skip the check
+                // If price feed is negative or deviation is too high, we do not allow the stETH deposit at all, something is wrong with the markets and deposit
+                // via stETH will be blocked until it stablises (either because of underlying lido solvency/liquidity issue or oracle manipulation)
                 (, int256 answer, , uint256 updatedAt,) = stEthPriceFeed.latestRoundData();
                 if (answer <= 0) revert InvalidPriceFeed();
                 if (updatedAt + STALE_PRICE_WINDOW >= block.timestamp) {

--- a/src/utils/PausableUntil.sol
+++ b/src/utils/PausableUntil.sol
@@ -17,7 +17,7 @@ contract PausableUntil {
         }
     }
 
-    uint256 public constant MAX_PAUSE_DURATION = 1 days;
+    uint256 public constant MAX_PAUSE_DURATION = 7 days;
     uint256 public constant PAUSER_UNTIL_COOLDOWN = 1 days;
 
     event PausedUntil(uint256 pausedUntil);

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -43,7 +43,7 @@ contract LiquifierTest is TestSetup {
         _enable_deposit(address(stEthStrategy));
 
         vm.startPrank(owner);
-        liquifierInstance.registerToken(address(stEth), address(stEthStrategy), true, 0, 50, 1000, false); // 50 ether timeBoundCap, 1000 ether total cap
+        liquifierInstance.registerToken(address(stEth), address(stEthStrategy), true, 100, 50, 1000, false); // 1% discount, 50 ether timeBoundCap, 1000 ether total cap
         vm.stopPrank();
 
         dummyToken = new DummyERC20();
@@ -179,7 +179,7 @@ contract LiquifierTest is TestSetup {
 
         vm.startPrank(owner);
         dummyToken = new DummyERC20();
-        liquifierInstance.registerToken(address(dummyToken), address(0), true, 0, 50, 1000, true);
+        liquifierInstance.registerToken(address(dummyToken), address(0), true, 100, 50, 1000, true);
         vm.stopPrank();
 
         vm.warp(block.timestamp + 20);
@@ -300,7 +300,7 @@ contract LiquifierTest is TestSetup {
 
         vm.startPrank(owner);
         DummyERC20 dummyToken2 = new DummyERC20();
-        liquifierInstance.registerToken(address(dummyToken2), address(0), true, 0, 50, 1000, true);
+        liquifierInstance.registerToken(address(dummyToken2), address(0), true, 100, 50, 1000, true);
         vm.stopPrank();
 
         uint256 x = 5 ether;
@@ -664,6 +664,22 @@ contract LiquifierTest is TestSetup {
         assertEq(impl.MAX_PRICE_DEVIATION_IN_BPS(), 500);
     }
 
+    function test_registerToken_revertsOnZeroDiscountRate() public {
+        _setUp(MAINNET_FORK);
+
+        vm.prank(owner);
+        vm.expectRevert(Liquifier.InvalidDiscountRate.selector);
+        liquifierInstance.registerToken(address(stEth), address(stEthStrategy), true, 0, 50, 1000, false);
+    }
+
+    function test_registerToken_revertsOnDiscountRateAboveScale() public {
+        _setUp(MAINNET_FORK);
+
+        vm.prank(owner);
+        vm.expectRevert(Liquifier.InvalidDiscountRate.selector);
+        liquifierInstance.registerToken(address(stEth), address(stEthStrategy), true, 10_001, 50, 1000, false);
+    }
+
     function test_updateDiscountInBasisPoints_revertsOnZero() public {
         // The exact attack scenario T1-11 closes: a compromised admin tries to
         // set discount to 0 to mint eETH 1:1 against an LST.
@@ -742,20 +758,5 @@ contract LiquifierTest is TestSetup {
         uint256 marketValue = liquifierInstance.quoteByMarketValue(address(stEth), amount);
         uint256 expected = (10_000 - 500) * marketValue / 10_000;
         assertEq(liquifierInstance.quoteByDiscountedValue(address(stEth), amount), expected);
-    }
-
-    function test_quoteByDiscountedValue_zeroDiscountUnreachableViaSetter() public {
-        // Even if quoteByDiscountedValue would return marketValue at discount=0,
-        // the setter must prevent ever reaching that state. This pins the invariant.
-        _setUp(MAINNET_FORK);
-
-        vm.prank(owner);
-        vm.expectRevert(Liquifier.InvalidDiscountRate.selector);
-        liquifierInstance.updateDiscountInBasisPoints(address(stEth), 0);
-
-        // Pre-existing registration discount is 0 (from _setUp), but no admin can
-        // re-affirm or reset it to 0 going forward.
-        (, , , , uint16 discountAfter, , , , , , ) = liquifierInstance.tokenInfos(address(stEth));
-        assertEq(discountAfter, 0); // unchanged, but locked from being re-set to 0
     }
 }

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -661,7 +661,7 @@ contract LiquifierTest is TestSetup {
         Liquifier impl = new Liquifier(address(1), address(2), 250, 1 days, 500);
         assertEq(address(impl.stEthPriceFeed()), address(2));
         assertEq(impl.STALE_PRICE_WINDOW(), 1 days);
-        assertEq(impl.MAX_PRICE_DEVIATION_In_BPS(), 500);
+        assertEq(impl.MAX_PRICE_DEVIATION_IN_BPS(), 500);
     }
 
     function test_updateDiscountInBasisPoints_revertsOnZero() public {

--- a/test/PausableUntil.t.sol
+++ b/test/PausableUntil.t.sol
@@ -82,7 +82,7 @@ contract PausableUntilTest is Test {
     }
 
     function test_constants() public view {
-        assertEq(harness.MAX_PAUSE_DURATION(), 1 days);
+        assertEq(harness.MAX_PAUSE_DURATION(), 7 days);
         assertEq(harness.PAUSER_UNTIL_COOLDOWN(), 1 days);
     }
 
@@ -415,7 +415,7 @@ contract PausableUntilIntegrationTest is Test {
     function test_consume_unblockedAfterPauseUntilExpires() public {
         vm.prank(pauseUntilPauser);
         limiter.pauseContractUntil();
-        vm.warp(block.timestamp + 1 days + 1);
+        vm.warp(block.timestamp + 7 days + 1);
 
         vm.prank(consumer);
         limiter.consume(LIMIT_ID, 1_000);

--- a/test/fork-tests/LiquifierStEthPriceFeedFork.t.sol
+++ b/test/fork-tests/LiquifierStEthPriceFeedFork.t.sol
@@ -30,7 +30,7 @@ contract LiquifierStEthPriceFeedForkTest is TestSetup {
     function test_immutables_pointAtLiveChainlinkFeed() public view {
         assertEq(address(liquifierInstance.stEthPriceFeed()), CHAINLINK_STETH_ETH_FEED);
         assertEq(liquifierInstance.STALE_PRICE_WINDOW(), 24 hours);
-        assertEq(liquifierInstance.MAX_PRICE_DEVIATION_In_BPS(), 500);
+        assertEq(liquifierInstance.MAX_PRICE_DEVIATION_IN_BPS(), 500);
     }
 
     function test_liveFeed_returnsFreshAnswer() public view {
@@ -151,7 +151,7 @@ contract LiquifierStEthPriceFeedForkTest is TestSetup {
         uint256 deviation = chainlinkValue > marketValue ? chainlinkValue - marketValue : marketValue - chainlinkValue;
         uint256 bps = liquifierInstance.BASIS_POINT_SCALE();
 
-        if (fresh && (deviation * bps) / marketValue > liquifierInstance.MAX_PRICE_DEVIATION_In_BPS()) {
+        if (fresh && (deviation * bps) / marketValue > liquifierInstance.MAX_PRICE_DEVIATION_IN_BPS()) {
             vm.expectRevert(Liquifier.InvalidStEthPrice.selector);
             liquifierInstance.quoteByMarketValue(address(stEth), amount);
         } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens on-chain validation for `registerToken` discounts and extends the maximum pause-until duration, both of which can change operational behavior and revert paths; remaining changes are largely renames/tests/CI env wiring.
> 
> **Overview**
> **Hardens `Liquifier` token registration and stETH quoting invariants.** `registerToken` now enforces a non-zero discount within `[MIN_DISCOUNT_RATE_IN_BPS, BASIS_POINT_SCALE]`, and tests/fixtures are updated to register tokens with a non-zero discount.
> 
> **Extends pause-until behavior.** `PausableUntil.MAX_PAUSE_DURATION` is increased from `1 days` to `7 days`, with corresponding test updates.
> 
> **Misc cleanup and CI wiring.** Renames `MAX_PRICE_DEVIATION_In_BPS` to `MAX_PRICE_DEVIATION_IN_BPS` (and updates references/tests), adds clarifying comments around the Chainlink-vs-Curve stETH deviation check, and passes `OP_RPC_URL` into the Forge test workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d8d87084f8afc04cb6cb5bb7b510f8cc783125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->