### PR TITLE
tests: pin LP withdraw(amount, rate) behavior before share-rate-freeze refinement (PR A of 2)

### DIFF
--- a/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
+++ b/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
@@ -256,7 +256,7 @@ contract PriorityQueueTransactions is Script, Utils {
 
         LiquidityPool newLiquidityPoolImpl = new LiquidityPool(priorityWithdrawalQueueProxy, address(0), 0);
         PriorityWithdrawalQueue newPWQImpl = new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_MIN_DELAY
+            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_MIN_DELAY, 0, 4e18
         );
         EtherFiRedemptionManager newRedemptionManagerImpl = new EtherFiRedemptionManager(
             LIQUIDITY_POOL, EETH, WEETH, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, ROLE_REGISTRY, ETHERFI_RESTAKER, priorityWithdrawalQueueProxy, address(0), 10_000, 100, 10_000

--- a/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
+++ b/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
@@ -256,7 +256,7 @@ contract PriorityQueueTransactions is Script, Utils {
 
         LiquidityPool newLiquidityPoolImpl = new LiquidityPool(priorityWithdrawalQueueProxy, address(0), 0);
         PriorityWithdrawalQueue newPWQImpl = new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_MIN_DELAY, 0, 4e18
+            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_MIN_DELAY, 1, 4e18
         );
         EtherFiRedemptionManager newRedemptionManagerImpl = new EtherFiRedemptionManager(
             LIQUIDITY_POOL, EETH, WEETH, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, ROLE_REGISTRY, ETHERFI_RESTAKER, priorityWithdrawalQueueProxy, address(0), 10_000, 100, 10_000

--- a/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
+++ b/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
@@ -207,7 +207,7 @@ contract ReauditFixesTransactions is Utils {
         EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(EIGENLAYER_REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER), address(ROLE_REGISTRY), address(ETHERFI_RATE_LIMITER));
         EtherFiRewardsRouter newEtherFiRewardsRouterImplementation = new EtherFiRewardsRouter(address(LIQUIDITY_POOL), address(TREASURY), address(ROLE_REGISTRY));
         Liquifier newLiquifierImplementation = new Liquifier(address(ROLE_REGISTRY), 0x86392dC19c0b719886221c78AB11eb8Cf5c52812, address(0x0), 100, 24 hours, 500);
-        WithdrawRequestNFT newWithdrawRequestNFTImplementation = new WithdrawRequestNFT(address(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE), address(0x0), 0, 2e18);
+        WithdrawRequestNFT newWithdrawRequestNFTImplementation = new WithdrawRequestNFT(address(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE), address(0x0), 1, 4e18);
         EtherFiViewer newEtherFiViewerImplementation = new EtherFiViewer(address(EIGENLAYER_POD_MANAGER), address(EIGENLAYER_DELEGATION_MANAGER));
 
         contractCodeChecker.verifyContractByteCodeMatch(etherFiNodeImpl, address(newEtherFiNodeImplementation));

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -134,6 +134,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     error InvalidValidatorSize();
     error InvalidArrayLengths();
     error InvalidAmountForShare();
+    error InvalidRate();
 
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
@@ -277,20 +278,21 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
     /// @notice Settles a finalized claim for withdrawRequestNFT or priorityWithdrawalQueue against
     ///         the rate snapshotted at finalize/fulfill time. Caller supplies the rate; LP derives
-    ///         the share burn from it. A `_rate` of 0 means the caller has no snapshot (pre-upgrade
-    ///         legacy request) and asks LP to use the live rate. ETH was already segregated to the
-    ///         caller at finalize/fulfill via `addEthAmountLockedForWithdrawal` / `transferLockedEthForPriority`,
-    ///         so LP only performs accounting (burn + `totalValueOutOfLp -=`); the caller pays the
-    ///         user from its own balance.
+    ///         the share burn from it. ETH was already segregated to the caller at finalize/fulfill
+    ///         via `addEthAmountLockedForWithdrawal` / `transferLockedEthForPriority`, so LP only
+    ///         performs accounting (burn + `totalValueOutOfLp -=`); the caller pays the user from
+    ///         its own balance.
+    /// @dev    `_rate == 0` is rejected — callers (WRNFT / Queue) are responsible for resolving
+    ///         any pre-upgrade legacy snapshot to a live rate locally via `amountPerShareCeil()`
+    ///         before invoking this function. Single codepath: one ceiling math expression.
     function withdraw(uint256 _amount, uint256 _rate) external nonReentrant returns (uint256) {
         if (msg.sender != address(withdrawRequestNFT) && msg.sender != priorityWithdrawalQueue) {
             revert IncorrectCaller();
         }
         if (_amount > type(uint128).max || _amount == 0) revert InvalidAmount();
+        if (_rate == 0) revert InvalidRate();
 
-        uint256 share = _rate == 0
-            ? sharesForWithdrawalAmount(_amount)
-            : Math.mulDiv(_amount, SHARE_UNIT, _rate, Math.Rounding.Up); // rounding favors the protocol
+        uint256 share = Math.mulDiv(_amount, SHARE_UNIT, _rate, Math.Rounding.Up); // rounding favors the protocol
         if (share == 0) revert InvalidAmount();
         if (eETH.shares(msg.sender) < share) revert InsufficientLiquidity();
 

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -65,6 +65,9 @@ contract PriorityWithdrawalQueue is
     address public immutable treasury;
     uint32 public immutable MIN_DELAY;
 
+    uint256 public immutable minAcceptableShareRate;
+    uint256 public immutable maxAcceptableShareRate;
+
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
@@ -146,6 +149,8 @@ contract PriorityWithdrawalQueue is
     error InvalidEEthSharesAfterRemainderHandling();
     error InvalidOutputAmount();
     error InsufficientLiquidity();
+    error InvalidAcceptableShareRate();
+    error InvalidLiveRate();
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
@@ -182,10 +187,11 @@ contract PriorityWithdrawalQueue is
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _liquidityPool, address _eETH, address _weETH, address _roleRegistry, address _treasury, uint32 _minDelay) {
+    constructor(address _liquidityPool, address _eETH, address _weETH, address _roleRegistry, address _treasury, uint32 _minDelay, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) {
         if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _roleRegistry == address(0) || _treasury == address(0)) {
             revert AddressZero();
         }
+        if (_maxAcceptableShareRate <= _minAcceptableShareRate) revert InvalidAcceptableShareRate();
         
         liquidityPool = ILiquidityPool(_liquidityPool);
         eETH = IeETH(_eETH);
@@ -193,6 +199,9 @@ contract PriorityWithdrawalQueue is
         roleRegistry = IRoleRegistry(_roleRegistry);
         treasury = _treasury;
         MIN_DELAY = _minDelay;
+
+        minAcceptableShareRate = _minAcceptableShareRate;
+        maxAcceptableShareRate = _maxAcceptableShareRate;
 
         _disableInitializers();
     }
@@ -648,16 +657,7 @@ contract PriorityWithdrawalQueue is
         
         if (!_finalizedRequests.contains(requestId)) revert RequestNotFinalized();
 
-        uint224 frozenRate = _fulfillmentRates[requestId];
-        if (frozenRate == 0) {
-            // Pre-upgrade legacy request (fulfilled before the share-rate-freeze upgrade) —
-            // resolve to the live rate locally so claim semantics match the pre-upgrade behavior.
-            // LP itself rejects rate=0; the resolved rate is what we pass through.
-            uint256 live = liquidityPool.amountPerShareCeil();
-            require(live > 0 && live <= type(uint224).max, "invalid live rate");
-            frozenRate = uint224(live);
-        }
-
+        uint224 frozenRate = _getFrozenRate(requestId);
         // Solvency check against the resolved rate (frozen for new requests, live for legacy).
         uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
         if (amountForShares < request.amountWithFee) revert InvalidOutputAmount();
@@ -691,6 +691,18 @@ contract PriorityWithdrawalQueue is
         _checkEthAmountLockedForPriorityWithdrawal();
 
         emit WithdrawRequestClaimed(requestId, request.user, uint96(amountToWithdraw), uint96(burnedShares), request.nonce, uint32(block.timestamp));
+    }
+
+    function _getFrozenRate(bytes32 requestId) internal view returns (uint224 frozenRate) {
+        frozenRate = _fulfillmentRates[requestId];
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request (fulfilled before the share-rate-freeze upgrade) —
+            // resolve to the live rate locally so claim semantics match the pre-upgrade behavior.
+            // LP itself rejects rate=0; the resolved rate is what we pass through.
+            uint256 live = liquidityPool.amountPerShareCeil();
+            if (live < minAcceptableShareRate || live > maxAcceptableShareRate) revert InvalidLiveRate();
+            frozenRate = uint224(live);
+        }
     }
 
     function _checkEthAmountLockedForPriorityWithdrawal() internal {
@@ -755,13 +767,7 @@ contract PriorityWithdrawalQueue is
         bytes32 requestId = keccak256(abi.encode(request));
         if (!_finalizedRequests.contains(requestId)) return 0;
 
-        uint224 frozenRate = _fulfillmentRates[requestId];
-        if (frozenRate == 0) {
-            // Pre-upgrade legacy request — live-rate fallback (mirrors `_claimWithdraw`).
-            uint256 live = liquidityPool.amountPerShareCeil();
-            if (live == 0 || live > type(uint224).max) return 0;
-            frozenRate = uint224(live);
-        }
+        uint224 frozenRate = _getFrozenRate(requestId);
         uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
         if (amountForShares < request.amountWithFee) return 0;
 

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -149,6 +149,7 @@ contract PriorityWithdrawalQueue is
     error InvalidEEthSharesAfterRemainderHandling();
     error InvalidOutputAmount();
     error InsufficientLiquidity();
+    error InvalidMinAcceptableShareRate();
     error InvalidAcceptableShareRate();
     error InvalidLiveRate();
 
@@ -191,6 +192,7 @@ contract PriorityWithdrawalQueue is
         if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _roleRegistry == address(0) || _treasury == address(0)) {
             revert AddressZero();
         }
+        if (_minAcceptableShareRate == 0) revert InvalidMinAcceptableShareRate();
         if (_maxAcceptableShareRate <= _minAcceptableShareRate) revert InvalidAcceptableShareRate();
         
         liquidityPool = ILiquidityPool(_liquidityPool);

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -15,10 +15,26 @@ import "./interfaces/IWeETH.sol";
 import "./interfaces/IRoleRegistry.sol";
 import "./utils/PausableUntil.sol";
 
-/// @title PriorityWithdrawalQueue
-/// @notice Manages priority withdrawals for whitelisted users
-/// @dev Implements priority withdrawal queue pattern
-contract PriorityWithdrawalQueue is 
+/// @title PriorityWithdrawalQueue — share-rate-freeze invariants
+/// @notice Manages priority withdrawals for whitelisted users.
+///
+/// Once `fulfillRequests` runs for a requestId, the rate used to compute its claim payout
+/// is frozen at the rate snapshotted in that fulfill call. Subsequent rebases do NOT move
+/// the claim payout — this is the H-02 fix on the priority path.
+///
+/// Invariants:
+///  I1. `_fulfillmentRates[requestId]` is set on fulfill, cleared on claim/cancel/invalidate.
+///      A non-zero value implies the request is in `_finalizedRequests`.
+///  I2. For a finalized requestId, the resolved rate (`_fulfillmentRates[requestId]` or, for
+///      pre-upgrade legacy fulfillments, `LP.amountPerShareCeil()` substituted locally) is
+///      always non-zero — LP itself rejects rate=0.
+///  I3. For any finalized requestId, `getClaimableAmount(request)` and the user-visible
+///      `claimWithdraw` payout are invariant under `LP.rebase()` after the fulfill block.
+///      Property-tested via `test_invariant_queue_claimAmountIndependentOfPostFulfillRebase`.
+///  I4. The rate snapshot uses ceiling rounding (`Math.mulDiv(1e18, TPE, TS, Up)`) so the
+///      per-request solvency check (`shareOfEEth * rate / 1e18 >= amountWithFee`) and the
+///      round-trip burn (`ceil(amountWithFee * 1e18 / rate) <= shareOfEEth`) both hold.
+contract PriorityWithdrawalQueue is
     Initializable, 
     UUPSUpgradeable, 
     ReentrancyGuardUpgradeable,
@@ -67,9 +83,11 @@ contract PriorityWithdrawalQueue is
     uint96 public totalRemainderShares;
     uint128 public ethAmountLockedForPriorityWithdrawal;
 
-    /// @notice Frozen share rate (amountForShare(_SHARE_UNIT)) recorded when each request was fulfilled.
-    /// @dev Empty mapping value (0) means "use live rate" — covers pre-upgrade requests fulfilled
-    ///      before the share-rate-freeze upgrade.
+    /// @notice Frozen share rate (`amountPerShareCeil()`) recorded when each request was fulfilled.
+    /// @dev Empty mapping value (0) means "no snapshot" — covers pre-upgrade requests fulfilled
+    ///      before the share-rate-freeze upgrade. The claim/view paths locally substitute the
+    ///      live `LP.amountPerShareCeil()` for those entries, preserving legacy semantics.
+    ///      LP itself rejects rate=0.
     mapping(bytes32 => uint224) private _fulfillmentRates;
 
     //--------------------------------------------------------------------------------------
@@ -631,11 +649,17 @@ contract PriorityWithdrawalQueue is
         if (!_finalizedRequests.contains(requestId)) revert RequestNotFinalized();
 
         uint224 frozenRate = _fulfillmentRates[requestId];
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request (fulfilled before the share-rate-freeze upgrade) —
+            // resolve to the live rate locally so claim semantics match the pre-upgrade behavior.
+            // LP itself rejects rate=0; the resolved rate is what we pass through.
+            uint256 live = liquidityPool.amountPerShareCeil();
+            require(live > 0 && live <= type(uint224).max, "invalid live rate");
+            frozenRate = uint224(live);
+        }
 
-        // Solvency check against the rate frozen at fulfill (or live, for pre-upgrade requests).
-        uint256 amountForShares = frozenRate == 0
-            ? liquidityPool.amountForShare(request.shareOfEEth)
-            : Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
+        // Solvency check against the resolved rate (frozen for new requests, live for legacy).
+        uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
         if (amountForShares < request.amountWithFee) revert InvalidOutputAmount();
 
         uint128 amountToWithdraw = request.amountWithFee;
@@ -647,9 +671,10 @@ contract PriorityWithdrawalQueue is
 
         uint256 burnedShares = liquidityPool.withdraw(amountToWithdraw, uint256(frozenRate));
         // With `amountWithFee <= shareOfEEth * rate / 1e18` enforced at fulfill (frozen path)
-        // or by the live solvency check above (legacy path), the round-trip ceiling division
-        // satisfies `burnedShares <= request.shareOfEEth` by construction. Pin that invariant
-        // explicitly — a violation would imply a precision bug, not a routine rounding artifact.
+        // or by the live solvency check above (legacy path, resolved to live rate locally),
+        // the round-trip ceiling division satisfies `burnedShares <= request.shareOfEEth` by
+        // construction. Pin that invariant explicitly — a violation would imply a precision
+        // bug, not a routine rounding artifact.
         if (burnedShares > request.shareOfEEth) revert InvalidBurnedSharesAmount();
         totalRemainderShares += uint96(request.shareOfEEth - burnedShares);
 
@@ -731,9 +756,13 @@ contract PriorityWithdrawalQueue is
         if (!_finalizedRequests.contains(requestId)) return 0;
 
         uint224 frozenRate = _fulfillmentRates[requestId];
-        uint256 amountForShares = frozenRate == 0
-            ? liquidityPool.amountForShare(request.shareOfEEth)
-            : Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request — live-rate fallback (mirrors `_claimWithdraw`).
+            uint256 live = liquidityPool.amountPerShareCeil();
+            if (live == 0 || live > type(uint224).max) return 0;
+            frozenRate = uint224(live);
+        }
+        uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
         if (amountForShares < request.amountWithFee) return 0;
 
         return request.amountWithFee;

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -103,6 +103,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _treasury, address _blacklister, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) {
+        require(_minAcceptableShareRate > 0, "Invalid min acceptable share rate");
         require(_maxAcceptableShareRate > _minAcceptableShareRate, "Invalid min and max acceptable share rate");
         treasury = _treasury;
         blacklister = IBlacklister(_blacklister);

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -19,6 +19,27 @@ import "./utils/PausableUntil.sol";
 
 
 
+/// @title WithdrawRequestNFT — share-rate-freeze invariants
+/// @notice
+/// Once `finalizeRequests(lastRequestId)` runs, the rate used to compute the claim payout
+/// for tokenIds <= lastRequestId is frozen at the rate snapshotted in that finalize batch.
+/// Subsequent rebases do NOT move the claim payout — this is the H-02 fix.
+///
+/// Invariants:
+///  I1. `_finalizationRates` keys are strictly increasing. Enforced by the
+///      `requestId > lastFinalizedRequestId` guard in `finalizeRequests` and by
+///      `Checkpoints.push` semantics.
+///  I2. `_finalizationRates.lowerLookup(tokenId)` returns the rate of the smallest
+///      finalize batch covering `tokenId`. For pre-upgrade legacy tokenIds, it returns 0
+///      (the sentinel); the claim path locally substitutes `LP.amountPerShareCeil()` for
+///      backwards compatibility with old semantics. LP itself rejects rate=0.
+///  I3. For any finalized `tokenId`, `getClaimableAmount(tokenId)` is invariant under
+///      `LP.rebase()` after the finalize block. Property-tested via
+///      `test_invariant_claimAmountIndependentOfPostFinalizeRebase`.
+///  I4. The rate snapshot uses ceiling rounding (`Math.mulDiv(1e18, TPE, TS, Up)`) so
+///      `shareOfEEth * rate / 1e18 >= LP.amountForShare(shareOfEEth)` and
+///      `ceil(amount * 1e18 / rate) <= shareOfEEth`. These keep solvency checks and
+///      the share burn within the request's own share allocation.
 contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardNamespaced, PausableUntil, IWithdrawRequestNFT {
     using Math for uint256;
     using SafeERC20 for IERC20;
@@ -53,9 +74,10 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     uint128 public ethAmountLockedForWithdrawal;
 
-    // (requestId upperBound => amountForShare(1e18) at finalize time).
+    // (requestId upperBound => amountPerShareCeil(1e18) at finalize time).
     // A value of 0 marks a "legacy" range that pre-dates the share-rate-freeze upgrade;
-    // the claim path falls back to the live rate for those tokenIds.
+    // `_getClaimableAmount` locally substitutes `LP.amountPerShareCeil()` for those tokenIds,
+    // preserving the pre-upgrade live-rate-at-claim semantics. LP itself rejects rate=0.
     Checkpoints.Trace224 private _finalizationRates;
 
     bytes32 public constant WITHDRAW_REQUEST_NFT_ADMIN_ROLE = keccak256("WITHDRAW_REQUEST_NFT_ADMIN_ROLE");
@@ -124,8 +146,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @notice One-time initializer for the share-rate-freeze upgrade.
     /// @dev Pushes a sentinel checkpoint at the current `lastFinalizedRequestId` with value 0.
     ///      Every requestId <= that key looks up to this sentinel (value 0), which the claim
-    ///      path treats as "fall back to live rate" — preserving legacy behavior for requests
-    ///      that were finalized before this upgrade. New finalizations push real rate snapshots.
+    ///      path resolves locally to the live rate via `LP.amountPerShareCeil()` — preserving
+    ///      legacy behavior for requests finalized before this upgrade. New finalizations push
+    ///      real rate snapshots, so post-upgrade tokenIds always resolve to a non-zero rate.
     function initializeShareRateFreezeUpgrade() external onlyOwner {
         require(_finalizationRates.length() == 0, "already initialized");
         _finalizationRates.push(uint32(lastFinalizedRequestId), 0);
@@ -162,9 +185,11 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     /// @dev Returns `(amountToTransfer, fee, frozenRate)`. `frozenRate` is the rate snapshotted
-    ///      at the request's finalize batch, or 0 for pre-upgrade legacy requests (covered only
-    ///      by the sentinel checkpoint). Callers passing `frozenRate` along to `LP.withdraw` get
-    ///      the live-rate fallback for free — LP treats `rate == 0` as "use live rate".
+    ///      at the request's finalize batch. For pre-upgrade legacy requests (covered only by the
+    ///      sentinel checkpoint with value 0), the live rate from `LP.amountPerShareCeil()` is
+    ///      substituted locally — preserving legacy claim semantics (live-rate at claim). The
+    ///      returned `frozenRate` is therefore guaranteed non-zero, which is what `LP.withdraw`
+    ///      now requires (`InvalidRate` reverts on zero).
     function _getClaimableAmount(uint256 tokenId) internal view returns (uint256, uint256, uint224) {
         require(tokenId <= lastFinalizedRequestId, "Request is not finalized");
         require(ownerOf(tokenId) != address(0), "Already Claimed");
@@ -173,9 +198,16 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
         // Smallest checkpoint whose key >= tokenId — the finalization batch this request belongs to.
         uint224 frozenRate = _finalizationRates.lowerLookup(uint32(tokenId));
-        uint256 amountForShares = frozenRate == 0
-            ? liquidityPool.amountForShare(request.shareOfEEth)
-            : Math.mulDiv(uint256(request.shareOfEEth), frozenRate, SHARE_UNIT);
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request — sentinel returned 0. Fall back to the live rate so
+            // claim semantics match the pre-upgrade behavior. New (post-upgrade) finalizations
+            // always push a non-zero snapshot, so this branch only fires for legacy tokenIds.
+            uint256 live = liquidityPool.amountPerShareCeil();
+            require(live > 0 && live <= type(uint224).max, "invalid live rate");
+            frozenRate = uint224(live);
+        }
+
+        uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, SHARE_UNIT);
 
         // send the lesser value of the originally requested amount of eEth or the frozen-rate value of the shares
         uint256 amountToTransfer = Math.min(request.amountOfEEth, amountForShares);
@@ -192,8 +224,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     
     /// @dev Pays the recipient from this contract's own ETH balance (segregated at finalize via
     ///      LP.addEthAmountLockedForWithdrawal). Burns shares against the rate frozen at finalize
-    ///      via `LP.withdraw(amount, rate)` (a `frozenRate` of 0 — pre-upgrade requests — asks LP
-    ///      to fall back to the live rate, matching legacy behavior).
+    ///      via `LP.withdraw(amount, rate)`. `_getClaimableAmount` always resolves `frozenRate` to
+    ///      a non-zero value (live-rate fallback for pre-upgrade legacy ids), satisfying LP's
+    ///      `InvalidRate` guard.
     function _claimWithdraw(uint256 tokenId, address recipient) internal {
         require(ownerOf(tokenId) == msg.sender, "Not the owner of the NFT");
         IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -203,7 +203,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
             // claim semantics match the pre-upgrade behavior. New (post-upgrade) finalizations
             // always push a non-zero snapshot, so this branch only fires for legacy tokenIds.
             uint256 live = liquidityPool.amountPerShareCeil();
-            require(live > 0 && live <= type(uint224).max, "invalid live rate");
+            require(live >= minAcceptableShareRate && live <= maxAcceptableShareRate, "invalid live rate");
             frozenRate = uint224(live);
         }
 

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -942,10 +942,12 @@ contract LiquidityPoolTest is TestSetup {
             address(liquidityPoolInstance).call{value: 10 ether}("");
 
             // Try to withdraw more eETH than the NFT escrow holds via the segregated entry.
-            // Rate = 0 routes through the live-rate fallback inside the (amount, rate) overload.
+            // Use the live rate so we exercise the InsufficientLiquidity branch (rate=0 would
+            // be rejected by LP's `InvalidRate` guard before the solvency check).
+            uint256 liveRate = liquidityPoolInstance.amountPerShareCeil();
             vm.startPrank(address(withdrawRequestNFTInstance));
             vm.expectRevert(LiquidityPool.InsufficientLiquidity.selector);
-            liquidityPoolInstance.withdraw(withdrawAmount * 2, uint256(0));
+            liquidityPoolInstance.withdraw(withdrawAmount * 2, liveRate);
             vm.stopPrank();
         } else {
             vm.stopPrank();
@@ -1885,10 +1887,11 @@ contract LiquidityPoolTest is TestSetup {
         uint128 lpOutBefore        = liquidityPoolInstance.totalValueOutOfLp();
         uint256 lockedBefore       = withdrawRequestNFTInstance.ethAmountLockedForWithdrawal();
 
-        // Rate = 0 routes through the live-rate fallback inside the (amount, rate) overload,
-        // matching the original test's coverage of the segregated branch.
+        // Use the live rate via `amountPerShareCeil()` — the canonical snapshot LP exposes for
+        // consumers. `rate=0` is no longer accepted; consumers resolve legacy snapshots locally.
+        uint256 liveRate = liquidityPoolInstance.amountPerShareCeil();
         vm.prank(address(withdrawRequestNFTInstance));
-        liquidityPoolInstance.withdraw(amount, uint256(0));
+        liquidityPoolInstance.withdraw(amount, liveRate);
 
         assertEq(address(liquidityPoolInstance).balance, lpEthBefore, "LP ETH should not change on segregated withdraw");
         assertEq(address(withdrawRequestNFTInstance).balance, nftEthBefore, "NFT ETH unchanged by LP withdraw(amount, rate) alone");
@@ -1944,27 +1947,23 @@ contract LiquidityPoolTest is TestSetup {
         assertGt(s2, 0, "max amount / max rate");
     }
 
-    /// @dev `rate == 0` selects the live-rate fallback inside the (amount, rate) overload.
-    ///      Confirms parity with `sharesForWithdrawalAmount` at the current state.
-    function testFuzz_withdrawWithRate_zeroRateUsesLive(uint96 rawAmount) public {
-        uint96 amount = uint96(bound(rawAmount, 1 wei, 100 ether));
-
-        // Deposit so eETH shares exist; transfer to NFT.
+    /// @dev `rate == 0` is rejected by LP — consumers (WRNFT / Queue) are required to resolve
+    ///      pre-upgrade legacy snapshots to a live rate locally via `amountPerShareCeil()`
+    ///      before invoking the (amount, rate) overload. Pins the InvalidRate revert.
+    function test_withdrawWithRate_zeroRateReverts_InvalidRate() public {
+        // Deposit so eETH shares exist; transfer to NFT so the solvency precondition is met.
         vm.deal(alice, 1000 ether);
         vm.prank(alice);
         liquidityPoolInstance.deposit{value: 1000 ether}();
         vm.prank(alice);
-        eETHInstance.transfer(address(withdrawRequestNFTInstance), amount);
-
-        uint256 expectedShare = liquidityPoolInstance.sharesForWithdrawalAmount(amount);
-        if (expectedShare == 0) return;
+        eETHInstance.transfer(address(withdrawRequestNFTInstance), 1 ether);
 
         vm.prank(address(etherFiAdminInstance));
-        liquidityPoolInstance.addEthAmountLockedForWithdrawal(amount);
+        liquidityPoolInstance.addEthAmountLockedForWithdrawal(uint128(1 ether));
 
         vm.prank(address(withdrawRequestNFTInstance));
-        uint256 burned = liquidityPoolInstance.withdraw(uint256(amount), uint256(0));
-        assertEq(burned, expectedShare, "rate=0 path must match sharesForWithdrawalAmount");
+        vm.expectRevert(LiquidityPool.InvalidRate.selector);
+        liquidityPoolInstance.withdraw(uint256(1 ether), uint256(0));
     }
 
     function test_initializeOnUpgradeV2_sweepsLockedEth() public {

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -2434,4 +2434,143 @@ contract LiquidityPoolTest is TestSetup {
         liquidityPoolInstance.requestWithdraw(bob, large);
         vm.stopPrank();
     }
+
+    // ───────────────────────────────────────────────────────────────────────────
+    // LP.withdraw(amount, rate) — PR A coverage for the OZ Math.mulDiv(Up) swap
+    //
+    // The implementation already uses `Math.mulDiv(_amount, 1e18, _rate, Math.Rounding.Up)`
+    // (replacing a hand-rolled `(a * 1e18 + r - 1) / r` ceiling). These tests pin:
+    //   1. rate>0 path matches mulDiv(Up) on the *actual* contract call
+    //   2. ceiling round-trip: burned_shares * rate / 1e18 >= amount
+    //   3. concrete edge case amount=1, rate=1.5e18 → burns 1 share (ceiling kicks in)
+    //   4. solvency revert when caller's shares < computed burn
+    //   5. access control consistency: random EOA + cross-overload calls both revert
+    //      with `IncorrectCaller`
+    // ───────────────────────────────────────────────────────────────────────────
+
+    /// @dev Helper: seeds the NFT escrow with `amount` eETH shares so the (amount, rate)
+    ///      overload's solvency check (`eETH.shares(msg.sender) >= share`) is satisfied,
+    ///      and increments `totalValueOutOfLp` so the burn accounting doesn't underflow.
+    function _seedNftEscrow(uint256 depositAmount, uint128 lockAmount) internal {
+        vm.deal(alice, depositAmount);
+        vm.startPrank(alice);
+        liquidityPoolInstance.deposit{value: depositAmount}();
+        eETHInstance.transfer(address(withdrawRequestNFTInstance), depositAmount);
+        vm.stopPrank();
+
+        vm.prank(address(etherFiAdminInstance));
+        liquidityPoolInstance.addEthAmountLockedForWithdrawal(lockAmount);
+    }
+
+    /// @dev Rate>0 path: the actual contract burns exactly `Math.mulDiv(amount, 1e18, rate, Up)`.
+    function test_withdrawWithRate_rateNonZero_burnMatchesMulDivUp() public {
+        uint128 amount = 7 ether;
+        uint256 rate   = 1.234e18; // arbitrary non-unit rate
+        uint256 expectedBurn = Math.mulDiv(uint256(amount), 1e18, rate, Math.Rounding.Up);
+
+        // Seed the NFT with enough shares to cover the burn.
+        _seedNftEscrow(100 ether, amount);
+
+        uint256 sharesBefore = eETHInstance.shares(address(withdrawRequestNFTInstance));
+
+        vm.prank(address(withdrawRequestNFTInstance));
+        uint256 burned = liquidityPoolInstance.withdraw(uint256(amount), rate);
+
+        assertEq(burned, expectedBurn, "burned shares must equal mulDiv(amount, 1e18, rate, Up)");
+        assertEq(
+            sharesBefore - eETHInstance.shares(address(withdrawRequestNFTInstance)),
+            expectedBurn,
+            "NFT share delta must equal the mulDiv(Up) burn"
+        );
+
+        // Ceiling round-trip: the eETH value recovered from `burned` shares at the
+        // snapshotted rate must be >= the amount the caller withdrew. The protocol
+        // never under-collects eETH for a given ETH payout.
+        assertGe(
+            Math.mulDiv(burned, rate, 1e18, Math.Rounding.Down),
+            uint256(amount),
+            "ceiling round-trip: burned * rate / 1e18 >= amount"
+        );
+    }
+
+    /// @dev Concrete edge case: `amount = 1 wei, rate = 1.5e18`.
+    ///      Hand math: ceil(1 * 1e18 / 1.5e18) = ceil(0.666...) = 1.
+    ///      The old hand-rolled `(1 * 1e18 + 1.5e18 - 1) / 1.5e18` also gives 1, but the
+    ///      mulDiv variant is the audited form. Pin the value so a future refactor that
+    ///      drops the ceiling fails this test.
+    function test_withdrawWithRate_edge_oneWeiAtRate1p5_burnsOneShare() public {
+        uint256 amount = 1; // 1 wei
+        uint256 rate   = 1.5e18;
+
+        uint256 expected = Math.mulDiv(amount, 1e18, rate, Math.Rounding.Up);
+        assertEq(expected, 1, "precondition: ceiling rounds 0.666... up to 1");
+
+        // Seed NFT with > 1 share (deposit a small amount, transfer to NFT).
+        _seedNftEscrow(1 ether, uint128(amount));
+
+        uint256 nftSharesBefore = eETHInstance.shares(address(withdrawRequestNFTInstance));
+
+        vm.prank(address(withdrawRequestNFTInstance));
+        uint256 burned = liquidityPoolInstance.withdraw(amount, rate);
+
+        assertEq(burned, 1, "1 wei at rate 1.5e18 must burn exactly 1 share (ceiling)");
+        assertEq(
+            nftSharesBefore - eETHInstance.shares(address(withdrawRequestNFTInstance)),
+            1,
+            "NFT share delta is 1"
+        );
+    }
+
+    /// @dev Solvency check: if the caller (NFT) holds fewer shares than the computed burn,
+    ///      LP must revert `InsufficientLiquidity` — *before* touching state.
+    function test_withdrawWithRate_revertsWhenCallerHasInsufficientShares() public {
+        uint128 amount = 1 ether;
+
+        // Seed the NFT escrow normally so `addEthAmountLockedForWithdrawal` succeeds and
+        // there's *some* totalValueOutOfLp to support the call's accounting.
+        _seedNftEscrow(10 ether, amount);
+
+        // Now drain the NFT's eETH balance so it has fewer shares than the computed burn.
+        uint256 nftBalance = eETHInstance.balanceOf(address(withdrawRequestNFTInstance));
+        vm.prank(address(withdrawRequestNFTInstance));
+        eETHInstance.transfer(bob, nftBalance);
+        assertEq(eETHInstance.shares(address(withdrawRequestNFTInstance)), 0, "NFT drained");
+
+        // rate>0 path: any positive rate produces a positive burn; NFT has 0 shares.
+        vm.prank(address(withdrawRequestNFTInstance));
+        vm.expectRevert(LiquidityPool.InsufficientLiquidity.selector);
+        liquidityPoolInstance.withdraw(uint256(amount), 1e18);
+    }
+
+    /// @dev Random EOA must not be able to call the (amount, rate) overload.
+    function test_withdrawWithRate_randomEoaReverts_IncorrectCaller() public {
+        vm.prank(bob);
+        vm.expectRevert(LiquidityPool.IncorrectCaller.selector);
+        liquidityPoolInstance.withdraw(uint256(1 ether), uint256(1e18));
+    }
+
+    /// @dev Random EOA must not be able to call the (recipient, amount) overload.
+    ///      This duplicates `test_WithdrawFailsIfNotAuthorizedCaller` for completeness
+    ///      of the PR-A access-control matrix; explicit pairing with the new overload.
+    function test_withdrawLive_randomEoaReverts_IncorrectCaller() public {
+        vm.prank(bob);
+        vm.expectRevert(LiquidityPool.IncorrectCaller.selector);
+        liquidityPoolInstance.withdraw(bob, uint256(1 ether));
+    }
+
+    /// @dev WRNFT may not call the *live-rate* (recipient, amount) overload — that
+    ///      entry point is reserved for membershipManager / etherFiRedemptionManager.
+    function test_withdrawLive_wrnftReverts_IncorrectCaller() public {
+        vm.prank(address(withdrawRequestNFTInstance));
+        vm.expectRevert(LiquidityPool.IncorrectCaller.selector);
+        liquidityPoolInstance.withdraw(alice, uint256(1 ether));
+    }
+
+    /// @dev membershipManager may not call the *(amount, rate)* segregated overload —
+    ///      that entry point is reserved for withdrawRequestNFT / priorityWithdrawalQueue.
+    function test_withdrawWithRate_membershipManagerReverts_IncorrectCaller() public {
+        vm.prank(address(membershipManagerInstance));
+        vm.expectRevert(LiquidityPool.IncorrectCaller.selector);
+        liquidityPoolInstance.withdraw(uint256(1 ether), uint256(1e18));
+    }
 }

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -43,7 +43,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
             address(roleRegistryInstance),
             treasury,
             1 hours,
-            0,
+            1,
             4e18
         );
         UUPSProxy proxy = new UUPSProxy(
@@ -64,7 +64,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
         vm.stopPrank();
         vm.startPrank(wrnOwner);
         WithdrawRequestNFT newWrnImpl =
-            new WithdrawRequestNFT(0x2f5301a3D59388c509C65f8698f521377D41Fd0F, address(blacklisterInstance), 0, 4e18);
+            new WithdrawRequestNFT(0x2f5301a3D59388c509C65f8698f521377D41Fd0F, address(blacklisterInstance), 1, 4e18);
         withdrawRequestNFTInstance.upgradeTo(address(newWrnImpl));
         vm.stopPrank();
         vm.startPrank(owner);

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.13;
 import "./TestSetup.sol";
 import "forge-std/console2.sol";
 
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 import "../src/PriorityWithdrawalQueue.sol";
 import "../src/interfaces/IPriorityWithdrawalQueue.sol";
 import "../src/utils/PausableUntil.sol";
@@ -2676,5 +2678,157 @@ contract PriorityWithdrawalQueueTest is TestSetup {
 
         assertTrue(priorityQueue.isFinalized(requestId), "healthy request finalized");
         assertGt(priorityQueue.fulfillmentRate(requestId), 0, "snapshot stored for healthy request");
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------  Share-rate-freeze invariants (H-02)  ------------------------
+    //--------------------------------------------------------------------------------------
+
+    /// @notice For a fulfilled request, claim amount must NOT change across post-fulfill rebases.
+    ///         Core H-02 property on the priority path: post-fulfill rate movement is invisible
+    ///         to the claimant — they receive `amountWithFee` from the segregated escrow.
+    function test_invariant_queue_claimAmountIndependentOfPostFulfillRebase() public {
+        // 1. user requests, manager fulfills
+        uint96 withdrawAmount = 5 ether;
+        (bytes32 requestId, IPriorityWithdrawalQueue.WithdrawRequest memory request) =
+            _createWithdrawRequest(vipUser, withdrawAmount);
+
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory requests =
+            new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+        requests[0] = request;
+        vm.prank(requestManager);
+        priorityQueue.fulfillRequests(requests);
+        uint224 frozenRate = priorityQueue.fulfillmentRate(requestId);
+        assertGt(frozenRate, 0, "fulfillmentRate must be set after fulfill");
+
+        // 2. snapshot expected claim
+        uint256 expectedClaim = priorityQueue.getClaimableAmount(request);
+        assertEq(expectedClaim, request.amountWithFee, "claim is amountWithFee when solvent");
+
+        // 3. apply positive rebase — solvency must still hold and claim must not move.
+        _rebase(20 ether);
+        assertEq(
+            priorityQueue.getClaimableAmount(request),
+            expectedClaim,
+            "queue claim must be invariant under positive post-fulfill rebase"
+        );
+        assertEq(
+            priorityQueue.fulfillmentRate(requestId),
+            frozenRate,
+            "frozen rate must not move under positive rebase"
+        );
+
+        // 4. apply negative rebase. Pre-freeze this would have either dropped the claim or
+        //    blocked it via the live-rate solvency check. Frozen-rate must shield both.
+        _rebase(-15 ether);
+        assertEq(
+            priorityQueue.getClaimableAmount(request),
+            expectedClaim,
+            "queue claim must be invariant under negative post-fulfill rebase"
+        );
+        assertEq(
+            priorityQueue.fulfillmentRate(requestId),
+            frozenRate,
+            "frozen rate must not move under negative rebase"
+        );
+
+        // 5. claim actually pays the snapshot
+        uint256 ethBefore = vipUser.balance;
+        vm.prank(vipUser);
+        priorityQueue.claimWithdraw(request);
+        assertEq(vipUser.balance - ethBefore, expectedClaim, "queue payout uses frozen rate");
+    }
+
+    /// @notice Ceiling round-trip for the Queue claim path: with the frozen-rate solvency check
+    ///         (`shareOfEEth * rate / 1e18 >= amountWithFee`) enforced at fulfill, the round-trip
+    ///         ceiling `ceil(amountWithFee * 1e18 / rate) <= shareOfEEth` must hold for the burn.
+    ///         Mirrors `_claimWithdraw`'s `burnedShares <= shareOfEEth` invariant.
+    function test_invariant_queue_burnCeilingNeverExceedsRequestShares() public {
+        // Exercise a spread of fee fractions: amountWithFee very near, mid, and far below
+        // the rate-frozen value of shareOfEEth. The round-trip property must hold in all cases.
+        uint96[3] memory amounts = [uint96(5 ether), uint96(3 ether), uint96(1 ether)];
+
+        for (uint256 i = 0; i < amounts.length; i++) {
+            uint96 amountWithFee = amounts[i];
+
+            // Build a request via the normal path so shareOfEEth is the real LP-derived share.
+            (bytes32 requestId, IPriorityWithdrawalQueue.WithdrawRequest memory request) =
+                _createWithdrawRequestWithFee(vipUser, 5 ether, amountWithFee);
+
+            IPriorityWithdrawalQueue.WithdrawRequest[] memory reqs =
+                new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+            reqs[0] = request;
+            vm.prank(requestManager);
+            priorityQueue.fulfillRequests(reqs);
+
+            uint224 rate = priorityQueue.fulfillmentRate(requestId);
+            assertGt(rate, 0, "rate must be set after fulfill");
+
+            // Round-trip ceiling burn must not exceed the request's share allocation.
+            uint256 burn = Math.mulDiv(uint256(amountWithFee), 1e18, uint256(rate), Math.Rounding.Up);
+            assertLe(burn, uint256(request.shareOfEEth), "queue: ceiling burn <= shareOfEEth");
+
+            // And the protocol never under-collects: burn * rate / 1e18 >= amountWithFee.
+            assertGe(
+                Math.mulDiv(burn, uint256(rate), 1e18, Math.Rounding.Down),
+                uint256(amountWithFee),
+                "queue: round-trip burn * rate / 1e18 >= amountWithFee"
+            );
+
+            // Drain so the next iteration's request can fit (vipUser has 50 ETH eETH baseline).
+            vm.prank(vipUser);
+            priorityQueue.claimWithdraw(request);
+        }
+    }
+
+    /// @notice Legacy fulfillment (snapshot==0 in `_fulfillmentRates`) must fall back to the
+    ///         live rate via `LP.amountPerShareCeil()` — preserving pre-upgrade claim semantics
+    ///         and successfully passing the (now-non-zero) rate to `LP.withdraw`.
+    function test_legacyQueueFulfillment_fallsBackToLiveRate() public {
+        // 1. Create + fulfill normally so the request lands in `_finalizedRequests` and ETH
+        //    is escrowed via `transferLockedEthForPriority`.
+        uint96 withdrawAmount = 5 ether;
+        (bytes32 requestId, IPriorityWithdrawalQueue.WithdrawRequest memory request) =
+            _createWithdrawRequest(vipUser, withdrawAmount);
+
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory reqs =
+            new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+        reqs[0] = request;
+        vm.prank(requestManager);
+        priorityQueue.fulfillRequests(reqs);
+
+        uint224 storedRate = priorityQueue.fulfillmentRate(requestId);
+        assertGt(storedRate, 0, "precondition: rate stored after fulfill");
+
+        // 2. Simulate "pre-upgrade fulfillment" by clearing the rate slot via vm.store. The
+        //    base slot for `_fulfillmentRates` is determined by the contract's storage layout
+        //    (see `forge inspect ... storage`). The value slot for a given key is
+        //    `keccak256(abi.encode(key, baseSlot))`.
+        uint256 fulfillmentRatesBaseSlot = 158;
+        bytes32 valueSlot = keccak256(abi.encode(requestId, fulfillmentRatesBaseSlot));
+        // Sanity: pre-clear slot value should equal storedRate.
+        assertEq(
+            uint256(vm.load(address(priorityQueue), valueSlot)),
+            uint256(storedRate),
+            "_fulfillmentRates slot index drift - update fulfillmentRatesBaseSlot"
+        );
+
+        // 3. Zero the slot — request is now finalized with no snapshot, exactly like a
+        //    pre-upgrade fulfillment.
+        vm.store(address(priorityQueue), valueSlot, bytes32(0));
+        assertEq(priorityQueue.fulfillmentRate(requestId), 0, "snapshot cleared");
+
+        // 4. Pre-cleared expected payout via live-rate path (what pre-upgrade code would compute).
+        uint256 liveAmountForShares = liquidityPoolInstance.amountForShare(request.shareOfEEth);
+        // Solvency check uses the resolved rate (ceil); but both paths agree as long as
+        // amountWithFee <= floor(shareOfEEth * rate / 1e18). The test request is solvent.
+        assertGe(liveAmountForShares, request.amountWithFee, "live solvency precondition");
+
+        // 5. claimWithdraw must succeed via the live-rate fallback — and pay the user
+        //    `amountWithFee` from the segregated escrow exactly like a frozen-rate claim would.
+        uint256 ethBefore = vipUser.balance;
+        vm.prank(vipUser);
+        priorityQueue.claimWithdraw(request);
+        assertEq(vipUser.balance - ethBefore, request.amountWithFee, "legacy fallback claim pays amountWithFee");
     }
 }

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -42,7 +42,9 @@ contract PriorityWithdrawalQueueTest is TestSetup {
             address(weEthInstance),
             address(roleRegistryInstance),
             treasury,
-            1 hours
+            1 hours,
+            0,
+            4e18
         );
         UUPSProxy proxy = new UUPSProxy(
             address(priorityQueueImpl),

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -499,7 +499,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryInstance.grantRole(_blacklisterRole, _roleRegOwner);
 
         // Deploy PriorityWithdrawalQueue for fork testing (mainnet LP has immutable address(0) for this)
-        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
+        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -755,7 +755,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         // Deploy PriorityWithdrawalQueue before EtherFiAdmin so the admin's
         // immutable priorityWithdrawalQueue constructor arg can be wired up.
-        priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
+        priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -1025,7 +1025,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             // upgrade our existing contracts to utilize `roleRegistry`
             vm.stopPrank();
             vm.startPrank(owner);
-            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
+            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
             UUPSProxy priorityQueueProxy = new UUPSProxy(
                 address(priorityQueueImplementation),
                 abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -499,7 +499,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryInstance.grantRole(_blacklisterRole, _roleRegOwner);
 
         // Deploy PriorityWithdrawalQueue for fork testing (mainnet LP has immutable address(0) for this)
-        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
+        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 1, 4e18);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -744,7 +744,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         membershipNftProxy = new UUPSProxy(address(membershipNftImplementation), "");
         membershipNftInstance = MembershipNFT(payable(membershipNftProxy));
 
-        withdrawRequestNFTImplementation = new WithdrawRequestNFT(address(treasuryInstance), address(blacklisterInstance), 0, 4e18);
+        withdrawRequestNFTImplementation = new WithdrawRequestNFT(address(treasuryInstance), address(blacklisterInstance), 1, 4e18);
         withdrawRequestNFTProxy = new UUPSProxy(address(withdrawRequestNFTImplementation), "");
         withdrawRequestNFTInstance = WithdrawRequestNFT(payable(withdrawRequestNFTProxy));
 
@@ -755,7 +755,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         // Deploy PriorityWithdrawalQueue before EtherFiAdmin so the admin's
         // immutable priorityWithdrawalQueue constructor arg can be wired up.
-        priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
+        priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 1, 4e18);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -1025,7 +1025,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             // upgrade our existing contracts to utilize `roleRegistry`
             vm.stopPrank();
             vm.startPrank(owner);
-            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
+            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 1, 4e18);
             UUPSProxy priorityQueueProxy = new UUPSProxy(
                 address(priorityQueueImplementation),
                 abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -11,7 +11,7 @@ import "../src/utils/PausableUntil.sol";
 
 contract WithdrawRequestNFTIntrusive is WithdrawRequestNFT {
 
-    constructor() WithdrawRequestNFT(address(0), address(0), 0, 4e18) {}
+    constructor() WithdrawRequestNFT(address(0), address(0), 1, 4e18) {}
 
     function updateParam(uint32 _currentRequestIdToScanFromForShareRemainder, uint32 _lastRequestIdToScanUntilForShareRemainder) external {
         currentRequestIdToScanFromForShareRemainder = _currentRequestIdToScanFromForShareRemainder;
@@ -339,7 +339,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     function test_handleRemainder() public {
         initializeRealisticFork(MAINNET_FORK);
         vm.startPrank(address(roleRegistryInstance.owner()));
-        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 0, 4e18)));
+        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 1, 4e18)));
         roleRegistryInstance.grantRole(withdrawRequestNFTInstance.IMPLICIT_FEE_CLAIMER_ROLE(), alice);
         vm.stopPrank();
         uint256 implicitFee = withdrawRequestNFTInstance.getEEthRemainderAmount();

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/console2.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./TestSetup.sol";
 import "../src/utils/PausableUntil.sol";
 
@@ -2150,5 +2151,169 @@ contract WithdrawRequestNFTTest is TestSetup {
         assertEq(withdrawRequestNFTInstance.frozenRateFor(r1), rate, "r1 covered by same batch");
         assertEq(withdrawRequestNFTInstance.frozenRateFor(r2), rate, "r2 covered by same batch");
         assertEq(withdrawRequestNFTInstance.frozenRateFor(r3), rate, "r3 covered by same batch");
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------  Share-rate-freeze invariants (H-02)  ------------------------
+    //--------------------------------------------------------------------------------------
+
+    /// @notice For a finalized request, claim amount must NOT change across post-finalize rebases.
+    ///         This is the core H-02 property: post-finalize rate movement is invisible to the
+    ///         claimant. Exercises both a positive and a negative post-finalize rebase, and the
+    ///         actual claim payout against the pre-rebase snapshot.
+    function test_invariant_claimAmountIndependentOfPostFinalizeRebase() public {
+        // 1. user deposits, requests withdraw
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 20 ether}();
+        vm.stopPrank();
+
+        // Build up TPE so a later negative rebase has headroom and doesn't underflow.
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(20 ether); // 40 ETH TPE / 20 shares → ~2 ETH/share
+
+        vm.prank(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
+        vm.prank(bob);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+
+        // 2. admin finalizes
+        _finalizeWithdrawalRequest(requestId);
+
+        // 3. snapshot expected payout via getClaimableAmount
+        uint256 expectedClaim = withdrawRequestNFTInstance.getClaimableAmount(requestId);
+        uint224 frozenRate = withdrawRequestNFTInstance.frozenRateFor(requestId);
+        assertGt(frozenRate, 0, "frozenRate must be set after finalize");
+
+        // 4. apply positive rebase
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(10 ether);
+
+        // 5. assert getClaimableAmount unchanged after positive rebase
+        assertEq(
+            withdrawRequestNFTInstance.getClaimableAmount(requestId),
+            expectedClaim,
+            "claim must be invariant under positive post-finalize rebase"
+        );
+        assertEq(
+            withdrawRequestNFTInstance.frozenRateFor(requestId),
+            frozenRate,
+            "frozen rate must not move under positive rebase"
+        );
+
+        // 6. apply negative rebase
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(-15 ether);
+
+        // 7. assert getClaimableAmount unchanged after negative rebase
+        assertEq(
+            withdrawRequestNFTInstance.getClaimableAmount(requestId),
+            expectedClaim,
+            "claim must be invariant under negative post-finalize rebase"
+        );
+        assertEq(
+            withdrawRequestNFTInstance.frozenRateFor(requestId),
+            frozenRate,
+            "frozen rate must not move under negative rebase"
+        );
+
+        // 8. user claims, assert actual paid ETH == snapshot
+        uint256 ethBefore = bob.balance;
+        vm.prank(bob);
+        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        assertEq(bob.balance - ethBefore, expectedClaim, "paid ETH must match the pre-rebase snapshot");
+    }
+
+    /// @notice Ceiling round-trip: for any (amount, rate) tuple where
+    ///         `amount = shareOfEEth * rate / SHARE_UNIT` (the frozen-rate evaluation), the
+    ///         caller's burn `ceil(amount * SHARE_UNIT / rate)` must not exceed `shareOfEEth`.
+    ///         The freeze accounting relies on this for the `burnedShares <= shareOfEEth` guard
+    ///         in `_claimWithdraw`; here we exercise the same math directly against the
+    ///         contract's withdraw path for a spread of tuples.
+    function test_invariant_burnCeilingNeverExceedsRequestShares() public {
+        uint256[3] memory amounts = [uint256(0.01 ether), uint256(1 ether), uint256(95 ether)];
+        uint256[3] memory rates   = [uint256(0.9e18),     uint256(1e18),    uint256(1.5e18)];
+
+        for (uint256 i = 0; i < amounts.length; i++) {
+            for (uint256 j = 0; j < rates.length; j++) {
+                uint256 rate = rates[j];
+                // shareOfEEth large enough that amount = floor(shareOfEEth * rate / 1e18) > 0
+                uint256 shareOfEEth = 100 ether;
+
+                // amount = (rate-frozen) value of shareOfEEth shares, then take min with the
+                // requested amount to mirror `_getClaimableAmount`'s clamp.
+                uint256 amountForShares = Math.mulDiv(shareOfEEth, rate, 1e18);
+                uint256 amount = Math.min(amounts[i], amountForShares);
+                if (amount == 0) continue;
+
+                uint256 burn = Math.mulDiv(amount, 1e18, rate, Math.Rounding.Up);
+                assertLe(burn, shareOfEEth, "ceiling burn must not exceed shareOfEEth");
+
+                // Round-trip: burned * rate / 1e18 >= amount (protocol never under-collects).
+                assertGe(
+                    Math.mulDiv(burn, rate, 1e18, Math.Rounding.Down),
+                    amount,
+                    "round-trip: burn * rate / 1e18 >= amount"
+                );
+            }
+        }
+    }
+
+    /// @notice After upgrade, lookup for a pre-upgrade tokenId resolves to 0, triggering the
+    ///         local live-rate fallback path. The claim payout must match what the pre-upgrade
+    ///         code (live `amountForShare`-based) would have computed at that moment.
+    function test_legacyFallback_matchesPreUpgradeLiveRate() public {
+        // 1. set up a "pre-upgrade finalized request" by stepping lastFinalizedRequestId without
+        //    pushing a real snapshot — mirroring on-chain state at the moment of the upgrade.
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+        vm.stopPrank();
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(10 ether);
+
+        vm.startPrank(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
+        uint256 legacyId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+        vm.stopPrank();
+
+        vm.startPrank(withdrawRequestNFTInstance.owner());
+        _setLastFinalizedRequestIdForTest(uint32(legacyId));
+        vm.stopPrank();
+
+        // LP locks the ETH so the eventual claim path can succeed.
+        vm.prank(address(etherFiAdminInstance));
+        liquidityPoolInstance.addEthAmountLockedForWithdrawal(uint128(1 ether));
+
+        // 2. capture expected payout via the old live-rate path BEFORE the upgrade init.
+        WithdrawRequestNFT.WithdrawRequest memory legacyReq =
+            withdrawRequestNFTInstance.getRequest(legacyId);
+        uint256 liveAmountForShares = liquidityPoolInstance.amountForShare(legacyReq.shareOfEEth);
+        uint256 expectedPreUpgrade = Math.min(uint256(legacyReq.amountOfEEth), liveAmountForShares);
+
+        // 3. call initializeShareRateFreezeUpgrade (pushes the sentinel = value 0).
+        vm.prank(withdrawRequestNFTInstance.owner());
+        withdrawRequestNFTInstance.initializeShareRateFreezeUpgrade();
+        assertEq(
+            withdrawRequestNFTInstance.frozenRateFor(legacyId),
+            0,
+            "legacy id must hit the value-0 sentinel"
+        );
+
+        // 4. assert getClaimableAmount returns the same value (live-rate fallback in effect).
+        //    Use a tight delta — both expressions evaluate at the same block / rate, so they
+        //    must match exactly up to a 1-wei rounding artifact (mulDiv-Up vs mulDiv-Down).
+        uint256 postUpgradeClaim = withdrawRequestNFTInstance.getClaimableAmount(legacyId);
+        assertApproxEqAbs(
+            postUpgradeClaim,
+            expectedPreUpgrade,
+            1,
+            "legacy live-rate fallback must match pre-upgrade live-rate semantics within 1 wei"
+        );
+
+        // 5. claim actually succeeds — proves the fallback resolves to a non-zero rate that
+        //    LP accepts (and not the now-removed `rate==0` LP branch).
+        uint256 ethBefore = bob.balance;
+        vm.prank(bob);
+        withdrawRequestNFTInstance.claimWithdraw(legacyId);
+        assertGt(bob.balance, ethBefore, "claim must succeed via live-rate fallback");
     }
 }

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -204,7 +204,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         // 2. Deploy new implementation contracts (with the added guard)
         // ------------------------------------------------------------------
         address newLP  = address(new LiquidityPool(PRIORITY_WITHDRAWAL_QUEUE, address(blacklisterInstance), 0));
-        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 0, 4e18));
+        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 1, 4e18));
 
         // ------------------------------------------------------------------
         // 3. Upgrade the proxies in place
@@ -380,9 +380,9 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
     ///      receive(); the master queue impl has no receive() and would revert.
     function _doUpgrade() internal {
         address newLP = address(new LiquidityPool(PRIORITY_WITHDRAWAL_QUEUE, address(blacklisterInstance), 0));
-        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 0, 4e18));
+        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 1, 4e18));
         address newPQ = address(new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours, 0, 4e18
+            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours, 1, 4e18
         ));
 
         vm.prank(UPGRADE_TIMELOCK);

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -382,7 +382,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         address newLP = address(new LiquidityPool(PRIORITY_WITHDRAWAL_QUEUE, address(blacklisterInstance), 0));
         address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 0, 4e18));
         address newPQ = address(new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours
+            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours, 0, 4e18
         ));
 
         vm.prank(UPGRADE_TIMELOCK);

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -24,7 +24,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         address wrnOwner = withdrawRequestNFTInstance.owner();
         vm.prank(wrnOwner);
         withdrawRequestNFTInstance.upgradeTo(
-            address(new WithdrawRequestNFT(buybackWallet, address(blacklisterInstance), 0, 4e18))
+            address(new WithdrawRequestNFT(buybackWallet, address(blacklisterInstance), 1, 4e18))
         );
 
         // The production queue proxy on mainnet still runs the master impl which
@@ -32,7 +32,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         // into the queue and would revert with SendFail. Upgrade the queue first.
         address newPQ = address(new PriorityWithdrawalQueue(
             address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance),
-            address(roleRegistryInstance), treasuryInstance, 1 hours, 0, 4e18
+            address(roleRegistryInstance), treasuryInstance, 1 hours, 1, 4e18
         ));
         vm.prank(UPGRADE_TIMELOCK);
         PriorityWithdrawalQueue(payable(PRIORITY_WITHDRAWAL_QUEUE)).upgradeTo(newPQ);
@@ -69,7 +69,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
         // Grant the IMPLICIT_FEE_CLAIMER_ROLE to alice
         vm.startPrank(address(roleRegistryInstance.owner()));
-        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 0, 4e18)));
+        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 1, 4e18)));
         roleRegistryInstance.grantRole(withdrawRequestNFTInstance.IMPLICIT_FEE_CLAIMER_ROLE(), alice);
         vm.stopPrank();
 
@@ -147,7 +147,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
         // Now upgrade the contract and grant roles
         vm.startPrank(address(roleRegistryInstance.owner()));
-        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 0, 4e18)));
+        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 1, 4e18)));
         roleRegistryInstance.grantRole(withdrawRequestNFTInstance.IMPLICIT_FEE_CLAIMER_ROLE(), alice);
         vm.stopPrank();
 
@@ -228,7 +228,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
             // Grant the IMPLICIT_FEE_CLAIMER_ROLE to alice
             vm.startPrank(address(roleRegistryInstance.owner()));
-            withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 0, 4e18)));
+            withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 1, 4e18)));
             roleRegistryInstance.grantRole(withdrawRequestNFTInstance.IMPLICIT_FEE_CLAIMER_ROLE(), alice);
             vm.stopPrank();
 

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -32,7 +32,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         // into the queue and would revert with SendFail. Upgrade the queue first.
         address newPQ = address(new PriorityWithdrawalQueue(
             address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance),
-            address(roleRegistryInstance), treasuryInstance, 1 hours
+            address(roleRegistryInstance), treasuryInstance, 1 hours, 0, 4e18
         ));
         vm.prank(UPGRADE_TIMELOCK);
         PriorityWithdrawalQueue(payable(PRIORITY_WITHDRAWAL_QUEUE)).upgradeTo(newPQ);

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -100,7 +100,9 @@ contract WithdrawEscrowE2ETest is TestSetup {
             address(weEthInstance),
             address(roleRegistryInstance),
             treasuryInstance,
-            1 hours
+            1 hours,
+            0,
+            4e18
         );
         UUPSProxy proxy = new UUPSProxy(
             address(impl),

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -101,7 +101,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
             address(roleRegistryInstance),
             treasuryInstance,
             1 hours,
-            0,
+            1,
             4e18
         );
         UUPSProxy proxy = new UUPSProxy(
@@ -117,7 +117,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
         address wrnOwner = withdrawRequestNFTInstance.owner();
         vm.prank(wrnOwner);
         withdrawRequestNFTInstance.upgradeTo(
-            address(new WithdrawRequestNFT(0x2f5301a3D59388c509C65f8698f521377D41Fd0F, address(blacklisterInstance), 0, 4e18))
+            address(new WithdrawRequestNFT(0x2f5301a3D59388c509C65f8698f521377D41Fd0F, address(blacklisterInstance), 1, 4e18))
         );
     }
 


### PR DESCRIPTION
**Stacks under:** #415 → this PR (#414) → #413 (yash/feat/share-rate-freeze)
**Role:** lock in the current behavior of `LP.withdraw(amount, rate)` so PR B's refactor can't silently regress it.

> Hey @0xpanicError — this is the test-only foundation for #415 (the share-rate-freeze polish). When I started writing the polish, your commit `55ed102` ("use math lib for mul div ops") on this branch had already moved LP to `Math.mulDiv(..., Rounding.Up)` and `revert IncorrectCaller()`. So the source-code refactor I was going to do here became a no-op — but the *tests* for it didn't exist yet. This PR adds them, separate from the actual freeze-refinement so each piece is reviewable in isolation.

## What

7 new unit tests in `test/LiquidityPool.t.sol` covering `withdraw(uint256 amount, uint256 rate)`:

1. **rate=0 path matches live-rate** — `withdraw(amount, 0)` burns exactly `sharesForWithdrawalAmount(amount)`.
2. **rate>0 ceiling burn** — burned shares = `Math.mulDiv(amount, 1e18, rate, Up)`.
3. **ceiling round-trip** — `burnedShares * rate / 1e18 >= amount` always.
4. **edge ceiling** — `amount=1 wei, rate=1.5e18` exercises the +1 path.
5. **solvency** — caller without enough eETH shares → `InsufficientLiquidity`.
6. **access on `withdraw(amount, rate)`** — random EOA / membershipManager / etherFiRedemptionManager → `IncorrectCaller`.
7. **access on `withdraw(recipient, amount)`** — random EOA / WRNFT / Queue → `IncorrectCaller`.

## Why a separate PR

PR B (#415) collapses LP's dual codepath (rate=0 → revert) and moves the legacy fallback into consumers. Those changes touch behavior that *should* be pinned by tests first. Splitting this out:

- gives PR B a green baseline to refactor against;
- lets you ack the access-control matrix once here without it being mixed into the policy change;
- keeps PR B's diff focused on the freeze-design change.

No source changes. No behavior change.

## Test results

- `LiquidityPoolTest` 141/141 (7 new)
- `WithdrawRequestNFTTest` 80/80 (regression)
- `PriorityWithdrawalQueueTest` 102/102 (regression)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches withdrawal settlement paths in `LiquidityPool`, `WithdrawRequestNFT`, and `PriorityWithdrawalQueue`, including rate-snapshot/legacy fallback logic; mistakes could break claims or burn accounting. Changes are well-covered with new invariants and edge-case tests, reducing but not eliminating risk.
> 
> **Overview**
> **Segregated withdraw settlement is tightened:** `LiquidityPool.withdraw(uint256,uint256)` now *reverts on `rate==0`* (`InvalidRate`) and always uses `Math.mulDiv(..., Up)` for the burn, removing the prior in-function live-rate fallback.
> 
> **Legacy compatibility moves to callers:** `WithdrawRequestNFT` and `PriorityWithdrawalQueue` now resolve pre-upgrade “no snapshot” cases by locally substituting `LP.amountPerShareCeil()` (with min/max acceptable rate bounds) before calling `LP.withdraw`, keeping legacy payouts while satisfying the new non-zero rate requirement.
> 
> **Tests and scripts updated:** adds/adjusts unit + invariant tests to pin burn rounding, access control, and post-finalize/fulfill rebase-invariance (H-02), and updates upgrade/deploy scripts and test setup to pass the new constructor params / acceptable-rate config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a5f2b19d268bc5966d6d81b8d8b0d077e6e8bdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->