### PR TITLE
yash/feat/pause-until-mint-burn

### DIFF
--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -160,6 +160,11 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _unpauseUntil();
     }
 
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     function permit(
         address owner,
         address spender,

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -14,8 +14,9 @@ import "./interfaces/ILiquidityPool.sol";
 import "./AssetRecovery.sol";
 import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IBlacklister.sol";
+import "./utils/PausableUntil.sol";
 
-contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20PermitUpgradeable, IeETH, AssetRecovery {
+contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, IERC20PermitUpgradeable, IeETH, AssetRecovery {
     using CountersUpgradeable for CountersUpgradeable.Counter;
     ILiquidityPool public liquidityPool;
 
@@ -76,7 +77,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         liquidityPool = ILiquidityPool(_liquidityPool);
     }
 
-    function mintShares(address _user, uint256 _share) external onlyPoolContract whenNotPaused {
+    function mintShares(address _user, uint256 _share) external onlyPoolContract whenNotPaused whenNotPausedUntil {
         blacklister.nonBlacklisted(_user);
         shares[_user] += _share;
         totalShares += _share;
@@ -85,7 +86,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         emit TransferShares(address(0), _user, _share);
     }
 
-    function burnShares(address _user, uint256 _share) external whenNotPaused {
+    function burnShares(address _user, uint256 _share) external whenNotPaused whenNotPausedUntil {
         require(msg.sender == address(liquidityPool), "Incorrect Caller");
         blacklister.nonBlacklisted(_user);
         require(shares[_user] >= _share, "BURN_AMOUNT_EXCEEDS_BALANCE");
@@ -147,6 +148,16 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IERC20P
         if(!roleRegistry.hasRole(roleRegistry.PROTOCOL_UNPAUSER(), msg.sender)) revert IncorrectRole();
         paused = false;
         emit Unpaused();
+    }
+
+    function pauseContractUntil() external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_UNTIL_ROLE(), msg.sender)) revert IncorrectRole();
+        _pauseUntil();
+    }
+
+    function unpauseContractUntil() external {
+        if (!roleRegistry.hasRole(roleRegistry.UNPAUSE_UNTIL_ROLE(), msg.sender)) revert IncorrectRole();
+        _unpauseUntil();
     }
 
     function permit(

--- a/test/EETH.t.sol
+++ b/test/EETH.t.sol
@@ -682,16 +682,25 @@ contract EETHTest is TestSetup {
 
     address pauseUntilPauser = makeAddr("pauseUntilPauser");
     address unpauseUntilUnpauser = makeAddr("unpauseUntilUnpauser");
+    address pauseUntilDurationSetter = makeAddr("pauseUntilDurationSetter");
 
     function _grantPauseUntilRoles() internal {
         vm.startPrank(roleRegistryInstance.owner());
         roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), pauseUntilPauser);
         roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), unpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), pauseUntilDurationSetter);
         vm.stopPrank();
         // Foundry's default block.timestamp is too small — the cooldown check is
         // `lastPauseTimestamp + MAX_PAUSE_DURATION + COOLDOWN > block.timestamp`,
         // which fires on the very first call unless we warp forward past that sum.
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        // Resolve MAX_PAUSE_DURATION before the prank — otherwise the nested
+        // staticcall consumes the prank and setPauseUntilDuration is called by
+        // the test contract instead of pauseUntilDurationSetter.
+        uint256 maxDuration = eETHInstance.MAX_PAUSE_DURATION();
+        vm.prank(pauseUntilDurationSetter);
+        eETHInstance.setPauseUntilDuration(maxDuration);
     }
 
     function _eETHPausedUntil() internal view returns (uint256) {
@@ -855,5 +864,47 @@ contract EETHTest is TestSetup {
         vm.prank(address(liquidityPoolInstance));
         eETHInstance.mintShares(alice, 100);
         assertEq(eETHInstance.shares(alice), 100);
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        _grantPauseUntilRoles();
+        uint256 maxDur = eETHInstance.MAX_PAUSE_DURATION();
+
+        vm.prank(bob);
+        vm.expectRevert(EETH.IncorrectRole.selector);
+        eETHInstance.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(EETH.IncorrectRole.selector);
+        eETHInstance.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        _grantPauseUntilRoles();
+        uint256 d = eETHInstance.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(pauseUntilDurationSetter);
+        eETHInstance.setPauseUntilDuration(d);
+
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+        assertEq(eETHInstance.pausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantPauseUntilRoles();
+        uint256 belowMin = eETHInstance.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = eETHInstance.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        eETHInstance.setPauseUntilDuration(belowMin);
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        eETHInstance.setPauseUntilDuration(aboveMax);
     }
 }

--- a/test/EETH.t.sol
+++ b/test/EETH.t.sol
@@ -4,6 +4,7 @@ import "./TestSetup.sol";
 import "./TestERC20.sol";
 import "./TestERC721.sol";
 import "../src/helpers/Blacklister.sol";
+import "../src/utils/PausableUntil.sol";
 
 // Helper contract to force ETH into a contract using selfdestruct
 contract ForceETHSender {
@@ -665,5 +666,194 @@ contract EETHTest is TestSetup {
         vm.prank(alice);
         eETHInstance.transfer(bob, 0.5 ether);
         assertEq(eETHInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    // -------------------------------------------------------------------------
+    // pauseContractUntil / unpauseContractUntil
+    //
+    // EETH inherits PausableUntil; `mintShares` and `burnShares` carry the
+    // `whenNotPausedUntil` modifier. Entry points are gated by PAUSE_UNTIL_ROLE
+    // / UNPAUSE_UNTIL_ROLE on RoleRegistry. The state lives in a fixed namespaced
+    // storage slot — read via vm.load when we need to assert it.
+    // -------------------------------------------------------------------------
+
+    bytes32 constant PAUSABLE_UNTIL_SLOT =
+        0x2c7e4bc092c2002f0baaf2f47367bc442b098266b43d189dafe4cb25f1e1fea2;
+
+    address pauseUntilPauser = makeAddr("pauseUntilPauser");
+    address unpauseUntilUnpauser = makeAddr("unpauseUntilUnpauser");
+
+    function _grantPauseUntilRoles() internal {
+        vm.startPrank(roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), pauseUntilPauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), unpauseUntilUnpauser);
+        vm.stopPrank();
+        // Foundry's default block.timestamp is too small — the cooldown check is
+        // `lastPauseTimestamp + MAX_PAUSE_DURATION + COOLDOWN > block.timestamp`,
+        // which fires on the very first call unless we warp forward past that sum.
+        if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+    }
+
+    function _eETHPausedUntil() internal view returns (uint256) {
+        return uint256(vm.load(address(eETHInstance), PAUSABLE_UNTIL_SLOT));
+    }
+
+    // ---- pauseContractUntil role gating -------------------------------------
+
+    function test_EETH_pauseContractUntil_requiresRole() public {
+        _grantPauseUntilRoles();
+
+        vm.prank(bob);
+        vm.expectRevert(EETH.IncorrectRole.selector);
+        eETHInstance.pauseContractUntil();
+
+        // PROTOCOL_PAUSER (admin) alone is insufficient — needs PAUSE_UNTIL_ROLE.
+        vm.prank(admin);
+        vm.expectRevert(EETH.IncorrectRole.selector);
+        eETHInstance.pauseContractUntil();
+
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+        assertEq(_eETHPausedUntil(), block.timestamp + eETHInstance.MAX_PAUSE_DURATION());
+    }
+
+    function test_EETH_unpauseContractUntil_requiresRole() public {
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        vm.prank(bob);
+        vm.expectRevert(EETH.IncorrectRole.selector);
+        eETHInstance.unpauseContractUntil();
+
+        // PROTOCOL_UNPAUSER (admin) alone is insufficient — needs UNPAUSE_UNTIL_ROLE.
+        vm.prank(admin);
+        vm.expectRevert(EETH.IncorrectRole.selector);
+        eETHInstance.unpauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        eETHInstance.unpauseContractUntil();
+        assertEq(_eETHPausedUntil(), 0);
+    }
+
+    function test_EETH_unpauseContractUntil_revertsIfNotPaused() public {
+        _grantPauseUntilRoles();
+        vm.prank(unpauseUntilUnpauser);
+        vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
+        eETHInstance.unpauseContractUntil();
+    }
+
+    function test_EETH_pauseContractUntil_revertsIfAlreadyPaused() public {
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        // Re-pausing while already paused-until hits _requireNotPausedUntil inside _pauseUntil.
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, _eETHPausedUntil())
+        );
+        eETHInstance.pauseContractUntil();
+    }
+
+    function test_EETH_pauseContractUntil_cooldownEnforced() public {
+        _grantPauseUntilRoles();
+
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        // Unpause and re-attempt before cooldown ends. Cooldown = MAX_PAUSE_DURATION + PAUSER_UNTIL_COOLDOWN.
+        vm.prank(unpauseUntilUnpauser);
+        eETHInstance.unpauseContractUntil();
+
+        // Warp past MAX_PAUSE_DURATION (so we are no longer pausedUntil) but not past the cooldown.
+        vm.warp(block.timestamp + eETHInstance.MAX_PAUSE_DURATION() + 1);
+
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(PausableUntil.PauserCooldownStillActive.selector);
+        eETHInstance.pauseContractUntil();
+
+        // After the cooldown window also passes, same pauser can re-pause.
+        vm.warp(block.timestamp + eETHInstance.PAUSER_UNTIL_COOLDOWN());
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+    }
+
+    // ---- pause-until blocks mint/burn ---------------------------------------
+
+    function test_EETH_mintShares_revertsWhenPausedUntil() public {
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.mintShares(alice, 100);
+    }
+
+    function test_EETH_burnShares_revertsWhenPausedUntil() public {
+        // Mint before pausing — mint path is also gated, so we can't do it after.
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.mintShares(alice, 100);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.burnShares(alice, 50);
+    }
+
+    // ---- pause-until does NOT block transfers -------------------------------
+    // Only mint/burn carry the modifier; transfers route through `_transferShares`
+    // which is gated only by `whenNotPaused` (the legacy boolean pause).
+
+    function test_EETH_transfer_notBlockedByPauseContractUntil() public {
+        _aliceWithEEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 0.5 ether);
+        assertEq(eETHInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    // ---- recovery paths -----------------------------------------------------
+
+    function test_EETH_mintShares_unblockedAfterPauseExpires() public {
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        // Strict `>=` comparison in _requireNotPausedUntil ⇒ opens at exactly `pausedUntil + 1`.
+        vm.warp(block.timestamp + eETHInstance.MAX_PAUSE_DURATION() + 1);
+
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.mintShares(alice, 100);
+        assertEq(eETHInstance.shares(alice), 100);
+    }
+
+    function test_EETH_mintShares_unblockedAfterManualUnpause() public {
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        eETHInstance.unpauseContractUntil();
+
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.mintShares(alice, 100);
+        assertEq(eETHInstance.shares(alice), 100);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new time-based pause mechanism that can block `mintShares`/`burnShares`, changing core supply/share mutation behavior and introducing new role-gated admin entrypoints and cooldown/duration logic.
> 
> **Overview**
> `EETH` now inherits `PausableUntil` and gates `mintShares`/`burnShares` with `whenNotPausedUntil`, allowing admins to temporarily freeze share minting/burning without affecting transfers.
> 
> Adds role-gated endpoints `pauseContractUntil`, `unpauseContractUntil`, and `setPauseUntilDuration` (with min/max duration and cooldown enforcement), plus an extensive new test suite covering role checks, cooldown behavior, expiry/unpause recovery, and ensuring transfers remain unaffected by pause-until.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa9d63162cdc5770ee15a0130e151be8daa1560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->