### PR TITLE
yash/feat/enforce-oracle-quorum

### DIFF
--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -52,6 +52,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     event ReportPublished(uint32 consensusVersion, uint32 refSlotFrom, uint32 refSlotTo, uint32 refBlockFrom, uint32 refBlockTo, bytes32 indexed hash);
     event ReportSubmitted(uint32 consensusVersion, uint32 refSlotFrom, uint32 refSlotTo, uint32 refBlockFrom, uint32 refBlockTo, bytes32 indexed hash, address indexed committeeMember);
 
+    error InvalidQuorum();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _etherFiAdmin, address _roleRegistry) {
@@ -239,7 +240,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         numCommitteeMembers++;
         numActiveCommitteeMembers++;
         committeeMemberStates[_address] = CommitteeMemberState(true, true, 0, 0);
-
+        _checkQuorum();
         emit CommitteeMemberAdded(_address);
     }
 
@@ -248,7 +249,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         numCommitteeMembers--;
         if (committeeMemberStates[_address].enabled) numActiveCommitteeMembers--;
         delete committeeMemberStates[_address];
-
+        _checkQuorum();
         emit CommitteeMemberRemoved(_address);
     }
 
@@ -261,13 +262,13 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         } else {
             numActiveCommitteeMembers--;
         }
-
+        _checkQuorum();
         emit CommitteeMemberUpdated(_address, _enabled);
     }
 
     function setQuorumSize(uint32 _quorumSize) public onlyAdmin {
         quorumSize = _quorumSize;
-
+        _checkQuorum();
         emit QuorumUpdated(_quorumSize);
     }
 
@@ -302,6 +303,10 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
 
     function getImplementation() external view returns (address) {
         return _getImplementation();
+    }
+
+    function _checkQuorum() internal view {
+        if (numActiveCommitteeMembers < quorumSize || numActiveCommitteeMembers / quorumSize > 2) revert InvalidQuorum();
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -306,7 +306,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     }
 
     function _checkQuorum() internal view {
-        if (numActiveCommitteeMembers < quorumSize || numActiveCommitteeMembers / quorumSize > 2) revert InvalidQuorum();
+        if (numActiveCommitteeMembers < quorumSize || numActiveCommitteeMembers > 2 * quorumSize) revert InvalidQuorum();
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -516,27 +516,23 @@ contract EtherFiOracleTest is TestSetup {
     }
 
     function test_SD_5() public {
+        // numActive=3 (alice, bob, chad), quorum stays at the default 2 because
+        // setQuorumSize(5) would now revert with InvalidQuorum (numActive < quorum).
         vm.prank(owner);
         etherFiOracleInstance.addCommitteeMember(chad);
 
-        vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(5);
-        
         _moveClock(1024 + 2 * slotsPerEpoch);
-        
+
         // alice submits the period 2 report
         vm.prank(alice);
         etherFiOracleInstance.submitReport(reportAtPeriod2A);
-           
+
         // check the consensus state
         bytes32 reportHash = etherFiOracleInstance.generateReportHash(reportAtPeriod2A);
         (uint32 support, bool consensusReached, uint32 consensusTimestamp) = etherFiOracleInstance.consensusStates(reportHash);
         assertEq(support, 1);
         assertEq(consensusReached, false);
         assertEq(consensusTimestamp, 0);
-
-        vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
 
         // bob submits the period 2 report
         uint32 curTimestamp = uint32(block.timestamp);
@@ -936,6 +932,93 @@ contract EtherFiOracleTest is TestSetup {
         vm.prank(owner);
         vm.expectRevert("Already registered");
         etherFiOracleInstance.addCommitteeMember(chad);
+    }
+
+    // ========== _checkQuorum invariant tests ==========
+    // _checkQuorum reverts with InvalidQuorum when:
+    //   - numActiveCommitteeMembers < quorumSize (too few members for the quorum), or
+    //   - numActiveCommitteeMembers / quorumSize > 2 (quorum too small relative to membership).
+    // The check runs after every add/remove/manage/setQuorum mutation, so each
+    // mutation needs to leave the (members, quorum) pair inside the valid band.
+
+    function test_setQuorumSize_revertsWhenAboveActiveMembers() public {
+        // numActive = 2 (alice, bob); quorum = 3 violates numActive < quorum
+        vm.prank(owner);
+        vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
+        etherFiOracleInstance.setQuorumSize(3);
+    }
+
+    function test_setQuorumSize_revertsWhenRatioTooLow() public {
+        // First grow membership to 3 so the ratio path is reachable
+        vm.prank(owner);
+        etherFiOracleInstance.addCommitteeMember(chad);
+
+        // 3 / 1 = 3 > 2 -> revert (quorum is too small for the active set)
+        vm.prank(owner);
+        vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
+        etherFiOracleInstance.setQuorumSize(1);
+    }
+
+    function test_setQuorumSize_acceptsAtEqualityBoundary() public {
+        // numActive == quorum is allowed (numActive < quorum is the failing edge)
+        vm.prank(owner);
+        etherFiOracleInstance.setQuorumSize(2);
+        assertEq(etherFiOracleInstance.quorumSize(), 2);
+    }
+
+    function test_addCommitteeMember_revertsWhenRatioWouldExceedTwo() public {
+        // Drop quorum to 1 first (legal at numActive=2 since 2/1=2, not > 2)
+        vm.prank(owner);
+        etherFiOracleInstance.setQuorumSize(1);
+
+        // Adding chad makes numActive=3, and 3/1 = 3 > 2 -> revert
+        vm.prank(owner);
+        vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
+        etherFiOracleInstance.addCommitteeMember(chad);
+    }
+
+    function test_removeCommitteeMember_revertsWhenBelowQuorum() public {
+        // numActive=2, quorum=2; removing alice drops numActive to 1 < quorum -> revert
+        vm.prank(owner);
+        vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
+        etherFiOracleInstance.removeCommitteeMember(alice);
+    }
+
+    function test_removeCommitteeMember_okWhenMemberWasDisabled() public {
+        // Disabling alice already accounted for the numActive drop, so removing her
+        // (which only touches numCommitteeMembers, not numActive) keeps quorum valid.
+        vm.prank(owner);
+        etherFiOracleInstance.addCommitteeMember(chad);
+        // numActive=3 after add; disable alice -> numActive=2, quorum=2 (still valid)
+        vm.prank(owner);
+        etherFiOracleInstance.manageCommitteeMember(alice, false);
+
+        vm.prank(owner);
+        etherFiOracleInstance.removeCommitteeMember(alice);
+
+        assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 2);
+        assertEq(etherFiOracleInstance.numCommitteeMembers(), 2);
+    }
+
+    function test_manageCommitteeMember_disablingRevertsWhenBelowQuorum() public {
+        // numActive=2, quorum=2; disabling bob drops numActive to 1 -> revert
+        vm.prank(owner);
+        vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
+        etherFiOracleInstance.manageCommitteeMember(bob, false);
+    }
+
+    function test_manageCommitteeMember_reenableKeepsQuorumValid() public {
+        // First need a disable that is legal (so add chad to give us headroom)
+        vm.prank(owner);
+        etherFiOracleInstance.addCommitteeMember(chad);
+        vm.prank(owner);
+        etherFiOracleInstance.manageCommitteeMember(chad, false);
+        assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 2);
+
+        // Re-enable chad: numActive goes back to 3, quorum=2, still valid
+        vm.prank(owner);
+        etherFiOracleInstance.manageCommitteeMember(chad, true);
+        assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 3);
     }
 
     // ========== EtherFiAdmin Additional Coverage Tests ==========

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -420,14 +420,6 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         vm.expectRevert(RoleRegistry.OnlyOperatingTimelock.selector);
         etherFiRedemptionManagerInstance.setCapacity(10 ether, ETH_ADDRESS);
         vm.stopPrank();
-
-        // User without role attempts admin-only actions
-        vm.startPrank(user);
-        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
-        etherFiRedemptionManagerInstance.pauseContract();
-        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
-        etherFiRedemptionManagerInstance.unPauseContract();
-        vm.stopPrank();
     }
 
     function test_mainnet_redeem_eEth() public {

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1127,9 +1127,14 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         } else {
             genesisSlotTimestamp = 0;
         }
-        etherFiOracleInstance.initialize(2, 1024, 0, 32, 12, genesisSlotTimestamp);
+        // Initialize quorum at 1 so we can add committee members one-by-one
+        // without tripping the new _checkQuorum invariant
+        // (numActive < quorum reverts). Once both members are registered,
+        // raise quorum to its real value of 2.
+        etherFiOracleInstance.initialize(1, 1024, 0, 32, 12, genesisSlotTimestamp);
         etherFiOracleInstance.addCommitteeMember(alice);
         etherFiOracleInstance.addCommitteeMember(bob);
+        etherFiOracleInstance.setQuorumSize(2);
 
         vm.stopPrank();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new quorum invariants that can revert admin/ops actions (adding/removing/enabling members or changing quorum), which could block governance operations if misconfigured. Logic is simple but touches core oracle consensus configuration and initialization flows.
> 
> **Overview**
> Enforces an oracle quorum invariant by adding `_checkQuorum()` (reverting with `InvalidQuorum`) and calling it after every committee/quorum mutation, ensuring `quorumSize <= numActiveCommitteeMembers <= 2 * quorumSize`.
> 
> Updates tests and setup to accommodate the new invariant (initialize with quorum `1`, add initial members, then raise to `2`), and adds targeted unit tests covering the new revert boundaries; also removes a redundant role-negative pause/unpause check in `EtherFiRedemptionManager` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec882c3fa07ef3689269ea01d5d1e239f2f416bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->