### PR TITLE
EETH: PausableUntil (gate full ERC20 surface)

### DIFF
--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -97,7 +97,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit TransferShares(_user, address(0), _share);
     }
 
-    function transfer(address _recipient, uint256 _amount) external override(IeETH, IERC20Upgradeable) returns (bool) {
+    function transfer(address _recipient, uint256 _amount) external override(IeETH, IERC20Upgradeable) whenNotPausedUntil returns (bool) {
         _transfer(msg.sender, _recipient, _amount);
         return true;
     }
@@ -106,19 +106,19 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return allowances[_owner][_spender];
     }
 
-    function approve(address _spender, uint256 _amount) external override(IeETH, IERC20Upgradeable) returns (bool) {
+    function approve(address _spender, uint256 _amount) external override(IeETH, IERC20Upgradeable) whenNotPaused whenNotPausedUntil returns (bool) {
         _approve(msg.sender, _spender, _amount);
         return true;
     }
 
-    function increaseAllowance(address _spender, uint256 _increaseAmount) external returns (bool) {
+    function increaseAllowance(address _spender, uint256 _increaseAmount) external whenNotPaused whenNotPausedUntil returns (bool) {
         address owner = msg.sender;
         uint256 currentAllowance = allowance(owner, _spender);
         _approve(owner, _spender,currentAllowance + _increaseAmount);
         return true;
     }
 
-    function decreaseAllowance(address _spender, uint256 _decreaseAmount) external returns (bool) {
+    function decreaseAllowance(address _spender, uint256 _decreaseAmount) external whenNotPaused whenNotPausedUntil returns (bool) {
         address owner = msg.sender;
         uint256 currentAllowance = allowance(owner, _spender);
         require(currentAllowance >= _decreaseAmount, "ERC20: decreased allowance below zero");
@@ -128,7 +128,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return true;
     }
 
-    function transferFrom(address _sender, address _recipient, uint256 _amount) external override(IeETH, IERC20Upgradeable) returns (bool) {
+    function transferFrom(address _sender, address _recipient, uint256 _amount) external override(IeETH, IERC20Upgradeable) whenNotPausedUntil returns (bool) {
         uint256 currentAllowance = allowances[_sender][msg.sender];
         require(currentAllowance >= _amount, "TRANSFER_AMOUNT_EXCEEDS_ALLOWANCE");
         unchecked {
@@ -173,7 +173,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public virtual override(IeETH, IERC20PermitUpgradeable) {
+    ) public virtual override(IeETH, IERC20PermitUpgradeable) whenNotPaused whenNotPausedUntil {
         require(block.timestamp <= deadline, "ERC20Permit: expired deadline");
 
         bytes32 structHash = keccak256(abi.encode(_PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));
@@ -216,7 +216,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit Approval(_owner, _spender, _amount);
     }
 
-    function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal whenNotPaused {
+    function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal whenNotPaused whenNotPausedUntil {
         blacklister.nonBlacklisted(_sender);
         blacklister.nonBlacklisted(_recipient);
         require(_sender != address(0), "TRANSFER_FROM_THE_ZERO_ADDRESS");

--- a/test/EETH.t.sol
+++ b/test/EETH.t.sol
@@ -822,16 +822,155 @@ contract EETHTest is TestSetup {
         eETHInstance.burnShares(alice, 50);
     }
 
-    // ---- pause-until does NOT block transfers -------------------------------
-    // Only mint/burn carry the modifier; transfers route through `_transferShares`
-    // which is gated only by `whenNotPaused` (the legacy boolean pause).
+    // ---- pause-until blocks the full ERC20 surface --------------------------
+    // Symmetric with the WeETH PausableUntil scope (PR #405): `transfer`,
+    // `transferFrom`, `approve`, `permit`, `increaseAllowance`,
+    // `decreaseAllowance`, plus `_transferShares` itself, all carry
+    // `whenNotPausedUntil`.
 
-    function test_EETH_transfer_notBlockedByPauseContractUntil() public {
+    function test_EETH_transfer_revertsWhenPausedUntil() public {
         _aliceWithEEth(1 ether);
 
         _grantPauseUntilRoles();
         vm.prank(pauseUntilPauser);
         eETHInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.transfer(bob, 0.5 ether);
+    }
+
+    function test_EETH_transferFrom_revertsWhenPausedUntil() public {
+        _aliceWithEEth(1 ether);
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.prank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.transferFrom(alice, bob, 0.5 ether);
+    }
+
+    function test_EETH_approve_revertsWhenPausedUntil() public {
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.approve(bob, 1 ether);
+    }
+
+    function test_EETH_increaseAllowance_revertsWhenPausedUntil() public {
+        // Seed an allowance before the pause window opens.
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.increaseAllowance(bob, 1 ether);
+    }
+
+    function test_EETH_decreaseAllowance_revertsWhenPausedUntil() public {
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.decreaseAllowance(bob, 0.5 ether);
+    }
+
+    function test_EETH_permit_revertsWhenPausedUntil() public {
+        // Pre-compute a valid permit on eEth for alice (priv key = 2).
+        uint256 aliceNonce = eETHInstance.nonces(alice);
+        ILiquidityPool.PermitInput memory permitInput = createPermitInput(
+            2, bob, 1 ether, aliceNonce, 2 ** 256 - 1, eETHInstance.DOMAIN_SEPARATOR()
+        );
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.permit(alice, bob, 1 ether, 2 ** 256 - 1, permitInput.v, permitInput.r, permitInput.s);
+    }
+
+    function test_EETH_erc20Surface_unblockedAfterPauseExpires() public {
+        _aliceWithEEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        // Strict `>=` comparison in _requireNotPausedUntil ⇒ opens at exactly `pausedUntil + 1`.
+        vm.warp(block.timestamp + eETHInstance.MAX_PAUSE_DURATION() + 1);
+
+        // Every gated surface should now work again without a manual unpause.
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+        assertEq(eETHInstance.allowance(alice, bob), 1 ether);
+
+        vm.prank(alice);
+        eETHInstance.increaseAllowance(bob, 0.5 ether);
+        assertEq(eETHInstance.allowance(alice, bob), 1.5 ether);
+
+        vm.prank(alice);
+        eETHInstance.decreaseAllowance(bob, 0.5 ether);
+        assertEq(eETHInstance.allowance(alice, bob), 1 ether);
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 0.25 ether);
+        assertEq(eETHInstance.balanceOf(bob), 0.25 ether);
+
+        vm.prank(bob);
+        eETHInstance.transferFrom(alice, bob, 0.25 ether);
+        assertEq(eETHInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    function test_EETH_transfer_unblockedAfterManualUnpauseUntil() public {
+        _aliceWithEEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        eETHInstance.unpauseContractUntil();
 
         vm.prank(alice);
         eETHInstance.transfer(bob, 0.5 ether);


### PR DESCRIPTION
Follow-up to https://github.com/etherfi-protocol/smart-contracts/pull/405. Per the question flagged in that PR body, the maintainer chose **symmetric scope** — eETH should gate the same surface as weETH.

## What changes

Before: `EETH` gates only `mintShares` / `burnShares` under `whenNotPausedUntil`. The ERC20 surface (`transfer` / `transferFrom` / `approve` / `permit` / `increaseAllowance` / `decreaseAllowance`) was only gated by the permanent `paused` boolean (and `approve` / `permit` / `increaseAllowance` / `decreaseAllowance` had no pause gate at all).

After: all ERC20-surface external functions and the internal `_transferShares` are gated by `whenNotPausedUntil` (in addition to `whenNotPaused`).

| Function | Before | After |
|---|---|---|
| `mintShares` / `burnShares` | `whenNotPaused whenNotPausedUntil` | unchanged |
| `transfer` / `transferFrom` | only `_transferShares` had `whenNotPaused` | `whenNotPausedUntil` on the externals + `whenNotPaused whenNotPausedUntil` on `_transferShares` |
| `approve` | (no pause gate) | `whenNotPaused whenNotPausedUntil` |
| `increaseAllowance` / `decreaseAllowance` | (no pause gate) | `whenNotPaused whenNotPausedUntil` |
| `permit` | (no pause gate) | `whenNotPaused whenNotPausedUntil` |

Approach: defense-in-depth. Externals `transfer` / `transferFrom` carry the modifier directly so that future refactors of `_transferShares` cannot accidentally drop the gate; `_transferShares` also keeps it so any new internal caller inherits the gate.

`transferFrom` deliberately does not carry `whenNotPaused` on the external (matching its pre-PR shape) — the `_transfer` it invokes still hits `_transferShares`'s `whenNotPaused`, so the boolean pause path is unchanged. All other surface that was already ungated by `whenNotPaused` (`approve`, `permit`, `increaseAllowance`, `decreaseAllowance`) gains both `whenNotPaused` and `whenNotPausedUntil` here, since the prior absence of any pause gate on those was almost certainly an oversight.

## Mainnet rollout

`PausableUntil` storage is already initialized on eETH (from PR #401/#402), so this is a behavior-change-on-paused-state-only upgrade. `pauseUntilDuration` continues to be set via `setPauseUntilDuration` (role-gated).

## Tests

`test/EETH.t.sol`: 8 new / updated cases — one revert case per ERC20 entrypoint (`transfer`, `transferFrom`, `approve`, `increaseAllowance`, `decreaseAllowance`, `permit`), plus end-to-end resumption after the pause window elapses and after manual `unpauseContractUntil`. The prior negative assertion `test_EETH_transfer_notBlockedByPauseContractUntil` is replaced by `test_EETH_transfer_revertsWhenPausedUntil`. All 50 EETH tests pass; WeETH regression tests still pass.

## Note for reviewers

`forge build` / `forge test` were run with `--skip "script/el-exits/*"` to bypass two pre-existing broken script files on the base branch (`hoodiTestTopUp.s.sol`, `topUpFork.s.sol`); those are unrelated and out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pausing behavior for `eETH` by making `pauseContractUntil` block transfers and approvals, which could affect integrations that expect ERC20 operations to work during time-bounded pauses. The change is isolated to pause states but touches core token entrypoints.
> 
> **Overview**
> Aligns `EETH` with `WeETH` by extending `whenNotPausedUntil` to the full ERC20 surface: `transfer`, `transferFrom`, `approve`, `permit`, `increaseAllowance`, `decreaseAllowance`, and the internal `_transferShares` now revert while `pauseContractUntil` is active (with `approve`/`permit`/allowance helpers also gaining `whenNotPaused`).
> 
> Updates `EETH.t.sol` to replace the previous “transfers not blocked” assertion and add coverage that each ERC20 entrypoint reverts during `pausedUntil`, and that functionality resumes after expiry or `unpauseContractUntil`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29d25a4f73edd8268337b092400da15b34ed5578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->