### PR TITLE
fix: drop OracleReport stale field in val-consolidation scripts

### DIFF
--- a/script/el-exits/val-consolidations/hoodiTestTopUp.s.sol
+++ b/script/el-exits/val-consolidations/hoodiTestTopUp.s.sol
@@ -62,7 +62,7 @@ contract HoodiTestTopUp is Script, ArrayTestHelper {
         IEtherFiOracle.OracleReport memory report;
         uint256[] memory emptyVals = new uint256[](0);
         report = IEtherFiOracle.OracleReport(
-            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0
+            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
 
         (report.refSlotFrom, report.refSlotTo, report.refBlockFrom) = etherFiOracleInstance.blockStampForNextReport();

--- a/script/el-exits/val-consolidations/topUpFork.s.sol
+++ b/script/el-exits/val-consolidations/topUpFork.s.sol
@@ -70,7 +70,7 @@ contract TopUpFork is Script, Deployed, Utils, ArrayTestHelper {
         IEtherFiOracle.OracleReport memory report;
         uint256[] memory emptyVals = new uint256[](0);
         report = IEtherFiOracle.OracleReport(
-            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, emptyVals, 0, 0
+            etherFiOracleInstance.consensusVersion(), 0, 0, 0, 0, 0, 0, emptyVals, 0, 0
         );
 
         (report.refSlotFrom, report.refSlotTo, report.refBlockFrom) = etherFiOracleInstance.blockStampForNextReport();


### PR DESCRIPTION
Strictly-scoped fix for an issue already present on `pankaj/feat/security-upgrades` that blocks clean local verification (`forge build` without `--skip`).

## 1. `forge build` failure — stale `OracleReport` field (FIXED)

`OracleReport` was reduced from 11 fields to 10 on this branch (removed `validatorsToExit`). Two scripts still construct with 11 positional args and fail to compile:

- `script/el-exits/val-consolidations/hoodiTestTopUp.s.sol:64-66`
- `script/el-exits/val-consolidations/topUpFork.s.sol:72-74`

The 9th arg (`emptyVals`) was the deleted `validatorsToExit` field. Dropped it in both files. Verified: `forge build` (no `--skip`) now succeeds (`Compiler run successful with warnings:`, no errors).

## 2. `test_upgrade_only_by_owner` — NOT REPRODUCIBLE on this base

The task brief flagged this test as failing on base. After investigation, **the test passes locally on the current `pankaj/feat/security-upgrades` head** (`6274ed3 Merge pull request #401 from etherfi-protocol/yash/feat/pause-until-mint-burn`) — no test fix is needed.

Verification:
```
$ forge test --match-test test_upgrade_only_by_owner -vv
Ran 1 test for test/EtherFiRedemptionManager.t.sol:EtherFiRedemptionManagerTest
[PASS] test_upgrade_only_by_owner() (gas: 18069950)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 5.86s
```

Full `EtherFiRedemptionManagerTest` suite: **59 passed; 0 failed; 0 skipped.**

### Why it works

The PR migrated `_authorizeUpgrade` on `EtherFiRedemptionManager` from `onlyOwner` to `roleRegistry.onlyProtocolUpgrader(msg.sender)` (`src/EtherFiRedemptionManager.sol:441-443`). `RoleRegistry.onlyProtocolUpgrader` (`src/RoleRegistry.sol:79-81`) checks `owner() != account` and reverts with `OnlyProtocolUpgrader()` otherwise.

In the test, `owner` is set by `initializeRealisticFork(MAINNET_FORK)` to `addressProviderInstance.getContractAddress("EtherFiTimelock")` (`test/TestSetup.sol:405`). On mainnet that resolves to `0x9f26d4C958fD811A1F59B01B86Be7dFFc9d20761` — the `UPGRADE_TIMELOCK`, which is also the `RoleRegistry` owner. So `vm.prank(owner)` followed by `upgradeTo(impl)` passes `onlyProtocolUpgrader`. And `vm.prank(chad)` followed by `upgradeTo(impl)` reverts with `OnlyProtocolUpgrader()`, satisfying the loose `vm.expectRevert()`.

Trace excerpt from `-vvvv` confirming:
```
[0] VM::prank(0x1efF47bc3a10a45D4B230B5d10E37751FE6AA718)  // chad
[0] VM::expectRevert(custom error 0xf4844814)
RoleRegistry::onlyProtocolUpgrader(0x1efF47...) -> [Revert] OnlyProtocolUpgrader()

[0] VM::prank(0x9f26d4C958fD811A1F59B01B86Be7dFFc9d20761)  // owner == roleRegistry.owner()
EtherFiRedemptionManager::upgradeTo(...) -> Upgraded
```

If a reviewer is seeing this fail on a different setup (different `MAINNET_RPC_URL`, pinned block where AddressProvider entry differs, etc.), please share repro details and I'll dig further. Otherwise no test changes needed.

## Scope

Strictly the two `OracleReport` constructor sites. No other changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to two Forge scripts and only adjust struct initialization to match the updated `OracleReport` layout; no protocol contract logic is modified.
> 
> **Overview**
> Fixes compilation of the validator-consolidation top-up scripts by updating `IEtherFiOracle.OracleReport` initialization to match the current 10-field struct (drops the removed positional `emptyVals` argument).
> 
> This affects `hoodiTestTopUp.s.sol` and `topUpFork.s.sol` only, unblocking `forge build` for local verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d4a672a3eaa3e29d523d70cb5ac2f2df609e36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->