### PR TITLE
yash/feat/more-sanity-checks

### DIFF
--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -359,6 +359,18 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         if (finalizedWithdrawalAmountPerDay > maxFinalizedWithdrawalAmountPerDay) return (false, "EtherFiAdmin: finalized withdrawal amount exceeds max");
         if (_report.finalizedWithdrawalAmount > address(liquidityPool).balance) return (false, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
 
+        // valdate finalized request id
+        uint32 lastFinalizedRequestId = withdrawRequestNft.lastFinalizedRequestId();
+        if (_report.lastFinalizedWithdrawalRequestId < lastFinalizedRequestId) return (false, "EtherFiAdmin: finalized withdrawal request id is less than last finalized request id");
+        uint256 sumOfRequests;
+        for (uint256 i = lastFinalizedRequestId + 1; i <= _report.lastFinalizedWithdrawalRequestId; i++) {
+            IWithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNft.getRequest(i);
+            if (request.isValid) {
+                sumOfRequests += request.amountOfEEth;
+            }
+        }
+        if (sumOfRequests != _report.finalizedWithdrawalAmount) return (false, "EtherFiAdmin: sum of requests does not match finalized withdrawal amount");
+
         // report is valid
         return (true, "");
     }

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -138,6 +138,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         if (msg.value > type(uint128).max) revert InvalidAmount();
         totalValueOutOfLp -= uint128(msg.value);
         totalValueInLp += uint128(msg.value);
+        _checkTotalValueInLp();
         _checkMinAmountForShare();
     }
 
@@ -204,6 +205,8 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
             if (queueLocked > 0) _sendFund(address(priorityWithdrawalQueue), queueLocked);
         }
 
+        _checkTotalValueInLp();
+        _checkMinAmountForShare();
         escrowMigrationCompleted = true;
     }
 
@@ -274,9 +277,11 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         totalValueInLp -= uint128(_amount);
         eETH.burnShares(msg.sender, share);
 
+        _sendFund(_recipient, _amount);
+
+        _checkTotalValueInLp();
         _checkMinAmountForShare();
 
-        _sendFund(_recipient, _amount);
         return share;
     }
 
@@ -366,9 +371,9 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
         // liquidity pool supplies 1 eth per validator
         uint256 outboundEthAmountFromLp = 1 ether * _bidIds.length;
-        _accountForEthSentOut(outboundEthAmountFromLp);
-
         stakingManager.createBeaconValidators{value: outboundEthAmountFromLp}(_depositData, _bidIds, _etherFiNode);
+
+        _accountForEthSentOut(outboundEthAmountFromLp);
     }
 
     /// @notice send remaining eth to deposit contract to activate the provided validators
@@ -411,9 +416,9 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         }
 
         uint256 outboundEthAmountFromLp = remainingEthPerValidator * _validatorIds.length;
-        _accountForEthSentOut(outboundEthAmountFromLp);
-
         stakingManager.confirmAndFundBeaconValidators{value: outboundEthAmountFromLp}(depositData, validatorSizeWei);
+
+        _accountForEthSentOut(outboundEthAmountFromLp);
     }
 
     /// @notice send remaining eth to deposit contract to activate the provided validators
@@ -429,9 +434,9 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         uint256 remainingEthPerValidator = _validatorSizeWei - stakingManager.initialDepositAmount();
 
         uint256 outboundEthAmountFromLp = remainingEthPerValidator * _depositData.length;
-        _accountForEthSentOut(outboundEthAmountFromLp);
-
         stakingManager.confirmAndFundBeaconValidators{value: outboundEthAmountFromLp}(_depositData, _validatorSizeWei);
+
+        _accountForEthSentOut(outboundEthAmountFromLp);
     }
 
     /// @dev set the size of validators created when caling batchApproveRegistration().
@@ -551,6 +556,9 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         totalValueOutOfLp  += _amount;
 
         _sendFund(address(withdrawRequestNFT), _amount);
+
+        _checkTotalValueInLp();
+        _checkMinAmountForShare();
     }
 
     /// @notice Locks ETH for the priority withdrawal queue by transferring from LP to the queue contract. TVL preserved by InLp/OutOfLp rebalance.
@@ -563,6 +571,9 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         totalValueOutOfLp  += _amount;
 
         _sendFund(priorityWithdrawalQueue, _amount);
+
+        _checkTotalValueInLp();
+        _checkMinAmountForShare();
     }
 
     /// @notice Returns ETH from the priority queue back to LP on a finalized cancel. Inverse of transferLockedEthForPriority.
@@ -571,6 +582,9 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         if (msg.value != _amount || _amount == 0) revert InvalidAmount();
         totalValueOutOfLp -= uint128(_amount);
         totalValueInLp    += uint128(_amount);
+
+        _checkTotalValueInLp();
+        _checkMinAmountForShare();
     }
 
     function burnEEthShares(uint256 shares) external {
@@ -607,6 +621,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
         eETH.mintShares(_recipient, share);
 
+        _checkTotalValueInLp();
         _checkMinAmountForShare();
 
         return share;
@@ -629,6 +644,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     function _accountForEthSentOut(uint256 _amount) internal {
         totalValueOutOfLp += uint128(_amount);
         totalValueInLp -= uint128(_amount);
+        _checkTotalValueInLp();
         _checkMinAmountForShare();
     }
 
@@ -679,6 +695,10 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
             return 0;
         }
         return (_share * getTotalPooledEther()) / totalShares;
+    }
+
+    function _checkTotalValueInLp() internal view {
+        if (totalValueInLp > address(this).balance) revert InsufficientLiquidity();
     }
 
     function _checkMinAmountForShare() internal view {

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -714,7 +714,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     function _checkTotalValueInLp() internal view {
-        if (totalValueInLp != address(this).balance) revert InsufficientLiquidity();
+        if (totalValueInLp > address(this).balance) revert InsufficientLiquidity();
     }
 
     function _checkMinAmountForShare() internal view {

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -302,8 +302,12 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @param amount requested amount to withdraw from contract
     /// @return uint256 requestId of the WithdrawRequestNFT
     function requestWithdraw(address recipient, uint256 amount) public whenNotPaused nonReentrant nonBlacklisted returns (uint256) {
-        if (amount < MIN_WITHDRAW_AMOUNT || amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
+        if (amount == 0) revert InvalidShareAmount();
+        if (amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         IBlacklister(blacklister).nonBlacklisted(recipient);
+        if (amount < MIN_WITHDRAW_AMOUNT) {
+            amount = IERC20(address(eETH)).balanceOf(msg.sender);
+        }
         uint256 share = sharesForAmount(amount);
         if (share == 0) revert InvalidShareAmount();
 

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -302,12 +302,12 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @param amount requested amount to withdraw from contract
     /// @return uint256 requestId of the WithdrawRequestNFT
     function requestWithdraw(address recipient, uint256 amount) public whenNotPaused nonReentrant nonBlacklisted returns (uint256) {
-        if (amount == 0) revert InvalidShareAmount();
-        if (amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         IBlacklister(blacklister).nonBlacklisted(recipient);
+        if (amount == 0) revert InvalidWithdrawalAmount();
         if (amount < MIN_WITHDRAW_AMOUNT) {
             amount = IERC20(address(eETH)).balanceOf(msg.sender);
         }
+        if (amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         uint256 share = sharesForAmount(amount);
         if (share == 0) revert InvalidShareAmount();
 

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -714,7 +714,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     function _checkTotalValueInLp() internal view {
-        if (totalValueInLp > address(this).balance) revert InsufficientLiquidity();
+        if (totalValueInLp != address(this).balance) revert InsufficientLiquidity();
     }
 
     function _checkMinAmountForShare() internal view {

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -81,6 +81,12 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     uint256 public immutable MIN_AMOUNT_FOR_SHARE;
 
     //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    uint256 public constant MIN_WITHDRAW_AMOUNT = 0.01 ether;
+    uint256 public constant MAX_WITHDRAW_AMOUNT = 1000 ether;
+
+    //--------------------------------------------------------------------------------------
     //-------------------------------------  ROLES  ---------------------------------------
     //--------------------------------------------------------------------------------------
 
@@ -115,6 +121,8 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
     error IncorrectCaller();
     error InvalidAmount();
+    error InvalidWithdrawalAmount();
+    error InvalidShareAmount();
     error DataNotSet();
     error InsufficientLiquidity();
     error SendFail();
@@ -291,8 +299,9 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @param amount requested amount to withdraw from contract
     /// @return uint256 requestId of the WithdrawRequestNFT
     function requestWithdraw(address recipient, uint256 amount) public whenNotPaused nonReentrant returns (uint256) {
+        if (amount < MIN_WITHDRAW_AMOUNT || amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         uint256 share = sharesForAmount(amount);
-        if (amount > type(uint96).max || amount == 0 || share == 0) revert InvalidAmount();
+        if (share == 0) revert InvalidShareAmount();
 
         // transfer shares to WithdrawRequestNFT contract from this contract
         IERC20(address(eETH)).safeTransferFrom(msg.sender, address(withdrawRequestNFT), amount);

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -304,9 +304,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     function requestWithdraw(address recipient, uint256 amount) public whenNotPaused nonReentrant nonBlacklisted returns (uint256) {
         IBlacklister(blacklister).nonBlacklisted(recipient);
         if (amount == 0) revert InvalidWithdrawalAmount();
-        if (amount < MIN_WITHDRAW_AMOUNT) {
-            amount = IERC20(address(eETH)).balanceOf(msg.sender);
-        }
+        if (amount < MIN_WITHDRAW_AMOUNT && amount != IERC20(address(eETH)).balanceOf(msg.sender)) revert InvalidWithdrawalAmount();
         if (amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         uint256 share = sharesForAmount(amount);
         if (share == 0) revert InvalidShareAmount();

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -123,6 +123,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     error InvalidMaxPriceDeviationInBps();
     error InvalidRoleRegistry();
     error InvalidPriceFeed();
+    error StalePriceFeed();
     error InvalidStEthPrice();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -324,11 +325,10 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
                 // via stETH will be blocked until it stablises (either because of underlying lido solvency/liquidity issue or oracle manipulation)
                 (, int256 answer, , uint256 updatedAt,) = stEthPriceFeed.latestRoundData();
                 if (answer <= 0) revert InvalidPriceFeed();
-                if (updatedAt + STALE_PRICE_WINDOW >= block.timestamp) {
-                    uint256 pricefeedValue = (uint256(answer) * _amount) / 1e18;
-                    uint256 deviation = pricefeedValue > _marketValue ? pricefeedValue - _marketValue : _marketValue - pricefeedValue;
-                    if (deviation * BASIS_POINT_SCALE / _marketValue > MAX_PRICE_DEVIATION_IN_BPS) revert InvalidStEthPrice();
-                }
+                if (updatedAt + STALE_PRICE_WINDOW < block.timestamp) revert StalePriceFeed();
+                uint256 pricefeedValue = (uint256(answer) * _amount) / 1e18;
+                uint256 deviation = pricefeedValue > _marketValue ? pricefeedValue - _marketValue : _marketValue - pricefeedValue;
+                if (deviation * BASIS_POINT_SCALE / _marketValue > MAX_PRICE_DEVIATION_IN_BPS) revert InvalidStEthPrice();
             } else {
                 _marketValue = _amount; /// 1:1 from stETH to eETH
             }

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -639,7 +639,7 @@ contract PriorityWithdrawalQueue is
     }
 
     function _checkEthAmountLockedForPriorityWithdrawal() internal {
-        if (ethAmountLockedForPriorityWithdrawal > address(liquidityPool).balance) revert InsufficientLiquidity();
+        if (ethAmountLockedForPriorityWithdrawal > address(this).balance) revert InsufficientLiquidity();
     }
 
     function _authorizeUpgrade(address) internal override {

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -121,6 +121,7 @@ contract PriorityWithdrawalQueue is
     error InvalidBurnedSharesAmount();
     error InvalidEEthSharesAfterRemainderHandling();
     error InvalidOutputAmount();
+    error InsufficientLiquidity();
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
@@ -174,6 +175,10 @@ contract PriorityWithdrawalQueue is
 
     receive() external payable {
         require(msg.sender == address(liquidityPool), "Only LP");
+        if (liquidityPool.escrowMigrationCompleted()) {
+            ethAmountLockedForPriorityWithdrawal += uint128(msg.value);
+        }
+        _checkEthAmountLockedForPriorityWithdrawal();
     }
 
     function initialize() external initializer {
@@ -345,8 +350,6 @@ contract PriorityWithdrawalQueue is
 
             emit WithdrawRequestFinalized(requestId, request.user, request.amountOfEEth, request.shareOfEEth, request.nonce, uint32(block.timestamp));
         }
-
-        ethAmountLockedForPriorityWithdrawal += uint128(totalAmountToLock);
 
         if (totalAmountToLock > 0) {
             liquidityPool.transferLockedEthForPriority(uint128(totalAmountToLock));
@@ -586,6 +589,7 @@ contract PriorityWithdrawalQueue is
         if (wasFinalized) {
             ethAmountLockedForPriorityWithdrawal -= uint128(request.amountOfEEth);
             liquidityPool.returnLockedEth{value: request.amountOfEEth}(request.amountOfEEth);
+            _checkEthAmountLockedForPriorityWithdrawal();
         }
 
         uint256 amountForShares = liquidityPool.amountForShare(request.shareOfEEth);
@@ -629,8 +633,13 @@ contract PriorityWithdrawalQueue is
         if (feeEth > 0) {
             liquidityPool.returnLockedEth{value: feeEth}(feeEth);
         }
+        _checkEthAmountLockedForPriorityWithdrawal();
 
         emit WithdrawRequestClaimed(requestId, request.user, uint96(amountToWithdraw), uint96(sharesToBurn), request.nonce, uint32(block.timestamp));
+    }
+
+    function _checkEthAmountLockedForPriorityWithdrawal() internal {
+        if (ethAmountLockedForPriorityWithdrawal > address(liquidityPool).balance) revert InsufficientLiquidity();
     }
 
     function _authorizeUpgrade(address) internal override {

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -22,8 +22,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     using SafeERC20 for IERC20;
 
     uint256 private constant BASIS_POINT_SCALE = 1e4;
-    uint256 public constant MIN_WITHDRAW_AMOUNT = 0.01 ether;
-    uint256 public constant MAX_WITHDRAW_AMOUNT = 1000 ether;
     // this treasury address is set to ethfi buyback wallet address
     address public immutable treasury;
     
@@ -65,7 +63,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     event Unpaused(address account);
 
     error IncorrectRole();
-    error InvalidWithdrawalAmount();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _treasury) {
@@ -119,7 +116,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @param fee fee to be subtracted from amount when recipient calls claimWithdraw
     /// @return uint256 id of the withdraw request
     function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient, uint256 fee) external onlyLiquidityPool whenNotPaused returns (uint256) {
-        if (amountOfEEth < MIN_WITHDRAW_AMOUNT || amountOfEEth > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         uint256 requestId = nextRequestId++;
         uint32 feeGwei = uint32(fee / 1 gwei);
 

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -108,6 +108,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     receive() external payable {
         require(msg.sender == address(liquidityPool), "Only LP");
         ethAmountLockedForWithdrawal += uint128(msg.value);
+        _checkEthAmountLockedForWithdrawal();
     }
 
     /// @notice creates a withdraw request and issues an associated NFT to the recipient
@@ -117,7 +118,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @param recipient address to recieve with WithdrawRequestNFT
     /// @param fee fee to be subtracted from amount when recipient calls claimWithdraw
     /// @return uint256 id of the withdraw request
-    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient, uint256 fee) external payable onlyLiquidityPool whenNotPaused returns (uint256) {
+    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient, uint256 fee) external onlyLiquidityPool whenNotPaused returns (uint256) {
         if (amountOfEEth < MIN_WITHDRAW_AMOUNT || amountOfEEth > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         uint256 requestId = nextRequestId++;
         uint32 feeGwei = uint32(fee / 1 gwei);
@@ -131,6 +132,11 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     function getClaimableAmount(uint256 tokenId) public view returns (uint256) {
+        (uint256 amountToTransfer, uint256 fee) = _getClaimableAmount(tokenId);
+        return amountToTransfer - fee;
+    }
+
+    function _getClaimableAmount(uint256 tokenId) internal view returns (uint256, uint256) {
         require(tokenId <= lastFinalizedRequestId, "Request is not finalized");
         require(ownerOf(tokenId) != address(0), "Already Claimed");
 
@@ -140,8 +146,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         uint256 amountForShares = liquidityPool.amountForShare(request.shareOfEEth);
         uint256 amountToTransfer = (request.amountOfEEth < amountForShares) ? request.amountOfEEth : amountForShares;
         uint256 fee = uint256(request.feeGwei) * 1 gwei;
-
-        return amountToTransfer - fee;
+        return (amountToTransfer, fee);
     }
 
     /// @notice called by the NFT owner to claim their ETH
@@ -157,7 +162,8 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
         require(request.isValid, "Request is not valid");
 
-        uint256 amountToWithdraw = getClaimableAmount(tokenId);
+        (uint256 amountToTransfer, uint256 fee) = _getClaimableAmount(tokenId);
+        uint256 amountToWithdraw = amountToTransfer - fee;
         uint256 shareAmountToBurnForWithdrawal = liquidityPool.sharesForWithdrawalAmount(amountToWithdraw);
 
         // transfer eth to recipient
@@ -167,16 +173,16 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         // update accounting
         totalRemainderEEthShares += request.shareOfEEth - shareAmountToBurnForWithdrawal;
 
-        require(ethAmountLockedForWithdrawal >= request.amountOfEEth, "insufficient escrow");
-        ethAmountLockedForWithdrawal -= uint128(uint256(request.amountOfEEth));
+        require(ethAmountLockedForWithdrawal >= amountToTransfer, "insufficient escrow");
+        ethAmountLockedForWithdrawal -= uint128(amountToTransfer);
 
         uint256 amountBurnedShare = liquidityPool.withdraw(recipient, amountToWithdraw);
         assert (amountBurnedShare == shareAmountToBurnForWithdrawal);
 
-        // ETH was transferred to this contract at finalize time via LP.addEthAmountLockedForWithdrawal.
-        require(address(this).balance >= amountToWithdraw, "Insufficient escrow");
         (bool ok, ) = payable(recipient).call{value: amountToWithdraw}("");
         require(ok, "ETH transfer failed");
+
+        _checkEthAmountLockedForWithdrawal();
 
         emit WithdrawRequestClaimed(uint32(tokenId), amountToWithdraw, amountBurnedShare, recipient, 0);
     }
@@ -324,6 +330,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         if (strandedFeeEth > 0) {
             (bool ok, ) = payable(address(liquidityPool)).call{value: strandedFeeEth}("");
             require(ok, "fee return failed");
+            _checkEthAmountLockedForWithdrawal();
         }
     }
 
@@ -343,6 +350,10 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
             uint256 tokenId = firstTokenId + i;
             require(_requests[tokenId].isValid || msg.sender == owner(), "INVALID_REQUEST");
         }
+    }
+
+    function _checkEthAmountLockedForWithdrawal() internal view {
+        require(address(this).balance >= ethAmountLockedForWithdrawal, "Insufficient escrow");
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}

--- a/src/interfaces/ILiquidityPool.sol
+++ b/src/interfaces/ILiquidityPool.sol
@@ -51,6 +51,7 @@ interface ILiquidityPool {
     function amountForShare(uint256 _share) external view returns (uint256);
     function eETH() external view returns (IeETH);
     function DEPRECATED_ethAmountLockedForWithdrawal() external view returns (uint128);
+    function escrowMigrationCompleted() external view returns (bool);
 
     function deposit() external payable returns (uint256);
     function deposit(address _referral) external payable returns (uint256);

--- a/src/interfaces/IWithdrawRequestNFT.sol
+++ b/src/interfaces/IWithdrawRequestNFT.sol
@@ -10,7 +10,7 @@ interface IWithdrawRequestNFT {
     }
 
     function initialize(address _liquidityPoolAddress, address _eEthAddress, address _membershipManager) external;
-    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester, uint256 fee) external payable returns (uint256);
+    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester, uint256 fee) external returns (uint256);
     function claimWithdraw(uint256 requestId) external;
 
     function getRequest(uint256 requestId) external view returns (WithdrawRequest memory);

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1516,14 +1516,17 @@ contract EtherFiOracleTest is TestSetup {
     // within the per-day cap processes cleanly and advances the LP's locked
     // accounting.
     function test_executeTasks_finalizedWithdrawalWithinCap_succeeds() public {
-        vm.deal(alice, 200 ether);
-        vm.prank(alice);
-        liquidityPoolInstance.deposit{value: 200 ether}();
+        // Seed via bob so requestWithdraw caller has eETH; the sum-of-requests
+        // gate requires a real request to back the finalized amount.
+        _unpauseWithdrawNFT();
+        _seedLp(200 ether);
+        uint256 requestId = _makeWithdrawRequest(10 ether);
 
         uint256 lockedBefore = withdrawRequestNFTInstance.ethAmountLockedForWithdrawal();
 
         IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
         report.finalizedWithdrawalAmount = 10 ether;
+        report.lastFinalizedWithdrawalRequestId = uint32(requestId);
 
         _moveClock(1 days / 12);
         _executeAdminTasks(report);
@@ -1553,9 +1556,9 @@ contract EtherFiOracleTest is TestSetup {
     // next rebase) bumps the balance while accounting lags — a finalized
     // withdrawal drawing on those funds should still pass the check.
     function test_executeTasks_finalizedWithdrawalWithinLpBalance_succeeds() public {
-        vm.deal(alice, 10 ether);
-        vm.prank(alice);
-        liquidityPoolInstance.deposit{value: 10 ether}();
+        _unpauseWithdrawNFT();
+        _seedLp(10 ether);
+        uint256 requestId = _makeWithdrawRequest(6 ether);
 
         // addEthAmountLockedForWithdrawal now requires totalValueInLp >= amount (strict guard).
         // Deposit ensures totalValueInLp (10) >= finalizedWithdrawalAmount (6).
@@ -1565,6 +1568,7 @@ contract EtherFiOracleTest is TestSetup {
 
         IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
         report.finalizedWithdrawalAmount = 6 ether; // <= totalValueInLp (10)
+        report.lastFinalizedWithdrawalRequestId = uint32(requestId);
 
         _moveClock(1 days / 12);
         _executeAdminTasks(report);
@@ -1832,6 +1836,283 @@ contract EtherFiOracleTest is TestSetup {
         assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
     }
 
+    // =====================================================================
+    // _validateReport: lastFinalizedWithdrawalRequestId / sum-of-requests gate
+    //
+    // The new sanity check sums valid request amounts in
+    // (state.lastFinalizedRequestId, report.lastFinalizedWithdrawalRequestId]
+    // and requires it to equal report.finalizedWithdrawalAmount. It also
+    // refuses to roll the on-chain cursor backwards. Each test pins one
+    // branch of that logic.
+    // =====================================================================
+
+    // Report claims more was finalized than the on-chain requests sum to.
+    // 1 ether of real request, report says 2 ether → mismatch.
+    function test_canExecuteTasks_falseWhenReportedAmountAboveSum() public {
+        _unpauseWithdrawNFT();
+        _seedLp(10 ether);
+        uint256 r1 = _makeWithdrawRequest(1 ether);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = uint32(r1);
+        report.finalizedWithdrawalAmount = 2 ether;
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: sum of requests does not match finalized withdrawal amount");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    // Symmetric: report claims less than the on-chain sum.
+    // 2 ether of real request, report says 1 ether → mismatch.
+    function test_canExecuteTasks_falseWhenReportedAmountBelowSum() public {
+        _unpauseWithdrawNFT();
+        _seedLp(10 ether);
+        uint256 r1 = _makeWithdrawRequest(2 ether);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = uint32(r1);
+        report.finalizedWithdrawalAmount = 1 ether;
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: sum of requests does not match finalized withdrawal amount");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    // Equality edge: report's cursor == state's cursor. The loop bounds
+    // collapse to zero iterations so sum is 0. A non-zero amount can't be
+    // explained by any request → mismatch. (LP is seeded so the
+    // exceeds-LP-liquidity gate ahead of the sum check doesn't trip first.)
+    function test_canExecuteTasks_falseWhenIdEqualsCursorButAmountNonZero() public {
+        _unpauseWithdrawNFT();
+        _seedLp(10 ether);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        // state's lastFinalizedRequestId is 0 (fresh setup) and we report 0 too
+        report.lastFinalizedWithdrawalRequestId = 0;
+        report.finalizedWithdrawalAmount = 1 ether;
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: sum of requests does not match finalized withdrawal amount");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    // Equality edge, valid case: cursor == state, amount == 0. Loop is a
+    // no-op and sum 0 == amount 0. This is the steady-state "nothing
+    // happened this period" report.
+    function test_canExecuteTasks_trueWhenIdEqualsCursorAndAmountZero() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = 0;
+        report.finalizedWithdrawalAmount = 0;
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+    }
+
+    // Happy path: single valid request, sum matches.
+    function test_canExecuteTasks_trueWhenSumMatchesSingleRequest() public {
+        _unpauseWithdrawNFT();
+        _seedLp(10 ether);
+        uint256 r1 = _makeWithdrawRequest(3 ether);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = uint32(r1);
+        report.finalizedWithdrawalAmount = 3 ether;
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+
+        etherFiAdminInstance.executeTasks(report);
+        assertEq(withdrawRequestNFTInstance.lastFinalizedRequestId(), uint32(r1));
+    }
+
+    // Happy path: loop runs over many ids; sum across all of them matches.
+    function test_canExecuteTasks_trueWhenSumMatchesMultipleRequests() public {
+        _unpauseWithdrawNFT();
+        _seedLp(20 ether);
+        _makeWithdrawRequest(1 ether);
+        _makeWithdrawRequest(2 ether);
+        uint256 r3 = _makeWithdrawRequest(3 ether);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = uint32(r3);
+        report.finalizedWithdrawalAmount = 6 ether; // 1 + 2 + 3
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+    }
+
+    // Invalidated requests are excluded from the sum (request.isValid gates
+    // the accumulator). The oracle must report only the valid total.
+    function test_canExecuteTasks_trueWhenInvalidRequestsExcludedFromSum() public {
+        _unpauseWithdrawNFT();
+        _seedLp(20 ether);
+        _makeWithdrawRequest(1 ether);
+        uint256 r2 = _makeWithdrawRequest(2 ether);
+        uint256 r3 = _makeWithdrawRequest(3 ether);
+
+        _invalidateRequest(r2);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = uint32(r3);
+        report.finalizedWithdrawalAmount = 4 ether; // 1 + 3; r2 excluded
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+    }
+
+    // Mirror: if the oracle accidentally counts an invalidated request's
+    // amount, the sum overshoots the on-chain total → revert.
+    function test_canExecuteTasks_falseWhenInvalidRequestIncludedInSum() public {
+        _unpauseWithdrawNFT();
+        _seedLp(20 ether);
+        _makeWithdrawRequest(1 ether);
+        uint256 r2 = _makeWithdrawRequest(2 ether);
+        uint256 r3 = _makeWithdrawRequest(3 ether);
+
+        _invalidateRequest(r2);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = uint32(r3);
+        report.finalizedWithdrawalAmount = 6 ether; // wrong: still counts r2
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert("EtherFiAdmin: sum of requests does not match finalized withdrawal amount");
+        etherFiAdminInstance.executeTasks(report);
+    }
+
+    // Cleanup scenario: every pending request was invalidated. Cursor still
+    // advances past them but amount stays 0 and the sum check passes.
+    function test_canExecuteTasks_trueWhenAllRequestsInvalidAndAmountZero() public {
+        _unpauseWithdrawNFT();
+        _seedLp(10 ether);
+        uint256 r1 = _makeWithdrawRequest(1 ether);
+        uint256 r2 = _makeWithdrawRequest(2 ether);
+
+        _invalidateRequest(r1);
+        _invalidateRequest(r2);
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = uint32(r2);
+        report.finalizedWithdrawalAmount = 0;
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), true);
+    }
+
+    // The cursor cannot move backwards. After processing r1 in a first
+    // report, a follow-up with lastFinalizedWithdrawalRequestId < state's
+    // cursor is rejected by the strict `<` guard before the sum loop runs.
+    function test_canExecuteTasks_falseWhenIdLessThanStateCursor() public {
+        _unpauseWithdrawNFT();
+        _seedLp(20 ether);
+        uint256 r1 = _makeWithdrawRequest(2 ether);
+
+        IEtherFiOracle.OracleReport memory firstReport = _emptyOracleReport();
+        firstReport.lastFinalizedWithdrawalRequestId = uint32(r1);
+        firstReport.finalizedWithdrawalAmount = 2 ether;
+        _moveClock(1 days / 12);
+        _executeAdminTasks(firstReport);
+
+        assertEq(withdrawRequestNFTInstance.lastFinalizedRequestId(), uint32(r1));
+
+        // Second report points to id 0, less than state's cursor (r1 = 1).
+        IEtherFiOracle.OracleReport memory secondReport = _emptyOracleReport();
+        secondReport.lastFinalizedWithdrawalRequestId = 0;
+        secondReport.finalizedWithdrawalAmount = 0;
+        _moveClock(1 days / 12);
+        _submitForConsensus(secondReport);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(secondReport), false);
+
+        vm.expectRevert("EtherFiAdmin: finalized withdrawal request id is less than last finalized request id");
+        etherFiAdminInstance.executeTasks(secondReport);
+    }
+
+    // Cursor advances on each successful report. A second report finalizing
+    // only the newly-created request sums only over the new range, not the
+    // already-finalized r1.
+    function test_canExecuteTasks_trueOnSecondReportAfterCursorAdvances() public {
+        _unpauseWithdrawNFT();
+        _seedLp(20 ether);
+        uint256 r1 = _makeWithdrawRequest(1 ether);
+
+        IEtherFiOracle.OracleReport memory firstReport = _emptyOracleReport();
+        firstReport.lastFinalizedWithdrawalRequestId = uint32(r1);
+        firstReport.finalizedWithdrawalAmount = 1 ether;
+        _moveClock(1 days / 12);
+        _executeAdminTasks(firstReport);
+
+        uint256 r2 = _makeWithdrawRequest(2 ether);
+
+        IEtherFiOracle.OracleReport memory secondReport = _emptyOracleReport();
+        secondReport.lastFinalizedWithdrawalRequestId = uint32(r2);
+        secondReport.finalizedWithdrawalAmount = 2 ether; // only the new request
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(secondReport);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(secondReport), true);
+
+        etherFiAdminInstance.executeTasks(secondReport);
+        assertEq(withdrawRequestNFTInstance.lastFinalizedRequestId(), uint32(r2));
+    }
+
+    // Successive report mistakenly resums from id 0 instead of just the new
+    // range, so the amount double-counts r1 (already finalized). Mismatch
+    // trips the sum gate, not the "id less than cursor" gate.
+    function test_canExecuteTasks_falseOnSecondReportSummingFromZero() public {
+        _unpauseWithdrawNFT();
+        _seedLp(20 ether);
+        uint256 r1 = _makeWithdrawRequest(1 ether);
+
+        IEtherFiOracle.OracleReport memory firstReport = _emptyOracleReport();
+        firstReport.lastFinalizedWithdrawalRequestId = uint32(r1);
+        firstReport.finalizedWithdrawalAmount = 1 ether;
+        _moveClock(1 days / 12);
+        _executeAdminTasks(firstReport);
+
+        uint256 r2 = _makeWithdrawRequest(2 ether);
+
+        IEtherFiOracle.OracleReport memory secondReport = _emptyOracleReport();
+        secondReport.lastFinalizedWithdrawalRequestId = uint32(r2);
+        // Oracle bug: re-counted r1 (already finalized) into the new amount.
+        secondReport.finalizedWithdrawalAmount = 3 ether; // r1 + r2 instead of r2
+
+        _moveClock(1 days / 12);
+        _submitForConsensus(secondReport);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(secondReport), false);
+
+        vm.expectRevert("EtherFiAdmin: sum of requests does not match finalized withdrawal amount");
+        etherFiAdminInstance.executeTasks(secondReport);
+    }
+
     // ========== EtherFiAdmin finalizeWithdrawalsWhenStale Tests ==========
 
     // Permissionless escape hatch that lets anyone finalize pending withdrawal
@@ -1866,6 +2147,21 @@ contract EtherFiOracleTest is TestSetup {
     function _invalidateRequest(uint256 requestId) internal {
         vm.prank(alice);
         withdrawRequestNFTInstance.invalidateRequest(requestId);
+    }
+
+    // Forces LP balance AND totalValueInLp to `target` in lockstep so the
+    // strict tVIL <= balance invariant enforced by _checkTotalValueInLp
+    // stays intact. vm.deal alone would drop balance without touching tVIL
+    // and trip the invariant on the next addEthAmountLockedForWithdrawal.
+    // Slot 207 packs totalValueOutOfLp (offset 0) and totalValueInLp
+    // (offset 16) per `forge inspect LiquidityPool storage`.
+    function _forceLpBalanceAndTVIL(uint128 target) internal {
+        bytes32 slot = bytes32(uint256(207));
+        bytes32 raw = vm.load(address(liquidityPoolInstance), slot);
+        uint128 outOf = uint128(uint256(raw)); // low 128 bits = totalValueOutOfLp
+        bytes32 packed = bytes32((uint256(target) << 128) | uint256(outOf));
+        vm.store(address(liquidityPoolInstance), slot, packed);
+        vm.deal(address(liquidityPoolInstance), uint256(target));
     }
 
     // Roll forward until block.number == lastHandledReportRefBlock + STALE_ORACLE_REPORT_BLOCK_WINDOW
@@ -2084,15 +2380,14 @@ contract EtherFiOracleTest is TestSetup {
     // valid request the LP can't cover. The leftover request stays pending.
     function test_finalizeWithdrawalsWhenStale_stopsAtLiquidityLimit() public {
         _unpauseWithdrawNFT();
-        // Deposit enough to create the requests, but we'll cap LP balance
-        // below what's needed to clear all of them.
         _seedLp(20 ether);
         uint256 r1 = _makeWithdrawRequest(3 ether);
         _makeWithdrawRequest(4 ether);
         uint256 r3 = _makeWithdrawRequest(5 ether);
 
         // Cap LP balance at 5 ether: r1 fits (3), r1+r2 doesn't (7 > 5), break.
-        vm.deal(address(liquidityPoolInstance), 5 ether);
+        // Lockstep tVIL so the post-lock invariant holds.
+        _forceLpBalanceAndTVIL(5 ether);
 
         _advanceToStaleBoundary();
 
@@ -2197,8 +2492,9 @@ contract EtherFiOracleTest is TestSetup {
         uint256 r1 = _makeWithdrawRequest(3 ether);
         uint256 r2 = _makeWithdrawRequest(4 ether);
 
-        // First call: only r1 fits.
-        vm.deal(address(liquidityPoolInstance), 3 ether);
+        // First call: only r1 fits. Lockstep tVIL with balance so the
+        // post-lock invariant holds when r1 gets finalized.
+        _forceLpBalanceAndTVIL(3 ether);
         _advanceToStaleBoundary();
         etherFiAdminInstance.finalizeWithdrawalsWhenStale();
         assertEq(withdrawRequestNFTInstance.lastFinalizedRequestId(), uint32(r1));

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -1158,7 +1158,6 @@ contract LiquidityPoolTest is TestSetup {
         liquidityPoolInstance.setFeeRecipient(bob);
         vm.stopPrank();
 
-        vm.deal(address(liquidityPoolInstance), 10 ether);
         vm.startPrank(address(etherFiAdminInstance));
         liquidityPoolInstance.payProtocolFees(5 ether);
         assertEq(eETHInstance.balanceOf(bob), 5 ether);

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -59,7 +59,7 @@ contract LiquidityPoolTest is TestSetup {
 
         liquidityPoolInstance.deposit{value: 1 ether}();
 
-        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
+        vm.expectRevert(LiquidityPool.InvalidShareAmount.selector);
         liquidityPoolInstance.requestWithdraw(alice, 0);
 
         vm.stopPrank();
@@ -2221,15 +2221,18 @@ contract LiquidityPoolTest is TestSetup {
         assertEq(request.amountOfEEth, amt, "MIN_WITHDRAW_AMOUNT request should be created");
     }
 
-    function test_requestWithdraw_belowMin_reverts() public {
+    function test_requestWithdraw_belowMin_withdrawsFullBalance() public {
         uint96 amt = uint96(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT()) - 1;
 
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 1 ether}();
-        eETHInstance.approve(address(liquidityPoolInstance), amt);
-        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
-        liquidityPoolInstance.requestWithdraw(bob, amt);
+        uint256 balance = eETHInstance.balanceOf(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), balance);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amt);
         vm.stopPrank();
+
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
+        assertEq(request.amountOfEEth, balance, "below-MIN request should withdraw full balance");
     }
 
     function test_requestWithdraw_atMax_succeeds() public {
@@ -2295,20 +2298,23 @@ contract LiquidityPoolTest is TestSetup {
         assertEq(request.amountOfEEth, large, "membership-burn whale withdraw should bypass MAX cap");
     }
 
-    /// @dev Contrast: same amounts that `requestMembershipNFTWithdraw` accepts
-    ///      MUST revert via the user-facing `requestWithdraw` path. Locks in
-    ///      that the exemption is scoped to the membership-manager entry point.
-    function test_requestWithdraw_userFlow_rejectsAmountsMembershipFlowAccepts() public {
+    /// @dev Contrast with `requestMembershipNFTWithdraw`, which accepts both dust
+    ///      and whale amounts unchanged. Via the user-facing `requestWithdraw`:
+    ///        - dust (< MIN) is rewritten to the caller's full eETH balance
+    ///        - large (> MAX) still reverts with InvalidWithdrawalAmount
+    function test_requestWithdraw_userFlow_dustWithdrawsFullBalance_largeReverts() public {
         uint256 dust = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() - 1;
         uint256 large = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT() + 1 ether;
 
         vm.deal(bob, large + 1 ether);
         vm.startPrank(bob);
         liquidityPoolInstance.deposit{value: large + 1 ether}();
-        eETHInstance.approve(address(liquidityPoolInstance), large);
+        uint256 balance = eETHInstance.balanceOf(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), balance);
 
-        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
-        liquidityPoolInstance.requestWithdraw(bob, dust);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, dust);
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
+        assertEq(request.amountOfEEth, balance, "dust request should withdraw bob's full balance");
 
         vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
         liquidityPoolInstance.requestWithdraw(bob, large);

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -59,7 +59,7 @@ contract LiquidityPoolTest is TestSetup {
 
         liquidityPoolInstance.deposit{value: 1 ether}();
 
-        vm.expectRevert(LiquidityPool.InvalidShareAmount.selector);
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
         liquidityPoolInstance.requestWithdraw(alice, 0);
 
         vm.stopPrank();
@@ -2306,9 +2306,9 @@ contract LiquidityPoolTest is TestSetup {
         uint256 dust = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() - 1;
         uint256 large = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT() + 1 ether;
 
-        vm.deal(bob, large + 1 ether);
+        vm.deal(bob, dust - 10);
         vm.startPrank(bob);
-        liquidityPoolInstance.deposit{value: large + 1 ether}();
+        liquidityPoolInstance.deposit{value: dust - 10}();
         uint256 balance = eETHInstance.balanceOf(bob);
         eETHInstance.approve(address(liquidityPoolInstance), balance);
 

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -59,7 +59,7 @@ contract LiquidityPoolTest is TestSetup {
 
         liquidityPoolInstance.deposit{value: 1 ether}();
 
-        vm.expectRevert(LiquidityPool.InvalidAmount.selector);
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
         liquidityPoolInstance.requestWithdraw(alice, 0);
 
         vm.stopPrank();
@@ -1464,7 +1464,7 @@ contract LiquidityPoolTest is TestSetup {
         vm.startPrank(alice);
         liquidityPoolInstance.deposit{value: tooLargeAmount}();
         eETHInstance.approve(address(liquidityPoolInstance), tooLargeAmount);
-        vm.expectRevert(LiquidityPool.InvalidAmount.selector);
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
         liquidityPoolInstance.requestWithdraw(alice, tooLargeAmount);
         vm.stopPrank();
     }
@@ -2197,5 +2197,121 @@ contract LiquidityPoolTest is TestSetup {
         vm.prank(address(0));
         vm.expectRevert(bytes("migration not complete"));
         liquidityPoolInstance.transferLockedEthForPriority(1 ether);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------  MIN / MAX WITHDRAW AMOUNT TESTS  -----------------------------
+    //--------------------------------------------------------------------------------------
+
+    function test_constants_minMaxWithdrawAmount() public view {
+        assertEq(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT(), 0.01 ether, "MIN_WITHDRAW_AMOUNT mismatch");
+        assertEq(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT(), 1000 ether, "MAX_WITHDRAW_AMOUNT mismatch");
+    }
+
+    function test_requestWithdraw_atMin_succeeds() public {
+        uint96 amt = uint96(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT());
+
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), amt);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.stopPrank();
+
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
+        assertEq(request.amountOfEEth, amt, "MIN_WITHDRAW_AMOUNT request should be created");
+    }
+
+    function test_requestWithdraw_belowMin_reverts() public {
+        uint96 amt = uint96(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT()) - 1;
+
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), amt);
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.stopPrank();
+    }
+
+    function test_requestWithdraw_atMax_succeeds() public {
+        uint96 amt = uint96(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT());
+
+        vm.deal(bob, uint256(amt) + 1 ether);
+        vm.startPrank(bob);
+        liquidityPoolInstance.deposit{value: uint256(amt) + 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), amt);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.stopPrank();
+
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
+        assertEq(request.amountOfEEth, amt, "MAX_WITHDRAW_AMOUNT request should be created");
+    }
+
+    function test_requestWithdraw_aboveMax_reverts() public {
+        uint96 amt = uint96(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT()) + 1;
+
+        vm.deal(bob, uint256(amt) + 1 ether);
+        vm.startPrank(bob);
+        liquidityPoolInstance.deposit{value: uint256(amt) + 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), amt);
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.stopPrank();
+    }
+
+    /// @dev MembershipManager-originated withdrawals (`requestMembershipNFTWithdraw`)
+    ///      go through a dedicated LP entry point and must NOT be subject to the
+    ///      user-facing MIN/MAX cap — otherwise membership-burn flows break for
+    ///      tiny dust balances or whales above the cap. These tests pin the
+    ///      exemption: identical amounts that would revert via `requestWithdraw`
+    ///      must succeed via `requestMembershipNFTWithdraw`.
+    function test_requestMembershipNFTWithdraw_belowMin_succeeds() public {
+        // Seed the MembershipManager with eETH.
+        vm.deal(address(membershipManagerInstance), 1 ether);
+        vm.startPrank(address(membershipManagerInstance));
+        liquidityPoolInstance.deposit{value: 1 ether}(address(membershipManagerInstance), address(0));
+
+        uint256 dust = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() - 1; // below user cap
+        eETHInstance.approve(address(liquidityPoolInstance), dust);
+        uint256 reqId = liquidityPoolInstance.requestMembershipNFTWithdraw(alice, dust, 0);
+        vm.stopPrank();
+
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(reqId);
+        assertEq(request.amountOfEEth, dust, "membership-burn dust withdraw should bypass MIN cap");
+    }
+
+    function test_requestMembershipNFTWithdraw_aboveMax_succeeds() public {
+        uint256 large = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT() + 1 ether; // above user cap
+
+        // Seed the MembershipManager with enough eETH to cover the large request.
+        vm.deal(address(membershipManagerInstance), large + 1 ether);
+        vm.startPrank(address(membershipManagerInstance));
+        liquidityPoolInstance.deposit{value: large + 1 ether}(address(membershipManagerInstance), address(0));
+
+        eETHInstance.approve(address(liquidityPoolInstance), large);
+        uint256 reqId = liquidityPoolInstance.requestMembershipNFTWithdraw(alice, large, 0);
+        vm.stopPrank();
+
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(reqId);
+        assertEq(request.amountOfEEth, large, "membership-burn whale withdraw should bypass MAX cap");
+    }
+
+    /// @dev Contrast: same amounts that `requestMembershipNFTWithdraw` accepts
+    ///      MUST revert via the user-facing `requestWithdraw` path. Locks in
+    ///      that the exemption is scoped to the membership-manager entry point.
+    function test_requestWithdraw_userFlow_rejectsAmountsMembershipFlowAccepts() public {
+        uint256 dust = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() - 1;
+        uint256 large = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT() + 1 ether;
+
+        vm.deal(bob, large + 1 ether);
+        vm.startPrank(bob);
+        liquidityPoolInstance.deposit{value: large + 1 ether}();
+        eETHInstance.approve(address(liquidityPoolInstance), large);
+
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, dust);
+
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, large);
+        vm.stopPrank();
     }
 }

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -2221,18 +2221,14 @@ contract LiquidityPoolTest is TestSetup {
         assertEq(request.amountOfEEth, amt, "MIN_WITHDRAW_AMOUNT request should be created");
     }
 
-    function test_requestWithdraw_belowMin_withdrawsFullBalance() public {
+    function test_requestWithdraw_belowMin_amountNotEqualToBalance_reverts() public {
         uint96 amt = uint96(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT()) - 1;
 
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 1 ether}();
-        uint256 balance = eETHInstance.balanceOf(bob);
-        eETHInstance.approve(address(liquidityPoolInstance), balance);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amt);
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, amt);
         vm.stopPrank();
-
-        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
-        assertEq(request.amountOfEEth, balance, "below-MIN request should withdraw full balance");
     }
 
     function test_requestWithdraw_atMax_succeeds() public {
@@ -2306,9 +2302,9 @@ contract LiquidityPoolTest is TestSetup {
         uint256 dust = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() - 1;
         uint256 large = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT() + 1 ether;
 
-        vm.deal(bob, dust - 10);
+        vm.deal(bob, dust);
         vm.startPrank(bob);
-        liquidityPoolInstance.deposit{value: dust - 10}();
+        liquidityPoolInstance.deposit{value: dust}();
         uint256 balance = eETHInstance.balanceOf(bob);
         eETHInstance.approve(address(liquidityPoolInstance), balance);
 

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -65,7 +65,11 @@ contract LiquifierTest is TestSetup {
 
         vm.deal(alice, 1000000000 ether);
 
-        vm.startPrank(liquifierInstance.owner());
+        vm.startPrank(owner);
+        // Curve quoting on a 20k stETH input incurs heavy slippage and trips
+        // the chainlink/curve deviation predicate before the cap check fires.
+        // This test is about the cap, so quote 1:1 instead.
+        liquifierInstance.updateQuoteStEthWithCurve(false);
         liquifierInstance.updateDepositCap(address(stEth), 50, 100);
         vm.stopPrank();
 
@@ -83,6 +87,7 @@ contract LiquifierTest is TestSetup {
     function test_deposit_stEth() public {
         initializeRealisticFork(MAINNET_FORK);
         setUpLiquifier(MAINNET_FORK);
+        _mockFreshStEthFeed();
 
         vm.deal(alice, 100 ether);
 
@@ -127,6 +132,7 @@ contract LiquifierTest is TestSetup {
     function test_deopsit_stEth_with_explicit_permit() public {
         initializeRealisticFork(MAINNET_FORK);
         setUpLiquifier(MAINNET_FORK);
+        _mockFreshStEthFeed();
 
         // Clear any code at alice's address to make it act like an EOA (External Owned Account)
         vm.etch(alice, "");
@@ -160,6 +166,18 @@ contract LiquifierTest is TestSetup {
         permitInput = createPermitInput(2, address(liquifierInstance), 1 ether, stEth.nonces(alice), 2**256 - 1, stEth.DOMAIN_SEPARATOR());
         permitInput2 = ILiquifier.PermitInput({value: permitInput.value, deadline: permitInput.deadline, v: permitInput.v, r: permitInput.r, s: permitInput.s});
         liquifierInstance.depositWithERC20WithPermit(address(stEth), 1 ether, address(0), permitInput2);
+    }
+
+    /// On realistic mainnet fork, the live stETH/ETH feed has a ~24h heartbeat
+    /// and may sit just past STALE_PRICE_WINDOW depending on fork-block timing
+    /// (or after vm.warp). Pin it to a fresh, ~1:1 answer so deposits exercising
+    /// the curve-quoting path don't revert with StalePriceFeed.
+    function _mockFreshStEthFeed() internal {
+        vm.mockCall(
+            stEthChainlinkFeed,
+            abi.encodeWithSignature("latestRoundData()"),
+            abi.encode(uint80(0), int256(1 ether), uint256(0), block.timestamp, uint80(0))
+        );
     }
 
     function _enable_deposit(address _strategy) internal {
@@ -582,6 +600,8 @@ contract LiquifierTest is TestSetup {
         liquifierInstance.pauseContractUntil();
 
         vm.warp(block.timestamp + liquifierInstance.MAX_PAUSE_DURATION() + 1);
+        // Refresh after warp — pause window is days, well past STALE_PRICE_WINDOW.
+        _mockFreshStEthFeed();
 
         vm.prank(alice);
         liquifierInstance.depositWithERC20(address(stEth), 1 ether, address(0));
@@ -591,6 +611,7 @@ contract LiquifierTest is TestSetup {
         initializeRealisticFork(MAINNET_FORK);
         setUpLiquifier(MAINNET_FORK);
         _grantLiqPauseUntilRoles();
+        _mockFreshStEthFeed();
 
         vm.deal(alice, 10 ether);
         vm.startPrank(alice);

--- a/test/LiquifierStEthPriceFeed.t.sol
+++ b/test/LiquifierStEthPriceFeed.t.sol
@@ -103,13 +103,13 @@ contract LiquifierStEthPriceFeedTest is Test {
         liquifier.quoteByMarketValue(stEth, 1 ether);
     }
 
-    /// Stale price (updatedAt + window < now): check is skipped, quote returns curve value.
-    function test_stalePrice_skipsCheck() public {
+    /// Stale price (updatedAt + window < now): check reverts
+    function test_stalePrice_reverts() public {
         feed.set(int256(1000 ether), block.timestamp - STALE_WINDOW - 1); // arbitrarily large but stale
         curve.set(0.99 ether);
 
-        uint256 q = liquifier.quoteByMarketValue(stEth, 1 ether);
-        assertEq(q, 0.99 ether);
+        vm.expectRevert(Liquifier.StalePriceFeed.selector);
+        liquifier.quoteByMarketValue(stEth, 1 ether);
     }
 
     /// Boundary: updatedAt + window == block.timestamp counts as fresh (`>=`),
@@ -122,13 +122,13 @@ contract LiquifierStEthPriceFeedTest is Test {
         liquifier.quoteByMarketValue(stEth, 1 ether);
     }
 
-    /// Boundary: one second past the window — stale, check skipped.
+    /// Boundary: one second past the window — stale, reverts.
     function test_stalenessBoundary_oneSecondPastWindow_skipped() public {
         feed.set(int256(2 ether), block.timestamp - STALE_WINDOW - 1);
         curve.set(0.5 ether);
 
-        uint256 q = liquifier.quoteByMarketValue(stEth, 1 ether);
-        assertEq(q, 0.5 ether);
+        vm.expectRevert(Liquifier.StalePriceFeed.selector);
+        liquifier.quoteByMarketValue(stEth, 1 ether);
     }
 
     /// Fresh price within deviation tolerance: passes. Curve says 0.99, chainlink says 1.0;
@@ -220,7 +220,10 @@ contract LiquifierStEthPriceFeedTest is Test {
         if (answer <= 0) {
             vm.expectRevert(Liquifier.InvalidPriceFeed.selector);
             liquifier.quoteByMarketValue(stEth, amount);
-        } else if (fresh && (deviation * BPS) / marketValue > MAX_DEVIATION_BPS) {
+        } else if (!fresh) {
+            vm.expectRevert(Liquifier.StalePriceFeed.selector);
+            liquifier.quoteByMarketValue(stEth, amount);
+        } else if ((deviation * BPS) / marketValue > MAX_DEVIATION_BPS) {
             vm.expectRevert(Liquifier.InvalidStEthPrice.selector);
             liquifier.quoteByMarketValue(stEth, amount);
         } else {

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -1013,6 +1013,109 @@ contract PriorityWithdrawalQueueTest is TestSetup {
     }
 
     //--------------------------------------------------------------------------------------
+    //------ _checkEthAmountLockedForPriorityWithdrawal: queue-own-balance invariant -------
+    //
+    // Regression: the check used to read liquidityPool.balance instead of
+    // address(this).balance. Since the LP normally holds far more ETH than
+    // the queue's own escrow, a real shortfall (queue.balance < locked)
+    // would silently pass the buggy check, while an unrelated dip in LP
+    // balance could trip it spuriously. Each test below arranges
+    // queue.balance < ethAmountLockedForPriorityWithdrawal with LP healthy,
+    // then triggers one of the three call sites and asserts the fixed
+    // check reverts with InsufficientLiquidity. Under the pre-fix code
+    // these operations completed silently, leaving the invariant broken.
+    //--------------------------------------------------------------------------------------
+
+    // receive() path — fulfillRequests → LP.transferLockedEthForPriority →
+    // queue.receive() bumps locked and runs the check.
+    function test_checkEthLockedInvariant_revertsInReceiveWhenQueueDrained() public {
+        (, IPriorityWithdrawalQueue.WithdrawRequest memory r1) =
+            _createWithdrawRequest(vipUser, 10 ether);
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory batch =
+            new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+        batch[0] = r1;
+        vm.prank(requestManager);
+        priorityQueue.fulfillRequests(batch);
+
+        assertEq(priorityQueue.ethAmountLockedForPriorityWithdrawal(), 10 ether);
+        assertEq(address(priorityQueue).balance, 10 ether);
+
+        // Drain queue's ETH without touching the counter; LP stays healthy
+        // so the old (buggy) LP-balance check would still pass.
+        vm.deal(address(priorityQueue), 5 ether);
+        assertGt(
+            address(liquidityPoolInstance).balance,
+            priorityQueue.ethAmountLockedForPriorityWithdrawal(),
+            "LP still healthy - bug would mask the shortfall"
+        );
+
+        // Fulfilling r2 sends 1 ETH from LP -> queue. receive() bumps locked
+        // to 11; queue.balance becomes 6. New check: 11 > 6 -> revert with
+        // InsufficientLiquidity, which LP._sendFund re-wraps as "SendFail"
+        // when the value-bearing call returns false.
+        (, IPriorityWithdrawalQueue.WithdrawRequest memory r2) =
+            _createWithdrawRequest(vipUser, 1 ether);
+        batch[0] = r2;
+        vm.prank(requestManager);
+        vm.expectRevert(bytes("SendFail"));
+        priorityQueue.fulfillRequests(batch);
+    }
+
+    // _cancelWithdrawRequest path — invalidateRequests on a finalized
+    // request decrements locked, returns ETH to LP, then runs the check.
+    function test_checkEthLockedInvariant_revertsInCancelWhenQueueDrained() public {
+        (, IPriorityWithdrawalQueue.WithdrawRequest memory r1) =
+            _createWithdrawRequest(vipUser, 10 ether);
+        (, IPriorityWithdrawalQueue.WithdrawRequest memory r2) =
+            _createWithdrawRequest(vipUser, 10 ether);
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory batch =
+            new IPriorityWithdrawalQueue.WithdrawRequest[](2);
+        batch[0] = r1;
+        batch[1] = r2;
+        vm.prank(requestManager);
+        priorityQueue.fulfillRequests(batch);
+
+        assertEq(priorityQueue.ethAmountLockedForPriorityWithdrawal(), 20 ether);
+        assertEq(address(priorityQueue).balance, 20 ether);
+
+        // Drain to 15 — leaves enough to fund the cancel's ETH return to LP
+        // (queue needs 10 to send back), but post-op state has
+        // queue.balance = 5 < locked = 10 → new check trips.
+        vm.deal(address(priorityQueue), 15 ether);
+
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory cancelBatch =
+            new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+        cancelBatch[0] = r1;
+        vm.prank(requestManager);
+        vm.expectRevert(PriorityWithdrawalQueue.InsufficientLiquidity.selector);
+        priorityQueue.invalidateRequests(cancelBatch);
+    }
+
+    // _claimWithdraw path — user-facing claim sends ETH to user, then runs
+    // the check. No fee here (amountWithFee == amountOfEEth at 1:1 share rate),
+    // so the post-claim balance comparison is the direct shortfall test.
+    function test_checkEthLockedInvariant_revertsInClaimWhenQueueDrained() public {
+        (, IPriorityWithdrawalQueue.WithdrawRequest memory r1) =
+            _createWithdrawRequest(vipUser, 10 ether);
+        (, IPriorityWithdrawalQueue.WithdrawRequest memory r2) =
+            _createWithdrawRequest(vipUser, 10 ether);
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory batch =
+            new IPriorityWithdrawalQueue.WithdrawRequest[](2);
+        batch[0] = r1;
+        batch[1] = r2;
+        vm.prank(requestManager);
+        priorityQueue.fulfillRequests(batch);
+
+        // Drain to 15: claim r1 (10 to user, no fee) leaves queue.balance = 5
+        // and locked = 10 → check trips.
+        vm.deal(address(priorityQueue), 15 ether);
+
+        vm.prank(vipUser);
+        vm.expectRevert(PriorityWithdrawalQueue.InsufficientLiquidity.selector);
+        priorityQueue.claimWithdraw(r1);
+    }
+
+    //--------------------------------------------------------------------------------------
     //------------------------------  FULL FLOW TESTS  -------------------------------------
     //--------------------------------------------------------------------------------------
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -64,6 +64,27 @@ import "../src/DepositAdapter.sol";
 import "../src/interfaces/IWeETHWithdrawAdapter.sol";
 import "../src/PriorityWithdrawalQueue.sol";
 
+/// @notice Funds a contract by sending ETH from a fresh EOA via low-level call so the target's
+///         receive()/fallback runs and any accounting it does stays in sync with its balance.
+///         Use instead of vm.deal whenever the target relies on receive() side effects.
+function fundContract(address target, uint256 amount) {
+    Vm cheats = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    address funder = address(uint160(uint256(keccak256("test.eth.funder"))));
+    cheats.deal(funder, funder.balance + amount);
+    cheats.prank(funder);
+    (bool ok, ) = target.call{value: amount}("");
+    require(ok, "fundContract: send failed");
+}
+
+/// @notice Same as fundContract, but pranks `from` instead of a generic EOA. Use when receive() is caller-gated.
+function fundContractFrom(address target, uint256 amount, address from) {
+    Vm cheats = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    cheats.deal(from, from.balance + amount);
+    cheats.prank(from);
+    (bool ok, ) = target.call{value: amount}("");
+    require(ok, "fundContractFrom: send failed");
+}
+
 contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
     event Schedule(address target, uint256 value, bytes data, bytes32 predecessor, bytes32 salt, uint256 delay);

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -1032,7 +1032,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         
         // Direct call to requestWithdraw with fee (simulating MembershipManager)
         vm.prank(address(liquidityPoolInstance));
-        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw{value: 0}(1 ether, 1 ether, bob, fee);
+        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(1 ether, 1 ether, bob, fee);
 
         WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
         assertEq(request.feeGwei, uint32(fee / 1 gwei), "Fee should be stored correctly");
@@ -1055,7 +1055,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // Create request with fee via direct call
         vm.prank(address(liquidityPoolInstance));
-        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw{value: 0}(uint96(amount), uint96(amount), bob, fee);
+        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(uint96(amount), uint96(amount), bob, fee);
 
         // Add more liquidity to ensure withdrawal can be fulfilled
         vm.deal(alice, 10 ether);
@@ -1098,7 +1098,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // Create a fee-bearing withdraw request directly (simulating MembershipManager)
         vm.prank(address(liquidityPoolInstance));
-        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw{value: 0}(
+        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(
             uint96(amount), uint96(amount), bob, fee
         );
 

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -246,23 +246,29 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     // Sub-wei rounding scenario from the original SD-6 report. The MIN_WITHDRAW_AMOUNT
-    // gate (now on the LiquidityPool) blocks any request smaller than 0.01 ether, so
-    // the rounding path is unreachable from the public API. Pin the new behavior: the
-    // legacy 9-wei request reverts with InvalidWithdrawalAmount before any state is touched.
-    function test_SD_6_requestBelowMinReverts() public {
+    // gate on the LiquidityPool now rewrites any below-MIN request to the caller's full
+    // eETH balance instead of reverting. Pin the new behavior: a legacy 9-wei request
+    // mints a single request for bob's full eETH balance, leaving no dust behind to
+    // round around.
+    function test_SD_6_requestBelowMin_withdrawsFullBalance() public {
         vm.deal(bob, 98);
 
         vm.startPrank(bob);
         liquidityPoolInstance.deposit{value: 98}();
-        eETHInstance.approve(address(liquidityPoolInstance), 98);
         vm.stopPrank();
 
         vm.prank(address(membershipManagerInstance));
         liquidityPoolInstance.rebase(2);
 
-        vm.prank(bob);
-        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
-        liquidityPoolInstance.requestWithdraw(bob, 9);
+        vm.startPrank(bob);
+        uint256 balance = eETHInstance.balanceOf(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), balance);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 9);
+        vm.stopPrank();
+
+        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
+        assertEq(request.amountOfEEth, balance, "below-MIN request should withdraw bob's full balance");
+        assertEq(eETHInstance.balanceOf(bob), 0, "bob should have no eETH dust left");
     }
 
 

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -246,15 +246,15 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     // Sub-wei rounding scenario from the original SD-6 report. The MIN_WITHDRAW_AMOUNT
-    // gate on the LiquidityPool now rewrites any below-MIN request to the caller's full
-    // eETH balance instead of reverting. Pin the new behavior: a legacy 9-wei request
-    // mints a single request for bob's full eETH balance, leaving no dust behind to
+    // gate on the LiquidityPool rewrites any below-MIN request if amount is equal to the 
+    // caller's full eETH balance instead of reverting. Pin the new behavior: a legacy 9-wei
+    // request mints a single request for bob's full eETH balance, leaving no dust behind to
     // round around.
     function test_SD_6_requestBelowMin_withdrawsFullBalance() public {
-        vm.deal(bob, 98);
+        vm.deal(bob, 9);
 
         vm.startPrank(bob);
-        liquidityPoolInstance.deposit{value: 98}();
+        liquidityPoolInstance.deposit{value: 9}();
         vm.stopPrank();
 
         vm.prank(address(membershipManagerInstance));
@@ -263,7 +263,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.startPrank(bob);
         uint256 balance = eETHInstance.balanceOf(bob);
         eETHInstance.approve(address(liquidityPoolInstance), balance);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 9);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, balance);
         vm.stopPrank();
 
         WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -246,9 +246,9 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     // Sub-wei rounding scenario from the original SD-6 report. The MIN_WITHDRAW_AMOUNT
-    // gate now blocks any request smaller than 0.01 ether, so the rounding path is
-    // unreachable from the public API. Pin the new behavior: the legacy 9-wei request
-    // reverts with InvalidWithdrawalAmount before any state is touched.
+    // gate (now on the LiquidityPool) blocks any request smaller than 0.01 ether, so
+    // the rounding path is unreachable from the public API. Pin the new behavior: the
+    // legacy 9-wei request reverts with InvalidWithdrawalAmount before any state is touched.
     function test_SD_6_requestBelowMinReverts() public {
         vm.deal(bob, 98);
 
@@ -261,7 +261,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         liquidityPoolInstance.rebase(2);
 
         vm.prank(bob);
-        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
         liquidityPoolInstance.requestWithdraw(bob, 9);
     }
 
@@ -338,7 +338,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     function testFuzz_RequestWithdraw(uint96 depositAmount, uint96 withdrawAmount, address recipient) public {
         // Assume valid conditions — withdraw amount must satisfy [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT].
         vm.assume(depositAmount >= 1 ether && depositAmount <= 1000 ether);
-        vm.assume(withdrawAmount >= withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT() && withdrawAmount <= depositAmount);
+        vm.assume(withdrawAmount >= liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() && withdrawAmount <= depositAmount);
         vm.assume(recipient != address(0) && recipient != address(liquidityPoolInstance));
         // Filter out contracts that don't implement IERC721Receiver - only allow EOAs
         vm.assume(recipient.code.length == 0);
@@ -368,8 +368,8 @@ contract WithdrawRequestNFTTest is TestSetup {
         assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), withdrawAmount, "Incorrect contract eETH balance");
         assertEq(withdrawRequestNFTInstance.nextRequestId(), requestId + 1, "Incorrect next request ID");
 
-        uint256 minAmount = withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT();
-        uint256 maxAmount = withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT();
+        uint256 minAmount = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT();
+        uint256 maxAmount = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT();
         if (eETHInstance.balanceOf(bob) >= minAmount) {
             uint256 reqAmount = eETHInstance.balanceOf(bob);
             if (reqAmount > maxAmount) reqAmount = maxAmount;
@@ -392,8 +392,8 @@ contract WithdrawRequestNFTTest is TestSetup {
         // [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT] gate; without bound() the cascading
         // vm.assume calls hit forge's input-rejection cap at low probability.
         depositAmount = uint96(bound(depositAmount, 1 ether, 1e6 ether));
-        uint96 maxWithdraw = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT());
-        uint96 minWithdraw = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT());
+        uint96 maxWithdraw = uint96(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT());
+        uint96 minWithdraw = uint96(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT());
         uint96 withdrawCeil = depositAmount < maxWithdraw ? depositAmount : maxWithdraw;
         withdrawAmount = uint96(bound(withdrawAmount, minWithdraw, withdrawCeil));
         rebaseAmount = uint96(bound(rebaseAmount, 0.5 ether, depositAmount));
@@ -517,7 +517,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     function testFuzz_InvalidateRequest(uint96 depositAmount, uint96 withdrawAmount, address recipient) public {
         // Assume valid conditions — withdraw amount must satisfy [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT].
         vm.assume(depositAmount >= 1 ether && depositAmount <= 1000 ether);
-        vm.assume(withdrawAmount >= withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT() && withdrawAmount <= depositAmount);
+        vm.assume(withdrawAmount >= liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() && withdrawAmount <= depositAmount);
         vm.assume(recipient != address(0) && recipient != address(liquidityPoolInstance) && recipient != alice && recipient != admin && recipient != (address(etherFiAdminInstance)) && recipient != roleRegistryInstance.owner());
         // Filter out contracts that don't implement IERC721Receiver - only allow EOAs
         vm.assume(recipient.code.length == 0);
@@ -1632,98 +1632,6 @@ contract WithdrawRequestNFTTest is TestSetup {
     /// @dev Off-by-one: the token at EXACTLY lastFinalizedRequestId is finalized
     ///      and therefore must NOT be invalidatable. The next token (id + 1) is
     ///      not finalized and must still be invalidatable.
-    //--------------------------------------------------------------------------------------
-    //----------------------  MIN / MAX WITHDRAW AMOUNT TESTS  -----------------------------
-    //--------------------------------------------------------------------------------------
-
-    function test_constants_minMaxWithdrawAmount() public view {
-        assertEq(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT(), 0.01 ether, "MIN_WITHDRAW_AMOUNT mismatch");
-        assertEq(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT(), 1000 ether, "MAX_WITHDRAW_AMOUNT mismatch");
-    }
-
-    function test_requestWithdraw_atMin_succeeds() public {
-        uint96 amt = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT());
-
-        startHoax(bob);
-        liquidityPoolInstance.deposit{value: 1 ether}();
-        eETHInstance.approve(address(liquidityPoolInstance), amt);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amt);
-        vm.stopPrank();
-
-        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
-        assertEq(request.amountOfEEth, amt, "MIN_WITHDRAW_AMOUNT request should be created");
-    }
-
-    function test_requestWithdraw_belowMin_reverts() public {
-        uint96 amt = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT()) - 1;
-
-        startHoax(bob);
-        liquidityPoolInstance.deposit{value: 1 ether}();
-        eETHInstance.approve(address(liquidityPoolInstance), amt);
-        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
-        liquidityPoolInstance.requestWithdraw(bob, amt);
-        vm.stopPrank();
-    }
-
-    function test_requestWithdraw_atMax_succeeds() public {
-        uint96 amt = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT());
-
-        vm.deal(bob, uint256(amt) + 1 ether);
-        vm.startPrank(bob);
-        liquidityPoolInstance.deposit{value: uint256(amt) + 1 ether}();
-        eETHInstance.approve(address(liquidityPoolInstance), amt);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, amt);
-        vm.stopPrank();
-
-        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
-        assertEq(request.amountOfEEth, amt, "MAX_WITHDRAW_AMOUNT request should be created");
-    }
-
-    function test_requestWithdraw_aboveMax_reverts() public {
-        uint96 amt = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT()) + 1;
-
-        vm.deal(bob, uint256(amt) + 1 ether);
-        vm.startPrank(bob);
-        liquidityPoolInstance.deposit{value: uint256(amt) + 1 ether}();
-        eETHInstance.approve(address(liquidityPoolInstance), amt);
-        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
-        liquidityPoolInstance.requestWithdraw(bob, amt);
-        vm.stopPrank();
-    }
-
-    /// @dev Direct call (bypassing LP) hits the gate first.
-    function test_requestWithdraw_direct_belowMin_reverts() public {
-        uint96 amt = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT()) - 1;
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
-        withdrawRequestNFTInstance.requestWithdraw(amt, amt, bob, 0);
-    }
-
-    function test_requestWithdraw_direct_aboveMax_reverts() public {
-        uint96 amt = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT()) + 1;
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert(WithdrawRequestNFT.InvalidWithdrawalAmount.selector);
-        withdrawRequestNFTInstance.requestWithdraw(amt, amt, bob, 0);
-    }
-
-    function test_requestWithdraw_direct_atMin_succeeds() public {
-        uint96 amt = uint96(withdrawRequestNFTInstance.MIN_WITHDRAW_AMOUNT());
-
-        vm.prank(address(liquidityPoolInstance));
-        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(amt, amt, bob, 0);
-        assertEq(withdrawRequestNFTInstance.getRequest(requestId).amountOfEEth, amt);
-    }
-
-    function test_requestWithdraw_direct_atMax_succeeds() public {
-        uint96 amt = uint96(withdrawRequestNFTInstance.MAX_WITHDRAW_AMOUNT());
-
-        vm.prank(address(liquidityPoolInstance));
-        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(amt, amt, bob, 0);
-        assertEq(withdrawRequestNFTInstance.getRequest(requestId).amountOfEEth, amt);
-    }
-
     function test_invalidateRequest_boundary_atLastFinalizedRequestId() public {
         uint256 r1 = _requestFor(bob, 1 ether);
         uint256 r2 = _requestFor(bob, 1 ether);

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -4,6 +4,7 @@ import "forge-std/console2.sol";
 import "forge-std/Test.sol";
 import {StdStorage, stdStorage} from "forge-std/StdStorage.sol";
 import "../../test/common/ArrayTestHelper.sol";
+import {fundContract} from "../TestSetup.sol";
 import "../../src/interfaces/ILiquidityPool.sol";
 import "../../src/interfaces/IStakingManager.sol";
 import "../../src/StakingManager.sol";
@@ -123,10 +124,15 @@ contract PreludeTest is Test, ArrayTestHelper {
         roleRegistry.grantRole(stakingManager.STAKING_MANAGER_NODE_CREATOR_ROLE(), admin);
         roleRegistry.grantRole(stakingManager.STAKING_MANAGER_ADMIN_ROLE(), admin);
         roleRegistry.grantRole(liquidityPoolImpl.LIQUIDITY_POOL_VALIDATOR_APPROVER_ROLE(), admin);
+        roleRegistry.grantRole(liquidityPoolImpl.LIQUIDITY_POOL_VALIDATOR_CREATOR_ROLE(), admin);
         roleRegistry.grantRole(liquidityPoolImpl.LIQUIDITY_POOL_ADMIN_ROLE(), admin);
         roleRegistry.grantRole(rateLimiter.ETHERFI_RATE_LIMITER_ADMIN_ROLE(), admin);
         roleRegistry.grantRole(etherFiNodesManager.ETHERFI_NODES_MANAGER_LEGACY_LINKER_ROLE(), elExiter);
         vm.stopPrank();
+
+        // register admin as a validator spawner so helper_createValidator can drive validator creation through LP entry points
+        vm.prank(admin);
+        liquidityPool.registerValidatorSpawner(admin);
 
         vm.startPrank(admin);
         rateLimiter.createNewLimiter(etherFiNodesManager.UNRESTAKING_LIMIT_ID(), 172_800_000_000_000, 2_000_000_000);
@@ -215,13 +221,15 @@ contract PreludeTest is Test, ArrayTestHelper {
             depositDataRoot: initialDepositRoot,
             ipfsHashForEncryptedValidatorKey: "test_ipfs_hash"
         });
-        vm.deal(address(liquidityPool), 10000 ether);
+        // Fund the LP through receive() so balance and totalValueInLp stay in sync (vm.deal would clobber balance only).
+        fundContract(address(liquidityPool), 10000 ether);
 
-        vm.prank(address(liquidityPool));
-        stakingManager.registerBeaconValidators(toArray(initialDepositData), toArray_u256(params.bidId), params.etherFiNode);
+        // Drive validator creation through LP entry points so _accountForEthSentOut keeps accounting consistent.
+        vm.prank(admin);
+        liquidityPool.batchRegister(toArray(initialDepositData), toArray_u256(params.bidId), params.etherFiNode);
 
-        vm.prank(address(liquidityPool));
-        stakingManager.createBeaconValidators{value: 1 ether}(toArray(initialDepositData), toArray_u256(params.bidId), params.etherFiNode);
+        vm.prank(admin);
+        liquidityPool.batchCreateBeaconValidators(toArray(initialDepositData), toArray_u256(params.bidId), params.etherFiNode);
 
         uint256 confirmAmount = params.validatorSize - 1 ether;
 
@@ -238,8 +246,8 @@ contract PreludeTest is Test, ArrayTestHelper {
             depositDataRoot: confirmDepositRoot,
             ipfsHashForEncryptedValidatorKey: "test_ipfs_hash"
         });
-        vm.prank(address(liquidityPool));
-        stakingManager.confirmAndFundBeaconValidators{value: confirmAmount}(toArray(confirmDepositData), params.validatorSize);
+        vm.prank(admin);
+        liquidityPool.confirmAndFundBeaconValidators(toArray(confirmDepositData), params.validatorSize);
 
         if (params.withdrawable) {
             // Poke some withdrawable funds into the restakedExecutionLayerGwei storage slot of the eigenpod.
@@ -584,12 +592,15 @@ contract PreludeTest is Test, ArrayTestHelper {
             ipfsHashForEncryptedValidatorKey: "test_ipfs_hash"
         });
 
-        vm.deal(address(liquidityPool), 100 ether);
-        vm.prank(address(liquidityPool));
-        stakingManager.registerBeaconValidators(toArray(initialDepositData), bidIds, etherFiNode);
-        
-        vm.prank(address(liquidityPool));
-        stakingManager.createBeaconValidators{value: 1 ether}(toArray(initialDepositData), bidIds, etherFiNode);
+        // Fund the LP through receive() so balance and totalValueInLp stay in sync.
+        fundContract(address(liquidityPool), 100 ether);
+
+        // Drive validator creation through LP entry points so _accountForEthSentOut keeps accounting consistent.
+        vm.prank(admin);
+        liquidityPool.batchRegister(toArray(initialDepositData), bidIds, etherFiNode);
+
+        vm.prank(admin);
+        liquidityPool.batchCreateBeaconValidators(toArray(initialDepositData), bidIds, etherFiNode);
 
         uint256 validatorSize = 32 ether;
         uint256 confirmAmount = validatorSize - 1 ether;
@@ -608,8 +619,8 @@ contract PreludeTest is Test, ArrayTestHelper {
             ipfsHashForEncryptedValidatorKey: "test_ipfs_hash"
         });
 
-        vm.prank(address(liquidityPool));
-        stakingManager.confirmAndFundBeaconValidators{value: confirmAmount}(toArray(confirmDepositData), validatorSize);
+        vm.prank(admin);
+        liquidityPool.confirmAndFundBeaconValidators(toArray(confirmDepositData), validatorSize);
     }
 
     function test_withdrawRestakedValidatorETH() public {

--- a/test/fork-tests/LiquifierStEthPriceFeedFork.t.sol
+++ b/test/fork-tests/LiquifierStEthPriceFeedFork.t.sol
@@ -47,7 +47,13 @@ contract LiquifierStEthPriceFeedForkTest is TestSetup {
     // Happy path: live curve quote vs. live chainlink answer
     // -----------------------------------------------------------------------
 
-    function test_quoteByMarketValue_passesWithLiveData() public view {
+    function test_quoteByMarketValue_passesWithLiveData() public {
+        // The live feed has a ~24h heartbeat and can drift past STALE_PRICE_WINDOW
+        // depending on which block the fork lands on. Pin the live answer at a
+        // fresh updatedAt so this test isn't sensitive to fork-block selection.
+        (, int256 answer, , ,) = AggregatorV3Interface(CHAINLINK_STETH_ETH_FEED).latestRoundData();
+        _mockChainlinkAnswer(answer, block.timestamp);
+
         uint256 q = liquifierInstance.quoteByMarketValue(address(stEth), 1 ether);
         // stETH is roughly 1 ETH; curve quote can be slightly under par, never above.
         assertLe(q, 1 ether, "marketValue capped at amount via _min");
@@ -76,17 +82,16 @@ contract LiquifierStEthPriceFeedForkTest is TestSetup {
     }
 
     // -----------------------------------------------------------------------
-    // Skip path: mocked stale feed bypasses the check
+    // Stale path: mocked stale feed reverts
     // -----------------------------------------------------------------------
 
-    function test_quoteByMarketValue_skipsCheckOnMockedStaleFeed() public {
+    function test_quoteByMarketValue_revertsOnMockedStaleFeed() public {
         uint256 staleWindow = liquifierInstance.STALE_PRICE_WINDOW();
-        // updatedAt + window < now → stale → check skipped even with absurd answer.
+        // updatedAt + window < now → stale → revert.
         _mockChainlinkAnswer(int256(100 ether), block.timestamp - staleWindow - 1);
 
-        uint256 q = liquifierInstance.quoteByMarketValue(address(stEth), 1 ether);
-        assertGt(q, 0);
-        assertLe(q, 1 ether);
+        vm.expectRevert(Liquifier.StalePriceFeed.selector);
+        liquifierInstance.quoteByMarketValue(address(stEth), 1 ether);
     }
 
     // -----------------------------------------------------------------------
@@ -107,21 +112,18 @@ contract LiquifierStEthPriceFeedForkTest is TestSetup {
         vm.stopPrank();
     }
 
-    /// Same flow with a stale mocked feed succeeds (check skipped).
-    function test_depositWithERC20_passesOnMockedStaleFeed() public {
+    /// Same flow with a stale mocked feed reverts.
+    function test_depositWithERC20_revertsOnMockedStaleFeed() public {
         _seedStEth(alice, 2 ether);
 
         uint256 staleWindow = liquifierInstance.STALE_PRICE_WINDOW();
         _mockChainlinkAnswer(int256(100 ether), block.timestamp - staleWindow - 1);
 
-        uint256 eEthBefore = eETHInstance.balanceOf(alice);
-
         vm.startPrank(alice);
         stEth.approve(address(liquifierInstance), 1 ether);
+        vm.expectRevert(Liquifier.StalePriceFeed.selector);
         liquifierInstance.depositWithERC20(address(stEth), 1 ether, address(0));
         vm.stopPrank();
-
-        assertGt(eETHInstance.balanceOf(alice), eEthBefore, "deposit should mint eETH");
     }
 
     // -----------------------------------------------------------------------
@@ -151,7 +153,10 @@ contract LiquifierStEthPriceFeedForkTest is TestSetup {
         uint256 deviation = chainlinkValue > marketValue ? chainlinkValue - marketValue : marketValue - chainlinkValue;
         uint256 bps = liquifierInstance.BASIS_POINT_SCALE();
 
-        if (fresh && (deviation * bps) / marketValue > liquifierInstance.MAX_PRICE_DEVIATION_IN_BPS()) {
+        if (!fresh) {
+            vm.expectRevert(Liquifier.StalePriceFeed.selector);
+            liquifierInstance.quoteByMarketValue(address(stEth), amount);
+        } else if ((deviation * bps) / marketValue > liquifierInstance.MAX_PRICE_DEVIATION_IN_BPS()) {
             vm.expectRevert(Liquifier.InvalidStEthPrice.selector);
             liquifierInstance.quoteByMarketValue(address(stEth), amount);
         } else {

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import "forge-std/console2.sol";
 import "forge-std/Test.sol";
 import "../../test/common/ArrayTestHelper.sol";
+import {fundContract} from "../TestSetup.sol";
 
 import "../../src/libraries/DepositDataRootGenerator.sol";
 
@@ -494,7 +495,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         uint256[] memory bidIds = new uint256[](1);
         bidIds[0] = 999999;
 
-        vm.deal(address(liquidityPool), 100 ether);
+        fundContract(address(liquidityPool), 100 ether);
 
         vm.prank(admin);
         // Will revert because validator is not in REGISTERED status
@@ -543,7 +544,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         liquidityPool.batchRegister(depositDataArray, createdBids, etherFiNode);
 
         // Fund LP with sufficient ETH (1 ether per validator)
-        vm.deal(address(liquidityPool), 100 ether);
+        fundContract(address(liquidityPool), 100 ether);
 
         // Now create validators
         vm.prank(admin);
@@ -590,11 +591,11 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         vm.prank(spawner);
         liquidityPool.batchRegister(depositDataArray, createdBids, etherFiNode);
 
-        // Record initial balances
+        fundContract(address(liquidityPool), 100 ether);
+
+        // Record balances after funding so the assertions measure only the validator-creation delta
         uint128 initialTotalOut = liquidityPool.totalValueOutOfLp();
         uint128 initialTotalIn = liquidityPool.totalValueInLp();
-
-        vm.deal(address(liquidityPool), 100 ether);
 
         uint256 expectedEthOut = 1 ether; // 1 ether per validator
 
@@ -659,7 +660,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         vm.prank(spawner);
         liquidityPool.batchRegister(depositData, createdBids, etherFiNode);
 
-        vm.deal(address(liquidityPool), 100 ether);
+        fundContract(address(liquidityPool), 100 ether);
 
         // Create all validators - should require 3 ether
         vm.prank(admin);
@@ -761,7 +762,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         liquidityPool.batchRegister(toArray(depositData), createdBids, etherFiNode);
 
         // Confirm the validator
-        vm.deal(address(liquidityPool), 100 ether);
+        fundContract(address(liquidityPool), 100 ether);
         vm.prank(admin);
         liquidityPool.batchCreateBeaconValidators(toArray(depositData), createdBids, etherFiNode);
 

--- a/test/integration-tests/Withdraw.t.sol
+++ b/test/integration-tests/Withdraw.t.sol
@@ -20,6 +20,35 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
 
         // Handle any pending oracle report that hasn't been processed yet
         _syncOracleReportState();
+
+        // The new sum-of-requests sanity check in EtherFiAdmin requires every request
+        // in (lastFinalizedRequestId, lastFinalizedWithdrawalRequestId] to be summed
+        // into the report's finalizedWithdrawalAmount. On a realistic mainnet fork,
+        // there is a pre-existing backlog of pending requests that would otherwise
+        // dominate the sum and trip the per-day cap. Fast-forward lastFinalizedRequestId
+        // to nextRequestId-1 so each test starts from a clean "no pending backlog" state.
+        _flushPendingWithdrawalBacklog();
+    }
+
+    function _flushPendingWithdrawalBacklog() internal {
+        address roleOwner = roleRegistryInstance.owner();
+
+        vm.startPrank(roleOwner);
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), address(this));
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        uint32 head = withdrawRequestNFTInstance.nextRequestId();
+        if (head > 0) {
+            withdrawRequestNFTInstance.finalizeRequests(head - 1);
+        }
+
+        // The per-day cap is checked as (amount * 1 days / elapsedTime). Tests warp only
+        // a few epochs forward, so even a 1-ETH finalization blows up to ~10k ETH/day.
+        // Raise the cap to the contract-enforced ceiling so realistic-fork tests can run.
+        etherFiAdminInstance.updateMaxFinalizedWithdrawalAmountPerDay(
+            etherFiAdminInstance.MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY()
+        );
     }
 
     /// @dev Syncs oracle/admin state so AVS_OPERATOR_1 and AVS_OPERATOR_2 can submit reports.
@@ -60,6 +89,20 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_2);
         etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_2);
         vm.stopPrank();
+    }
+
+    /// @dev Mirrors EtherFiAdmin._validateReport's sum-of-requests sanity check.
+    ///      On a realistic mainnet fork there are pending requests between
+    ///      `lastFinalizedRequestId()` and the test's new request, all of which
+    ///      contribute to the report's required `finalizedWithdrawalAmount`.
+    function _sumValidRequestAmounts(uint32 _lastFinalizedRequestIdInclusive) internal view returns (uint128) {
+        uint256 sum;
+        uint32 from = withdrawRequestNFTInstance.lastFinalizedRequestId() + 1;
+        for (uint256 i = from; i <= _lastFinalizedRequestIdInclusive; i++) {
+            IWithdrawRequestNFT.WithdrawRequest memory r = withdrawRequestNFTInstance.getRequest(i);
+            if (r.isValid) sum += r.amountOfEEth;
+        }
+        return uint128(sum);
     }
 
     function test_Withdraw_EtherFiRedemptionManager_redeemEEth() public {
@@ -273,6 +316,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
             etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
+        report.finalizedWithdrawalAmount = _sumValidRequestAmounts(report.lastFinalizedWithdrawalRequestId);
 
         (report.refSlotFrom, report.refSlotTo, report.refBlockFrom) = etherFiOracleInstance.blockStampForNextReport();
         // Set refBlockTo to a block number that is < block.number and > lastAdminExecutionBlock
@@ -337,6 +381,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
             etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
+        report.finalizedWithdrawalAmount = _sumValidRequestAmounts(report.lastFinalizedWithdrawalRequestId);
 
         (report.refSlotFrom, report.refSlotTo, report.refBlockFrom) = etherFiOracleInstance.blockStampForNextReport();
         // Set refBlockTo to a block number that is < block.number and > lastAdminExecutionBlock
@@ -409,6 +454,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
             etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
+        report.finalizedWithdrawalAmount = _sumValidRequestAmounts(report.lastFinalizedWithdrawalRequestId);
 
         (report.refSlotFrom, report.refSlotTo, report.refBlockFrom) = etherFiOracleInstance.blockStampForNextReport();
         // Set refBlockTo to a block number that is < block.number and > lastAdminExecutionBlock
@@ -509,6 +555,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
             etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
+        report.finalizedWithdrawalAmount = _sumValidRequestAmounts(report.lastFinalizedWithdrawalRequestId);
 
         (report.refSlotFrom, report.refSlotTo, report.refBlockFrom) = etherFiOracleInstance.blockStampForNextReport();
         // Set refBlockTo to a block number that is < block.number and > lastAdminExecutionBlock
@@ -594,6 +641,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
             etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
+        report.finalizedWithdrawalAmount = _sumValidRequestAmounts(report.lastFinalizedWithdrawalRequestId);
 
         (report.refSlotFrom, report.refSlotTo, report.refBlockFrom) = etherFiOracleInstance.blockStampForNextReport();
         // Set refBlockTo to a block number that is < block.number and > lastAdminExecutionBlock


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens oracle report acceptance and adds new invariants around LP/NFT/queue escrow accounting, which can cause previously-valid reports/withdrawals/deposits to revert if integrators don’t match the new expectations.
> 
> **Overview**
> Adds a **new oracle-report sanity gate** in `EtherFiAdmin._validateReport` that prevents the finalized-withdrawal cursor from moving backwards and requires `finalizedWithdrawalAmount` to exactly equal the sum of on-chain valid withdrawal requests in the reported `(lastFinalizedRequestId, lastFinalizedWithdrawalRequestId]` range.
> 
> Hardens **escrow/accounting invariants** across `LiquidityPool`, `WithdrawRequestNFT`, and `PriorityWithdrawalQueue` by asserting internal locked counters never exceed each contract’s ETH balance, and by reordering validator-funding accounting to occur after external calls.
> 
> Moves **MIN/MAX withdrawal amount enforcement** to `LiquidityPool.requestWithdraw` (with special handling for “withdraw all” below-min requests) and removes the corresponding checks/`payable` usage from `WithdrawRequestNFT.requestWithdraw`.
> 
> Makes `Liquifier`’s stETH path **revert on stale Chainlink data** (`StalePriceFeed`) instead of skipping deviation checks, and updates unit/fork tests plus new helpers (`fundContract*`) to keep ETH balances and internal accounting in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e06135b3f340691301ec3c35f1c9d96b4e2d06b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->