### PR TITLE
WeETH: gate wrap/unwrap/transfer/approve/permit under PausableUntil

### DIFF
--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -12,8 +12,9 @@ import "./interfaces/IRateProvider.sol";
 import "./AssetRecovery.sol";
 import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IBlacklister.sol";
+import "./utils/PausableUntil.sol";
 
-contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20PermitUpgradeable, IRateProvider, AssetRecovery {
+contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20PermitUpgradeable, IRateProvider, AssetRecovery, PausableUntil {
 
     IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
@@ -71,7 +72,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     /// @notice Wraps eEth
     /// @param _eETHAmount the amount of eEth to wrap
     /// @return returns the amount of weEth the user receives
-    function wrap(uint256 _eETHAmount) public returns (uint256) {
+    function wrap(uint256 _eETHAmount) public whenNotPausedUntil returns (uint256) {
         require(_eETHAmount > 0, "weETH: can't wrap zero eETH");
         uint256 weEthAmount = liquidityPool.sharesForAmount(_eETHAmount);
         _mint(msg.sender, weEthAmount);
@@ -84,6 +85,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     /// @return returns the amount of weEth the user receives
     function wrapWithPermit(uint256 _eETHAmount, ILiquidityPool.PermitInput calldata _permit)
         external
+        whenNotPausedUntil
         returns (uint256)
     {
         try eETH.permit(msg.sender, address(this), _permit.value, _permit.deadline, _permit.v, _permit.r, _permit.s) {} catch {}
@@ -93,7 +95,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
     /// @notice Unwraps weETH
     /// @param _weETHAmount the amount of weETH to unwrap
     /// @return returns the amount of eEth the user receives
-    function unwrap(uint256 _weETHAmount) external returns (uint256) {
+    function unwrap(uint256 _weETHAmount) external whenNotPausedUntil returns (uint256) {
         require(_weETHAmount > 0, "Cannot unwrap a zero amount");
         uint256 eETHAmount = liquidityPool.amountForShare(_weETHAmount);
         _burn(msg.sender, _weETHAmount);
@@ -111,6 +113,49 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         if(!roleRegistry.hasRole(roleRegistry.PROTOCOL_UNPAUSER(), msg.sender)) revert IncorrectRole();
         paused = false;
         emit Unpaused();
+    }
+
+    function pauseContractUntil() external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_UNTIL_ROLE(), msg.sender)) revert IncorrectRole();
+        _pauseUntil();
+    }
+
+    function unpauseContractUntil() external {
+        if (!roleRegistry.hasRole(roleRegistry.UNPAUSE_UNTIL_ROLE(), msg.sender)) revert IncorrectRole();
+        _unpauseUntil();
+    }
+
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
+    // --- ERC20 overrides gated under PausableUntil ---
+    // The legacy `paused` boolean (gated through `_beforeTokenTransfer`) is
+    // preserved alongside this — the two pause systems are orthogonal.
+
+    function transfer(address to, uint256 amount) public override whenNotPausedUntil returns (bool) {
+        return super.transfer(to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override whenNotPausedUntil returns (bool) {
+        return super.transferFrom(from, to, amount);
+    }
+
+    function approve(address spender, uint256 amount) public override whenNotPausedUntil returns (bool) {
+        return super.approve(spender, amount);
+    }
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public override whenNotPausedUntil {
+        super.permit(owner, spender, value, deadline, v, r, s);
     }
 
     function recoverETH(address payable to, uint256 amount) external {

--- a/test/WeETH.t.sol
+++ b/test/WeETH.t.sol
@@ -6,6 +6,7 @@ import "./TestERC20.sol";
 import "./TestERC721.sol";
 import {ForceETHSender} from "./EETH.t.sol";
 import "../src/helpers/Blacklister.sol";
+import "../src/utils/PausableUntil.sol";
 
 contract WeETHTest is TestSetup {
     function setUp() public {
@@ -665,6 +666,303 @@ contract WeETHTest is TestSetup {
         blacklisterInstance.blacklistUser(alice);
         vm.prank(owner);
         blacklisterInstance.unblacklistUser(alice);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 0.5 ether);
+        assertEq(weEthInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    // -------------------------------------------------------------------------
+    // pauseContractUntil / unpauseContractUntil
+    //
+    // WeETH inherits PausableUntil; wrap/unwrap and the ERC20 surface
+    // (transfer / transferFrom / approve / permit / wrapWithPermit) all carry
+    // the `whenNotPausedUntil` modifier. Entry points are gated by
+    // PAUSE_UNTIL_ROLE / UNPAUSE_UNTIL_ROLE / PAUSE_DURATION_SETTER on
+    // RoleRegistry. State lives in a fixed namespaced storage slot.
+    // -------------------------------------------------------------------------
+
+    bytes32 constant WEETH_PAUSABLE_UNTIL_SLOT =
+        0x2c7e4bc092c2002f0baaf2f47367bc442b098266b43d189dafe4cb25f1e1fea2;
+
+    address pauseUntilPauser = makeAddr("weEthPauseUntilPauser");
+    address unpauseUntilUnpauser = makeAddr("weEthUnpauseUntilUnpauser");
+    address pauseUntilDurationSetter = makeAddr("weEthPauseUntilDurationSetter");
+
+    function _grantWeEthPauseUntilRoles() internal {
+        vm.startPrank(roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), pauseUntilPauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), unpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), pauseUntilDurationSetter);
+        vm.stopPrank();
+        // Foundry's default block.timestamp is too small — the cooldown check is
+        // `lastPauseTimestamp + pauseUntilDuration + COOLDOWN > block.timestamp`,
+        // which fires on the very first call unless we warp forward past that sum.
+        if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        // Resolve MAX_PAUSE_DURATION before the prank — otherwise the nested
+        // staticcall consumes the prank and setPauseUntilDuration is called by
+        // the test contract instead of pauseUntilDurationSetter.
+        uint256 maxDuration = weEthInstance.MAX_PAUSE_DURATION();
+        vm.prank(pauseUntilDurationSetter);
+        weEthInstance.setPauseUntilDuration(maxDuration);
+    }
+
+    function _weEthPausedUntil() internal view returns (uint256) {
+        return uint256(vm.load(address(weEthInstance), WEETH_PAUSABLE_UNTIL_SLOT));
+    }
+
+    // ---- pauseContractUntil role gating -------------------------------------
+
+    function test_WeETH_pauseContractUntil_requiresRole() public {
+        _grantWeEthPauseUntilRoles();
+
+        vm.prank(bob);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.pauseContractUntil();
+
+        // PROTOCOL_PAUSER (admin) alone is insufficient — needs PAUSE_UNTIL_ROLE.
+        vm.prank(admin);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.pauseContractUntil();
+
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+        assertEq(_weEthPausedUntil(), block.timestamp + weEthInstance.MAX_PAUSE_DURATION());
+    }
+
+    function test_WeETH_unpauseContractUntil_requiresRole() public {
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        vm.prank(bob);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.unpauseContractUntil();
+
+        // PROTOCOL_UNPAUSER (admin) alone is insufficient — needs UNPAUSE_UNTIL_ROLE.
+        vm.prank(admin);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.unpauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        weEthInstance.unpauseContractUntil();
+        assertEq(_weEthPausedUntil(), 0);
+    }
+
+    function test_WeETH_setPauseUntilDuration_requiresRole() public {
+        _grantWeEthPauseUntilRoles();
+        uint256 maxDur = weEthInstance.MAX_PAUSE_DURATION();
+
+        vm.prank(bob);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient.
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.setPauseUntilDuration(maxDur);
+    }
+
+    function test_WeETH_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantWeEthPauseUntilRoles();
+        uint256 belowMin = weEthInstance.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = weEthInstance.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        weEthInstance.setPauseUntilDuration(belowMin);
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        weEthInstance.setPauseUntilDuration(aboveMax);
+    }
+
+    function test_WeETH_pauseContractUntil_cooldownEnforced() public {
+        _grantWeEthPauseUntilRoles();
+
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        // Unpause and re-attempt before cooldown ends.
+        // Cooldown = MAX_PAUSE_DURATION + PAUSER_UNTIL_COOLDOWN.
+        vm.prank(unpauseUntilUnpauser);
+        weEthInstance.unpauseContractUntil();
+
+        // Warp past MAX_PAUSE_DURATION (so we are no longer pausedUntil) but not past the cooldown.
+        vm.warp(block.timestamp + weEthInstance.MAX_PAUSE_DURATION() + 1);
+
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(PausableUntil.PauserCooldownStillActive.selector);
+        weEthInstance.pauseContractUntil();
+
+        // After the cooldown window also passes, same pauser can re-pause.
+        vm.warp(block.timestamp + weEthInstance.PAUSER_UNTIL_COOLDOWN());
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+    }
+
+    // ---- pause-until blocks wrap/unwrap -------------------------------------
+
+    function test_WeETH_wrap_revertsWhenPausedUntil() public {
+        _aliceWithEEth(1 ether);
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _weEthPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.wrap(1 ether);
+    }
+
+    function test_WeETH_wrapWithPermit_revertsWhenPausedUntil() public {
+        // Set up alice with eEth and a valid permit signature.
+        vm.deal(bob, 10 ether);
+        vm.prank(bob);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+
+        startHoax(alice);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+        vm.stopPrank();
+
+        uint256 aliceNonce = eETHInstance.nonces(alice);
+        ILiquidityPool.PermitInput memory permitInput = createPermitInput(
+            2, address(weEthInstance), 5 ether, aliceNonce, 2 ** 256 - 1, eETHInstance.DOMAIN_SEPARATOR()
+        );
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _weEthPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.wrapWithPermit(5 ether, permitInput);
+    }
+
+    function test_WeETH_unwrap_revertsWhenPausedUntil() public {
+        _aliceWithWeEth(1 ether);
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _weEthPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.unwrap(0.5 ether);
+    }
+
+    // ---- pause-until blocks ERC20 surface -----------------------------------
+
+    function test_WeETH_transfer_revertsWhenPausedUntil() public {
+        _aliceWithWeEth(1 ether);
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _weEthPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.transfer(bob, 0.5 ether);
+    }
+
+    function test_WeETH_transferFrom_revertsWhenPausedUntil() public {
+        _aliceWithWeEth(1 ether);
+        vm.prank(alice);
+        weEthInstance.approve(bob, 1 ether);
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _weEthPausedUntil();
+
+        vm.prank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.transferFrom(alice, bob, 0.5 ether);
+    }
+
+    function test_WeETH_approve_revertsWhenPausedUntil() public {
+        _aliceWithWeEth(1 ether);
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _weEthPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.approve(bob, 1 ether);
+    }
+
+    function test_WeETH_permit_revertsWhenPausedUntil() public {
+        _aliceWithWeEth(1 ether);
+
+        // Pre-compute a valid permit on weEth for alice (priv key = 2).
+        uint256 aliceNonce = weEthInstance.nonces(alice);
+        ILiquidityPool.PermitInput memory permitInput = createPermitInput(
+            2, bob, 1 ether, aliceNonce, 2 ** 256 - 1, weEthInstance.DOMAIN_SEPARATOR()
+        );
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _weEthPausedUntil();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.permit(alice, bob, 1 ether, 2 ** 256 - 1, permitInput.v, permitInput.r, permitInput.s);
+    }
+
+    // ---- recovery: pause-until window elapses or manual unpause -------------
+
+    function test_WeETH_wrap_unblockedAfterPauseExpires() public {
+        _aliceWithEEth(1 ether);
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        // Strict `>=` comparison in _requireNotPausedUntil ⇒ opens at exactly `pausedUntil + 1`.
+        vm.warp(block.timestamp + weEthInstance.MAX_PAUSE_DURATION() + 1);
+
+        vm.prank(alice);
+        weEthInstance.wrap(1 ether);
+        assertEq(weEthInstance.balanceOf(alice), 1 ether);
+    }
+
+    function test_WeETH_transfer_unblockedAfterManualUnpause() public {
+        _aliceWithWeEth(1 ether);
+
+        _grantWeEthPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        weEthInstance.unpauseContractUntil();
 
         vm.prank(alice);
         weEthInstance.transfer(bob, 0.5 ether);


### PR DESCRIPTION
Addresses https://github.com/etherfi-protocol/smart-contracts/pull/385#discussion_r3246616811.

## Why

Per the review thread, `blacklistUntil` on its own is not a sufficient safety surface for weETH if we ever need to halt token movement quickly. `PausableUntil` was added to eETH mint/burn in PR #401/#402; this PR extends symmetric coverage to weETH.

## Gated operations

All ERC20 surface that moves balances or approvals:
- `wrap` / `wrapWithPermit`
- `unwrap`
- `transfer` / `transferFrom`
- `approve`
- `permit`

## Admin

Three entrypoints, role-gated through `RoleRegistry` (same pattern as `EtherFiRateLimiter` / `EETH`):
- `pauseContractUntil` — `PAUSE_UNTIL_ROLE`
- `unpauseContractUntil` — `UNPAUSE_UNTIL_ROLE`
- `setPauseUntilDuration` — `PAUSE_DURATION_SETTER`

The existing permanent `paused` boolean (gated through `_beforeTokenTransfer`) is preserved; `PausableUntil` uses namespaced storage so the two pause systems don't collide.

## Tests (all under `test/WeETH.t.sol::WeETHTest`)

- Role gating for all three admin entrypoints (PAUSE_UNTIL_ROLE / UNPAUSE_UNTIL_ROLE / PAUSE_DURATION_SETTER) — including that `PROTOCOL_PAUSER` is insufficient.
- `wrap`, `wrapWithPermit`, `unwrap`, `transfer`, `transferFrom`, `approve`, `permit` revert with `ContractPausedUntil(<until>)` during the timed pause window.
- Pauser cooldown enforced: same address can't repause within `MAX_PAUSE_DURATION + PAUSER_UNTIL_COOLDOWN`.
- Invalid durations (`<MIN_PAUSE_DURATION`, `>MAX_PAUSE_DURATION`) rejected.
- Gated functions work again after the window elapses (no manual unpause needed) and after manual `unpauseContractUntil`.

## Mainnet rollout

After upgrade, `pauseUntilDuration` must be initialized (within `[MIN_PAUSE_DURATION, MAX_PAUSE_DURATION]`) before `pauseContractUntil` can be used. Suggested initial value: 8h (= `MIN_PAUSE_DURATION`), matching the EETH rollout default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new role-gated timed pause mechanism that can block all weETH balance/approval mutations; mistakes in role configuration or pause duration initialization could unexpectedly halt user transfers/wraps.
> 
> **Overview**
> Adds `PausableUntil` to `WeETH` and gates `wrap`, `wrapWithPermit`, `unwrap`, and the ERC20 mutation surface (`transfer`, `transferFrom`, `approve`, `permit`) behind `whenNotPausedUntil`.
> 
> Introduces three new admin entrypoints—`pauseContractUntil`, `unpauseContractUntil`, and `setPauseUntilDuration`—each role-gated via `RoleRegistry` (`PAUSE_UNTIL_ROLE`, `UNPAUSE_UNTIL_ROLE`, `PAUSE_DURATION_SETTER`) while preserving the existing legacy `paused` boolean pause path.
> 
> Extends `WeETH.t.sol` with comprehensive tests for role gating, revert behavior during the timed pause window, cooldown enforcement, invalid duration checks, and resumption after expiry or manual unpause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef7340414235419ac5d5691857991f0c920e7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->