### PR TITLE
yash/feat/pause-until-transfers

### DIFF
--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -77,7 +77,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         liquidityPool = ILiquidityPool(_liquidityPool);
     }
 
-    function mintShares(address _user, uint256 _share) external onlyPoolContract whenNotPaused whenNotPausedUntil {
+    function mintShares(address _user, uint256 _share) external onlyPoolContract whenNotPaused {
         blacklister.nonBlacklisted(_user);
         shares[_user] += _share;
         totalShares += _share;
@@ -86,7 +86,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit TransferShares(address(0), _user, _share);
     }
 
-    function burnShares(address _user, uint256 _share) external whenNotPaused whenNotPausedUntil {
+    function burnShares(address _user, uint256 _share) external whenNotPaused {
         require(msg.sender == address(liquidityPool), "Incorrect Caller");
         blacklister.nonBlacklisted(_user);
         require(shares[_user] >= _share, "BURN_AMOUNT_EXCEEDS_BALANCE");
@@ -216,9 +216,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit Approval(_owner, _spender, _amount);
     }
 
-    function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal whenNotPaused {
+    function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal whenNotPaused{
         blacklister.nonBlacklisted(_sender);
         blacklister.nonBlacklisted(_recipient);
+        blacklister.nonBlacklisted(msg.sender);
         require(_sender != address(0), "TRANSFER_FROM_THE_ZERO_ADDRESS");
         require(_recipient != address(0), "TRANSFER_TO_THE_ZERO_ADDRESS");
         require(_sharesAmount <= shares[_sender], "TRANSFER_AMOUNT_EXCEEDS_BALANCE");
@@ -294,6 +295,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
 
     modifier whenNotPaused() {
         require(!paused, "PAUSED");
+        _requireNotPausedUntil();
         _;
     }
 }

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -10,10 +10,11 @@ import "./interfaces/ILiquidityPool.sol";
 import "./interfaces/IRateProvider.sol";
 
 import "./AssetRecovery.sol";
+import "./utils/PausableUntil.sol";
 import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IBlacklister.sol";
 
-contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20PermitUpgradeable, IRateProvider, AssetRecovery {
+contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, ERC20PermitUpgradeable, IRateProvider, AssetRecovery {
 
     IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
@@ -113,6 +114,21 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         emit Unpaused();
     }
 
+    function pauseContractUntil() external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_UNTIL_ROLE(), msg.sender)) revert IncorrectRole();
+        _pauseUntil();
+    }
+
+    function unpauseContractUntil() external {
+        if (!roleRegistry.hasRole(roleRegistry.UNPAUSE_UNTIL_ROLE(), msg.sender)) revert IncorrectRole();
+        _unpauseUntil();
+    }
+
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external {
+        if (!roleRegistry.hasRole(roleRegistry.PAUSE_DURATION_SETTER(), msg.sender)) revert IncorrectRole();
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
     function recoverETH(address payable to, uint256 amount) external {
         if(!roleRegistry.hasRole(WEETH_OPERATING_ADMIN_ROLE, msg.sender)) revert IncorrectRole();
         _recoverETH(to, amount);
@@ -145,8 +161,10 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ERC20Pe
         uint256 /* amount */
     ) internal virtual override {
         require(!paused, "PAUSED");
+        _requireNotPausedUntil();
         blacklister.nonBlacklisted(from);
         blacklister.nonBlacklisted(to);
+        blacklister.nonBlacklisted(msg.sender);
     }
 
     //--------------------------------------------------------------------------------------

--- a/test/EETH.t.sol
+++ b/test/EETH.t.sol
@@ -671,9 +671,11 @@ contract EETHTest is TestSetup {
     // -------------------------------------------------------------------------
     // pauseContractUntil / unpauseContractUntil
     //
-    // EETH inherits PausableUntil; `mintShares` and `burnShares` carry the
-    // `whenNotPausedUntil` modifier. Entry points are gated by PAUSE_UNTIL_ROLE
-    // / UNPAUSE_UNTIL_ROLE on RoleRegistry. The state lives in a fixed namespaced
+    // EETH inherits PausableUntil. The pause-until check now lives inside the
+    // `whenNotPaused` modifier (`_requireNotPausedUntil`), so every share-mutating
+    // path — `mintShares`, `burnShares`, and `_transferShares` (i.e. `transfer` /
+    // `transferFrom`) — is gated. Entry points are gated by PAUSE_UNTIL_ROLE /
+    // UNPAUSE_UNTIL_ROLE on RoleRegistry. The state lives in a fixed namespaced
     // storage slot — read via vm.load when we need to assert it.
     // -------------------------------------------------------------------------
 
@@ -822,20 +824,38 @@ contract EETHTest is TestSetup {
         eETHInstance.burnShares(alice, 50);
     }
 
-    // ---- pause-until does NOT block transfers -------------------------------
-    // Only mint/burn carry the modifier; transfers route through `_transferShares`
-    // which is gated only by `whenNotPaused` (the legacy boolean pause).
+    // ---- pause-until blocks transfer / transferFrom -------------------------
 
-    function test_EETH_transfer_notBlockedByPauseContractUntil() public {
+    function test_EETH_transfer_revertsWhenPausedUntil() public {
         _aliceWithEEth(1 ether);
 
         _grantPauseUntilRoles();
         vm.prank(pauseUntilPauser);
         eETHInstance.pauseContractUntil();
+        uint256 pausedUntilTs = _eETHPausedUntil();
 
         vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
         eETHInstance.transfer(bob, 0.5 ether);
-        assertEq(eETHInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    function test_EETH_transferFrom_revertsWhenPausedUntil() public {
+        _aliceWithEEth(1 ether);
+        vm.prank(alice);
+        eETHInstance.approve(bob, 1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+        uint256 pausedUntilTs = _eETHPausedUntil();
+
+        vm.prank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        eETHInstance.transferFrom(alice, bob, 0.5 ether);
     }
 
     // ---- recovery paths -----------------------------------------------------
@@ -864,6 +884,56 @@ contract EETHTest is TestSetup {
         vm.prank(address(liquidityPoolInstance));
         eETHInstance.mintShares(alice, 100);
         assertEq(eETHInstance.shares(alice), 100);
+    }
+
+    function test_EETH_transfer_unblockedAfterPauseExpires() public {
+        _aliceWithEEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        vm.warp(block.timestamp + eETHInstance.MAX_PAUSE_DURATION() + 1);
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 0.5 ether);
+        assertEq(eETHInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    function test_EETH_transfer_unblockedAfterManualUnpause() public {
+        _aliceWithEEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        eETHInstance.pauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        eETHInstance.unpauseContractUntil();
+
+        vm.prank(alice);
+        eETHInstance.transfer(bob, 0.5 ether);
+        assertEq(eETHInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    // ---- spender (msg.sender) blacklist on transferFrom ---------------------
+    // `_transferShares` now blacklist-checks msg.sender in addition to from/to,
+    // so a blacklisted spender cannot move tokens even between clean parties.
+
+    function test_EETH_transferFrom_revertsWhenSpenderBlacklisted() public {
+        // Use a distinct spender so we can blacklist them without also tripping
+        // the from/to checks.
+        address spender = vm.addr(0xCAFE);
+
+        _aliceWithEEth(1 ether);
+        vm.prank(alice);
+        eETHInstance.approve(spender, 1 ether);
+
+        vm.prank(owner);
+        blacklisterInstance.blacklistUser(spender);
+
+        vm.prank(spender);
+        _expectBlacklistedRevert(spender);
+        eETHInstance.transferFrom(alice, bob, 0.5 ether);
     }
 
     // --- setPauseUntilDuration ---

--- a/test/WeETH.t.sol
+++ b/test/WeETH.t.sol
@@ -6,6 +6,7 @@ import "./TestERC20.sol";
 import "./TestERC721.sol";
 import {ForceETHSender} from "./EETH.t.sol";
 import "../src/helpers/Blacklister.sol";
+import "../src/utils/PausableUntil.sol";
 
 contract WeETHTest is TestSetup {
     function setUp() public {
@@ -669,5 +670,292 @@ contract WeETHTest is TestSetup {
         vm.prank(alice);
         weEthInstance.transfer(bob, 0.5 ether);
         assertEq(weEthInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    // -------------------------------------------------------------------------
+    // pauseContractUntil / unpauseContractUntil
+    //
+    // WeETH inherits PausableUntil. The `_beforeTokenTransfer` hook calls
+    // `_requireNotPausedUntil`, so every token movement — wrap (mint), unwrap
+    // (burn), transfer, transferFrom — is gated. Entry points are gated by
+    // PAUSE_UNTIL_ROLE / UNPAUSE_UNTIL_ROLE on RoleRegistry. The state lives in
+    // the same fixed namespaced storage slot as EETH (slot is per-contract; the
+    // path inside each contract is identical).
+    // -------------------------------------------------------------------------
+
+    bytes32 constant PAUSABLE_UNTIL_SLOT =
+        0x2c7e4bc092c2002f0baaf2f47367bc442b098266b43d189dafe4cb25f1e1fea2;
+
+    address pauseUntilPauser = makeAddr("pauseUntilPauser");
+    address unpauseUntilUnpauser = makeAddr("unpauseUntilUnpauser");
+    address pauseUntilDurationSetter = makeAddr("pauseUntilDurationSetter");
+
+    function _grantPauseUntilRoles() internal {
+        vm.startPrank(roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_UNTIL_ROLE(), pauseUntilPauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.UNPAUSE_UNTIL_ROLE(), unpauseUntilUnpauser);
+        roleRegistryInstance.grantRole(roleRegistryInstance.PAUSE_DURATION_SETTER(), pauseUntilDurationSetter);
+        vm.stopPrank();
+        // Foundry's default block.timestamp is too small to clear the cooldown
+        // check on the very first pause (lastPauseTimestamp[0] = 0 ⇒ trips
+        // 0 + MAX_PAUSE_DURATION + PAUSER_UNTIL_COOLDOWN > block.timestamp).
+        if (block.timestamp < 1_700_000_000) vm.warp(1_700_000_000);
+
+        // Resolve before prank — nested staticcall otherwise consumes the prank.
+        uint256 maxDuration = weEthInstance.MAX_PAUSE_DURATION();
+        vm.prank(pauseUntilDurationSetter);
+        weEthInstance.setPauseUntilDuration(maxDuration);
+    }
+
+    function _weETHPausedUntil() internal view returns (uint256) {
+        return uint256(vm.load(address(weEthInstance), PAUSABLE_UNTIL_SLOT));
+    }
+
+    // ---- pauseContractUntil role gating -------------------------------------
+
+    function test_WeETH_pauseContractUntil_requiresRole() public {
+        _grantPauseUntilRoles();
+
+        vm.prank(bob);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.pauseContractUntil();
+
+        // PROTOCOL_PAUSER (admin) alone is insufficient — needs PAUSE_UNTIL_ROLE.
+        vm.prank(admin);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.pauseContractUntil();
+
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+        assertEq(_weETHPausedUntil(), block.timestamp + weEthInstance.MAX_PAUSE_DURATION());
+    }
+
+    function test_WeETH_unpauseContractUntil_requiresRole() public {
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        vm.prank(bob);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.unpauseContractUntil();
+
+        // PROTOCOL_UNPAUSER (admin) alone is insufficient — needs UNPAUSE_UNTIL_ROLE.
+        vm.prank(admin);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.unpauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        weEthInstance.unpauseContractUntil();
+        assertEq(_weETHPausedUntil(), 0);
+    }
+
+    function test_WeETH_unpauseContractUntil_revertsIfNotPaused() public {
+        _grantPauseUntilRoles();
+        vm.prank(unpauseUntilUnpauser);
+        vm.expectRevert(PausableUntil.ContractNotPausedUntil.selector);
+        weEthInstance.unpauseContractUntil();
+    }
+
+    function test_WeETH_pauseContractUntil_revertsIfAlreadyPaused() public {
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, _weETHPausedUntil())
+        );
+        weEthInstance.pauseContractUntil();
+    }
+
+    function test_WeETH_pauseContractUntil_cooldownEnforced() public {
+        _grantPauseUntilRoles();
+
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        weEthInstance.unpauseContractUntil();
+
+        // Past MAX_PAUSE_DURATION but inside cooldown window — should still revert.
+        vm.warp(block.timestamp + weEthInstance.MAX_PAUSE_DURATION() + 1);
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(PausableUntil.PauserCooldownStillActive.selector);
+        weEthInstance.pauseContractUntil();
+
+        vm.warp(block.timestamp + weEthInstance.PAUSER_UNTIL_COOLDOWN());
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+    }
+
+    // ---- pause-until blocks every token movement ----------------------------
+
+    function test_WeETH_wrap_revertsWhenPausedUntil() public {
+        _aliceWithEEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+        uint256 pausedUntilTs = _weETHPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.wrap(1 ether);
+    }
+
+    function test_WeETH_unwrap_revertsWhenPausedUntil() public {
+        _aliceWithWeEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+        uint256 pausedUntilTs = _weETHPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.unwrap(0.5 ether);
+    }
+
+    function test_WeETH_transfer_revertsWhenPausedUntil() public {
+        _aliceWithWeEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+        uint256 pausedUntilTs = _weETHPausedUntil();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.transfer(bob, 0.5 ether);
+    }
+
+    function test_WeETH_transferFrom_revertsWhenPausedUntil() public {
+        _aliceWithWeEth(1 ether);
+        vm.prank(alice);
+        weEthInstance.approve(bob, 1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+        uint256 pausedUntilTs = _weETHPausedUntil();
+
+        vm.prank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUntil.ContractPausedUntil.selector, pausedUntilTs)
+        );
+        weEthInstance.transferFrom(alice, bob, 0.5 ether);
+    }
+
+    // ---- recovery paths -----------------------------------------------------
+
+    function test_WeETH_transfer_unblockedAfterPauseExpires() public {
+        _aliceWithWeEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        vm.warp(block.timestamp + weEthInstance.MAX_PAUSE_DURATION() + 1);
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 0.5 ether);
+        assertEq(weEthInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    function test_WeETH_transfer_unblockedAfterManualUnpause() public {
+        _aliceWithWeEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        vm.prank(unpauseUntilUnpauser);
+        weEthInstance.unpauseContractUntil();
+
+        vm.prank(alice);
+        weEthInstance.transfer(bob, 0.5 ether);
+        assertEq(weEthInstance.balanceOf(bob), 0.5 ether);
+    }
+
+    function test_WeETH_wrap_unblockedAfterPauseExpires() public {
+        _aliceWithEEth(1 ether);
+
+        _grantPauseUntilRoles();
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+
+        vm.warp(block.timestamp + weEthInstance.MAX_PAUSE_DURATION() + 1);
+
+        vm.prank(alice);
+        weEthInstance.wrap(1 ether);
+        assertGt(weEthInstance.balanceOf(alice), 0);
+    }
+
+    // ---- setPauseUntilDuration role gating ----------------------------------
+
+    function test_WeETH_setPauseUntilDuration_requiresRole() public {
+        _grantPauseUntilRoles();
+        uint256 maxDur = weEthInstance.MAX_PAUSE_DURATION();
+
+        vm.prank(bob);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.setPauseUntilDuration(maxDur);
+
+        // PAUSE_UNTIL_ROLE alone is insufficient.
+        vm.prank(pauseUntilPauser);
+        vm.expectRevert(WeETH.IncorrectRole.selector);
+        weEthInstance.setPauseUntilDuration(maxDur);
+    }
+
+    function test_WeETH_setPauseUntilDuration_setsValue() public {
+        _grantPauseUntilRoles();
+        uint256 d = weEthInstance.MIN_PAUSE_DURATION() + 1 hours;
+
+        vm.prank(pauseUntilDurationSetter);
+        weEthInstance.setPauseUntilDuration(d);
+
+        vm.prank(pauseUntilPauser);
+        weEthInstance.pauseContractUntil();
+        assertEq(weEthInstance.pausedUntil(), block.timestamp + d);
+    }
+
+    function test_WeETH_setPauseUntilDuration_revertsOnInvalidValue() public {
+        _grantPauseUntilRoles();
+        uint256 belowMin = weEthInstance.MIN_PAUSE_DURATION() - 1;
+        uint256 aboveMax = weEthInstance.MAX_PAUSE_DURATION() + 1;
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        weEthInstance.setPauseUntilDuration(belowMin);
+
+        vm.prank(pauseUntilDurationSetter);
+        vm.expectRevert(PausableUntil.InvalidPauseUntilDuration.selector);
+        weEthInstance.setPauseUntilDuration(aboveMax);
+    }
+
+    // ---- spender (msg.sender) blacklist on transferFrom ---------------------
+    // `_beforeTokenTransfer` now blacklist-checks msg.sender in addition to
+    // from/to, so a blacklisted spender cannot move tokens even between clean
+    // parties.
+
+    function test_WeETH_transferFrom_revertsWhenSpenderBlacklisted() public {
+        address spender = vm.addr(0xCAFE);
+
+        _aliceWithWeEth(1 ether);
+        vm.prank(alice);
+        weEthInstance.approve(spender, 1 ether);
+
+        vm.prank(owner);
+        blacklisterInstance.blacklistUser(spender);
+
+        vm.prank(spender);
+        _expectBlacklistedRevert(spender);
+        weEthInstance.transferFrom(alice, bob, 0.5 ether);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core token transfer/mint/burn gating by extending `pauseContractUntil` to block all movements and by adding `msg.sender` blacklist checks, which can affect integrations relying on `transferFrom`/wrapping behavior. Test coverage is expanded, but any mistake could temporarily freeze legitimate flows or change revert behavior.
> 
> **Overview**
> **Extends the time-based pause (`PausableUntil`) to fully halt token movement.** In `EETH`, the pause-until check is moved into `whenNotPaused`, so `pauseContractUntil` now blocks `transfer`/`transferFrom` in addition to `mintShares`/`burnShares`.
> 
> **Hardens blacklist enforcement for delegated transfers.** Both `EETH` share transfers and `WeETH` ERC20 transfers now also require `blacklister.nonBlacklisted(msg.sender)`, preventing a blacklisted spender from using `transferFrom` even if `from`/`to` are clean.
> 
> **Adds pause-until support to `WeETH` plus tests.** `WeETH` now inherits `PausableUntil`, exposes role-gated `pauseContractUntil`/`unpauseContractUntil`/`setPauseUntilDuration`, and `_beforeTokenTransfer` enforces the new pause-until gate; tests are updated/added to cover pause-until behavior and spender-blacklist reverts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb74796044adec60c260c3cd2853be66be663f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->