### PR TITLE
polish #413 for audit: single LP codepath, consumer-side legacy fallback (no new storage), H-02 invariant tests

### DIFF
--- a/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
+++ b/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
@@ -256,7 +256,7 @@ contract PriorityQueueTransactions is Script, Utils {
 
         LiquidityPool newLiquidityPoolImpl = new LiquidityPool(priorityWithdrawalQueueProxy, address(0), 0);
         PriorityWithdrawalQueue newPWQImpl = new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_MIN_DELAY
+            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_MIN_DELAY, 0, 4e18
         );
         EtherFiRedemptionManager newRedemptionManagerImpl = new EtherFiRedemptionManager(
             LIQUIDITY_POOL, EETH, WEETH, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, ROLE_REGISTRY, ETHERFI_RESTAKER, priorityWithdrawalQueueProxy, address(0), 10_000, 100, 10_000

--- a/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
+++ b/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
@@ -256,7 +256,7 @@ contract PriorityQueueTransactions is Script, Utils {
 
         LiquidityPool newLiquidityPoolImpl = new LiquidityPool(priorityWithdrawalQueueProxy, address(0), 0);
         PriorityWithdrawalQueue newPWQImpl = new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_MIN_DELAY, 0, 4e18
+            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_MIN_DELAY, 1, 4e18
         );
         EtherFiRedemptionManager newRedemptionManagerImpl = new EtherFiRedemptionManager(
             LIQUIDITY_POOL, EETH, WEETH, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, ROLE_REGISTRY, ETHERFI_RESTAKER, priorityWithdrawalQueueProxy, address(0), 10_000, 100, 10_000

--- a/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
+++ b/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
@@ -207,7 +207,7 @@ contract ReauditFixesTransactions is Utils {
         EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(EIGENLAYER_REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER), address(ROLE_REGISTRY), address(ETHERFI_RATE_LIMITER));
         EtherFiRewardsRouter newEtherFiRewardsRouterImplementation = new EtherFiRewardsRouter(address(LIQUIDITY_POOL), address(TREASURY), address(ROLE_REGISTRY));
         Liquifier newLiquifierImplementation = new Liquifier(address(ROLE_REGISTRY), 0x86392dC19c0b719886221c78AB11eb8Cf5c52812, address(0x0), 100, 24 hours, 500);
-        WithdrawRequestNFT newWithdrawRequestNFTImplementation = new WithdrawRequestNFT(address(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE), address(0x0), 0, 2e18);
+        WithdrawRequestNFT newWithdrawRequestNFTImplementation = new WithdrawRequestNFT(address(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE), address(0x0), 1, 4e18);
         EtherFiViewer newEtherFiViewerImplementation = new EtherFiViewer(address(EIGENLAYER_POD_MANAGER), address(EIGENLAYER_DELEGATION_MANAGER));
 
         contractCodeChecker.verifyContractByteCodeMatch(etherFiNodeImpl, address(newEtherFiNodeImplementation));

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -134,6 +134,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     error InvalidValidatorSize();
     error InvalidArrayLengths();
     error InvalidAmountForShare();
+    error InvalidRate();
 
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
@@ -277,20 +278,21 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
     /// @notice Settles a finalized claim for withdrawRequestNFT or priorityWithdrawalQueue against
     ///         the rate snapshotted at finalize/fulfill time. Caller supplies the rate; LP derives
-    ///         the share burn from it. A `_rate` of 0 means the caller has no snapshot (pre-upgrade
-    ///         legacy request) and asks LP to use the live rate. ETH was already segregated to the
-    ///         caller at finalize/fulfill via `addEthAmountLockedForWithdrawal` / `transferLockedEthForPriority`,
-    ///         so LP only performs accounting (burn + `totalValueOutOfLp -=`); the caller pays the
-    ///         user from its own balance.
+    ///         the share burn from it. ETH was already segregated to the caller at finalize/fulfill
+    ///         via `addEthAmountLockedForWithdrawal` / `transferLockedEthForPriority`, so LP only
+    ///         performs accounting (burn + `totalValueOutOfLp -=`); the caller pays the user from
+    ///         its own balance.
+    /// @dev    `_rate == 0` is rejected — callers (WRNFT / Queue) are responsible for resolving
+    ///         any pre-upgrade legacy snapshot to a live rate locally via `amountPerShareCeil()`
+    ///         before invoking this function. Single codepath: one ceiling math expression.
     function withdraw(uint256 _amount, uint256 _rate) external nonReentrant returns (uint256) {
         if (msg.sender != address(withdrawRequestNFT) && msg.sender != priorityWithdrawalQueue) {
             revert IncorrectCaller();
         }
         if (_amount > type(uint128).max || _amount == 0) revert InvalidAmount();
+        if (_rate == 0) revert InvalidRate();
 
-        uint256 share = _rate == 0
-            ? sharesForWithdrawalAmount(_amount)
-            : Math.mulDiv(_amount, SHARE_UNIT, _rate, Math.Rounding.Up); // rounding favors the protocol
+        uint256 share = Math.mulDiv(_amount, SHARE_UNIT, _rate, Math.Rounding.Up); // rounding favors the protocol
         if (share == 0) revert InvalidAmount();
         if (eETH.shares(msg.sender) < share) revert InsufficientLiquidity();
 

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -65,6 +65,9 @@ contract PriorityWithdrawalQueue is
     address public immutable treasury;
     uint32 public immutable MIN_DELAY;
 
+    uint256 public immutable minAcceptableShareRate;
+    uint256 public immutable maxAcceptableShareRate;
+
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
@@ -146,6 +149,8 @@ contract PriorityWithdrawalQueue is
     error InvalidEEthSharesAfterRemainderHandling();
     error InvalidOutputAmount();
     error InsufficientLiquidity();
+    error InvalidAcceptableShareRate();
+    error InvalidLiveRate();
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
@@ -182,10 +187,11 @@ contract PriorityWithdrawalQueue is
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _liquidityPool, address _eETH, address _weETH, address _roleRegistry, address _treasury, uint32 _minDelay) {
+    constructor(address _liquidityPool, address _eETH, address _weETH, address _roleRegistry, address _treasury, uint32 _minDelay, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) {
         if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _roleRegistry == address(0) || _treasury == address(0)) {
             revert AddressZero();
         }
+        if (_maxAcceptableShareRate <= _minAcceptableShareRate) revert InvalidAcceptableShareRate();
         
         liquidityPool = ILiquidityPool(_liquidityPool);
         eETH = IeETH(_eETH);
@@ -193,6 +199,9 @@ contract PriorityWithdrawalQueue is
         roleRegistry = IRoleRegistry(_roleRegistry);
         treasury = _treasury;
         MIN_DELAY = _minDelay;
+
+        minAcceptableShareRate = _minAcceptableShareRate;
+        maxAcceptableShareRate = _maxAcceptableShareRate;
 
         _disableInitializers();
     }
@@ -648,16 +657,7 @@ contract PriorityWithdrawalQueue is
         
         if (!_finalizedRequests.contains(requestId)) revert RequestNotFinalized();
 
-        uint224 frozenRate = _fulfillmentRates[requestId];
-        if (frozenRate == 0) {
-            // Pre-upgrade legacy request (fulfilled before the share-rate-freeze upgrade) —
-            // resolve to the live rate locally so claim semantics match the pre-upgrade behavior.
-            // LP itself rejects rate=0; the resolved rate is what we pass through.
-            uint256 live = liquidityPool.amountPerShareCeil();
-            require(live > 0 && live <= type(uint224).max, "invalid live rate");
-            frozenRate = uint224(live);
-        }
-
+        uint224 frozenRate = _getFrozenRate(requestId);
         // Solvency check against the resolved rate (frozen for new requests, live for legacy).
         uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
         if (amountForShares < request.amountWithFee) revert InvalidOutputAmount();
@@ -691,6 +691,18 @@ contract PriorityWithdrawalQueue is
         _checkEthAmountLockedForPriorityWithdrawal();
 
         emit WithdrawRequestClaimed(requestId, request.user, uint96(amountToWithdraw), uint96(burnedShares), request.nonce, uint32(block.timestamp));
+    }
+
+    function _getFrozenRate(bytes32 requestId) internal view returns (uint224 frozenRate) {
+        frozenRate = _fulfillmentRates[requestId];
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request (fulfilled before the share-rate-freeze upgrade) —
+            // resolve to the live rate locally so claim semantics match the pre-upgrade behavior.
+            // LP itself rejects rate=0; the resolved rate is what we pass through.
+            uint256 live = liquidityPool.amountPerShareCeil();
+            if (live < minAcceptableShareRate || live > maxAcceptableShareRate) revert InvalidLiveRate();
+            frozenRate = uint224(live);
+        }
     }
 
     function _checkEthAmountLockedForPriorityWithdrawal() internal {
@@ -755,13 +767,7 @@ contract PriorityWithdrawalQueue is
         bytes32 requestId = keccak256(abi.encode(request));
         if (!_finalizedRequests.contains(requestId)) return 0;
 
-        uint224 frozenRate = _fulfillmentRates[requestId];
-        if (frozenRate == 0) {
-            // Pre-upgrade legacy request — live-rate fallback (mirrors `_claimWithdraw`).
-            uint256 live = liquidityPool.amountPerShareCeil();
-            if (live == 0 || live > type(uint224).max) return 0;
-            frozenRate = uint224(live);
-        }
+        uint224 frozenRate = _getFrozenRate(requestId);
         uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
         if (amountForShares < request.amountWithFee) return 0;
 

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -149,6 +149,7 @@ contract PriorityWithdrawalQueue is
     error InvalidEEthSharesAfterRemainderHandling();
     error InvalidOutputAmount();
     error InsufficientLiquidity();
+    error InvalidMinAcceptableShareRate();
     error InvalidAcceptableShareRate();
     error InvalidLiveRate();
 
@@ -191,6 +192,7 @@ contract PriorityWithdrawalQueue is
         if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _roleRegistry == address(0) || _treasury == address(0)) {
             revert AddressZero();
         }
+        if (_minAcceptableShareRate == 0) revert InvalidMinAcceptableShareRate();
         if (_maxAcceptableShareRate <= _minAcceptableShareRate) revert InvalidAcceptableShareRate();
         
         liquidityPool = ILiquidityPool(_liquidityPool);

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -15,10 +15,26 @@ import "./interfaces/IWeETH.sol";
 import "./interfaces/IRoleRegistry.sol";
 import "./utils/PausableUntil.sol";
 
-/// @title PriorityWithdrawalQueue
-/// @notice Manages priority withdrawals for whitelisted users
-/// @dev Implements priority withdrawal queue pattern
-contract PriorityWithdrawalQueue is 
+/// @title PriorityWithdrawalQueue — share-rate-freeze invariants
+/// @notice Manages priority withdrawals for whitelisted users.
+///
+/// Once `fulfillRequests` runs for a requestId, the rate used to compute its claim payout
+/// is frozen at the rate snapshotted in that fulfill call. Subsequent rebases do NOT move
+/// the claim payout — this is the H-02 fix on the priority path.
+///
+/// Invariants:
+///  I1. `_fulfillmentRates[requestId]` is set on fulfill, cleared on claim/cancel/invalidate.
+///      A non-zero value implies the request is in `_finalizedRequests`.
+///  I2. For a finalized requestId, the resolved rate (`_fulfillmentRates[requestId]` or, for
+///      pre-upgrade legacy fulfillments, `LP.amountPerShareCeil()` substituted locally) is
+///      always non-zero — LP itself rejects rate=0.
+///  I3. For any finalized requestId, `getClaimableAmount(request)` and the user-visible
+///      `claimWithdraw` payout are invariant under `LP.rebase()` after the fulfill block.
+///      Property-tested via `test_invariant_queue_claimAmountIndependentOfPostFulfillRebase`.
+///  I4. The rate snapshot uses ceiling rounding (`Math.mulDiv(1e18, TPE, TS, Up)`) so the
+///      per-request solvency check (`shareOfEEth * rate / 1e18 >= amountWithFee`) and the
+///      round-trip burn (`ceil(amountWithFee * 1e18 / rate) <= shareOfEEth`) both hold.
+contract PriorityWithdrawalQueue is
     Initializable, 
     UUPSUpgradeable, 
     ReentrancyGuardUpgradeable,
@@ -67,9 +83,11 @@ contract PriorityWithdrawalQueue is
     uint96 public totalRemainderShares;
     uint128 public ethAmountLockedForPriorityWithdrawal;
 
-    /// @notice Frozen share rate (amountForShare(_SHARE_UNIT)) recorded when each request was fulfilled.
-    /// @dev Empty mapping value (0) means "use live rate" — covers pre-upgrade requests fulfilled
-    ///      before the share-rate-freeze upgrade.
+    /// @notice Frozen share rate (`amountPerShareCeil()`) recorded when each request was fulfilled.
+    /// @dev Empty mapping value (0) means "no snapshot" — covers pre-upgrade requests fulfilled
+    ///      before the share-rate-freeze upgrade. The claim/view paths locally substitute the
+    ///      live `LP.amountPerShareCeil()` for those entries, preserving legacy semantics.
+    ///      LP itself rejects rate=0.
     mapping(bytes32 => uint224) private _fulfillmentRates;
 
     //--------------------------------------------------------------------------------------
@@ -631,11 +649,17 @@ contract PriorityWithdrawalQueue is
         if (!_finalizedRequests.contains(requestId)) revert RequestNotFinalized();
 
         uint224 frozenRate = _fulfillmentRates[requestId];
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request (fulfilled before the share-rate-freeze upgrade) —
+            // resolve to the live rate locally so claim semantics match the pre-upgrade behavior.
+            // LP itself rejects rate=0; the resolved rate is what we pass through.
+            uint256 live = liquidityPool.amountPerShareCeil();
+            require(live > 0 && live <= type(uint224).max, "invalid live rate");
+            frozenRate = uint224(live);
+        }
 
-        // Solvency check against the rate frozen at fulfill (or live, for pre-upgrade requests).
-        uint256 amountForShares = frozenRate == 0
-            ? liquidityPool.amountForShare(request.shareOfEEth)
-            : Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
+        // Solvency check against the resolved rate (frozen for new requests, live for legacy).
+        uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
         if (amountForShares < request.amountWithFee) revert InvalidOutputAmount();
 
         uint128 amountToWithdraw = request.amountWithFee;
@@ -647,9 +671,10 @@ contract PriorityWithdrawalQueue is
 
         uint256 burnedShares = liquidityPool.withdraw(amountToWithdraw, uint256(frozenRate));
         // With `amountWithFee <= shareOfEEth * rate / 1e18` enforced at fulfill (frozen path)
-        // or by the live solvency check above (legacy path), the round-trip ceiling division
-        // satisfies `burnedShares <= request.shareOfEEth` by construction. Pin that invariant
-        // explicitly — a violation would imply a precision bug, not a routine rounding artifact.
+        // or by the live solvency check above (legacy path, resolved to live rate locally),
+        // the round-trip ceiling division satisfies `burnedShares <= request.shareOfEEth` by
+        // construction. Pin that invariant explicitly — a violation would imply a precision
+        // bug, not a routine rounding artifact.
         if (burnedShares > request.shareOfEEth) revert InvalidBurnedSharesAmount();
         totalRemainderShares += uint96(request.shareOfEEth - burnedShares);
 
@@ -731,9 +756,13 @@ contract PriorityWithdrawalQueue is
         if (!_finalizedRequests.contains(requestId)) return 0;
 
         uint224 frozenRate = _fulfillmentRates[requestId];
-        uint256 amountForShares = frozenRate == 0
-            ? liquidityPool.amountForShare(request.shareOfEEth)
-            : Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request — live-rate fallback (mirrors `_claimWithdraw`).
+            uint256 live = liquidityPool.amountPerShareCeil();
+            if (live == 0 || live > type(uint224).max) return 0;
+            frozenRate = uint224(live);
+        }
+        uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, _SHARE_UNIT);
         if (amountForShares < request.amountWithFee) return 0;
 
         return request.amountWithFee;

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -103,6 +103,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _treasury, address _blacklister, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) {
+        require(_minAcceptableShareRate > 0, "Invalid min acceptable share rate");
         require(_maxAcceptableShareRate > _minAcceptableShareRate, "Invalid min and max acceptable share rate");
         treasury = _treasury;
         blacklister = IBlacklister(_blacklister);

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -19,6 +19,27 @@ import "./utils/PausableUntil.sol";
 
 
 
+/// @title WithdrawRequestNFT — share-rate-freeze invariants
+/// @notice
+/// Once `finalizeRequests(lastRequestId)` runs, the rate used to compute the claim payout
+/// for tokenIds <= lastRequestId is frozen at the rate snapshotted in that finalize batch.
+/// Subsequent rebases do NOT move the claim payout — this is the H-02 fix.
+///
+/// Invariants:
+///  I1. `_finalizationRates` keys are strictly increasing. Enforced by the
+///      `requestId > lastFinalizedRequestId` guard in `finalizeRequests` and by
+///      `Checkpoints.push` semantics.
+///  I2. `_finalizationRates.lowerLookup(tokenId)` returns the rate of the smallest
+///      finalize batch covering `tokenId`. For pre-upgrade legacy tokenIds, it returns 0
+///      (the sentinel); the claim path locally substitutes `LP.amountPerShareCeil()` for
+///      backwards compatibility with old semantics. LP itself rejects rate=0.
+///  I3. For any finalized `tokenId`, `getClaimableAmount(tokenId)` is invariant under
+///      `LP.rebase()` after the finalize block. Property-tested via
+///      `test_invariant_claimAmountIndependentOfPostFinalizeRebase`.
+///  I4. The rate snapshot uses ceiling rounding (`Math.mulDiv(1e18, TPE, TS, Up)`) so
+///      `shareOfEEth * rate / 1e18 >= LP.amountForShare(shareOfEEth)` and
+///      `ceil(amount * 1e18 / rate) <= shareOfEEth`. These keep solvency checks and
+///      the share burn within the request's own share allocation.
 contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardNamespaced, PausableUntil, IWithdrawRequestNFT {
     using Math for uint256;
     using SafeERC20 for IERC20;
@@ -53,9 +74,10 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     uint128 public ethAmountLockedForWithdrawal;
 
-    // (requestId upperBound => amountForShare(1e18) at finalize time).
+    // (requestId upperBound => amountPerShareCeil(1e18) at finalize time).
     // A value of 0 marks a "legacy" range that pre-dates the share-rate-freeze upgrade;
-    // the claim path falls back to the live rate for those tokenIds.
+    // `_getClaimableAmount` locally substitutes `LP.amountPerShareCeil()` for those tokenIds,
+    // preserving the pre-upgrade live-rate-at-claim semantics. LP itself rejects rate=0.
     Checkpoints.Trace224 private _finalizationRates;
 
     bytes32 public constant WITHDRAW_REQUEST_NFT_ADMIN_ROLE = keccak256("WITHDRAW_REQUEST_NFT_ADMIN_ROLE");
@@ -124,8 +146,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @notice One-time initializer for the share-rate-freeze upgrade.
     /// @dev Pushes a sentinel checkpoint at the current `lastFinalizedRequestId` with value 0.
     ///      Every requestId <= that key looks up to this sentinel (value 0), which the claim
-    ///      path treats as "fall back to live rate" — preserving legacy behavior for requests
-    ///      that were finalized before this upgrade. New finalizations push real rate snapshots.
+    ///      path resolves locally to the live rate via `LP.amountPerShareCeil()` — preserving
+    ///      legacy behavior for requests finalized before this upgrade. New finalizations push
+    ///      real rate snapshots, so post-upgrade tokenIds always resolve to a non-zero rate.
     function initializeShareRateFreezeUpgrade() external onlyOwner {
         require(_finalizationRates.length() == 0, "already initialized");
         _finalizationRates.push(uint32(lastFinalizedRequestId), 0);
@@ -162,9 +185,11 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     /// @dev Returns `(amountToTransfer, fee, frozenRate)`. `frozenRate` is the rate snapshotted
-    ///      at the request's finalize batch, or 0 for pre-upgrade legacy requests (covered only
-    ///      by the sentinel checkpoint). Callers passing `frozenRate` along to `LP.withdraw` get
-    ///      the live-rate fallback for free — LP treats `rate == 0` as "use live rate".
+    ///      at the request's finalize batch. For pre-upgrade legacy requests (covered only by the
+    ///      sentinel checkpoint with value 0), the live rate from `LP.amountPerShareCeil()` is
+    ///      substituted locally — preserving legacy claim semantics (live-rate at claim). The
+    ///      returned `frozenRate` is therefore guaranteed non-zero, which is what `LP.withdraw`
+    ///      now requires (`InvalidRate` reverts on zero).
     function _getClaimableAmount(uint256 tokenId) internal view returns (uint256, uint256, uint224) {
         require(tokenId <= lastFinalizedRequestId, "Request is not finalized");
         require(ownerOf(tokenId) != address(0), "Already Claimed");
@@ -173,9 +198,16 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
         // Smallest checkpoint whose key >= tokenId — the finalization batch this request belongs to.
         uint224 frozenRate = _finalizationRates.lowerLookup(uint32(tokenId));
-        uint256 amountForShares = frozenRate == 0
-            ? liquidityPool.amountForShare(request.shareOfEEth)
-            : Math.mulDiv(uint256(request.shareOfEEth), frozenRate, SHARE_UNIT);
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request — sentinel returned 0. Fall back to the live rate so
+            // claim semantics match the pre-upgrade behavior. New (post-upgrade) finalizations
+            // always push a non-zero snapshot, so this branch only fires for legacy tokenIds.
+            uint256 live = liquidityPool.amountPerShareCeil();
+            require(live > 0 && live <= type(uint224).max, "invalid live rate");
+            frozenRate = uint224(live);
+        }
+
+        uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, SHARE_UNIT);
 
         // send the lesser value of the originally requested amount of eEth or the frozen-rate value of the shares
         uint256 amountToTransfer = Math.min(request.amountOfEEth, amountForShares);
@@ -192,8 +224,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     
     /// @dev Pays the recipient from this contract's own ETH balance (segregated at finalize via
     ///      LP.addEthAmountLockedForWithdrawal). Burns shares against the rate frozen at finalize
-    ///      via `LP.withdraw(amount, rate)` (a `frozenRate` of 0 — pre-upgrade requests — asks LP
-    ///      to fall back to the live rate, matching legacy behavior).
+    ///      via `LP.withdraw(amount, rate)`. `_getClaimableAmount` always resolves `frozenRate` to
+    ///      a non-zero value (live-rate fallback for pre-upgrade legacy ids), satisfying LP's
+    ///      `InvalidRate` guard.
     function _claimWithdraw(uint256 tokenId, address recipient) internal {
         require(ownerOf(tokenId) == msg.sender, "Not the owner of the NFT");
         IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -203,7 +203,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
             // claim semantics match the pre-upgrade behavior. New (post-upgrade) finalizations
             // always push a non-zero snapshot, so this branch only fires for legacy tokenIds.
             uint256 live = liquidityPool.amountPerShareCeil();
-            require(live > 0 && live <= type(uint224).max, "invalid live rate");
+            require(live >= minAcceptableShareRate && live <= maxAcceptableShareRate, "invalid live rate");
             frozenRate = uint224(live);
         }
 

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -942,10 +942,12 @@ contract LiquidityPoolTest is TestSetup {
             address(liquidityPoolInstance).call{value: 10 ether}("");
 
             // Try to withdraw more eETH than the NFT escrow holds via the segregated entry.
-            // Rate = 0 routes through the live-rate fallback inside the (amount, rate) overload.
+            // Use the live rate so we exercise the InsufficientLiquidity branch (rate=0 would
+            // be rejected by LP's `InvalidRate` guard before the solvency check).
+            uint256 liveRate = liquidityPoolInstance.amountPerShareCeil();
             vm.startPrank(address(withdrawRequestNFTInstance));
             vm.expectRevert(LiquidityPool.InsufficientLiquidity.selector);
-            liquidityPoolInstance.withdraw(withdrawAmount * 2, uint256(0));
+            liquidityPoolInstance.withdraw(withdrawAmount * 2, liveRate);
             vm.stopPrank();
         } else {
             vm.stopPrank();
@@ -1885,10 +1887,11 @@ contract LiquidityPoolTest is TestSetup {
         uint128 lpOutBefore        = liquidityPoolInstance.totalValueOutOfLp();
         uint256 lockedBefore       = withdrawRequestNFTInstance.ethAmountLockedForWithdrawal();
 
-        // Rate = 0 routes through the live-rate fallback inside the (amount, rate) overload,
-        // matching the original test's coverage of the segregated branch.
+        // Use the live rate via `amountPerShareCeil()` — the canonical snapshot LP exposes for
+        // consumers. `rate=0` is no longer accepted; consumers resolve legacy snapshots locally.
+        uint256 liveRate = liquidityPoolInstance.amountPerShareCeil();
         vm.prank(address(withdrawRequestNFTInstance));
-        liquidityPoolInstance.withdraw(amount, uint256(0));
+        liquidityPoolInstance.withdraw(amount, liveRate);
 
         assertEq(address(liquidityPoolInstance).balance, lpEthBefore, "LP ETH should not change on segregated withdraw");
         assertEq(address(withdrawRequestNFTInstance).balance, nftEthBefore, "NFT ETH unchanged by LP withdraw(amount, rate) alone");
@@ -1944,27 +1947,23 @@ contract LiquidityPoolTest is TestSetup {
         assertGt(s2, 0, "max amount / max rate");
     }
 
-    /// @dev `rate == 0` selects the live-rate fallback inside the (amount, rate) overload.
-    ///      Confirms parity with `sharesForWithdrawalAmount` at the current state.
-    function testFuzz_withdrawWithRate_zeroRateUsesLive(uint96 rawAmount) public {
-        uint96 amount = uint96(bound(rawAmount, 1 wei, 100 ether));
-
-        // Deposit so eETH shares exist; transfer to NFT.
+    /// @dev `rate == 0` is rejected by LP — consumers (WRNFT / Queue) are required to resolve
+    ///      pre-upgrade legacy snapshots to a live rate locally via `amountPerShareCeil()`
+    ///      before invoking the (amount, rate) overload. Pins the InvalidRate revert.
+    function test_withdrawWithRate_zeroRateReverts_InvalidRate() public {
+        // Deposit so eETH shares exist; transfer to NFT so the solvency precondition is met.
         vm.deal(alice, 1000 ether);
         vm.prank(alice);
         liquidityPoolInstance.deposit{value: 1000 ether}();
         vm.prank(alice);
-        eETHInstance.transfer(address(withdrawRequestNFTInstance), amount);
-
-        uint256 expectedShare = liquidityPoolInstance.sharesForWithdrawalAmount(amount);
-        if (expectedShare == 0) return;
+        eETHInstance.transfer(address(withdrawRequestNFTInstance), 1 ether);
 
         vm.prank(address(etherFiAdminInstance));
-        liquidityPoolInstance.addEthAmountLockedForWithdrawal(amount);
+        liquidityPoolInstance.addEthAmountLockedForWithdrawal(uint128(1 ether));
 
         vm.prank(address(withdrawRequestNFTInstance));
-        uint256 burned = liquidityPoolInstance.withdraw(uint256(amount), uint256(0));
-        assertEq(burned, expectedShare, "rate=0 path must match sharesForWithdrawalAmount");
+        vm.expectRevert(LiquidityPool.InvalidRate.selector);
+        liquidityPoolInstance.withdraw(uint256(1 ether), uint256(0));
     }
 
     function test_initializeOnUpgradeV2_sweepsLockedEth() public {

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -43,7 +43,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
             address(roleRegistryInstance),
             treasury,
             1 hours,
-            0,
+            1,
             4e18
         );
         UUPSProxy proxy = new UUPSProxy(
@@ -64,7 +64,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
         vm.stopPrank();
         vm.startPrank(wrnOwner);
         WithdrawRequestNFT newWrnImpl =
-            new WithdrawRequestNFT(0x2f5301a3D59388c509C65f8698f521377D41Fd0F, address(blacklisterInstance), 0, 4e18);
+            new WithdrawRequestNFT(0x2f5301a3D59388c509C65f8698f521377D41Fd0F, address(blacklisterInstance), 1, 4e18);
         withdrawRequestNFTInstance.upgradeTo(address(newWrnImpl));
         vm.stopPrank();
         vm.startPrank(owner);

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.13;
 import "./TestSetup.sol";
 import "forge-std/console2.sol";
 
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 import "../src/PriorityWithdrawalQueue.sol";
 import "../src/interfaces/IPriorityWithdrawalQueue.sol";
 import "../src/utils/PausableUntil.sol";
@@ -2676,5 +2678,157 @@ contract PriorityWithdrawalQueueTest is TestSetup {
 
         assertTrue(priorityQueue.isFinalized(requestId), "healthy request finalized");
         assertGt(priorityQueue.fulfillmentRate(requestId), 0, "snapshot stored for healthy request");
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------  Share-rate-freeze invariants (H-02)  ------------------------
+    //--------------------------------------------------------------------------------------
+
+    /// @notice For a fulfilled request, claim amount must NOT change across post-fulfill rebases.
+    ///         Core H-02 property on the priority path: post-fulfill rate movement is invisible
+    ///         to the claimant — they receive `amountWithFee` from the segregated escrow.
+    function test_invariant_queue_claimAmountIndependentOfPostFulfillRebase() public {
+        // 1. user requests, manager fulfills
+        uint96 withdrawAmount = 5 ether;
+        (bytes32 requestId, IPriorityWithdrawalQueue.WithdrawRequest memory request) =
+            _createWithdrawRequest(vipUser, withdrawAmount);
+
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory requests =
+            new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+        requests[0] = request;
+        vm.prank(requestManager);
+        priorityQueue.fulfillRequests(requests);
+        uint224 frozenRate = priorityQueue.fulfillmentRate(requestId);
+        assertGt(frozenRate, 0, "fulfillmentRate must be set after fulfill");
+
+        // 2. snapshot expected claim
+        uint256 expectedClaim = priorityQueue.getClaimableAmount(request);
+        assertEq(expectedClaim, request.amountWithFee, "claim is amountWithFee when solvent");
+
+        // 3. apply positive rebase — solvency must still hold and claim must not move.
+        _rebase(20 ether);
+        assertEq(
+            priorityQueue.getClaimableAmount(request),
+            expectedClaim,
+            "queue claim must be invariant under positive post-fulfill rebase"
+        );
+        assertEq(
+            priorityQueue.fulfillmentRate(requestId),
+            frozenRate,
+            "frozen rate must not move under positive rebase"
+        );
+
+        // 4. apply negative rebase. Pre-freeze this would have either dropped the claim or
+        //    blocked it via the live-rate solvency check. Frozen-rate must shield both.
+        _rebase(-15 ether);
+        assertEq(
+            priorityQueue.getClaimableAmount(request),
+            expectedClaim,
+            "queue claim must be invariant under negative post-fulfill rebase"
+        );
+        assertEq(
+            priorityQueue.fulfillmentRate(requestId),
+            frozenRate,
+            "frozen rate must not move under negative rebase"
+        );
+
+        // 5. claim actually pays the snapshot
+        uint256 ethBefore = vipUser.balance;
+        vm.prank(vipUser);
+        priorityQueue.claimWithdraw(request);
+        assertEq(vipUser.balance - ethBefore, expectedClaim, "queue payout uses frozen rate");
+    }
+
+    /// @notice Ceiling round-trip for the Queue claim path: with the frozen-rate solvency check
+    ///         (`shareOfEEth * rate / 1e18 >= amountWithFee`) enforced at fulfill, the round-trip
+    ///         ceiling `ceil(amountWithFee * 1e18 / rate) <= shareOfEEth` must hold for the burn.
+    ///         Mirrors `_claimWithdraw`'s `burnedShares <= shareOfEEth` invariant.
+    function test_invariant_queue_burnCeilingNeverExceedsRequestShares() public {
+        // Exercise a spread of fee fractions: amountWithFee very near, mid, and far below
+        // the rate-frozen value of shareOfEEth. The round-trip property must hold in all cases.
+        uint96[3] memory amounts = [uint96(5 ether), uint96(3 ether), uint96(1 ether)];
+
+        for (uint256 i = 0; i < amounts.length; i++) {
+            uint96 amountWithFee = amounts[i];
+
+            // Build a request via the normal path so shareOfEEth is the real LP-derived share.
+            (bytes32 requestId, IPriorityWithdrawalQueue.WithdrawRequest memory request) =
+                _createWithdrawRequestWithFee(vipUser, 5 ether, amountWithFee);
+
+            IPriorityWithdrawalQueue.WithdrawRequest[] memory reqs =
+                new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+            reqs[0] = request;
+            vm.prank(requestManager);
+            priorityQueue.fulfillRequests(reqs);
+
+            uint224 rate = priorityQueue.fulfillmentRate(requestId);
+            assertGt(rate, 0, "rate must be set after fulfill");
+
+            // Round-trip ceiling burn must not exceed the request's share allocation.
+            uint256 burn = Math.mulDiv(uint256(amountWithFee), 1e18, uint256(rate), Math.Rounding.Up);
+            assertLe(burn, uint256(request.shareOfEEth), "queue: ceiling burn <= shareOfEEth");
+
+            // And the protocol never under-collects: burn * rate / 1e18 >= amountWithFee.
+            assertGe(
+                Math.mulDiv(burn, uint256(rate), 1e18, Math.Rounding.Down),
+                uint256(amountWithFee),
+                "queue: round-trip burn * rate / 1e18 >= amountWithFee"
+            );
+
+            // Drain so the next iteration's request can fit (vipUser has 50 ETH eETH baseline).
+            vm.prank(vipUser);
+            priorityQueue.claimWithdraw(request);
+        }
+    }
+
+    /// @notice Legacy fulfillment (snapshot==0 in `_fulfillmentRates`) must fall back to the
+    ///         live rate via `LP.amountPerShareCeil()` — preserving pre-upgrade claim semantics
+    ///         and successfully passing the (now-non-zero) rate to `LP.withdraw`.
+    function test_legacyQueueFulfillment_fallsBackToLiveRate() public {
+        // 1. Create + fulfill normally so the request lands in `_finalizedRequests` and ETH
+        //    is escrowed via `transferLockedEthForPriority`.
+        uint96 withdrawAmount = 5 ether;
+        (bytes32 requestId, IPriorityWithdrawalQueue.WithdrawRequest memory request) =
+            _createWithdrawRequest(vipUser, withdrawAmount);
+
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory reqs =
+            new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+        reqs[0] = request;
+        vm.prank(requestManager);
+        priorityQueue.fulfillRequests(reqs);
+
+        uint224 storedRate = priorityQueue.fulfillmentRate(requestId);
+        assertGt(storedRate, 0, "precondition: rate stored after fulfill");
+
+        // 2. Simulate "pre-upgrade fulfillment" by clearing the rate slot via vm.store. The
+        //    base slot for `_fulfillmentRates` is determined by the contract's storage layout
+        //    (see `forge inspect ... storage`). The value slot for a given key is
+        //    `keccak256(abi.encode(key, baseSlot))`.
+        uint256 fulfillmentRatesBaseSlot = 158;
+        bytes32 valueSlot = keccak256(abi.encode(requestId, fulfillmentRatesBaseSlot));
+        // Sanity: pre-clear slot value should equal storedRate.
+        assertEq(
+            uint256(vm.load(address(priorityQueue), valueSlot)),
+            uint256(storedRate),
+            "_fulfillmentRates slot index drift - update fulfillmentRatesBaseSlot"
+        );
+
+        // 3. Zero the slot — request is now finalized with no snapshot, exactly like a
+        //    pre-upgrade fulfillment.
+        vm.store(address(priorityQueue), valueSlot, bytes32(0));
+        assertEq(priorityQueue.fulfillmentRate(requestId), 0, "snapshot cleared");
+
+        // 4. Pre-cleared expected payout via live-rate path (what pre-upgrade code would compute).
+        uint256 liveAmountForShares = liquidityPoolInstance.amountForShare(request.shareOfEEth);
+        // Solvency check uses the resolved rate (ceil); but both paths agree as long as
+        // amountWithFee <= floor(shareOfEEth * rate / 1e18). The test request is solvent.
+        assertGe(liveAmountForShares, request.amountWithFee, "live solvency precondition");
+
+        // 5. claimWithdraw must succeed via the live-rate fallback — and pay the user
+        //    `amountWithFee` from the segregated escrow exactly like a frozen-rate claim would.
+        uint256 ethBefore = vipUser.balance;
+        vm.prank(vipUser);
+        priorityQueue.claimWithdraw(request);
+        assertEq(vipUser.balance - ethBefore, request.amountWithFee, "legacy fallback claim pays amountWithFee");
     }
 }

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -42,7 +42,9 @@ contract PriorityWithdrawalQueueTest is TestSetup {
             address(weEthInstance),
             address(roleRegistryInstance),
             treasury,
-            1 hours
+            1 hours,
+            0,
+            4e18
         );
         UUPSProxy proxy = new UUPSProxy(
             address(priorityQueueImpl),

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -499,7 +499,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryInstance.grantRole(_blacklisterRole, _roleRegOwner);
 
         // Deploy PriorityWithdrawalQueue for fork testing (mainnet LP has immutable address(0) for this)
-        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
+        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -755,7 +755,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         // Deploy PriorityWithdrawalQueue before EtherFiAdmin so the admin's
         // immutable priorityWithdrawalQueue constructor arg can be wired up.
-        priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
+        priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -1025,7 +1025,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             // upgrade our existing contracts to utilize `roleRegistry`
             vm.stopPrank();
             vm.startPrank(owner);
-            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
+            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
             UUPSProxy priorityQueueProxy = new UUPSProxy(
                 address(priorityQueueImplementation),
                 abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -499,7 +499,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryInstance.grantRole(_blacklisterRole, _roleRegOwner);
 
         // Deploy PriorityWithdrawalQueue for fork testing (mainnet LP has immutable address(0) for this)
-        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
+        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 1, 4e18);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -744,7 +744,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         membershipNftProxy = new UUPSProxy(address(membershipNftImplementation), "");
         membershipNftInstance = MembershipNFT(payable(membershipNftProxy));
 
-        withdrawRequestNFTImplementation = new WithdrawRequestNFT(address(treasuryInstance), address(blacklisterInstance), 0, 4e18);
+        withdrawRequestNFTImplementation = new WithdrawRequestNFT(address(treasuryInstance), address(blacklisterInstance), 1, 4e18);
         withdrawRequestNFTProxy = new UUPSProxy(address(withdrawRequestNFTImplementation), "");
         withdrawRequestNFTInstance = WithdrawRequestNFT(payable(withdrawRequestNFTProxy));
 
@@ -755,7 +755,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         // Deploy PriorityWithdrawalQueue before EtherFiAdmin so the admin's
         // immutable priorityWithdrawalQueue constructor arg can be wired up.
-        priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
+        priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 1, 4e18);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -1025,7 +1025,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             // upgrade our existing contracts to utilize `roleRegistry`
             vm.stopPrank();
             vm.startPrank(owner);
-            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 0, 4e18);
+            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours, 1, 4e18);
             UUPSProxy priorityQueueProxy = new UUPSProxy(
                 address(priorityQueueImplementation),
                 abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -11,7 +11,7 @@ import "../src/utils/PausableUntil.sol";
 
 contract WithdrawRequestNFTIntrusive is WithdrawRequestNFT {
 
-    constructor() WithdrawRequestNFT(address(0), address(0), 0, 4e18) {}
+    constructor() WithdrawRequestNFT(address(0), address(0), 1, 4e18) {}
 
     function updateParam(uint32 _currentRequestIdToScanFromForShareRemainder, uint32 _lastRequestIdToScanUntilForShareRemainder) external {
         currentRequestIdToScanFromForShareRemainder = _currentRequestIdToScanFromForShareRemainder;
@@ -339,7 +339,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     function test_handleRemainder() public {
         initializeRealisticFork(MAINNET_FORK);
         vm.startPrank(address(roleRegistryInstance.owner()));
-        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 0, 4e18)));
+        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 1, 4e18)));
         roleRegistryInstance.grantRole(withdrawRequestNFTInstance.IMPLICIT_FEE_CLAIMER_ROLE(), alice);
         vm.stopPrank();
         uint256 implicitFee = withdrawRequestNFTInstance.getEEthRemainderAmount();

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/console2.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./TestSetup.sol";
 import "../src/utils/PausableUntil.sol";
 
@@ -2150,5 +2151,169 @@ contract WithdrawRequestNFTTest is TestSetup {
         assertEq(withdrawRequestNFTInstance.frozenRateFor(r1), rate, "r1 covered by same batch");
         assertEq(withdrawRequestNFTInstance.frozenRateFor(r2), rate, "r2 covered by same batch");
         assertEq(withdrawRequestNFTInstance.frozenRateFor(r3), rate, "r3 covered by same batch");
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------  Share-rate-freeze invariants (H-02)  ------------------------
+    //--------------------------------------------------------------------------------------
+
+    /// @notice For a finalized request, claim amount must NOT change across post-finalize rebases.
+    ///         This is the core H-02 property: post-finalize rate movement is invisible to the
+    ///         claimant. Exercises both a positive and a negative post-finalize rebase, and the
+    ///         actual claim payout against the pre-rebase snapshot.
+    function test_invariant_claimAmountIndependentOfPostFinalizeRebase() public {
+        // 1. user deposits, requests withdraw
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 20 ether}();
+        vm.stopPrank();
+
+        // Build up TPE so a later negative rebase has headroom and doesn't underflow.
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(20 ether); // 40 ETH TPE / 20 shares → ~2 ETH/share
+
+        vm.prank(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
+        vm.prank(bob);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+
+        // 2. admin finalizes
+        _finalizeWithdrawalRequest(requestId);
+
+        // 3. snapshot expected payout via getClaimableAmount
+        uint256 expectedClaim = withdrawRequestNFTInstance.getClaimableAmount(requestId);
+        uint224 frozenRate = withdrawRequestNFTInstance.frozenRateFor(requestId);
+        assertGt(frozenRate, 0, "frozenRate must be set after finalize");
+
+        // 4. apply positive rebase
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(10 ether);
+
+        // 5. assert getClaimableAmount unchanged after positive rebase
+        assertEq(
+            withdrawRequestNFTInstance.getClaimableAmount(requestId),
+            expectedClaim,
+            "claim must be invariant under positive post-finalize rebase"
+        );
+        assertEq(
+            withdrawRequestNFTInstance.frozenRateFor(requestId),
+            frozenRate,
+            "frozen rate must not move under positive rebase"
+        );
+
+        // 6. apply negative rebase
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(-15 ether);
+
+        // 7. assert getClaimableAmount unchanged after negative rebase
+        assertEq(
+            withdrawRequestNFTInstance.getClaimableAmount(requestId),
+            expectedClaim,
+            "claim must be invariant under negative post-finalize rebase"
+        );
+        assertEq(
+            withdrawRequestNFTInstance.frozenRateFor(requestId),
+            frozenRate,
+            "frozen rate must not move under negative rebase"
+        );
+
+        // 8. user claims, assert actual paid ETH == snapshot
+        uint256 ethBefore = bob.balance;
+        vm.prank(bob);
+        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        assertEq(bob.balance - ethBefore, expectedClaim, "paid ETH must match the pre-rebase snapshot");
+    }
+
+    /// @notice Ceiling round-trip: for any (amount, rate) tuple where
+    ///         `amount = shareOfEEth * rate / SHARE_UNIT` (the frozen-rate evaluation), the
+    ///         caller's burn `ceil(amount * SHARE_UNIT / rate)` must not exceed `shareOfEEth`.
+    ///         The freeze accounting relies on this for the `burnedShares <= shareOfEEth` guard
+    ///         in `_claimWithdraw`; here we exercise the same math directly against the
+    ///         contract's withdraw path for a spread of tuples.
+    function test_invariant_burnCeilingNeverExceedsRequestShares() public {
+        uint256[3] memory amounts = [uint256(0.01 ether), uint256(1 ether), uint256(95 ether)];
+        uint256[3] memory rates   = [uint256(0.9e18),     uint256(1e18),    uint256(1.5e18)];
+
+        for (uint256 i = 0; i < amounts.length; i++) {
+            for (uint256 j = 0; j < rates.length; j++) {
+                uint256 rate = rates[j];
+                // shareOfEEth large enough that amount = floor(shareOfEEth * rate / 1e18) > 0
+                uint256 shareOfEEth = 100 ether;
+
+                // amount = (rate-frozen) value of shareOfEEth shares, then take min with the
+                // requested amount to mirror `_getClaimableAmount`'s clamp.
+                uint256 amountForShares = Math.mulDiv(shareOfEEth, rate, 1e18);
+                uint256 amount = Math.min(amounts[i], amountForShares);
+                if (amount == 0) continue;
+
+                uint256 burn = Math.mulDiv(amount, 1e18, rate, Math.Rounding.Up);
+                assertLe(burn, shareOfEEth, "ceiling burn must not exceed shareOfEEth");
+
+                // Round-trip: burned * rate / 1e18 >= amount (protocol never under-collects).
+                assertGe(
+                    Math.mulDiv(burn, rate, 1e18, Math.Rounding.Down),
+                    amount,
+                    "round-trip: burn * rate / 1e18 >= amount"
+                );
+            }
+        }
+    }
+
+    /// @notice After upgrade, lookup for a pre-upgrade tokenId resolves to 0, triggering the
+    ///         local live-rate fallback path. The claim payout must match what the pre-upgrade
+    ///         code (live `amountForShare`-based) would have computed at that moment.
+    function test_legacyFallback_matchesPreUpgradeLiveRate() public {
+        // 1. set up a "pre-upgrade finalized request" by stepping lastFinalizedRequestId without
+        //    pushing a real snapshot — mirroring on-chain state at the moment of the upgrade.
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+        vm.stopPrank();
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(10 ether);
+
+        vm.startPrank(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
+        uint256 legacyId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+        vm.stopPrank();
+
+        vm.startPrank(withdrawRequestNFTInstance.owner());
+        _setLastFinalizedRequestIdForTest(uint32(legacyId));
+        vm.stopPrank();
+
+        // LP locks the ETH so the eventual claim path can succeed.
+        vm.prank(address(etherFiAdminInstance));
+        liquidityPoolInstance.addEthAmountLockedForWithdrawal(uint128(1 ether));
+
+        // 2. capture expected payout via the old live-rate path BEFORE the upgrade init.
+        WithdrawRequestNFT.WithdrawRequest memory legacyReq =
+            withdrawRequestNFTInstance.getRequest(legacyId);
+        uint256 liveAmountForShares = liquidityPoolInstance.amountForShare(legacyReq.shareOfEEth);
+        uint256 expectedPreUpgrade = Math.min(uint256(legacyReq.amountOfEEth), liveAmountForShares);
+
+        // 3. call initializeShareRateFreezeUpgrade (pushes the sentinel = value 0).
+        vm.prank(withdrawRequestNFTInstance.owner());
+        withdrawRequestNFTInstance.initializeShareRateFreezeUpgrade();
+        assertEq(
+            withdrawRequestNFTInstance.frozenRateFor(legacyId),
+            0,
+            "legacy id must hit the value-0 sentinel"
+        );
+
+        // 4. assert getClaimableAmount returns the same value (live-rate fallback in effect).
+        //    Use a tight delta — both expressions evaluate at the same block / rate, so they
+        //    must match exactly up to a 1-wei rounding artifact (mulDiv-Up vs mulDiv-Down).
+        uint256 postUpgradeClaim = withdrawRequestNFTInstance.getClaimableAmount(legacyId);
+        assertApproxEqAbs(
+            postUpgradeClaim,
+            expectedPreUpgrade,
+            1,
+            "legacy live-rate fallback must match pre-upgrade live-rate semantics within 1 wei"
+        );
+
+        // 5. claim actually succeeds — proves the fallback resolves to a non-zero rate that
+        //    LP accepts (and not the now-removed `rate==0` LP branch).
+        uint256 ethBefore = bob.balance;
+        vm.prank(bob);
+        withdrawRequestNFTInstance.claimWithdraw(legacyId);
+        assertGt(bob.balance, ethBefore, "claim must succeed via live-rate fallback");
     }
 }

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -204,7 +204,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         // 2. Deploy new implementation contracts (with the added guard)
         // ------------------------------------------------------------------
         address newLP  = address(new LiquidityPool(PRIORITY_WITHDRAWAL_QUEUE, address(blacklisterInstance), 0));
-        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 0, 4e18));
+        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 1, 4e18));
 
         // ------------------------------------------------------------------
         // 3. Upgrade the proxies in place
@@ -380,9 +380,9 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
     ///      receive(); the master queue impl has no receive() and would revert.
     function _doUpgrade() internal {
         address newLP = address(new LiquidityPool(PRIORITY_WITHDRAWAL_QUEUE, address(blacklisterInstance), 0));
-        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 0, 4e18));
+        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 1, 4e18));
         address newPQ = address(new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours, 0, 4e18
+            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours, 1, 4e18
         ));
 
         vm.prank(UPGRADE_TIMELOCK);

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -382,7 +382,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         address newLP = address(new LiquidityPool(PRIORITY_WITHDRAWAL_QUEUE, address(blacklisterInstance), 0));
         address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(blacklisterInstance), 0, 4e18));
         address newPQ = address(new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours
+            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours, 0, 4e18
         ));
 
         vm.prank(UPGRADE_TIMELOCK);

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -24,7 +24,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         address wrnOwner = withdrawRequestNFTInstance.owner();
         vm.prank(wrnOwner);
         withdrawRequestNFTInstance.upgradeTo(
-            address(new WithdrawRequestNFT(buybackWallet, address(blacklisterInstance), 0, 4e18))
+            address(new WithdrawRequestNFT(buybackWallet, address(blacklisterInstance), 1, 4e18))
         );
 
         // The production queue proxy on mainnet still runs the master impl which
@@ -32,7 +32,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         // into the queue and would revert with SendFail. Upgrade the queue first.
         address newPQ = address(new PriorityWithdrawalQueue(
             address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance),
-            address(roleRegistryInstance), treasuryInstance, 1 hours, 0, 4e18
+            address(roleRegistryInstance), treasuryInstance, 1 hours, 1, 4e18
         ));
         vm.prank(UPGRADE_TIMELOCK);
         PriorityWithdrawalQueue(payable(PRIORITY_WITHDRAWAL_QUEUE)).upgradeTo(newPQ);
@@ -69,7 +69,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
         // Grant the IMPLICIT_FEE_CLAIMER_ROLE to alice
         vm.startPrank(address(roleRegistryInstance.owner()));
-        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 0, 4e18)));
+        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 1, 4e18)));
         roleRegistryInstance.grantRole(withdrawRequestNFTInstance.IMPLICIT_FEE_CLAIMER_ROLE(), alice);
         vm.stopPrank();
 
@@ -147,7 +147,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
         // Now upgrade the contract and grant roles
         vm.startPrank(address(roleRegistryInstance.owner()));
-        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 0, 4e18)));
+        withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 1, 4e18)));
         roleRegistryInstance.grantRole(withdrawRequestNFTInstance.IMPLICIT_FEE_CLAIMER_ROLE(), alice);
         vm.stopPrank();
 
@@ -228,7 +228,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
             // Grant the IMPLICIT_FEE_CLAIMER_ROLE to alice
             vm.startPrank(address(roleRegistryInstance.owner()));
-            withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 0, 4e18)));
+            withdrawRequestNFTInstance.upgradeTo(address(new WithdrawRequestNFT(address(buybackWallet), address(blacklisterInstance), 1, 4e18)));
             roleRegistryInstance.grantRole(withdrawRequestNFTInstance.IMPLICIT_FEE_CLAIMER_ROLE(), alice);
             vm.stopPrank();
 

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -32,7 +32,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         // into the queue and would revert with SendFail. Upgrade the queue first.
         address newPQ = address(new PriorityWithdrawalQueue(
             address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance),
-            address(roleRegistryInstance), treasuryInstance, 1 hours
+            address(roleRegistryInstance), treasuryInstance, 1 hours, 0, 4e18
         ));
         vm.prank(UPGRADE_TIMELOCK);
         PriorityWithdrawalQueue(payable(PRIORITY_WITHDRAWAL_QUEUE)).upgradeTo(newPQ);

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -100,7 +100,9 @@ contract WithdrawEscrowE2ETest is TestSetup {
             address(weEthInstance),
             address(roleRegistryInstance),
             treasuryInstance,
-            1 hours
+            1 hours,
+            0,
+            4e18
         );
         UUPSProxy proxy = new UUPSProxy(
             address(impl),

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -101,7 +101,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
             address(roleRegistryInstance),
             treasuryInstance,
             1 hours,
-            0,
+            1,
             4e18
         );
         UUPSProxy proxy = new UUPSProxy(
@@ -117,7 +117,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
         address wrnOwner = withdrawRequestNFTInstance.owner();
         vm.prank(wrnOwner);
         withdrawRequestNFTInstance.upgradeTo(
-            address(new WithdrawRequestNFT(0x2f5301a3D59388c509C65f8698f521377D41Fd0F, address(blacklisterInstance), 0, 4e18))
+            address(new WithdrawRequestNFT(0x2f5301a3D59388c509C65f8698f521377D41Fd0F, address(blacklisterInstance), 1, 4e18))
         );
     }
 


### PR DESCRIPTION
**Stacks on:** #414 → #413 (yash/feat/share-rate-freeze) → pankaj/feat/security-upgrades
**Goal:** keep #413's design and property; shrink the audit surface; add the H-02 property as foundry invariants.

> Hey @0xpanicError — every change here is on top of your branch; the freeze design, the per-batch checkpoint, and the per-request fulfillment rate are unchanged. The diff is "where the fallback lives + which math primitive + invariant tests". Each section below states what changed and *why* relative to your version, so you can ack or reject piece by piece.

---

## 1. LiquidityPool — single codepath (was: rate=0 fallback inside LP)

**Before (your version):**
```solidity
uint256 share = _rate == 0
    ? sharesForWithdrawalAmount(_amount)
    : Math.mulDiv(_amount, 1e18, _rate, Math.Rounding.Up);
```

**After:**
```solidity
if (_rate == 0) revert InvalidRate();
uint256 share = Math.mulDiv(_amount, 1e18, _rate, Math.Rounding.Up);
```

**Why:** Two reasons.
1. **Audit cost.** LP today has two semantics behind one entrypoint ("burn at frozen rate" vs "burn at live rate"). Auditors must prove every property for both branches. Forcing `rate != 0` collapses LP to a single fixed equation — the freeze policy is now a property of the *caller*, not LP.
2. **Invariant clarity.** "LP always uses caller-supplied rate" is a one-line property. "LP uses caller-supplied rate, unless it's zero, in which case it falls back to live, but only for these two callers" is a four-line property with a footnote.

Updated two existing internal callsites that passed `rate=0` to pass `amountPerShareCeil()` explicitly.

## 2. WithdrawRequestNFT / PriorityWithdrawalQueue — fallback moved into consumers

**Before:** WRNFT and Queue would happily pass `rate=0` to LP for legacy (pre-upgrade) requests, and LP would substitute the live rate internally.

**After:** Each consumer resolves the rate locally:

```solidity
uint224 frozenRate = _fulfillmentRates[requestId]; // or _finalizationRates.lowerLookup(tokenId)
if (frozenRate == 0) {
    uint256 live = liquidityPool.amountPerShareCeil();
    require(live > 0 && live <= type(uint224).max, "invalid live rate");
    frozenRate = uint224(live);
}
// ... use frozenRate for solvency + pass to LP.withdraw(amount, frozenRate)
```

**Why:**
- **No new storage.** Specifically — *did not* add `legacyDefaultRate` storage var on the Queue (the obvious alternative). Sentinel push in `initializeShareRateFreezeUpgrade` keeps writing 0; the 0 is now an explicit "compute live locally" signal handled in one place per consumer.
- **Legacy claim semantics = pre-upgrade semantics.** Old (#413 today) and new both give legacy claimers the live rate at claim time. No drift, no audit-evidence burden to argue legacy users accept a new rate, no need to backfill historical rates.
- **Explicit at the call site.** Reading WRNFT/Queue, an auditor sees both branches (snapshot vs live) right where the decision is made.

## 3. OpenZeppelin `Math.mulDiv(..., Rounding.Up)` everywhere

LP already moved to this via commit `55ed102` on your branch. WRNFT's `_getClaimableAmount` was still using `* rate / SHARE_UNIT` — swapped to `Math.mulDiv(shareOfEEth, frozenRate, SHARE_UNIT)` to match. Queue's `fulfillRequests` snapshot path already calls `LP.amountPerShareCeil()` (which itself uses `Math.mulDiv`), so no change there.

**Why:** Audited primitive vs hand-rolled ceiling math eliminates a class of off-by-one findings before they're filed.

## 4. Foundry invariant tests inline (6 new)

In `test/WithdrawRequestNFT.t.sol`:
- `test_invariant_claimAmountIndependentOfPostFinalizeRebase` — the core H-02 property. Finalize → snapshot expected payout → rebase positive → rebase negative → assert `getClaimableAmount` unchanged → claim → assert actual ETH paid matches snapshot.
- `test_invariant_burnCeilingNeverExceedsRequestShares` — `Math.mulDiv(amount, 1e18, rate, Up) <= shareOfEEth` for the round-tripped (amount, rate, shareOfEEth) tuple.
- `test_legacyFallback_matchesPreUpgradeLiveRate` — finalize a request, push sentinel via `initializeShareRateFreezeUpgrade`, assert payout equals what the pre-upgrade live-rate path would have produced.

In `test/PriorityWithdrawalQueue.t.sol`: the three Queue-side equivalents (`test_invariant_queue_*` and `test_legacyQueueFulfillment_fallsBackToLiveRate`).

**Why:** These properties are the spec the auditor will write anyway. Giving them as foundry invariants up front shortens the engagement and catches regressions during code review here.

> One thing worth flagging: `test_legacyQueueFulfillment_fallsBackToLiveRate` pokes the `_fulfillmentRates` mapping via `vm.store` using a base slot derived from `forge inspect storage-layout`. Wrote it to fail loudly with a clear "slot index drift" assertion if the layout shifts, so a future storage change won't make this test silently green.

## 5. NatSpec invariant block on WRNFT and Queue

1-page docstring at the top of each contract listing I1–I4:
- **I1.** `_finalizationRates` keys are strictly increasing.
- **I2.** `lowerLookup(tokenId)` returns the rate of the smallest finalize batch covering `tokenId`; legacy returns 0 → local live-rate fallback.
- **I3.** For any finalized `tokenId`, `getClaimableAmount` is invariant under post-finalize rebase. Property-tested.
- **I4.** Rate snapshot uses ceiling rounding so solvency holds and burn ≤ request's own shares.

**Why:** Pre-resolved invariants for the auditor. Specs we'd otherwise write in a separate doc, in the code where they belong.

---

## Audit-surface delta vs your branch as-is

- LP: −1 branch, +1 revert, +0 storage, +0 public surface → single codepath
- WRNFT/Queue: same number of branches, moved one layer up where the decision is local and explicit
- Net new storage: **0**
- Net new public surface: **0** (`frozenRateFor` / `fulfillmentRate` were already yours)

## Test results

- `LiquidityPoolTest` 141/141
- `WithdrawRequestNFTTest` 83/83 (3 new invariants)
- `PriorityWithdrawalQueueTest` 105/105 (3 new invariants)
- 1 unrelated pre-existing `EtherFiRestakerTest::setUp` fork-RPC failure on the branch — not introduced here.

## Out of scope (deferred — happy to discuss separately)

- **Stranded post-finalize positive-rebase rewards** (the second motivation in #158). #413 doesn't address it either; if we want full #158-parity, that's its own PR + its own audit.
- **Backfilling historical `R_finalize` per batch.** Would let us drop the local live-rate fallback entirely. Did not pursue because the cost (script + on-chain backfill + verification) outweighed the audit surface saved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core withdrawal settlement math and upgrade-time constructor args for `WithdrawRequestNFT`/`PriorityWithdrawalQueue`, so a mistake could break claims or escrow accounting; changes are tightly scoped and backed by new invariant/property tests.
> 
> **Overview**
> **Segregated-withdraw accounting is now single-path in `LiquidityPool.withdraw(amount, rate)`.** The LP no longer treats `rate == 0` as “use live rate”; it now reverts with `InvalidRate` and always burns shares via a single `Math.mulDiv(..., Rounding.Up)` expression.
> 
> **Legacy/live-rate fallback moved to callers.** `WithdrawRequestNFT` and `PriorityWithdrawalQueue` now resolve missing snapshots (`0` sentinel for pre-upgrade finalizations/fulfillments) to `LP.amountPerShareCeil()` locally (with acceptable-rate bounds) before doing solvency math and calling LP, and `PriorityWithdrawalQueue` adds immutable min/max acceptable share-rate constructor params.
> 
> **Tests + scripts updated to reflect the new contract invariants.** Foundry adds H-02 invariant tests for claim amounts being rebase-invariant post-finalize/fulfill and for ceiling burn bounds, updates existing LP tests for the `InvalidRate` behavior, and upgrade/deploy scripts are adjusted for the new constructor args and bytecode checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50777e5b242d93d42cf69c505dfa9eebfcd455ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->