### PR TITLE
yash/feat/move-invalidate-role

### DIFF
--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -308,9 +308,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function _handleWithdrawals(IEtherFiOracle.OracleReport calldata _report) internal {
-        for (uint256 i = 0; i < _report.withdrawalRequestsToInvalidate.length; i++) {
-            withdrawRequestNft.invalidateRequest(_report.withdrawalRequestsToInvalidate[i]);
-        }
         _finalizeWithdrawals(_report.lastFinalizedWithdrawalRequestId, _report.finalizedWithdrawalAmount);
     }
     

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -225,7 +225,6 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
 
        bytes32 chunk3 = keccak256(
             abi.encode(
-                _report.withdrawalRequestsToInvalidate,
                 _report.lastFinalizedWithdrawalRequestId,
                 _report.finalizedWithdrawalAmount
             )

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -53,6 +53,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     uint128 public ethAmountLockedForWithdrawal;
 
     bytes32 public constant WITHDRAW_REQUEST_NFT_ADMIN_ROLE = keccak256("WITHDRAW_REQUEST_NFT_ADMIN_ROLE");
+    bytes32 public constant INVALIDATE_WITHDRAW_REQUEST_ROLE = keccak256("INVALIDATE_WITHDRAW_REQUEST_ROLE");
     bytes32 public constant IMPLICIT_FEE_CLAIMER_ROLE = keccak256("IMPLICIT_FEE_CLAIMER_ROLE");
 
     IBlacklister public immutable blacklister;
@@ -244,7 +245,8 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     /// @dev Admin can only invalidate requests that have NOT been finalized yet
-    function invalidateRequest(uint256 requestId) external onlyAdmin {
+    function invalidateRequest(uint256 requestId) external {
+        if (!roleRegistry.hasRole(INVALIDATE_WITHDRAW_REQUEST_ROLE, msg.sender)) revert IncorrectRole();
         require(requestId > lastFinalizedRequestId, "Cannot invalidate finalized request");
         require(isValid(requestId), "Request is not valid");
         _requests[requestId].isValid = false;

--- a/src/interfaces/IEtherFiOracle.sol
+++ b/src/interfaces/IEtherFiOracle.sol
@@ -11,7 +11,6 @@ interface IEtherFiOracle {
         int128 accruedRewards;
         int128 protocolFees;
         uint256[] validatorsToApprove;
-        uint256[] withdrawalRequestsToInvalidate;
         uint32 lastFinalizedWithdrawalRequestId;
         uint128 finalizedWithdrawalAmount;
     }

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -880,6 +880,10 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), address(etherFiAdminInstance));
         roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), address(admin));
 
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.INVALIDATE_WITHDRAW_REQUEST_ROLE(), address(alice));
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.INVALIDATE_WITHDRAW_REQUEST_ROLE(), address(etherFiAdminInstance));
+        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.INVALIDATE_WITHDRAW_REQUEST_ROLE(), address(admin));
+
         vm.startPrank(alice);
         etherFiAdminInstance.setValidatorTaskBatchSize(100);
         liquidityPoolInstance.setValidatorSizeWei(32 ether);
@@ -965,6 +969,16 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         etherFiAdminInstance.upgradeTo(newAdminImpl);
     }
 
+    function _upgradeOracleAndAdminForFork() internal {
+        address newOracleImpl = address(new EtherFiOracle(address(roleRegistryInstance)));
+        vm.prank(etherFiOracleInstance.owner());
+        etherFiOracleInstance.upgradeTo(newOracleImpl);
+
+        address newAdminImpl = address(new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000, 7200));
+        vm.prank(roleRegistryInstance.owner());
+        etherFiAdminInstance.upgradeTo(newAdminImpl);
+    }
+
     function setupRoleRegistry() public {
         // TODO: I don't love the coupling here but it was too easy to make tests
         // where the roleRegistry global var diverged from the one set in the manager instance.
@@ -1022,16 +1036,15 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         uint256[] memory validatorsToExit = new uint256[](0);
         uint256[] memory exitedValidators = new uint256[](0);
         uint32[] memory  exitTimestamps = new uint32[](0);
-        uint256[] memory withdrawalRequestsToInvalidate = new uint256[](0);
-        reportAtPeriod2A = IEtherFiOracle.OracleReport(1, 0, 1024 - 1, 0, 1024 - 1, 1, 0,validatorsToApprove, withdrawalRequestsToInvalidate, 0, 0);
-        reportAtPeriod2B = IEtherFiOracle.OracleReport(1, 0, 1024 - 1, 0, 1024 - 1, 1, 0,validatorsToApprove, withdrawalRequestsToInvalidate, 1, 0);
-        reportAtPeriod2C = IEtherFiOracle.OracleReport(2, 0, 1024 - 1, 0, 1024 - 1, 1, 0, validatorsToApprove, withdrawalRequestsToInvalidate, 1, 0);
-        reportAtPeriod3 = IEtherFiOracle.OracleReport(1, 0, 2048 - 1, 0, 2048 - 1, 1, 0, validatorsToApprove, withdrawalRequestsToInvalidate, 1, 0);
-        reportAtPeriod3A = IEtherFiOracle.OracleReport(1, 0, 2048 - 1, 0, 3 * 1024 - 1, 1, 0, validatorsToApprove, withdrawalRequestsToInvalidate, 1, 0);
-        reportAtPeriod3B = IEtherFiOracle.OracleReport(1, 0, 2048 - 1, 1, 2 * 1024 - 1, 1, 0, validatorsToApprove, withdrawalRequestsToInvalidate, 1, 0);
-        reportAtPeriod4 = IEtherFiOracle.OracleReport(1, 2 * 1024, 1024 * 3 - 1, 2 * 1024, 3 * 1024 - 1, 0, 0, validatorsToApprove, withdrawalRequestsToInvalidate, 1, 0);
-        reportAtSlot3071 = IEtherFiOracle.OracleReport(1, 2048, 3072 - 1, 2048, 3072 - 1, 1, 0, validatorsToApprove, withdrawalRequestsToInvalidate, 1, 0);
-        reportAtSlot4287 = IEtherFiOracle.OracleReport(1, 3264, 4288 - 1, 3264, 4288 - 1, 1, 0, validatorsToApprove, withdrawalRequestsToInvalidate, 1, 0);
+        reportAtPeriod2A = IEtherFiOracle.OracleReport(1, 0, 1024 - 1, 0, 1024 - 1, 1, 0,validatorsToApprove, 0, 0);
+        reportAtPeriod2B = IEtherFiOracle.OracleReport(1, 0, 1024 - 1, 0, 1024 - 1, 1, 0,validatorsToApprove, 1, 0);
+        reportAtPeriod2C = IEtherFiOracle.OracleReport(2, 0, 1024 - 1, 0, 1024 - 1, 1, 0, validatorsToApprove, 1, 0);
+        reportAtPeriod3 = IEtherFiOracle.OracleReport(1, 0, 2048 - 1, 0, 2048 - 1, 1, 0, validatorsToApprove, 1, 0);
+        reportAtPeriod3A = IEtherFiOracle.OracleReport(1, 0, 2048 - 1, 0, 3 * 1024 - 1, 1, 0, validatorsToApprove, 1, 0);
+        reportAtPeriod3B = IEtherFiOracle.OracleReport(1, 0, 2048 - 1, 1, 2 * 1024 - 1, 1, 0, validatorsToApprove, 1, 0);
+        reportAtPeriod4 = IEtherFiOracle.OracleReport(1, 2 * 1024, 1024 * 3 - 1, 2 * 1024, 3 * 1024 - 1, 0, 0, validatorsToApprove, 1, 0);
+        reportAtSlot3071 = IEtherFiOracle.OracleReport(1, 2048, 3072 - 1, 2048, 3072 - 1, 1, 0, validatorsToApprove, 1, 0);
+        reportAtSlot4287 = IEtherFiOracle.OracleReport(1, 3264, 4288 - 1, 3264, 4288 - 1, 1, 0, validatorsToApprove, 1, 0);
     }
 
     function _merkleSetup() internal {
@@ -1263,7 +1276,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         uint256[] memory emptyVals = new uint256[](0);
         uint32[] memory emptyVals32 = new uint32[](0);
         uint32 consensusVersion = etherFiOracleInstance.consensusVersion();
-        report = IEtherFiOracle.OracleReport(consensusVersion, 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0);
+        report = IEtherFiOracle.OracleReport(consensusVersion, 0, 0, 0, 0, 0, 0, emptyVals, 0, 0);
     }
 
     function calculatePermitDigest(address _owner, address spender, uint256 value, uint256 nonce, uint256 deadline, bytes32 domainSeparator) public pure returns (bytes32) {

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -539,14 +539,10 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // Non-admin cannot invalidate
         vm.prank(recipient);
-        vm.expectRevert("Caller is not admin");
+        vm.expectRevert(WithdrawRequestNFT.IncorrectRole.selector);
         withdrawRequestNFTInstance.invalidateRequest(requestId);
 
         // Admin invalidates request
-        vm.startPrank(roleRegistryInstance.owner());
-        console.log("roleRegistryInstance.owner()", roleRegistryInstance.owner());
-        roleRegistryInstance.grantRole(withdrawRequestNFTInstance.WITHDRAW_REQUEST_NFT_ADMIN_ROLE(), admin);
-        vm.stopPrank();
         vm.prank(admin);
         withdrawRequestNFTInstance.invalidateRequest(requestId);
 

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -20,6 +20,16 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         vm.prank(nodeOperatorManagerInstance.owner());
         nodeOperatorManagerInstance.upgradeTo(address(nodeOperatorManagerImpl));
 
+        // Upgrade Oracle and Admin to local impls so the new OracleReport ABI matches.
+        _upgradeOracleAndAdminForFork();
+
+        // Raise the per-day approval cap so executeTasks doesn't reject the validator approval.
+        address rrOwner = roleRegistryInstance.owner();
+        vm.startPrank(rrOwner);
+        roleRegistryInstance.grantRole(etherFiAdminInstance.ETHERFI_ORACLE_EXECUTOR_ADMIN_ROLE(), rrOwner);
+        etherFiAdminInstance.updateMaxNumValidatorsToApprovePerDay(etherFiAdminInstance.MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY());
+        vm.stopPrank();
+
         // Handle any pending oracle report that hasn't been processed yet
         _syncOracleReportState();
     }
@@ -202,7 +212,7 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         IEtherFiOracle.OracleReport memory report;
         uint256[] memory emptyVals = new uint256[](0);
         report = IEtherFiOracle.OracleReport(
-            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0
+            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
 
         (report.refSlotFrom, report.refSlotTo, report.refBlockFrom) = etherFiOracleInstance.blockStampForNextReport();

--- a/test/integration-tests/Withdraw.t.sol
+++ b/test/integration-tests/Withdraw.t.sol
@@ -15,6 +15,9 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         initializeRealisticFork(MAINNET_FORK);
         vm.etch(alice, bytes(""));
 
+        // Upgrade Oracle and Admin to local impls so the new OracleReport ABI matches.
+        _upgradeOracleAndAdminForFork();
+
         // Handle any pending oracle report that hasn't been processed yet
         _syncOracleReportState();
     }
@@ -267,7 +270,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         IEtherFiOracle.OracleReport memory report;
         uint256[] memory emptyVals = new uint256[](0);
         report = IEtherFiOracle.OracleReport(
-            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0
+            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
 
@@ -331,7 +334,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
                 IEtherFiOracle.OracleReport memory report;
         uint256[] memory emptyVals = new uint256[](0);
         report = IEtherFiOracle.OracleReport(
-            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0
+            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
 
@@ -403,7 +406,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         IEtherFiOracle.OracleReport memory report;
         uint256[] memory emptyVals = new uint256[](0);
         report = IEtherFiOracle.OracleReport(
-            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0
+            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
 
@@ -503,7 +506,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         IEtherFiOracle.OracleReport memory report;
         uint256[] memory emptyVals = new uint256[](0);
         report = IEtherFiOracle.OracleReport(
-            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0
+            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
 
@@ -588,7 +591,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         IEtherFiOracle.OracleReport memory report;
         uint256[] memory emptyVals = new uint256[](0);
         report = IEtherFiOracle.OracleReport(
-            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0
+            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
         report.lastFinalizedWithdrawalRequestId = uint32(requestId);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `IEtherFiOracle.OracleReport` ABI/report-hash inputs and alters authorization for `WithdrawRequestNFT.invalidateRequest`, which could break integrations or misconfigure permissions if roles aren’t granted correctly.
> 
> **Overview**
> **Oracle reports no longer carry withdrawal invalidations.** This removes `withdrawalRequestsToInvalidate` from `IEtherFiOracle.OracleReport`, updates `EtherFiOracle.generateReportHash` accordingly, and drops the invalidation loop from `EtherFiAdmin._handleWithdrawals` so admin execution only finalizes withdrawals.
> 
> **Withdraw request invalidation is now role-based.** `WithdrawRequestNFT` introduces `INVALIDATE_WITHDRAW_REQUEST_ROLE` and switches `invalidateRequest` from `onlyAdmin` to an explicit role check; tests and fork integration setups are updated to grant the new role and to upgrade forked `EtherFiOracle`/`EtherFiAdmin` implementations so the updated report ABI is usable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3ff827521132229515bf907191d8520664ddd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->