### PR TITLE
EtherFiAdmin: immutable ceilings for daily caps + drop EtherFiOracle.setEtherFiAdmin

### DIFF
--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -61,8 +61,8 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     bytes32 public constant ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE = keccak256("ETHERFI_ORACLE_EXECUTOR_TASK_MANAGER_ROLE");
 
     IPriorityWithdrawalQueue public immutable priorityWithdrawalQueue;
-    uint256 public constant MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY = 100_000 ether;
-    uint256 public constant MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY = 500;
+    uint256 public immutable MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY;
+    uint256 public immutable MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY;
 
     int256 public immutable MAX_ACCEPTABLE_REBASE_APR_IN_BPS;
     uint256 public immutable MAX_VALIDATOR_TASK_BATCH_SIZE;
@@ -88,15 +88,26 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     error NoWithdrawalsToFinalize();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _priorityWithdrawalQueue, int256 _maxAcceptableRebaseAprInBps, uint256 _maxValidatorTaskBatchSize, uint256 _staleOracleReportBlockWindow) {
+    constructor(
+        address _priorityWithdrawalQueue,
+        int256 _maxAcceptableRebaseAprInBps,
+        uint256 _maxValidatorTaskBatchSize,
+        uint256 _staleOracleReportBlockWindow,
+        uint256 _maxFinalizedWithdrawalAmountPerDay,
+        uint256 _maxNumValidatorsToApprovePerDay
+    ) {
         if (_priorityWithdrawalQueue == address(0)) revert InvalidPriorityWithdrawalQueue();
         if (_maxAcceptableRebaseAprInBps <= 0 || _maxAcceptableRebaseAprInBps > 10_000) revert InvalidMaxAcceptableRebaseApr();
         if (_maxValidatorTaskBatchSize == 0) revert InvalidValidatorTaskBatchSize();
         if (_staleOracleReportBlockWindow == 0) revert InvalidStaleOracleReportBlockWindow();
+        if (_maxFinalizedWithdrawalAmountPerDay == 0) revert InvalidMaxFinalizedWithdrawalAmountPerDay();
+        // _maxNumValidatorsToApprovePerDay = 0 is allowed (signals "pause new validators") per author intent
         priorityWithdrawalQueue = IPriorityWithdrawalQueue(_priorityWithdrawalQueue);
         MAX_ACCEPTABLE_REBASE_APR_IN_BPS = _maxAcceptableRebaseAprInBps;
         MAX_VALIDATOR_TASK_BATCH_SIZE = _maxValidatorTaskBatchSize;
         STALE_ORACLE_REPORT_BLOCK_WINDOW = _staleOracleReportBlockWindow;
+        MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY = _maxFinalizedWithdrawalAmountPerDay;
+        MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY = _maxNumValidatorsToApprovePerDay;
          _disableInitializers();
     }
 

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -298,11 +298,6 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         emit ConsensusVersionUpdated(_consensusVersion);
     }
 
-    function setEtherFiAdmin(address _etherFiAdminAddress) external onlyOwner {
-        require(etherFiAdmin == IEtherFiAdmin(address(0)), "EtherFiAdmin is already set");
-        etherFiAdmin = IEtherFiAdmin(_etherFiAdminAddress);
-    }
-    
     function unpublishReport(bytes32 _hash) external isAdmin {
         require(consensusStates[_hash].consensusReached, "Consensus is not reached yet");
         consensusStates[_hash].support = 0;

--- a/src/interfaces/IEtherFiOracle.sol
+++ b/src/interfaces/IEtherFiOracle.sol
@@ -51,7 +51,6 @@ interface IEtherFiOracle {
     function setQuorumSize(uint32 _quorumSize) external;
     function setOracleReportPeriod(uint32 _reportPeriodSlot) external;
     function setConsensusVersion(uint32 _consensusVersion) external;
-    function setEtherFiAdmin(address _etherFiAdminAddress) external;
 
     function pauseContract() external;
     function unPauseContract() external;

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -790,13 +790,6 @@ contract EtherFiOracleTest is TestSetup {
         assertTrue(genesisTime >= 0);
     }
 
-    function test_setEtherFiAdmin() public {
-        // EtherFiAdmin is already set in setUpTests, so we can only test the revert
-        vm.prank(owner);
-        vm.expectRevert("EtherFiAdmin is already set");
-        etherFiOracleInstance.setEtherFiAdmin(address(0x5678));
-    }
-
     function test_updateAdmin() public {
         address newAdmin = address(0x1234);
         bytes32 oracleAdminRole = etherFiOracleInstance.ETHERFI_ORACLE_ADMIN_ROLE();
@@ -1057,42 +1050,57 @@ contract EtherFiOracleTest is TestSetup {
     function test_constructor_priorityWithdrawalQueue_guardrail() public {
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidPriorityWithdrawalQueue.selector);
-        new EtherFiAdmin(address(0x0), 500, 1_000, 7200);
+        new EtherFiAdmin(address(0x0), 500, 1_000, 7200, 100_000 ether, 500);
     }
 
     function test_constructor_maxValidatorTaskBatchSize_guardrail() public {
-        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 500, 1_000, 7200);
+        EtherFiAdmin nonZeroValue = new EtherFiAdmin(address(0x1234), 500, 1_000, 7200, 100_000 ether, 500);
         assertEq(nonZeroValue.MAX_VALIDATOR_TASK_BATCH_SIZE(), 1_000);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidValidatorTaskBatchSize.selector);
-        new EtherFiAdmin(address(0x1234), 500, 0, 7200);
+        new EtherFiAdmin(address(0x1234), 500, 0, 7200, 100_000 ether, 500);
     }
 
     function test_constructor_maxAcceptableRebaseAprInBps_guardrail() public {
-        EtherFiAdmin validValue = new EtherFiAdmin(address(0x1234), 500, 1_000, 7200);
+        EtherFiAdmin validValue = new EtherFiAdmin(address(0x1234), 500, 1_000, 7200, 100_000 ether, 500);
         assertEq(validValue.MAX_ACCEPTABLE_REBASE_APR_IN_BPS(), 500);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(address(0x1234), 0, 1_000, 7200);
+        new EtherFiAdmin(address(0x1234), 0, 1_000, 7200, 100_000 ether, 500);
 
         // negative values revert
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(address(0x1234), -1, 1_000, 7200);
+        new EtherFiAdmin(address(0x1234), -1, 1_000, 7200, 100_000 ether, 500);
 
         // values above 10_000 revert
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(address(0x1234), 10_001, 1_000, 7200);
+        new EtherFiAdmin(address(0x1234), 10_001, 1_000, 7200, 100_000 ether, 500);
     }
 
     function test_constructor_staleOracleReportBlockWindow_guardrail() public {
-        EtherFiAdmin validValue = new EtherFiAdmin(address(0x1234), 500, 1_000, 7200);
+        EtherFiAdmin validValue = new EtherFiAdmin(address(0x1234), 500, 1_000, 7200, 100_000 ether, 500);
         assertEq(validValue.STALE_ORACLE_REPORT_BLOCK_WINDOW(), 7200);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidStaleOracleReportBlockWindow.selector);
-        new EtherFiAdmin(address(0x1234), 500, 1_000, 0);
+        new EtherFiAdmin(address(0x1234), 500, 1_000, 0, 100_000 ether, 500);
+    }
+
+    function test_constructor_maxFinalizedWithdrawalAmountPerDay_guardrail() public {
+        EtherFiAdmin validValue = new EtherFiAdmin(address(0x1234), 500, 1_000, 7200, 100_000 ether, 500);
+        assertEq(validValue.MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY(), 100_000 ether);
+
+        // value 0 reverts
+        vm.expectRevert(EtherFiAdmin.InvalidMaxFinalizedWithdrawalAmountPerDay.selector);
+        new EtherFiAdmin(address(0x1234), 500, 1_000, 7200, 0, 500);
+    }
+
+    function test_constructor_maxNumValidatorsToApprovePerDay_zero_is_allowed() public {
+        // _maxNumValidatorsToApprovePerDay = 0 is allowed (signals "pause new validators")
+        EtherFiAdmin zeroAllowed = new EtherFiAdmin(address(0x1234), 500, 1_000, 7200, 100_000 ether, 0);
+        assertEq(zeroAllowed.MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY(), 0);
     }
 
     function test_executeValidatorApprovalTask() public {

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -762,7 +762,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         );
         priorityQueueInstance = PriorityWithdrawalQueue(payable(address(priorityQueueProxy)));
 
-        etherFiAdminImplementation = new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000, 7200);
+        etherFiAdminImplementation = new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000, 7200, 100_000 ether, 500);
         etherFiAdminProxy = new UUPSProxy(address(etherFiAdminImplementation), "");
         etherFiAdminInstance = EtherFiAdmin(payable(etherFiAdminProxy));
 
@@ -912,7 +912,14 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         vm.startPrank(owner);
         // etherFiAdminInstance.updateAdmin(alice, true);
-        etherFiOracleInstance.setEtherFiAdmin(address(etherFiAdminInstance));
+        // EtherFiOracle.setEtherFiAdmin removed; write the etherFiAdmin storage slot directly for fresh test deploys.
+        // Slot 254 verified via `forge inspect EtherFiOracle storage-layout`.
+        // etherFiAdmin is packed at slot 254 offset 12 (20 bytes); preserve numCommitteeMembers (offset 4) and
+        // numActiveCommitteeMembers (offset 8) which share this slot.
+        bytes32 oracleSlot254 = vm.load(address(etherFiOracleInstance), bytes32(uint256(254)));
+        bytes32 mask = bytes32(uint256(type(uint160).max) << (12 * 8)); // 20 bytes at offset 12
+        bytes32 newSlot = (oracleSlot254 & ~mask) | bytes32(uint256(uint160(address(etherFiAdminInstance))) << (12 * 8));
+        vm.store(address(etherFiOracleInstance), bytes32(uint256(254)), newSlot);
         liquidityPoolInstance.initializeOnUpgrade(address(auctionManagerProxy), address(liquifierInstance));
         //stakingManagerInstance.initializeOnUpgrade(address(nodeOperatorManagerInstance), address(etherFiAdminInstance));
         auctionInstance.initializeOnUpgrade(address(membershipManagerInstance), 1 ether, address(nodeOperatorManagerInstance));
@@ -985,7 +992,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function _upgrade_etherfiAdmin() internal {
-        address newAdminImpl = address(new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000, 7200));
+        address newAdminImpl = address(new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000, 7200, 100_000 ether, 500));
         vm.prank(etherFiAdminInstance.owner());
         etherFiAdminInstance.upgradeTo(newAdminImpl);
     }
@@ -995,7 +1002,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         vm.prank(etherFiOracleInstance.owner());
         etherFiOracleInstance.upgradeTo(newOracleImpl);
 
-        address newAdminImpl = address(new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000, 7200));
+        address newAdminImpl = address(new EtherFiAdmin(address(priorityQueueInstance), 10_000, 1_000, 7200, 100_000 ether, 500));
         vm.prank(roleRegistryInstance.owner());
         etherFiAdminInstance.upgradeTo(newAdminImpl);
     }


### PR DESCRIPTION
Addresses @seongyun-ko's review comments on #385.

## Changes

### 1. Consistent ceiling pattern for `EtherFiAdmin` tunables (https://github.com/etherfi-protocol/smart-contracts/pull/385#discussion_r3246424290)

Before: `MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY` and `MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY` were hard-coded `constant`s while `MAX_ACCEPTABLE_REBASE_APR_IN_BPS` / `MAX_VALIDATOR_TASK_BATCH_SIZE` were `immutable` constructor params. Inconsistent.

After: all four ceilings are `immutable` constructor params. Runtime setters continue to enforce `<= ceiling`.

Constructor signature gained two trailing args:
- `_maxFinalizedWithdrawalAmountPerDay` (reverts on 0)
- `_maxNumValidatorsToApprovePerDay` (0 is allowed: signals "pause new validators")

`TestSetup` and the constructor-guardrail tests in `EtherFiOracle.t.sol` updated to pass the previous constants (`100_000 ether`, `500`) as defaults. Two new guardrail tests added.

### 2. Remove `EtherFiOracle.setEtherFiAdmin` (https://github.com/etherfi-protocol/smart-contracts/pull/385#discussion_r3246506495)

One-shot setter (guarded by a zero-address require). Mainnet already has `etherFiAdmin` set, so the setter is unreachable. Removed function, interface entry, and the `test_setEtherFiAdmin` test. `TestSetup` writes the storage slot directly via `vm.store` for fresh-deploy test paths.

Implementation note: `etherFiAdmin` lives at slot 254 offset 12, packed with `numCommitteeMembers` (offset 4) and `numActiveCommitteeMembers` (offset 8). The test setup reads the slot, masks only the address portion, and writes back to avoid clobbering the two `uint32` counters.

## Mainnet impact

- New `EtherFiAdmin` implementation requires re-deploy with the two new immutable ceilings. Reuse the existing values (`100_000 ether` and `500`) for parity.
- `EtherFiOracle` storage layout unchanged (the `etherFiAdmin` storage variable is retained) — only a function is removed. Safe upgrade.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `EtherFiAdmin` constructor immutables (requiring redeploy/upgrade wiring) and removes an on-chain setter, with tests now relying on direct storage-slot writes that could break if storage layout assumptions drift.
> 
> **Overview**
> **Makes `EtherFiAdmin` daily-cap ceilings configurable at deploy time.** `MAX_FINALIZED_WITHDRAWAL_AMOUNT_PER_DAY` and `MAX_NUM_VALIDATORS_TO_APPROVE_PER_DAY` move from hard-coded `constant`s to constructor `immutable`s, with new constructor args and guardrails (withdrawal cap must be nonzero; validator cap may be zero to effectively pause approvals).
> 
> **Removes the one-shot `EtherFiOracle.setEtherFiAdmin` wiring path.** The setter is deleted from `EtherFiOracle` and `IEtherFiOracle`, the associated test is removed, and `TestSetup` now seeds the `etherFiAdmin` reference by writing the packed storage slot directly via `vm.load`/`vm.store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fac243521c0362bac8c422f17fb2e30db3e2cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->