### PR TITLE
EtherFiRedemptionManager: also check msg.sender against blacklist

### DIFF
--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -136,6 +136,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param outputToken The token to redeem to (ETH or stETH).
      */
     function redeemEEth(uint256 eEthAmount, address receiver, address outputToken) public whenNotPaused nonReentrant nonBlacklisted(receiver) {
+        blacklister.nonBlacklisted(msg.sender);
         _redeemEEth(eEthAmount, receiver, outputToken);
     }
 
@@ -146,6 +147,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param outputToken The token to redeem to (ETH or stETH).
      */
     function redeemWeEth(uint256 weEthAmount, address receiver, address outputToken) public whenNotPaused nonReentrant nonBlacklisted(receiver) {
+        blacklister.nonBlacklisted(msg.sender);
         _redeemWeEth(weEthAmount, receiver, outputToken);
     }
 
@@ -157,6 +159,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param outputToken The token to redeem to (ETH or stETH).
      */
     function redeemEEthWithPermit(uint256 eEthAmount, address receiver, IeETH.PermitInput calldata permit, address outputToken) external whenNotPaused nonReentrant nonBlacklisted(receiver) {
+        blacklister.nonBlacklisted(msg.sender);
         try eEth.permit(msg.sender, address(this), permit.value, permit.deadline, permit.v, permit.r, permit.s) {} catch {}
         _redeemEEth(eEthAmount, receiver, outputToken);
     }
@@ -169,6 +172,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param outputToken The token to redeem to (ETH or stETH).
      */
     function redeemWeEthWithPermit(uint256 weEthAmount, address receiver, IWeETH.PermitInput calldata permit, address outputToken) external whenNotPaused nonReentrant nonBlacklisted(receiver) {
+        blacklister.nonBlacklisted(msg.sender);
         try weEth.permit(msg.sender, address(this), permit.value, permit.deadline, permit.v, permit.r, permit.s)  {} catch {}
         _redeemWeEth(weEthAmount, receiver, outputToken);
     }
@@ -456,7 +460,6 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     }
 
     modifier nonBlacklisted(address receiver) {
-        blacklister.nonBlacklisted(msg.sender);
         blacklister.nonBlacklisted(receiver);
         _;
     }

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -1953,4 +1953,158 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         vm.prank(user);
         etherFiRedemptionManagerInstance.redeemEEth(1 ether, user, ETH_ADDRESS);
     }
+
+    //--------------------------------------------------------------------------------------
+    //--------------------------  Blacklist: caller + receiver  ----------------------------
+    //--------------------------------------------------------------------------------------
+
+    function _expectBlacklistedRevert(address u) internal {
+        vm.expectRevert(abi.encodeWithSelector(Blacklister.BlacklistedUser.selector, u));
+    }
+
+    function _blacklist(address u) internal {
+        vm.prank(owner);
+        blacklisterInstance.blacklistUser(u);
+    }
+
+    function _setupBlacklistRedeemScenario() internal {
+        // Standard liquidity + user eETH/weETH balance + rate limiter.
+        _setupRedeemScenario();
+        // Pre-stage a weETH balance + approval so redeemWeEth tests can run end-to-end
+        // for the "neither blacklisted" smoke case.
+        vm.startPrank(user);
+        eETHInstance.approve(address(weEthInstance), 2 ether);
+        weEthInstance.wrap(2 ether);
+        IERC20(address(weEthInstance)).approve(address(etherFiRedemptionManagerInstance), type(uint256).max);
+        vm.stopPrank();
+    }
+
+    // 1) Caller blacklisted, receiver clean -> revert with BlacklistedUser(msg.sender)
+    function test_redeemEEth_revertsWhenCallerBlacklisted() public {
+        _setupBlacklistRedeemScenario();
+        address cleanReceiver = makeAddr("cleanReceiver");
+
+        _blacklist(user);
+
+        _expectBlacklistedRevert(user);
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemEEth(1 ether, cleanReceiver, ETH_ADDRESS);
+    }
+
+    function test_redeemWeEth_revertsWhenCallerBlacklisted() public {
+        _setupBlacklistRedeemScenario();
+        address cleanReceiver = makeAddr("cleanReceiver");
+
+        _blacklist(user);
+
+        _expectBlacklistedRevert(user);
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemWeEth(0.5 ether, cleanReceiver, ETH_ADDRESS);
+    }
+
+    function test_redeemEEthWithPermit_revertsWhenCallerBlacklistedBeforePermit() public {
+        _setupBlacklistRedeemScenario();
+        address cleanReceiver = makeAddr("cleanReceiver");
+
+        _blacklist(user);
+
+        // Permit input is irrelevant — the caller check must trip before the permit attempt.
+        IeETH.PermitInput memory emptyPermit;
+        _expectBlacklistedRevert(user);
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemEEthWithPermit(1 ether, cleanReceiver, emptyPermit, ETH_ADDRESS);
+    }
+
+    function test_redeemWeEthWithPermit_revertsWhenCallerBlacklistedBeforePermit() public {
+        _setupBlacklistRedeemScenario();
+        address cleanReceiver = makeAddr("cleanReceiver");
+
+        _blacklist(user);
+
+        IWeETH.PermitInput memory emptyPermit;
+        _expectBlacklistedRevert(user);
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemWeEthWithPermit(0.5 ether, cleanReceiver, emptyPermit, ETH_ADDRESS);
+    }
+
+    // 2) Caller clean, receiver blacklisted -> revert with BlacklistedUser(receiver) (regression)
+    function test_redeemEEth_revertsWhenReceiverBlacklisted() public {
+        _setupBlacklistRedeemScenario();
+        address dirtyReceiver = makeAddr("dirtyReceiver");
+
+        _blacklist(dirtyReceiver);
+
+        _expectBlacklistedRevert(dirtyReceiver);
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemEEth(1 ether, dirtyReceiver, ETH_ADDRESS);
+    }
+
+    function test_redeemWeEth_revertsWhenReceiverBlacklisted() public {
+        _setupBlacklistRedeemScenario();
+        address dirtyReceiver = makeAddr("dirtyReceiver");
+
+        _blacklist(dirtyReceiver);
+
+        _expectBlacklistedRevert(dirtyReceiver);
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemWeEth(0.5 ether, dirtyReceiver, ETH_ADDRESS);
+    }
+
+    // 3) Both blacklisted -> still reverts.
+    //
+    // The `nonBlacklisted(receiver)` modifier wraps the function body, so the receiver
+    // check fires before the inline `blacklister.nonBlacklisted(msg.sender)` call. The
+    // exact revert address is therefore the receiver. What matters for defense-in-depth
+    // is that the call reverts when *either* party is blacklisted; we lock down the
+    // ordering with this test so future refactors that move the caller check ahead of
+    // the modifier (or merge it back into the modifier) surface as an intentional change.
+    function test_redeemEEth_revertsWhenBothBlacklisted() public {
+        _setupBlacklistRedeemScenario();
+        address dirtyReceiver = makeAddr("dirtyReceiver");
+
+        _blacklist(user);
+        _blacklist(dirtyReceiver);
+
+        _expectBlacklistedRevert(dirtyReceiver);
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemEEth(1 ether, dirtyReceiver, ETH_ADDRESS);
+    }
+
+    function test_redeemEEthWithPermit_revertsWhenBothBlacklisted() public {
+        _setupBlacklistRedeemScenario();
+        address dirtyReceiver = makeAddr("dirtyReceiver");
+
+        _blacklist(user);
+        _blacklist(dirtyReceiver);
+
+        IeETH.PermitInput memory emptyPermit;
+        _expectBlacklistedRevert(dirtyReceiver);
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemEEthWithPermit(1 ether, dirtyReceiver, emptyPermit, ETH_ADDRESS);
+    }
+
+    // 4) Neither blacklisted -> smoke test that the entrypoint still succeeds
+    function test_redeemEEth_succeedsWhenNeitherBlacklisted() public {
+        _setupBlacklistRedeemScenario();
+        address cleanReceiver = makeAddr("cleanReceiver");
+
+        uint256 receiverBalBefore = cleanReceiver.balance;
+
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemEEth(1 ether, cleanReceiver, ETH_ADDRESS);
+
+        assertGt(cleanReceiver.balance, receiverBalBefore);
+    }
+
+    function test_redeemWeEth_succeedsWhenNeitherBlacklisted() public {
+        _setupBlacklistRedeemScenario();
+        address cleanReceiver = makeAddr("cleanReceiver");
+
+        uint256 receiverBalBefore = cleanReceiver.balance;
+
+        vm.prank(user);
+        etherFiRedemptionManagerInstance.redeemWeEth(0.5 ether, cleanReceiver, ETH_ADDRESS);
+
+        assertGt(cleanReceiver.balance, receiverBalBefore);
+    }
 }


### PR DESCRIPTION
Addresses https://github.com/etherfi-protocol/smart-contracts/pull/385#discussion_r3246527208.

## Change

`redeemEEth` / `redeemWeEth` / `redeemEEthWithPermit` / `redeemWeEthWithPermit` previously only checked the receiver against the blacklist via the `nonBlacklisted(receiver)` modifier. A blacklisted caller could still route funds to a clean receiver address.

This PR adds `blacklister.nonBlacklisted(msg.sender);` as the first statement of each entrypoint. For the permit variants, the check runs **before** the `try ... eEth.permit(...) catch {}` call, so a blacklisted caller cannot even attempt to spend a permit on someone else's behalf.

The single-arg `nonBlacklisted(receiver)` modifier is kept as-is — recipient enforcement still flows through it.

## Tests

`test/EtherFiRedemptionManager.t.sol` adds 10 cases covering:

- Caller blacklisted, receiver clean -> revert with `BlacklistedUser(msg.sender)` (eETH, weETH, both permit variants)
- Caller clean, receiver blacklisted -> revert with `BlacklistedUser(receiver)` (regression for both eETH and weETH paths)
- Both blacklisted -> still reverts; an inline comment documents that the modifier wraps the body so the receiver check fires first
- Neither blacklisted -> smoke test that the redeem still succeeds (eETH + weETH)

```
forge test --match-contract "EtherFiRedemptionManager" --match-test "Blacklist" -vv --skip "script/el-exits/**"
...
Suite result: ok. 10 passed; 0 failed; 0 skipped
```

Full suite: 68/69 pass; the 1 failure (`test_upgrade_only_by_owner`) is pre-existing on `pankaj/feat/security-upgrades` and unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core redemption entrypoints and changes who can redeem (now blocks blacklisted callers), so any mistake could impact user withdrawals; however the change is small and well-covered by new tests.
> 
> **Overview**
> Prevents blacklisted accounts from redeeming by adding an explicit `blacklister.nonBlacklisted(msg.sender)` check to `redeemEEth`, `redeemWeEth`, and both permit-based variants (with the permit path checking the caller *before* attempting `permit`).
> 
> Adds a dedicated blacklist test suite covering caller-blacklisted, receiver-blacklisted, both-blacklisted, and neither-blacklisted cases for eETH/weETH (including permit variants) to lock in revert behavior and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894fb1392e5b343000cc13e8545ce7133d1b5b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->