### PR TITLE
yash/feat/configure-pause-until-duration

### DIFF
--- a/src/CumulativeMerkleRewardsDistributor.sol
+++ b/src/CumulativeMerkleRewardsDistributor.sol
@@ -159,6 +159,11 @@ using SafeERC20 for IERC20;
         _unpauseUntil();
     }
 
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
 
     function getImplementation() external view returns (address) {return _getImplementation();}
 

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -98,6 +98,11 @@ contract EtherFiNodesManager is
         _unpauseUntil();
     }
 
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     /// @dev under normal conditions ETH should not accumulate in the EtherFiNode. This will forward
     ///   the eth to the liquidity pool in the event of ETH being accidentally sent there
     function sweepFunds(uint256 id) external onlyAdmin whenNotPaused {

--- a/src/EtherFiRateLimiter.sol
+++ b/src/EtherFiRateLimiter.sol
@@ -128,6 +128,12 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
         _unpauseUntil();
     }
 
+    /// @notice Sets the pause duration for the contract
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     //--------------------------------------------------------------------------------------
     //-----------------------------------  Core  -------------------------------------------
     //--------------------------------------------------------------------------------------

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -371,6 +371,10 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         _unpauseUntil();
     }
 
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external hasRole(roleRegistry.PAUSE_DURATION_SETTER()) {
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     function _redeemEEth(uint256 eEthAmount, address receiver, address outputToken) internal {
         require(eEthAmount <= eEth.balanceOf(msg.sender), "EtherFiRedemptionManager: Insufficient balance");
         require(canRedeem(eEthAmount, outputToken), "EtherFiRedemptionManager: Exceeded total redeemable amount");

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -558,6 +558,12 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _unpauseUntil();
     }
 
+    /// @notice Sets the pause duration for the contract
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     // Deprecated, just existing not to touch EtherFiAdmin contract
     function setStakingTargetWeights(uint32 _eEthWeight, uint32 _etherFanWeight) external {
     }

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -288,6 +288,12 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         _unpauseUntil();
     }
 
+    /// @notice Sets the pause duration for the contract
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     // ETH comes in, L2ETH is burnt
     function unwrapL2Eth(address _l2Eth) external payable nonReentrant returns (uint256) {
         if (msg.sender != l1SyncPool) revert IncorrectCaller();

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -462,6 +462,11 @@ contract PriorityWithdrawalQueue is
         _unpauseUntil();
     }
 
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     //--------------------------------------------------------------------------------------
     //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
     //--------------------------------------------------------------------------------------

--- a/src/RoleRegistry.sol
+++ b/src/RoleRegistry.sol
@@ -14,6 +14,7 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     bytes32 public constant PROTOCOL_UNPAUSER = keccak256("PROTOCOL_UNPAUSER");
     bytes32 public constant PAUSE_UNTIL_ROLE = keccak256("PAUSE_UNTIL_ROLE");
     bytes32 public constant UNPAUSE_UNTIL_ROLE = keccak256("UNPAUSE_UNTIL_ROLE");
+    bytes32 public constant PAUSE_DURATION_SETTER = keccak256("PAUSE_DURATION_SETTER");
 
     error OnlyProtocolUpgrader();
 

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -300,6 +300,11 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         _unpauseUntil();
     }
 
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     /// @dev Handles the remainder of the eEth shares after the claim of the withdraw request
     /// the remainder eETH share for a request = request.shareOfEEth - request.amountOfEEth / (eETH amount to eETH shares rate)
     /// - Splits the remainder into two parts:

--- a/src/helpers/WeETHWithdrawAdapter.sol
+++ b/src/helpers/WeETHWithdrawAdapter.sol
@@ -211,6 +211,15 @@ contract WeETHWithdrawAdapter is
         _unpauseUntil();
     }
 
+    /**
+     * @notice Sets the pause duration for the contract
+     * @param _pauseUntilDuration The new pause duration
+     */
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     //--------------------------------------------------------------------------------------
     //------------------------------------  GETTERS  ---------------------------------------
     //--------------------------------------------------------------------------------------

--- a/src/interfaces/ICumulativeMerkleRewardsDistributor.sol
+++ b/src/interfaces/ICumulativeMerkleRewardsDistributor.sol
@@ -30,6 +30,7 @@ interface ICumulativeMerkleRewardsDistributor {
     function unpause() external;
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
     // Claim the given amount of the token to the given address. Reverts if the inputs are invalid.
     function claim(
         address token, 

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -60,6 +60,7 @@ interface IEtherFiNodesManager {
     function unPauseContract() external;
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
 
     struct LegacyNodesManagerState {
         uint256[4] legacyPadding1;

--- a/src/interfaces/IEtherFiRateLimiter.sol
+++ b/src/interfaces/IEtherFiRateLimiter.sol
@@ -20,6 +20,7 @@ interface IEtherFiRateLimiter {
     function unPauseContract() external;
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
 
     // view functions
     function getLimit(bytes32 id) external view returns (uint64 capacity, uint64 remaining, uint64 refillRate, uint256 lastRefill);

--- a/src/interfaces/ILiquidityPool.sol
+++ b/src/interfaces/ILiquidityPool.sol
@@ -83,6 +83,7 @@ interface ILiquidityPool {
     function unPauseContract() external; 
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
 
     function setStakingTargetWeights(uint32 _eEthWeight, uint32 _etherFanWeight) external;  
     function setValidatorSizeWei(uint256 _size) external;

--- a/src/interfaces/ILiquifier.sol
+++ b/src/interfaces/ILiquifier.sol
@@ -128,6 +128,7 @@ interface ILiquifier {
 
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
 
     function roleRegistry() external view returns (IRoleRegistry);
     function LIQUIFIER_ADMIN_ROLE() external view returns (bytes32);

--- a/src/interfaces/IPriorityWithdrawalQueue.sol
+++ b/src/interfaces/IPriorityWithdrawalQueue.sol
@@ -65,6 +65,7 @@ interface IPriorityWithdrawalQueue {
     function unPauseContract() external;
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
 
     // Immutables
     function treasury() external view returns (address);

--- a/src/interfaces/IRoleRegistry.sol
+++ b/src/interfaces/IRoleRegistry.sol
@@ -98,6 +98,12 @@ interface IRoleRegistry {
     function UNPAUSE_UNTIL_ROLE() external view returns (bytes32);
 
     /**
+     * @notice Returns the PAUSE_DURATION_SETTER role identifier
+     * @return The bytes32 identifier for the PAUSE_DURATION_SETTER role
+     */
+    function PAUSE_DURATION_SETTER() external view returns (bytes32);
+
+    /**
      * @notice Returns the current owner of the contract
      * @return The address of the current owner
      */

--- a/src/interfaces/IWeETHWithdrawAdapter.sol
+++ b/src/interfaces/IWeETHWithdrawAdapter.sol
@@ -45,4 +45,5 @@ interface IWeETHWithdrawAdapter {
 
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
 }

--- a/src/interfaces/IWithdrawRequestNFT.sol
+++ b/src/interfaces/IWithdrawRequestNFT.sol
@@ -24,4 +24,5 @@ interface IWithdrawRequestNFT {
 
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
 }

--- a/src/utils/PausableUntil.sol
+++ b/src/utils/PausableUntil.sol
@@ -6,6 +6,7 @@ import "../interfaces/IRoleRegistry.sol";
 contract PausableUntil {
     struct PausableUntilStorage {
         uint256 pausedUntil;
+        uint256 pauseUntilDuration;
         mapping(address => uint256) lastPauseTimestamp;
     }
 
@@ -17,15 +18,30 @@ contract PausableUntil {
         }
     }
 
-    uint256 public constant MAX_PAUSE_DURATION = 7 days;
+    uint256 public constant MIN_PAUSE_DURATION = 8 hours;
+    uint256 public constant MAX_PAUSE_DURATION = 3 days;
     uint256 public constant PAUSER_UNTIL_COOLDOWN = 1 days;
 
+    event PauseUntilDurationSet(uint256 pauseUntilDuration);
     event PausedUntil(uint256 pausedUntil);
     event UnpausedUntil();
 
     error ContractPausedUntil(uint256 pausedUntil);
     error ContractNotPausedUntil();
     error PauserCooldownStillActive();
+    error InvalidPauseUntilDuration();
+
+    function pausedUntil() external view returns (uint256) {
+        return _getPausableUntilStorage().pausedUntil;
+    }
+
+    function pauseUntilDuration() external view returns (uint256) {
+        return _getPausableUntilStorage().pauseUntilDuration;
+    }
+
+    function lastPauseTimestamp(address pauser) external view returns (uint256) {
+        return _getPausableUntilStorage().lastPauseTimestamp[pauser];
+    }
 
     function _requireNotPausedUntil() internal view {
         uint256 pausedUntil = _getPausableUntilStorage().pausedUntil;
@@ -40,8 +56,9 @@ contract PausableUntil {
     function _pauseUntil() internal {
         _requireNotPausedUntil();
         PausableUntilStorage storage $ = _getPausableUntilStorage();
-        if ($.lastPauseTimestamp[msg.sender] + MAX_PAUSE_DURATION + PAUSER_UNTIL_COOLDOWN > block.timestamp) revert PauserCooldownStillActive();
-        $.pausedUntil = block.timestamp + MAX_PAUSE_DURATION;
+        uint256 pauseUntilDuration = $.pauseUntilDuration;
+        if ($.lastPauseTimestamp[msg.sender] + pauseUntilDuration + PAUSER_UNTIL_COOLDOWN > block.timestamp) revert PauserCooldownStillActive();
+        $.pausedUntil = block.timestamp + pauseUntilDuration;
         $.lastPauseTimestamp[msg.sender] = block.timestamp;
         emit PausedUntil($.pausedUntil);
     }
@@ -51,6 +68,12 @@ contract PausableUntil {
         PausableUntilStorage storage $ = _getPausableUntilStorage();
         $.pausedUntil = 0;
         emit UnpausedUntil();
+    }
+
+    function _setPauseUntilDuration(uint256 _pauseUntilDuration) internal {
+        if (_pauseUntilDuration < MIN_PAUSE_DURATION || _pauseUntilDuration > MAX_PAUSE_DURATION) revert InvalidPauseUntilDuration();
+        _getPausableUntilStorage().pauseUntilDuration = _pauseUntilDuration;
+        emit PauseUntilDurationSet(_pauseUntilDuration);
     }
 
     modifier whenNotPausedUntil() {

--- a/test/CumulativeMerkleRewardsDistributor.t.sol
+++ b/test/CumulativeMerkleRewardsDistributor.t.sol
@@ -182,15 +182,21 @@ contract  CumulativeMerkleRewardsDistributorTest is TestSetup {
 
    address pauseUntilPauser = makeAddr("pauseUntilPauser");
    address unpauseUntilUnpauser = makeAddr("unpauseUntilUnpauser");
+   address pauseUntilDurationSetter = makeAddr("pauseUntilDurationSetter");
 
    function _grantPauseUntilRoles(address pauserAddr, address unpauserAddr) internal {
        vm.startPrank(owner);
        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), pauserAddr);
        roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), unpauserAddr);
+       roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), pauseUntilDurationSetter);
        vm.stopPrank();
        // warp past MAX_PAUSE_DURATION + PAUSER_UNTIL_COOLDOWN so the first-pause cooldown
        // (which treats lastPauseTimestamp[pauser] = 0 as unix 0) is satisfied
        if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+       uint256 maxDur = cumulativeMerkleRewardsDistributorInstance.MAX_PAUSE_DURATION();
+       vm.prank(pauseUntilDurationSetter);
+       cumulativeMerkleRewardsDistributorInstance.setPauseUntilDuration(maxDur);
    }
 
    function _pausedUntil() internal view returns (uint256) {
@@ -248,6 +254,48 @@ contract  CumulativeMerkleRewardsDistributorTest is TestSetup {
        vm.prank(unpauseUntilUnpauser);
        vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
        cumulativeMerkleRewardsDistributorInstance.unpauseContractUntil();
+   }
+
+   // --- setPauseUntilDuration ---
+
+   function test_setPauseUntilDuration_requiresRole() public {
+       _grantPauseUntilRoles(pauseUntilPauser, unpauseUntilUnpauser);
+       uint256 maxDur = cumulativeMerkleRewardsDistributorInstance.MAX_PAUSE_DURATION();
+
+       vm.prank(chad);
+       vm.expectRevert(ICumulativeMerkleRewardsDistributor.IncorrectRole.selector);
+       cumulativeMerkleRewardsDistributorInstance.setPauseUntilDuration(maxDur);
+
+       // PAUSE_UNTIL_ROLE alone is insufficient
+       vm.prank(pauseUntilPauser);
+       vm.expectRevert(ICumulativeMerkleRewardsDistributor.IncorrectRole.selector);
+       cumulativeMerkleRewardsDistributorInstance.setPauseUntilDuration(maxDur);
+   }
+
+   function test_setPauseUntilDuration_setsValue() public {
+       _grantPauseUntilRoles(pauseUntilPauser, unpauseUntilUnpauser);
+       uint256 d = cumulativeMerkleRewardsDistributorInstance.MIN_PAUSE_DURATION() + 1 hours;
+
+       vm.prank(pauseUntilDurationSetter);
+       cumulativeMerkleRewardsDistributorInstance.setPauseUntilDuration(d);
+
+       vm.prank(pauseUntilPauser);
+       cumulativeMerkleRewardsDistributorInstance.pauseContractUntil();
+       assertEq(_pausedUntil(), block.timestamp + d);
+   }
+
+   function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+       _grantPauseUntilRoles(pauseUntilPauser, unpauseUntilUnpauser);
+       uint256 belowMin = cumulativeMerkleRewardsDistributorInstance.MIN_PAUSE_DURATION() - 1;
+       uint256 aboveMax = cumulativeMerkleRewardsDistributorInstance.MAX_PAUSE_DURATION() + 1;
+
+       vm.prank(pauseUntilDurationSetter);
+       vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+       cumulativeMerkleRewardsDistributorInstance.setPauseUntilDuration(belowMin);
+
+       vm.prank(pauseUntilDurationSetter);
+       vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+       cumulativeMerkleRewardsDistributorInstance.setPauseUntilDuration(aboveMax);
    }
 
    // --- each gated function (whenNotPaused → also blocked by pause-until) ---

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -794,6 +794,7 @@ contract EtherFiNodesManagerTest is TestSetup {
 
     address nmPauseUntilPauser = makeAddr("nmPauseUntilPauser");
     address nmUnpauseUntilUnpauser = makeAddr("nmUnpauseUntilUnpauser");
+    address nmPauseUntilDurationSetter = makeAddr("nmPauseUntilDurationSetter");
 
     function _grantNmPauseUntilRoles() internal {
         // Upgrade the RoleRegistry impl on the fork so it exposes PAUSE_UNTIL_ROLE / UNPAUSE_UNTIL_ROLE
@@ -802,8 +803,13 @@ contract EtherFiNodesManagerTest is TestSetup {
         roleRegistryInstance.upgradeTo(address(newImpl));
         roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), nmPauseUntilPauser);
         roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), nmUnpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), nmPauseUntilDurationSetter);
         vm.stopPrank();
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        uint256 maxDur = managerInstance.MAX_PAUSE_DURATION();
+        vm.prank(nmPauseUntilDurationSetter);
+        managerInstance.setPauseUntilDuration(maxDur);
     }
 
     function _nmPausedUntil() internal view returns (uint256) {
@@ -865,6 +871,47 @@ contract EtherFiNodesManagerTest is TestSetup {
         vm.prank(nmUnpauseUntilUnpauser);
         vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
         managerInstance.unpauseContractUntil();
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        _grantNmPauseUntilRoles();
+        uint256 maxDur = managerInstance.MAX_PAUSE_DURATION();
+
+        vm.prank(bob);
+        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        managerInstance.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient
+        vm.prank(nmPauseUntilPauser);
+        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        managerInstance.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        _grantNmPauseUntilRoles();
+        uint256 d = managerInstance.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(nmPauseUntilDurationSetter);
+        managerInstance.setPauseUntilDuration(d);
+
+        _pauseUntil();
+        assertEq(_nmPausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantNmPauseUntilRoles();
+        uint256 belowMin = managerInstance.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = managerInstance.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(nmPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        managerInstance.setPauseUntilDuration(belowMin);
+
+        vm.prank(nmPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        managerInstance.setPauseUntilDuration(aboveMax);
     }
 
     // --- each whenNotPaused-gated function (now also blocked via _requireNotPaused override) ---

--- a/test/EtherFiRateLimiter.t.sol
+++ b/test/EtherFiRateLimiter.t.sol
@@ -22,6 +22,7 @@ contract MockRoleRegistry is IRoleRegistry {
     bytes32 public constant PROTOCOL_UNPAUSER_ROLE = keccak256("PROTOCOL_UNPAUSER");
     bytes32 public constant PAUSE_UNTIL_ROLE = keccak256("PAUSE_UNTIL_ROLE");
     bytes32 public constant UNPAUSE_UNTIL_ROLE = keccak256("UNPAUSE_UNTIL_ROLE");
+    bytes32 public constant PAUSE_DURATION_SETTER = keccak256("PAUSE_DURATION_SETTER");
 
     constructor() {
         owner = msg.sender;
@@ -95,6 +96,7 @@ contract EtherFiRateLimiterTest is Test {
     address public upgrader = makeAddr("upgrader");
     address public pauseUntilPauser = makeAddr("pauseUntilPauser");
     address public unpauseUntilUnpauser = makeAddr("unpauseUntilUnpauser");
+    address public pauseUntilDurationSetter = makeAddr("pauseUntilDurationSetter");
 
     bytes32 public constant LIMIT_ID_1 = keccak256("LIMIT_1");
     bytes32 public constant LIMIT_ID_2 = keccak256("LIMIT_2");
@@ -131,11 +133,16 @@ contract EtherFiRateLimiterTest is Test {
         roleRegistry.grantRole(roleRegistry.PROTOCOL_UNPAUSER_ROLE(), unpauser);
         roleRegistry.grantRole(roleRegistry.PAUSE_UNTIL_ROLE(), pauseUntilPauser);
         roleRegistry.grantRole(roleRegistry.UNPAUSE_UNTIL_ROLE(), unpauseUntilUnpauser);
+        roleRegistry.grantRole(roleRegistry.PAUSE_DURATION_SETTER(), pauseUntilDurationSetter);
         roleRegistry.setProtocolUpgrader(upgrader, true);
 
         // warp past MAX_PAUSE_DURATION + PAUSER_UNTIL_COOLDOWN so a first pauseContractUntil
         // is not blocked by the per-pauser cooldown (which treats 0 as unix 0)
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        uint256 maxDur = rateLimiter.MAX_PAUSE_DURATION();
+        vm.prank(pauseUntilDurationSetter);
+        rateLimiter.setPauseUntilDuration(maxDur);
     }
 
     //--------------------------------------------------------------------------------------
@@ -1294,6 +1301,45 @@ contract EtherFiRateLimiterTest is Test {
         vm.prank(unpauseUntilUnpauser);
         vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
         rateLimiter.unpauseContractUntil();
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        uint256 maxDur = rateLimiter.MAX_PAUSE_DURATION();
+
+        vm.prank(unauthorizedUser);
+        vm.expectRevert(IEtherFiRateLimiter.IncorrectRole.selector);
+        rateLimiter.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone must not grant pause-duration capability
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(IEtherFiRateLimiter.IncorrectRole.selector);
+        rateLimiter.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        uint256 d = rateLimiter.MIN_PAUSE_DURATION() + 1 hours;
+        vm.prank(pauseUntilDurationSetter);
+        rateLimiter.setPauseUntilDuration(d);
+
+        // verify by pausing and checking the resulting pausedUntil
+        vm.prank(pauseUntilPauser);
+        rateLimiter.pauseContractUntil();
+        assertEq(_pausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        uint256 belowMin = rateLimiter.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = rateLimiter.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        rateLimiter.setPauseUntilDuration(belowMin);
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        rateLimiter.setPauseUntilDuration(aboveMax);
     }
 
     // --- gated function: consume() ---

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -1735,13 +1735,19 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
     address rmPauseUntilPauser = makeAddr("rmPauseUntilPauser");
     address rmUnpauseUntilUnpauser = makeAddr("rmUnpauseUntilUnpauser");
+    address rmPauseUntilDurationSetter = makeAddr("rmPauseUntilDurationSetter");
 
     function _grantRmPauseUntilRoles() internal {
         vm.startPrank(roleRegistryInstance.owner());
         roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), rmPauseUntilPauser);
         roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), rmUnpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), rmPauseUntilDurationSetter);
         vm.stopPrank();
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        uint256 maxDur = etherFiRedemptionManagerInstance.MAX_PAUSE_DURATION();
+        vm.prank(rmPauseUntilDurationSetter);
+        etherFiRedemptionManagerInstance.setPauseUntilDuration(maxDur);
     }
 
     function _rmPausedUntil() internal view returns (uint256) {
@@ -1817,6 +1823,48 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         vm.prank(rmUnpauseUntilUnpauser);
         vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
         etherFiRedemptionManagerInstance.unpauseContractUntil();
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        _grantRmPauseUntilRoles();
+        uint256 maxDur = etherFiRedemptionManagerInstance.MAX_PAUSE_DURATION();
+
+        vm.prank(bob);
+        vm.expectRevert();
+        etherFiRedemptionManagerInstance.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient
+        vm.prank(rmPauseUntilPauser);
+        vm.expectRevert();
+        etherFiRedemptionManagerInstance.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        _grantRmPauseUntilRoles();
+        uint256 d = etherFiRedemptionManagerInstance.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(rmPauseUntilDurationSetter);
+        etherFiRedemptionManagerInstance.setPauseUntilDuration(d);
+
+        vm.prank(rmPauseUntilPauser);
+        etherFiRedemptionManagerInstance.pauseContractUntil();
+        assertEq(_rmPausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantRmPauseUntilRoles();
+        uint256 belowMin = etherFiRedemptionManagerInstance.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = etherFiRedemptionManagerInstance.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(rmPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        etherFiRedemptionManagerInstance.setPauseUntilDuration(belowMin);
+
+        vm.prank(rmPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        etherFiRedemptionManagerInstance.setPauseUntilDuration(aboveMax);
     }
 
     // --- each gated function (whenNotPaused now also enforces pause-until via override) ---

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -1522,13 +1522,19 @@ contract LiquidityPoolTest is TestSetup {
 
     address lpPauseUntilPauser = makeAddr("lpPauseUntilPauser");
     address lpUnpauseUntilUnpauser = makeAddr("lpUnpauseUntilUnpauser");
+    address lpPauseUntilDurationSetter = makeAddr("lpPauseUntilDurationSetter");
 
     function _grantLpPauseUntilRoles() internal {
         vm.startPrank(roleRegistryInstance.owner());
         roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), lpPauseUntilPauser);
         roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), lpUnpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), lpPauseUntilDurationSetter);
         vm.stopPrank();
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        uint256 maxDur = liquidityPoolInstance.MAX_PAUSE_DURATION();
+        vm.prank(lpPauseUntilDurationSetter);
+        liquidityPoolInstance.setPauseUntilDuration(maxDur);
     }
 
     function _lpPausedUntil() internal view returns (uint256) {
@@ -1584,6 +1590,48 @@ contract LiquidityPoolTest is TestSetup {
         vm.prank(lpUnpauseUntilUnpauser);
         vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
         liquidityPoolInstance.unpauseContractUntil();
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        _grantLpPauseUntilRoles();
+        uint256 maxDur = liquidityPoolInstance.MAX_PAUSE_DURATION();
+
+        vm.prank(chad);
+        vm.expectRevert(abi.encodeWithSignature("IncorrectRole()"));
+        liquidityPoolInstance.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient
+        vm.prank(lpPauseUntilPauser);
+        vm.expectRevert(abi.encodeWithSignature("IncorrectRole()"));
+        liquidityPoolInstance.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        _grantLpPauseUntilRoles();
+        uint256 d = liquidityPoolInstance.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(lpPauseUntilDurationSetter);
+        liquidityPoolInstance.setPauseUntilDuration(d);
+
+        vm.prank(lpPauseUntilPauser);
+        liquidityPoolInstance.pauseContractUntil();
+        assertEq(_lpPausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantLpPauseUntilRoles();
+        uint256 belowMin = liquidityPoolInstance.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = liquidityPoolInstance.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(lpPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        liquidityPoolInstance.setPauseUntilDuration(belowMin);
+
+        vm.prank(lpPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        liquidityPoolInstance.setPauseUntilDuration(aboveMax);
     }
 
     // --- each whenNotPaused function must now also revert under pauseContractUntil ---

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -451,13 +451,19 @@ contract LiquifierTest is TestSetup {
 
     address liqPauseUntilPauser = makeAddr("liqPauseUntilPauser");
     address liqUnpauseUntilUnpauser = makeAddr("liqUnpauseUntilUnpauser");
+    address liqPauseUntilDurationSetter = makeAddr("liqPauseUntilDurationSetter");
 
     function _grantLiqPauseUntilRoles() internal {
         vm.startPrank(roleRegistryInstance.owner());
         roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), liqPauseUntilPauser);
         roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), liqUnpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), liqPauseUntilDurationSetter);
         vm.stopPrank();
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        uint256 maxDur = liquifierInstance.MAX_PAUSE_DURATION();
+        vm.prank(liqPauseUntilDurationSetter);
+        liquifierInstance.setPauseUntilDuration(maxDur);
     }
 
     function _liqPausedUntil() internal view returns (uint256) {
@@ -528,6 +534,54 @@ contract LiquifierTest is TestSetup {
         vm.prank(liqUnpauseUntilUnpauser);
         vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
         liquifierInstance.unpauseContractUntil();
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        initializeRealisticFork(MAINNET_FORK);
+        setUpLiquifier(MAINNET_FORK);
+        _grantLiqPauseUntilRoles();
+        uint256 maxDur = liquifierInstance.MAX_PAUSE_DURATION();
+
+        vm.prank(bob);
+        vm.expectRevert(Liquifier.IncorrectRole.selector);
+        liquifierInstance.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient
+        vm.prank(liqPauseUntilPauser);
+        vm.expectRevert(Liquifier.IncorrectRole.selector);
+        liquifierInstance.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        initializeRealisticFork(MAINNET_FORK);
+        setUpLiquifier(MAINNET_FORK);
+        _grantLiqPauseUntilRoles();
+        uint256 d = liquifierInstance.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(liqPauseUntilDurationSetter);
+        liquifierInstance.setPauseUntilDuration(d);
+
+        vm.prank(liqPauseUntilPauser);
+        liquifierInstance.pauseContractUntil();
+        assertEq(_liqPausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        initializeRealisticFork(MAINNET_FORK);
+        setUpLiquifier(MAINNET_FORK);
+        _grantLiqPauseUntilRoles();
+        uint256 belowMin = liquifierInstance.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = liquifierInstance.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(liqPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        liquifierInstance.setPauseUntilDuration(belowMin);
+
+        vm.prank(liqPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        liquifierInstance.setPauseUntilDuration(aboveMax);
     }
 
     // --- each gated function (whenNotPaused now also enforces pause-until via override) ---

--- a/test/PausableUntil.t.sol
+++ b/test/PausableUntil.t.sol
@@ -11,16 +11,9 @@ import "../src/interfaces/IEtherFiRateLimiter.sol";
 contract PausableUntilHarness is PausableUntil {
     function pauseUntil() external { _pauseUntil(); }
     function unpauseUntil() external { _unpauseUntil(); }
+    function setPauseUntilDuration(uint256 d) external { _setPauseUntilDuration(d); }
     function requireNotPausedUntil() external view { _requireNotPausedUntil(); }
     function requirePausedUntil() external view { _requirePausedUntil(); }
-
-    function pausedUntil() external view returns (uint256) {
-        return _getPausableUntilStorage().pausedUntil;
-    }
-
-    function lastPauseTimestamp(address pauser) external view returns (uint256) {
-        return _getPausableUntilStorage().lastPauseTimestamp[pauser];
-    }
 
     function gated() external view whenNotPausedUntil returns (bool) { return true; }
 }
@@ -33,6 +26,7 @@ contract MockRegistry is IRoleRegistry {
     bytes32 public constant UNPAUSE_UNTIL_ROLE = keccak256("UNPAUSE_UNTIL_ROLE");
     bytes32 public constant PROTOCOL_PAUSER = keccak256("PROTOCOL_PAUSER");
     bytes32 public constant PROTOCOL_UNPAUSER = keccak256("PROTOCOL_UNPAUSER");
+    bytes32 public constant PAUSE_DURATION_SETTER = keccak256("PAUSE_DURATION_SETTER");
 
     constructor() { owner = msg.sender; }
     function initialize(address _o) external override { owner = _o; }
@@ -52,6 +46,7 @@ contract PausableUntilTest is Test {
 
     bytes32 constant EXPECTED_SLOT = 0x2c7e4bc092c2002f0baaf2f47367bc442b098266b43d189dafe4cb25f1e1fea2;
 
+    event PauseUntilDurationSet(uint256 pauseUntilDuration);
     event PausedUntil(uint256 pausedUntil);
     event UnpausedUntil();
 
@@ -61,6 +56,7 @@ contract PausableUntilTest is Test {
         // (which treats lastPauseTimestamp[pauser] = 0 as literally "last paused at unix 0")
         // does not block the first pause in tests. On mainnet this is a non-issue.
         vm.warp(1_700_000_000);
+        harness.setPauseUntilDuration(harness.MAX_PAUSE_DURATION());
     }
 
     // --------------------------------------------------------
@@ -82,8 +78,69 @@ contract PausableUntilTest is Test {
     }
 
     function test_constants() public view {
-        assertEq(harness.MAX_PAUSE_DURATION(), 7 days);
+        assertEq(harness.MIN_PAUSE_DURATION(), 8 hours);
+        assertEq(harness.MAX_PAUSE_DURATION(), 3 days);
         assertEq(harness.PAUSER_UNTIL_COOLDOWN(), 1 days);
+    }
+
+    // --------------------------------------------------------
+    //  _setPauseUntilDuration
+    // --------------------------------------------------------
+
+    function test_setPauseUntilDuration_setsStateAndEmits() public {
+        uint256 d = harness.MIN_PAUSE_DURATION() + 1 hours;
+        vm.expectEmit(false, false, false, true);
+        emit PauseUntilDurationSet(d);
+        harness.setPauseUntilDuration(d);
+        assertEq(harness.pauseUntilDuration(), d);
+    }
+
+    function test_setPauseUntilDuration_acceptsMinBoundary() public {
+        harness.setPauseUntilDuration(harness.MIN_PAUSE_DURATION());
+        assertEq(harness.pauseUntilDuration(), harness.MIN_PAUSE_DURATION());
+    }
+
+    function test_setPauseUntilDuration_acceptsMaxBoundary() public {
+        harness.setPauseUntilDuration(harness.MAX_PAUSE_DURATION());
+        assertEq(harness.pauseUntilDuration(), harness.MAX_PAUSE_DURATION());
+    }
+
+    function test_setPauseUntilDuration_revertsBelowMin() public {
+        uint256 belowMin = harness.MIN_PAUSE_DURATION() - 1;
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        harness.setPauseUntilDuration(belowMin);
+    }
+
+    function test_setPauseUntilDuration_revertsAboveMax() public {
+        uint256 aboveMax = harness.MAX_PAUSE_DURATION() + 1;
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        harness.setPauseUntilDuration(aboveMax);
+    }
+
+    function test_setPauseUntilDuration_revertsOnZero() public {
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        harness.setPauseUntilDuration(0);
+    }
+
+    function test_setPauseUntilDuration_pausesForUpdatedDuration() public {
+        uint256 d = harness.MIN_PAUSE_DURATION();
+        harness.setPauseUntilDuration(d);
+
+        vm.prank(pauserA);
+        harness.pauseUntil();
+        assertEq(harness.pausedUntil(), block.timestamp + d);
+    }
+
+    function testFuzz_setPauseUntilDuration_acceptsInRange(uint256 d) public {
+        d = bound(d, harness.MIN_PAUSE_DURATION(), harness.MAX_PAUSE_DURATION());
+        harness.setPauseUntilDuration(d);
+        assertEq(harness.pauseUntilDuration(), d);
+    }
+
+    function testFuzz_setPauseUntilDuration_rejectsOutOfRange(uint256 d) public {
+        vm.assume(d < harness.MIN_PAUSE_DURATION() || d > harness.MAX_PAUSE_DURATION());
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        harness.setPauseUntilDuration(d);
     }
 
     // --------------------------------------------------------
@@ -346,6 +403,7 @@ contract PausableUntilIntegrationTest is Test {
     address unpauser = makeAddr("unpauser");
     address pauseUntilPauser = makeAddr("pauseUntilPauser");
     address unpauseUntilUnpauser = makeAddr("unpauseUntilUnpauser");
+    address pauseUntilDurationSetter = makeAddr("pauseUntilDurationSetter");
     address consumer = makeAddr("consumer");
     address outsider = makeAddr("outsider");
 
@@ -363,6 +421,7 @@ contract PausableUntilIntegrationTest is Test {
         registry.grantRole(registry.PROTOCOL_UNPAUSER(), unpauser);
         registry.grantRole(registry.PAUSE_UNTIL_ROLE(), pauseUntilPauser);
         registry.grantRole(registry.UNPAUSE_UNTIL_ROLE(), unpauseUntilUnpauser);
+        registry.grantRole(registry.PAUSE_DURATION_SETTER(), pauseUntilDurationSetter);
 
         vm.startPrank(admin);
         limiter.createNewLimiter(LIMIT_ID, 1_000_000_000_000, 1_000_000);
@@ -370,6 +429,10 @@ contract PausableUntilIntegrationTest is Test {
         vm.stopPrank();
 
         vm.warp(1_700_000_000);
+
+        uint256 maxDur = limiter.MAX_PAUSE_DURATION();
+        vm.prank(pauseUntilDurationSetter);
+        limiter.setPauseUntilDuration(maxDur);
     }
 
     // --- role gating ---
@@ -484,6 +547,53 @@ contract PausableUntilIntegrationTest is Test {
         // paused-until still blocks consume()
         vm.prank(consumer);
         vm.expectRevert();
+        limiter.consume(LIMIT_ID, 1_000);
+    }
+
+    // --- setPauseUntilDuration role gating & effects ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        uint256 maxDur = limiter.MAX_PAUSE_DURATION();
+
+        vm.prank(outsider);
+        vm.expectRevert(IEtherFiRateLimiter.IncorrectRole.selector);
+        limiter.setPauseUntilDuration(maxDur);
+
+        // PROTOCOL_PAUSER alone must not grant pause-duration capability
+        vm.prank(pauser);
+        vm.expectRevert(IEtherFiRateLimiter.IncorrectRole.selector);
+        limiter.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone must not grant pause-duration capability
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(IEtherFiRateLimiter.IncorrectRole.selector);
+        limiter.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        uint256 belowMin = limiter.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = limiter.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        limiter.setPauseUntilDuration(belowMin);
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        limiter.setPauseUntilDuration(aboveMax);
+    }
+
+    function test_setPauseUntilDuration_changesEffectivePauseLength() public {
+        uint256 d = limiter.MIN_PAUSE_DURATION();
+        vm.prank(pauseUntilDurationSetter);
+        limiter.setPauseUntilDuration(d);
+
+        vm.prank(pauseUntilPauser);
+        limiter.pauseContractUntil();
+
+        // pause should now lift after MIN_PAUSE_DURATION rather than MAX_PAUSE_DURATION
+        vm.warp(block.timestamp + d + 1);
+        vm.prank(consumer);
         limiter.consume(LIMIT_ID, 1_000);
     }
 

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -1372,6 +1372,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
 
     address pauseUntilPauser = makeAddr("pauseUntilPauser");
     address unpauseUntilUnpauser = makeAddr("unpauseUntilUnpauser");
+    address pauseUntilDurationSetter = makeAddr("pauseUntilDurationSetter");
 
     function _grantPauseUntilRoles() internal {
         // On the mainnet fork, the live RoleRegistry predates this PR and doesn't expose
@@ -1383,8 +1384,13 @@ contract PriorityWithdrawalQueueTest is TestSetup {
         roleRegistryInstance.upgradeTo(address(newImpl));
         roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), pauseUntilPauser);
         roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), unpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), pauseUntilDurationSetter);
         vm.stopPrank();
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        uint256 maxDur = priorityQueue.MAX_PAUSE_DURATION();
+        vm.prank(pauseUntilDurationSetter);
+        priorityQueue.setPauseUntilDuration(maxDur);
     }
 
     function _pausedUntil() internal view returns (uint256) {
@@ -1440,6 +1446,48 @@ contract PriorityWithdrawalQueueTest is TestSetup {
         vm.prank(unpauseUntilUnpauser);
         vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
         priorityQueue.unpauseContractUntil();
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        _grantPauseUntilRoles();
+        uint256 maxDur = priorityQueue.MAX_PAUSE_DURATION();
+
+        vm.prank(regularUser);
+        vm.expectRevert(PriorityWithdrawalQueue.IncorrectRole.selector);
+        priorityQueue.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(PriorityWithdrawalQueue.IncorrectRole.selector);
+        priorityQueue.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        _grantPauseUntilRoles();
+        uint256 d = priorityQueue.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(pauseUntilDurationSetter);
+        priorityQueue.setPauseUntilDuration(d);
+
+        vm.prank(pauseUntilPauser);
+        priorityQueue.pauseContractUntil();
+        assertEq(_pausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantPauseUntilRoles();
+        uint256 belowMin = priorityQueue.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = priorityQueue.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        priorityQueue.setPauseUntilDuration(belowMin);
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        priorityQueue.setPauseUntilDuration(aboveMax);
     }
 
     // --- each gated function (whenNotPaused → blocked by pause-until too) ---

--- a/test/WeETHWithdrawAdapter.t.sol
+++ b/test/WeETHWithdrawAdapter.t.sol
@@ -15,6 +15,7 @@ contract WeETHWithdrawAdapterTest is TestSetup {
 
     address pauseUntilPauser = makeAddr("pauseUntilPauser");
     address unpauseUntilUnpauser = makeAddr("unpauseUntilUnpauser");
+    address pauseUntilDurationSetter = makeAddr("pauseUntilDurationSetter");
 
     function setUp() public {
         setUpTests();
@@ -39,8 +40,13 @@ contract WeETHWithdrawAdapterTest is TestSetup {
         vm.startPrank(roleRegistryInstance.owner());
         roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), pauseUntilPauser);
         roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), unpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), pauseUntilDurationSetter);
         vm.stopPrank();
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        uint256 maxDur = adapter.MAX_PAUSE_DURATION();
+        vm.prank(pauseUntilDurationSetter);
+        adapter.setPauseUntilDuration(maxDur);
     }
 
     function _pausedUntil() internal view returns (uint256) {
@@ -105,6 +111,48 @@ contract WeETHWithdrawAdapterTest is TestSetup {
         vm.prank(unpauseUntilUnpauser);
         vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
         adapter.unpauseContractUntil();
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        _grantPauseUntilRoles();
+        uint256 maxDur = adapter.MAX_PAUSE_DURATION();
+
+        vm.prank(bob);
+        vm.expectRevert(WeETHWithdrawAdapter.IncorrectRole.selector);
+        adapter.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(WeETHWithdrawAdapter.IncorrectRole.selector);
+        adapter.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        _grantPauseUntilRoles();
+        uint256 d = adapter.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(pauseUntilDurationSetter);
+        adapter.setPauseUntilDuration(d);
+
+        vm.prank(pauseUntilPauser);
+        adapter.pauseContractUntil();
+        assertEq(_pausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantPauseUntilRoles();
+        uint256 belowMin = adapter.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = adapter.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        adapter.setPauseUntilDuration(belowMin);
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        adapter.setPauseUntilDuration(aboveMax);
     }
 
     // --- each gated function (whenNotPaused → blocked by pause-until too) ---

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -866,13 +866,19 @@ contract WithdrawRequestNFTTest is TestSetup {
 
     address wrPauseUntilPauser = makeAddr("wrPauseUntilPauser");
     address wrUnpauseUntilUnpauser = makeAddr("wrUnpauseUntilUnpauser");
+    address wrPauseUntilDurationSetter = makeAddr("wrPauseUntilDurationSetter");
 
     function _grantWrPauseUntilRoles() internal {
         vm.startPrank(roleRegistryInstance.owner());
         roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), wrPauseUntilPauser);
         roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), wrUnpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), wrPauseUntilDurationSetter);
         vm.stopPrank();
         if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        uint256 maxDur = withdrawRequestNFTInstance.MAX_PAUSE_DURATION();
+        vm.prank(wrPauseUntilDurationSetter);
+        withdrawRequestNFTInstance.setPauseUntilDuration(maxDur);
     }
 
     function _wrPausedUntil() internal view returns (uint256) {
@@ -928,6 +934,48 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.prank(wrUnpauseUntilUnpauser);
         vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
         withdrawRequestNFTInstance.unpauseContractUntil();
+    }
+
+    // --- setPauseUntilDuration ---
+
+    function test_setPauseUntilDuration_requiresRole() public {
+        _grantWrPauseUntilRoles();
+        uint256 maxDur = withdrawRequestNFTInstance.MAX_PAUSE_DURATION();
+
+        vm.prank(bob);
+        vm.expectRevert(WithdrawRequestNFT.IncorrectRole.selector);
+        withdrawRequestNFTInstance.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient
+        vm.prank(wrPauseUntilPauser);
+        vm.expectRevert(WithdrawRequestNFT.IncorrectRole.selector);
+        withdrawRequestNFTInstance.setPauseUntilDuration(maxDur);
+    }
+
+    function test_setPauseUntilDuration_setsValue() public {
+        _grantWrPauseUntilRoles();
+        uint256 d = withdrawRequestNFTInstance.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(wrPauseUntilDurationSetter);
+        withdrawRequestNFTInstance.setPauseUntilDuration(d);
+
+        vm.prank(wrPauseUntilPauser);
+        withdrawRequestNFTInstance.pauseContractUntil();
+        assertEq(_wrPausedUntil(), block.timestamp + d);
+    }
+
+    function test_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantWrPauseUntilRoles();
+        uint256 belowMin = withdrawRequestNFTInstance.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = withdrawRequestNFTInstance.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(wrPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        withdrawRequestNFTInstance.setPauseUntilDuration(belowMin);
+
+        vm.prank(wrPauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        withdrawRequestNFTInstance.setPauseUntilDuration(aboveMax);
     }
 
     // The scan-of-share-remainder gate was removed from unPauseContract / unpauseContractUntil.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes protocol pause-until semantics and storage by introducing a configurable pause duration, which could affect emergency pause behavior across multiple core contracts if misconfigured or not initialized on upgrade.
> 
> **Overview**
> Adds a new `PAUSE_DURATION_SETTER` role in `RoleRegistry` and wires a new external `setPauseUntilDuration(uint256)` entrypoint into all `PausableUntil`-based contracts (e.g. `LiquidityPool`, `Liquifier`, `EtherFiNodesManager`, `EtherFiRateLimiter`, `PriorityWithdrawalQueue`, `WithdrawRequestNFT`, `CumulativeMerkleRewardsDistributor`, `WeETHWithdrawAdapter`, `EtherFiRedemptionManager`).
> 
> Updates `PausableUntil` to store a configurable `pauseUntilDuration` (with `MIN_PAUSE_DURATION = 8 hours`, `MAX_PAUSE_DURATION = 3 days`), emit `PauseUntilDurationSet`, and use this value for both the pause length and per-pauser cooldown calculation instead of a fixed `MAX_PAUSE_DURATION`. Interfaces and tests are extended to cover the new role gating, bounds checking, and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4c612686ff317c7ae0d6771a374fa252ea78343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->