### PR TITLE
yash/fix/nethermind-audit

### DIFF
--- a/script/deploys/DeployCumulativeMerkleRewardsDistributor.sol
+++ b/script/deploys/DeployCumulativeMerkleRewardsDistributor.sol
@@ -34,7 +34,7 @@ contract DeployCumulativeMerkleRewardsDistributor is Script {
         bytes memory initializerData =  abi.encodeWithSelector(CumulativeMerkleRewardsDistributor.initialize.selector);
         CumulativeMerkleRewardsDistributor cumulativeMerkleRewardsDistributorImplementation = new CumulativeMerkleRewardsDistributor(roleRegistryProxyAddress);
         UUPSProxy cumulativeMerkleRewardsDistributorProxy = new UUPSProxy(address(cumulativeMerkleRewardsDistributorImplementation), initializerData);
-        CumulativeMerkleRewardsDistributor cumulativeMerkleInstance = CumulativeMerkleRewardsDistributor(address(cumulativeMerkleRewardsDistributorProxy));
+        CumulativeMerkleRewardsDistributor cumulativeMerkleInstance = CumulativeMerkleRewardsDistributor(payable(address(cumulativeMerkleRewardsDistributorProxy)));
         //cumulativeMerkleInstance.grantRole(keccak256("CUMULATIVE_MERKLE_REWARDS_DISTRIBUTOR_ADMIN_ROLE"), msg.sender);
         cumulativeMerkleInstance.transferOwnership(address(timelockAddress));
 

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -112,11 +112,6 @@ contract AuctionManager is
         __ReentrancyGuard_init();
     }
 
-    function initializeOnUpgrade(uint128 _accumulatedRevenueThreshold) external onlyOwner {
-        accumulatedRevenue = 0;
-        accumulatedRevenueThreshold = _accumulatedRevenueThreshold;
-    }
-
     /// @notice Creates bid(s) for the right to run a validator node when ETH is deposited
     /// @param _bidSize the number of bids that the node operator would like to create
     /// @param _bidAmountPerBid the ether value of each bid that is created

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -119,7 +119,7 @@ contract AuctionManager is
     function createBid(
         uint256 _bidSize,
         uint256 _bidAmountPerBid
-    ) external payable whenNotPaused nonReentrant nonBlacklisted returns (uint256[] memory) {
+    ) external payable nonReentrant whenNotPaused nonBlacklisted returns (uint256[] memory) {
         if (_bidSize == 0) revert InvalidBidSize();
         if (whitelistEnabled) {
             if (!nodeOperatorManager.isWhitelisted(msg.sender)) revert NotWhitelisted();

--- a/src/BucketRateLimiter.sol
+++ b/src/BucketRateLimiter.sol
@@ -4,12 +4,14 @@ import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "src/interfaces/IRateLimiter.sol";
 import "src/interfaces/IRoleRegistry.sol";
 import "lib/BucketLimiter.sol";
 
 contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, OwnableUpgradeable, UUPSUpgradeable {
+    using Math for uint256;
 
     error IncorrectCaller();
     error RateLimitExceeded();
@@ -45,14 +47,14 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
     function updateRateLimit(address sender, address tokenIn, uint256 amountIn, uint256 amountOut) external whenNotPaused {
         if (msg.sender != consumer) revert IncorrectCaller();
         // Count both 'amountIn' and 'amountOut' as rate limit consumption
-        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + RATE_PRECISION - 1) / RATE_PRECISION);
+        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut).ceilDiv(RATE_PRECISION));
         if (!BucketLimiter.consume(limit, consumedAmount)) revert RateLimitExceeded();
         if (limitsPerToken[tokenIn].lastRefill != 0 && !BucketLimiter.consume(limitsPerToken[tokenIn], consumedAmount)) revert TokenRateLimitExceeded();
     }
 
     function canConsume(address tokenIn, uint256 amountIn, uint256 amountOut) external view returns (bool) {
         // Count both 'amountIn' and 'amountOut' as rate limit consumption
-        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + RATE_PRECISION - 1) / RATE_PRECISION);
+        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut).ceilDiv(RATE_PRECISION));
         bool globalConsumable = BucketLimiter.canConsume(limit, consumedAmount);
         bool perTokenConsumable = limitsPerToken[tokenIn].lastRefill == 0 || BucketLimiter.canConsume(limitsPerToken[tokenIn], consumedAmount);
         return globalConsumable && perTokenConsumable;

--- a/src/BucketRateLimiter.sol
+++ b/src/BucketRateLimiter.sol
@@ -15,7 +15,7 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
     error RateLimitExceeded();
     error TokenRateLimitExceeded();
 
-    uint256 public constant GWEI_TO_WEI = 1e12;
+    uint256 public constant RATE_PRECISION = 1e12;
 
     BucketLimiter.Limit public limit;
     address public consumer;
@@ -45,14 +45,14 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
     function updateRateLimit(address sender, address tokenIn, uint256 amountIn, uint256 amountOut) external whenNotPaused {
         if (msg.sender != consumer) revert IncorrectCaller();
         // Count both 'amountIn' and 'amountOut' as rate limit consumption
-        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + GWEI_TO_WEI - 1) / GWEI_TO_WEI);
+        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + RATE_PRECISION - 1) / RATE_PRECISION);
         if (!BucketLimiter.consume(limit, consumedAmount)) revert RateLimitExceeded();
         if (limitsPerToken[tokenIn].lastRefill != 0 && !BucketLimiter.consume(limitsPerToken[tokenIn], consumedAmount)) revert TokenRateLimitExceeded();
     }
 
     function canConsume(address tokenIn, uint256 amountIn, uint256 amountOut) external view returns (bool) {
         // Count both 'amountIn' and 'amountOut' as rate limit consumption
-        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + GWEI_TO_WEI - 1) / GWEI_TO_WEI);
+        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + RATE_PRECISION - 1) / RATE_PRECISION);
         bool globalConsumable = BucketLimiter.canConsume(limit, consumedAmount);
         bool perTokenConsumable = limitsPerToken[tokenIn].lastRefill == 0 || BucketLimiter.canConsume(limitsPerToken[tokenIn], consumedAmount);
         return globalConsumable && perTokenConsumable;
@@ -60,31 +60,31 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
 
     function setCapacity(uint256 capacity) external onlyAdmin {
         // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
-        uint64 capacity64 = SafeCast.toUint64(capacity / GWEI_TO_WEI);
+        uint64 capacity64 = SafeCast.toUint64(capacity / RATE_PRECISION);
         BucketLimiter.setCapacity(limit, capacity64);
     }
 
     function setRefillRatePerSecond(uint256 refillRate) external onlyAdmin {
         // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
-        uint64 refillRate64 = SafeCast.toUint64(refillRate / GWEI_TO_WEI);
+        uint64 refillRate64 = SafeCast.toUint64(refillRate / RATE_PRECISION);
         BucketLimiter.setRefillRate(limit, refillRate64);
     }
 
     function registerToken(address token, uint256 capacity, uint256 refillRate) external onlyAdmin {
-        uint64 capacity64 = SafeCast.toUint64(capacity / GWEI_TO_WEI);
-        uint64 refillRate64 = SafeCast.toUint64(refillRate / GWEI_TO_WEI);
+        uint64 capacity64 = SafeCast.toUint64(capacity / RATE_PRECISION);
+        uint64 refillRate64 = SafeCast.toUint64(refillRate / RATE_PRECISION);
         limitsPerToken[token] = BucketLimiter.create(capacity64, refillRate64);
     }
 
     function setCapacityPerToken(address token, uint256 capacity) external onlyAdmin {
         // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
-        uint64 capacity64 = SafeCast.toUint64(capacity / GWEI_TO_WEI);
+        uint64 capacity64 = SafeCast.toUint64(capacity / RATE_PRECISION);
         BucketLimiter.setCapacity(limitsPerToken[token], capacity64);
     }
 
     function setRefillRatePerSecondPerToken(address token, uint256 refillRate) external onlyAdmin {
         // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
-        uint64 refillRate64 = SafeCast.toUint64(refillRate / GWEI_TO_WEI);
+        uint64 refillRate64 = SafeCast.toUint64(refillRate / RATE_PRECISION);
         BucketLimiter.setRefillRate(limitsPerToken[token], refillRate64);
     }
 

--- a/src/BucketRateLimiter.sol
+++ b/src/BucketRateLimiter.sol
@@ -15,6 +15,8 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
     error RateLimitExceeded();
     error TokenRateLimitExceeded();
 
+    uint256 public constant GWEI_TO_WEI = 1e12;
+
     BucketLimiter.Limit public limit;
     address public consumer;
 
@@ -43,14 +45,14 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
     function updateRateLimit(address sender, address tokenIn, uint256 amountIn, uint256 amountOut) external whenNotPaused {
         if (msg.sender != consumer) revert IncorrectCaller();
         // Count both 'amountIn' and 'amountOut' as rate limit consumption
-        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + 1e12 - 1) / 1e12);
+        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + GWEI_TO_WEI - 1) / GWEI_TO_WEI);
         if (!BucketLimiter.consume(limit, consumedAmount)) revert RateLimitExceeded();
         if (limitsPerToken[tokenIn].lastRefill != 0 && !BucketLimiter.consume(limitsPerToken[tokenIn], consumedAmount)) revert TokenRateLimitExceeded();
     }
 
     function canConsume(address tokenIn, uint256 amountIn, uint256 amountOut) external view returns (bool) {
         // Count both 'amountIn' and 'amountOut' as rate limit consumption
-        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + 1e12 - 1) / 1e12);
+        uint64 consumedAmount = SafeCast.toUint64((amountIn + amountOut + GWEI_TO_WEI - 1) / GWEI_TO_WEI);
         bool globalConsumable = BucketLimiter.canConsume(limit, consumedAmount);
         bool perTokenConsumable = limitsPerToken[tokenIn].lastRefill == 0 || BucketLimiter.canConsume(limitsPerToken[tokenIn], consumedAmount);
         return globalConsumable && perTokenConsumable;
@@ -58,31 +60,31 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
 
     function setCapacity(uint256 capacity) external onlyAdmin {
         // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
-        uint64 capacity64 = SafeCast.toUint64(capacity / 1e12);
+        uint64 capacity64 = SafeCast.toUint64(capacity / GWEI_TO_WEI);
         BucketLimiter.setCapacity(limit, capacity64);
     }
 
     function setRefillRatePerSecond(uint256 refillRate) external onlyAdmin {
         // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
-        uint64 refillRate64 = SafeCast.toUint64(refillRate / 1e12);
+        uint64 refillRate64 = SafeCast.toUint64(refillRate / GWEI_TO_WEI);
         BucketLimiter.setRefillRate(limit, refillRate64);
     }
 
     function registerToken(address token, uint256 capacity, uint256 refillRate) external onlyAdmin {
-        uint64 capacity64 = SafeCast.toUint64(capacity / 1e12);
-        uint64 refillRate64 = SafeCast.toUint64(refillRate / 1e12);
+        uint64 capacity64 = SafeCast.toUint64(capacity / GWEI_TO_WEI);
+        uint64 refillRate64 = SafeCast.toUint64(refillRate / GWEI_TO_WEI);
         limitsPerToken[token] = BucketLimiter.create(capacity64, refillRate64);
     }
 
     function setCapacityPerToken(address token, uint256 capacity) external onlyAdmin {
         // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
-        uint64 capacity64 = SafeCast.toUint64(capacity / 1e12);
+        uint64 capacity64 = SafeCast.toUint64(capacity / GWEI_TO_WEI);
         BucketLimiter.setCapacity(limitsPerToken[token], capacity64);
     }
 
     function setRefillRatePerSecondPerToken(address token, uint256 refillRate) external onlyAdmin {
         // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
-        uint64 refillRate64 = SafeCast.toUint64(refillRate / 1e12);
+        uint64 refillRate64 = SafeCast.toUint64(refillRate / GWEI_TO_WEI);
         BucketLimiter.setRefillRate(limitsPerToken[token], refillRate64);
     }
 

--- a/src/CumulativeMerkleRewardsDistributor.sol
+++ b/src/CumulativeMerkleRewardsDistributor.sol
@@ -4,11 +4,12 @@ pragma solidity ^0.8.24;
 import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {AssetRecovery} from "./AssetRecovery.sol";
 import {IRoleRegistry} from "./interfaces/IRoleRegistry.sol";
 import {PausableUntil} from "./utils/PausableUntil.sol";
 import {ICumulativeMerkleRewardsDistributor}  from "./interfaces/ICumulativeMerkleRewardsDistributor.sol";
 
-contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, OwnableUpgradeable, UUPSUpgradeable, PausableUntil {
+contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, OwnableUpgradeable, UUPSUpgradeable, PausableUntil, AssetRecovery {
 using SafeERC20 for IERC20;
 
 
@@ -42,6 +43,8 @@ using SafeERC20 for IERC20;
         _disableInitializers();
         roleRegistry = IRoleRegistry(_roleRegistry);
     }
+
+    receive() external payable {}
 
     function initialize() external initializer {
         __Ownable_init();
@@ -155,6 +158,13 @@ using SafeERC20 for IERC20;
         _setPauseUntilDuration(_pauseUntilDuration);
     }
 
+    function recoverETH(address payable to, uint256 amount) external onlyOperations {
+        _recoverETH(to, amount);
+    }
+
+    function recoverERC20(address token, address to, uint256 amount) external onlyOperations {
+        _recoverERC20(token, to, amount);
+    }
 
     function getImplementation() external view returns (address) {return _getImplementation();}
 

--- a/src/CumulativeMerkleRewardsDistributor.sol
+++ b/src/CumulativeMerkleRewardsDistributor.sol
@@ -158,11 +158,11 @@ using SafeERC20 for IERC20;
         _setPauseUntilDuration(_pauseUntilDuration);
     }
 
-    function recoverETH(address payable to, uint256 amount) external onlyOperations {
+    function recoverETH(address payable to, uint256 amount) external onlyAdmin {
         _recoverETH(to, amount);
     }
 
-    function recoverERC20(address token, address to, uint256 amount) external onlyOperations {
+    function recoverERC20(address token, address to, uint256 amount) external onlyAdmin {
         _recoverERC20(token, to, amount);
     }
 

--- a/src/CumulativeMerkleRewardsDistributor.sol
+++ b/src/CumulativeMerkleRewardsDistributor.sol
@@ -50,7 +50,7 @@ using SafeERC20 for IERC20;
         __Ownable_init();
         __UUPSUpgradeable_init();
         paused = false;
-        claimDelay = 172800; // 48 hours
+        claimDelay = 2 days; // 48 hours
     }
 
     function setClaimDelay(uint256 _claimDelay) external onlyOperations {

--- a/src/DepositAdapter.sol
+++ b/src/DepositAdapter.sol
@@ -5,6 +5,7 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "./interfaces/ILiquidityPool.sol";
 import "./interfaces/ILiquifier.sol";
@@ -16,6 +17,7 @@ import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IBlacklister.sol";
 
 contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
+    using SafeERC20 for IERC20;
 
     ILiquidityPool public immutable liquidityPool;
     ILiquifier public immutable liquifier;
@@ -79,7 +81,7 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
         if (wETH.allowance(msg.sender, address(this)) < _amount) revert AllowanceExceeded();
         if (wETH.balanceOf(msg.sender) < _amount) revert InsufficientBalance();
         
-        wETH.transferFrom(msg.sender, address(this), _amount);
+        IERC20(address(wETH)).safeTransferFrom(msg.sender, address(this), _amount);
         wETH.withdraw(_amount);
 
         uint256 eETHShares = liquidityPool.deposit{value: _amount}(_referral);
@@ -102,10 +104,10 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
 
         // Accounting for the 1-2 wei corner case
         uint256 initialBalance = stETH.balanceOf(address(this));
-        stETH.transferFrom(msg.sender, address(this), _amount);
+        IERC20(address(stETH)).safeTransferFrom(msg.sender, address(this), _amount);
         uint256 actualTransferredAmount = stETH.balanceOf(address(this)) - initialBalance;
 
-        stETH.approve(address(liquifier), actualTransferredAmount);
+        IERC20(address(stETH)).safeIncreaseAllowance(address(liquifier), actualTransferredAmount);
         uint256 eETHShares = liquifier.depositWithERC20(address(stETH), actualTransferredAmount, _referral);
         
         emit AdapterDeposit(msg.sender, actualTransferredAmount, SourceOfFunds.STETH, _referral);
@@ -124,14 +126,14 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
             if (_permit.deadline < block.timestamp) revert PermitExpired();
         }
 
-        wstETH.transferFrom(msg.sender, address(this), _amount);
+        IERC20(address(wstETH)).safeTransferFrom(msg.sender, address(this), _amount);
 
         // Accounting for the 1-2 wei corner case
         uint256 initialBalance = stETH.balanceOf(address(this));
         uint256 stETHAmount = wstETH.unwrap(_amount);
         uint256 actualTransferredAmount = stETH.balanceOf(address(this)) - initialBalance;
 
-        stETH.approve(address(liquifier), actualTransferredAmount);
+        IERC20(address(stETH)).safeIncreaseAllowance(address(liquifier), actualTransferredAmount);
         uint256 eETHShares = liquifier.depositWithERC20(address(stETH), actualTransferredAmount, _referral);
         
         emit AdapterDeposit(msg.sender, actualTransferredAmount, SourceOfFunds.WSTETH, _referral);
@@ -144,9 +146,9 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
 
     function _wrapAndReturn(uint256 _eEthShares) internal returns (uint256) {
         uint256 eEthAmount = liquidityPool.amountForShare(_eEthShares);
-        eETH.approve(address(weETH), eEthAmount);
+        IERC20(address(eETH)).safeIncreaseAllowance(address(weETH), eEthAmount);
         uint256 weEthAmount = weETH.wrap(eEthAmount);
-        weETH.transfer(msg.sender, weEthAmount);
+        IERC20(address(weETH)).safeTransfer(msg.sender, weEthAmount);
 
         return weEthAmount;
     }

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -200,15 +200,15 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _approve(owner, spender, value);
     }
 
-    function recoverETH(address payable to, uint256 amount) external onlyOperations {
+    function recoverETH(address payable to, uint256 amount) external onlyAdmin {
         _recoverETH(to, amount);
     }
 
-    function recoverERC20(address token, address to, uint256 amount) external onlyOperations{
+    function recoverERC20(address token, address to, uint256 amount) external onlyAdmin{
         _recoverERC20(token, to, amount);
     }
 
-    function recoverERC721(address token, address to, uint256 tokenId) external onlyOperations {
+    function recoverERC721(address token, address to, uint256 tokenId) external onlyAdmin {
         _recoverERC721(token, to, tokenId);
     }
 

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -63,7 +63,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     error TransferAmountExceedsBalance();
     error ContractPaused();
 
-    // TODO: Figure our what `name` and `version` are for
     constructor(address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter) {
         bytes32 hashedName = keccak256("EETH");
         bytes32 hashedVersion = keccak256("1");

--- a/src/EarlyAdopterPool.sol
+++ b/src/EarlyAdopterPool.sol
@@ -180,7 +180,7 @@ contract EarlyAdopterPool is Ownable, ReentrancyGuard, Pausable {
     /// @notice Sets claiming to be open, to allow users to claim their points
     /// @param _claimDeadline the amount of time in days until claiming will close
     function setClaimingOpen(uint256 _claimDeadline) public onlyOwner {        
-        claimDeadline = block.timestamp + (_claimDeadline * 86400);
+        claimDeadline = block.timestamp + (_claimDeadline * 1 days);
         claimingOpen = 1;
         endTime = block.timestamp;
 

--- a/src/EarlyAdopterPool.sol
+++ b/src/EarlyAdopterPool.sol
@@ -180,7 +180,7 @@ contract EarlyAdopterPool is Ownable, ReentrancyGuard, Pausable {
     /// @notice Sets claiming to be open, to allow users to claim their points
     /// @param _claimDeadline the amount of time in days until claiming will close
     function setClaimingOpen(uint256 _claimDeadline) public onlyOwner {        
-        claimDeadline = block.timestamp + (_claimDeadline * 1 days);
+        claimDeadline = block.timestamp + (_claimDeadline * 86400);
         claimingOpen = 1;
         endTime = block.timestamp;
 

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -102,7 +102,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     error IncorrectRole();
     error InvalidMaxAcceptableFinalizedWithdrawalAmount();
-    error InvalidMaxNumberOfRequestsToFinalizePerDay();
+    error InvalidMaxNumberOfRequestsToFinalizePerReport();
     error InvalidMaxFinalizedWithdrawalAmountPerDay();
     error InvalidMaxNumValidatorsToApprovePerDay();
     error InvalidAcceptableRebaseApr();
@@ -132,7 +132,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         if (_maxValidatorTaskBatchSize == 0) revert InvalidValidatorTaskBatchSize();
         if (_staleOracleReportBlockWindow == 0) revert InvalidStaleOracleReportBlockWindow();
         if (_maxAcceptableFinalizedWithdrawalAmountPerDay == 0) revert InvalidMaxAcceptableFinalizedWithdrawalAmount();
-        if (_maxNumberOfRequestsToFinalizePerReport == 0) revert InvalidMaxNumberOfRequestsToFinalizePerDay();
+        if (_maxNumberOfRequestsToFinalizePerReport == 0) revert InvalidMaxNumberOfRequestsToFinalizePerReport();
 
         etherFiOracle = IEtherFiOracle(_constructorAddresses.etherFiOracle);
         stakingManager = IStakingManager(_constructorAddresses.stakingManager);

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -54,11 +54,13 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     RoleRegistry private DEPRECATED_roleRegistry;
 
+    uint256 public lastStaleReportFinalizationTimestamp;
     uint256 public maxFinalizedWithdrawalAmountPerDay;
     uint256 public maxNumValidatorsToApprovePerDay;
 
     // Protocol fees must not exceed 1/MAX_PROTOCOL_FEE_INV_RATIO of total rewards (currently 20%).
     uint256 public constant MAX_PROTOCOL_FEE_INV_RATIO = 5;
+    uint256 public constant STALE_REPORT_FINALIZATION_COOLDOWN = 1 days;
 
     IEtherFiOracle public immutable etherFiOracle;
     IStakingManager public immutable stakingManager;
@@ -105,6 +107,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     error InvalidMaxAcceptableRebaseApr();
     error InvalidStaleOracleReportBlockWindow();
     error OracleReportNotStale();
+    error StaleReportFinalizationCooldown();
     error NoWithdrawalsToFinalize();
     error ReportValidationFailed(string reason);
     error ConsensusNotReached();
@@ -218,7 +221,8 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     /// @dev    Reverts with OracleReportNotStale if the window has not elapsed, or NoWithdrawalsToFinalize
     ///         if no valid pending requests can be covered.
     function finalizeWithdrawalsWhenStale() external {
-        if (block.number < lastHandledReportRefBlock + staleOracleReportBlockWindow) revert OracleReportNotStale();
+        if (block.number < etherFiOracle.lastPublishedReportRefBlock() + staleOracleReportBlockWindow) revert OracleReportNotStale();
+        if (block.timestamp < lastStaleReportFinalizationTimestamp + STALE_REPORT_FINALIZATION_COOLDOWN) revert StaleReportFinalizationCooldown();
 
         uint256 liquidity = address(liquidityPool).balance;
         uint32 currentRequestId = withdrawRequestNft.nextRequestId() - 1;
@@ -239,6 +243,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         }
         if (finalizedWithdrawalAmount == 0) revert NoWithdrawalsToFinalize();
         _finalizeWithdrawals(requestId, finalizedWithdrawalAmount);
+        lastStaleReportFinalizationTimestamp = block.timestamp;
     }
 
     //protocol owns the eth that was distributed to NO and treasury in eigenpods and etherfinodes 

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -229,7 +229,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         if (block.number < etherFiOracle.lastPublishedReportRefBlock() + staleOracleReportBlockWindow) revert OracleReportNotStale();
         if (block.timestamp < lastStaleReportFinalizationTimestamp + STALE_REPORT_FINALIZATION_COOLDOWN) revert StaleReportFinalizationCooldown();
 
-        uint256 liquidity = address(liquidityPool).balance;
+        uint256 liquidity = liquidityPool.totalValueInLp();
         uint32 currentRequestId = withdrawRequestNft.nextRequestId() - 1;
         uint32 lastFinalizedRequestId = withdrawRequestNft.lastFinalizedRequestId();
         uint32 requestId = lastFinalizedRequestId;
@@ -376,7 +376,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     function _validateWithdrawals(IEtherFiOracle.OracleReport calldata _report, uint256 elapsedTime) internal view returns (bool, string memory) {
         uint256 finalizedWithdrawalAmountPerDay = (_report.finalizedWithdrawalAmount * 1 days) / elapsedTime;
         if (finalizedWithdrawalAmountPerDay > maxFinalizedWithdrawalAmountPerDay) return (false, "EtherFiAdmin: finalized withdrawal amount exceeds max");
-        if (_report.finalizedWithdrawalAmount > address(liquidityPool).balance) return (false, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
+        if (_report.finalizedWithdrawalAmount > liquidityPool.totalValueInLp()) return (false, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
 
         // valdate finalized request id
         uint32 lastFinalizedRequestId = withdrawRequestNft.lastFinalizedRequestId();

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "./RoleRegistry.sol";
 
@@ -21,7 +22,7 @@ interface IEtherFiPausable {
 }
 
 contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
-
+    using Math for uint256;
 
     struct TaskStatus {
         bool completed;
@@ -275,7 +276,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
             return;
         }
 
-        uint256 numBatches = (_report.validatorsToApprove.length + validatorTaskBatchSize - 1) / validatorTaskBatchSize;
+        uint256 numBatches = (_report.validatorsToApprove.length).ceilDiv(validatorTaskBatchSize);
 
         for (uint256 i = 0; i < numBatches; i++) {
             uint256 start = i * validatorTaskBatchSize;
@@ -371,13 +372,13 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function _validateValidatorApprovals(IEtherFiOracle.OracleReport calldata _report, uint256 elapsedTime) internal view returns (bool, string memory) {
-        uint256 numValidatorsToApprovePerDay = (_report.validatorsToApprove.length * 1 days) / elapsedTime;
+        uint256 numValidatorsToApprovePerDay = _report.validatorsToApprove.length.mulDiv(1 days, elapsedTime);
         if (numValidatorsToApprovePerDay > maxNumValidatorsToApprovePerDay) return (false, "EtherFiAdmin: number of validators to approve exceeds max");
         return (true, "");
     }
 
     function _validateWithdrawals(IEtherFiOracle.OracleReport calldata _report, uint256 elapsedTime) internal view returns (bool, string memory) {
-        uint256 finalizedWithdrawalAmountPerDay = (_report.finalizedWithdrawalAmount * 1 days) / elapsedTime;
+        uint256 finalizedWithdrawalAmountPerDay = uint256(_report.finalizedWithdrawalAmount).mulDiv(1 days, elapsedTime);
         if (finalizedWithdrawalAmountPerDay > maxFinalizedWithdrawalAmountPerDay) return (false, "EtherFiAdmin: finalized withdrawal amount exceeds max");
         if (_report.finalizedWithdrawalAmount > liquidityPool.totalValueInLp()) return (false, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
 

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -74,6 +74,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     int256 public immutable maxAcceptableRebaseAprInBps;
     uint256 public immutable maxValidatorTaskBatchSize;
+    uint256 public immutable maxNumberOfRequestsToFinalizePerDay;
     uint256 public immutable maxAcceptableFinalizedWithdrawalAmountPerDay;
     uint256 public immutable maxAcceptableNumValidatorsToApprovePerDay;
     uint256 public immutable staleOracleReportBlockWindow;
@@ -100,6 +101,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     error IncorrectRole();
     error InvalidPriorityWithdrawalQueue();
     error InvalidMaxAcceptableFinalizedWithdrawalAmount();
+    error InvalidMaxNumberOfRequestsToFinalizePerDay();
     error InvalidMaxFinalizedWithdrawalAmountPerDay();
     error InvalidMaxNumValidatorsToApprovePerDay();
     error InvalidAcceptableRebaseApr();
@@ -122,12 +124,14 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         uint256 _maxValidatorTaskBatchSize,
         uint256 _staleOracleReportBlockWindow,
         uint256 _maxAcceptableFinalizedWithdrawalAmountPerDay,
-        uint256 _maxAcceptableNumValidatorsToApprovePerDay
+        uint256 _maxAcceptableNumValidatorsToApprovePerDay,
+        uint256 _maxNumberOfRequestsToFinalizePerDay
     ) {
         if (_maxAcceptableRebaseAprInBps <= 0 || _maxAcceptableRebaseAprInBps > 10_000) revert InvalidMaxAcceptableRebaseApr();
         if (_maxValidatorTaskBatchSize == 0) revert InvalidValidatorTaskBatchSize();
         if (_staleOracleReportBlockWindow == 0) revert InvalidStaleOracleReportBlockWindow();
         if (_maxAcceptableFinalizedWithdrawalAmountPerDay == 0) revert InvalidMaxAcceptableFinalizedWithdrawalAmount();
+        if (_maxNumberOfRequestsToFinalizePerDay == 0) revert InvalidMaxNumberOfRequestsToFinalizePerDay();
 
         etherFiOracle = IEtherFiOracle(_constructorAddresses.etherFiOracle);
         stakingManager = IStakingManager(_constructorAddresses.stakingManager);
@@ -144,8 +148,9 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         staleOracleReportBlockWindow = _staleOracleReportBlockWindow;
         maxAcceptableFinalizedWithdrawalAmountPerDay = _maxAcceptableFinalizedWithdrawalAmountPerDay;
         maxAcceptableNumValidatorsToApprovePerDay = _maxAcceptableNumValidatorsToApprovePerDay;
+        maxNumberOfRequestsToFinalizePerDay = _maxNumberOfRequestsToFinalizePerDay;
 
-         _disableInitializers();
+        _disableInitializers();
     }
 
     function initialize(
@@ -376,6 +381,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         // valdate finalized request id
         uint32 lastFinalizedRequestId = withdrawRequestNft.lastFinalizedRequestId();
         if (_report.lastFinalizedWithdrawalRequestId < lastFinalizedRequestId) return (false, "EtherFiAdmin: finalized withdrawal request id is less than last finalized request id");
+        if (_report.lastFinalizedWithdrawalRequestId - lastFinalizedRequestId > maxNumberOfRequestsToFinalizePerDay) return (false, "EtherFiAdmin: number of requests to finalize exceeds max");
         uint256 sumOfRequests;
         for (uint256 i = lastFinalizedRequestId + 1; i <= _report.lastFinalizedWithdrawalRequestId; i++) {
             IWithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNft.getRequest(i);

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -54,13 +54,13 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     RoleRegistry private DEPRECATED_roleRegistry;
 
-    uint256 public lastStaleReportFinalizationTimestamp;
+    uint256 public lastStaleReportFinalizationBlock;
     uint256 public maxFinalizedWithdrawalAmountPerDay;
     uint256 public maxNumValidatorsToApprovePerDay;
 
     // Protocol fees must not exceed 1/MAX_PROTOCOL_FEE_INV_RATIO of total rewards (currently 20%).
     uint256 public constant MAX_PROTOCOL_FEE_INV_RATIO = 5;
-    uint256 public constant STALE_REPORT_FINALIZATION_COOLDOWN = 1 days;
+    uint256 public constant STALE_REPORT_FINALIZATION_COOLDOWN = 7200; // 1 day
     uint256 public constant BASIS_POINTS_DENOMINATOR = 10_000;
 
     IEtherFiOracle public immutable etherFiOracle;
@@ -227,7 +227,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     ///         if no valid pending requests can be covered.
     function finalizeWithdrawalsWhenStale() external {
         if (block.number < etherFiOracle.lastPublishedReportRefBlock() + staleOracleReportBlockWindow) revert OracleReportNotStale();
-        if (block.timestamp < lastStaleReportFinalizationTimestamp + STALE_REPORT_FINALIZATION_COOLDOWN) revert StaleReportFinalizationCooldown();
+        if (block.number < lastStaleReportFinalizationBlock + STALE_REPORT_FINALIZATION_COOLDOWN) revert StaleReportFinalizationCooldown();
 
         uint256 liquidity = liquidityPool.totalValueInLp();
         uint32 currentRequestId = withdrawRequestNft.nextRequestId() - 1;
@@ -235,6 +235,9 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         uint32 requestId = lastFinalizedRequestId;
         uint128 finalizedWithdrawalAmount;
         while (requestId < currentRequestId) {
+            if (requestId - lastFinalizedRequestId > maxNumberOfRequestsToFinalizePerReport) {
+                break;
+            }
             IWithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNft.getRequest(requestId + 1);
             if (!request.isValid) {
                 requestId++;
@@ -248,7 +251,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         }
         if (finalizedWithdrawalAmount == 0) revert NoWithdrawalsToFinalize();
         _finalizeWithdrawals(requestId, finalizedWithdrawalAmount);
-        lastStaleReportFinalizationTimestamp = block.timestamp;
+        lastStaleReportFinalizationBlock = block.number;
     }
 
     //protocol owns the eth that was distributed to NO and treasury in eigenpods and etherfinodes 

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -75,7 +75,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     int256 public immutable maxAcceptableRebaseAprInBps;
     uint256 public immutable maxValidatorTaskBatchSize;
-    uint256 public immutable maxNumberOfRequestsToFinalizePerDay;
+    uint256 public immutable maxNumberOfRequestsToFinalizePerReport;
     uint256 public immutable maxAcceptableFinalizedWithdrawalAmountPerDay;
     uint256 public immutable maxAcceptableNumValidatorsToApprovePerDay;
     uint256 public immutable staleOracleReportBlockWindow;
@@ -125,13 +125,13 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         uint256 _staleOracleReportBlockWindow,
         uint256 _maxAcceptableFinalizedWithdrawalAmountPerDay,
         uint256 _maxAcceptableNumValidatorsToApprovePerDay,
-        uint256 _maxNumberOfRequestsToFinalizePerDay
+        uint256 _maxNumberOfRequestsToFinalizePerReport
     ) {
         if (_maxAcceptableRebaseAprInBps <= 0 || _maxAcceptableRebaseAprInBps > int256(BASIS_POINTS_DENOMINATOR)) revert InvalidMaxAcceptableRebaseApr();
         if (_maxValidatorTaskBatchSize == 0) revert InvalidValidatorTaskBatchSize();
         if (_staleOracleReportBlockWindow == 0) revert InvalidStaleOracleReportBlockWindow();
         if (_maxAcceptableFinalizedWithdrawalAmountPerDay == 0) revert InvalidMaxAcceptableFinalizedWithdrawalAmount();
-        if (_maxNumberOfRequestsToFinalizePerDay == 0) revert InvalidMaxNumberOfRequestsToFinalizePerDay();
+        if (_maxNumberOfRequestsToFinalizePerReport == 0) revert InvalidMaxNumberOfRequestsToFinalizePerDay();
 
         etherFiOracle = IEtherFiOracle(_constructorAddresses.etherFiOracle);
         stakingManager = IStakingManager(_constructorAddresses.stakingManager);
@@ -148,7 +148,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         staleOracleReportBlockWindow = _staleOracleReportBlockWindow;
         maxAcceptableFinalizedWithdrawalAmountPerDay = _maxAcceptableFinalizedWithdrawalAmountPerDay;
         maxAcceptableNumValidatorsToApprovePerDay = _maxAcceptableNumValidatorsToApprovePerDay;
-        maxNumberOfRequestsToFinalizePerDay = _maxNumberOfRequestsToFinalizePerDay;
+        maxNumberOfRequestsToFinalizePerReport = _maxNumberOfRequestsToFinalizePerReport;
 
         _disableInitializers();
     }
@@ -381,7 +381,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         // valdate finalized request id
         uint32 lastFinalizedRequestId = withdrawRequestNft.lastFinalizedRequestId();
         if (_report.lastFinalizedWithdrawalRequestId < lastFinalizedRequestId) return (false, "EtherFiAdmin: finalized withdrawal request id is less than last finalized request id");
-        if (_report.lastFinalizedWithdrawalRequestId - lastFinalizedRequestId > maxNumberOfRequestsToFinalizePerDay) return (false, "EtherFiAdmin: number of requests to finalize exceeds max");
+        if (_report.lastFinalizedWithdrawalRequestId - lastFinalizedRequestId > maxNumberOfRequestsToFinalizePerReport) return (false, "EtherFiAdmin: number of requests to finalize exceeds max");
         uint256 sumOfRequests;
         for (uint256 i = lastFinalizedRequestId + 1; i <= _report.lastFinalizedWithdrawalRequestId; i++) {
             IWithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNft.getRequest(i);

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -61,6 +61,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     // Protocol fees must not exceed 1/MAX_PROTOCOL_FEE_INV_RATIO of total rewards (currently 20%).
     uint256 public constant MAX_PROTOCOL_FEE_INV_RATIO = 5;
     uint256 public constant STALE_REPORT_FINALIZATION_COOLDOWN = 1 days;
+    uint256 public constant BASIS_POINTS_DENOMINATOR = 10_000;
 
     IEtherFiOracle public immutable etherFiOracle;
     IStakingManager public immutable stakingManager;
@@ -99,7 +100,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     event ValidatorApprovalTaskInvalidated(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
 
     error IncorrectRole();
-    error InvalidPriorityWithdrawalQueue();
     error InvalidMaxAcceptableFinalizedWithdrawalAmount();
     error InvalidMaxNumberOfRequestsToFinalizePerDay();
     error InvalidMaxFinalizedWithdrawalAmountPerDay();
@@ -127,7 +127,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         uint256 _maxAcceptableNumValidatorsToApprovePerDay,
         uint256 _maxNumberOfRequestsToFinalizePerDay
     ) {
-        if (_maxAcceptableRebaseAprInBps <= 0 || _maxAcceptableRebaseAprInBps > 10_000) revert InvalidMaxAcceptableRebaseApr();
+        if (_maxAcceptableRebaseAprInBps <= 0 || _maxAcceptableRebaseAprInBps > int256(BASIS_POINTS_DENOMINATOR)) revert InvalidMaxAcceptableRebaseApr();
         if (_maxValidatorTaskBatchSize == 0) revert InvalidValidatorTaskBatchSize();
         if (_staleOracleReportBlockWindow == 0) revert InvalidStaleOracleReportBlockWindow();
         if (_maxAcceptableFinalizedWithdrawalAmountPerDay == 0) revert InvalidMaxAcceptableFinalizedWithdrawalAmount();
@@ -352,7 +352,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         // - 10% APR = 0.0274% per day
         int256 apr;
         if (currentTVL > 0) {
-            apr = 10000 * (_report.accruedRewards * 365 days) / (currentTVL * int256(elapsedTime));
+            apr = int256(BASIS_POINTS_DENOMINATOR) * (_report.accruedRewards * 365 days) / (currentTVL * int256(elapsedTime));
         }
         int256 absApr = (apr > 0) ? apr : - apr;
         if (absApr > acceptableRebaseAprInBps) return (false, "EtherFiAdmin: TVL changed too much");

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -28,6 +28,10 @@ contract EtherFiNode is IEtherFiNode {
     uint32 public constant EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS = 100800;
     address public constant BEACON_ETH_STRATEGY_ADDRESS = address(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
+    /// @dev Suggested gas stipend for contract receiving ETH to perform a few
+    /// storage reads and writes, but low enough to prevent griefing.
+    uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
+
     //---------------------------------------------------------------------------
     //-----------------------------  Storage  -----------------------------------
     //---------------------------------------------------------------------------
@@ -161,7 +165,7 @@ contract EtherFiNode is IEtherFiNode {
         uint256 totalValueOutOfLp = liquidityPool.totalValueOutOfLp();
         balance = contractBalance < totalValueOutOfLp ? contractBalance : totalValueOutOfLp;
         if (balance > 0) {
-            (bool sent, ) = payable(address(liquidityPool)).call{value: balance, gas: 20000}("");
+            (bool sent, ) = payable(address(liquidityPool)).call{value: balance, gas: GAS_STIPEND_NO_GRIEF}("");
             if (!sent) revert TransferFailed();
             emit FundsTransferred(address(liquidityPool), balance);
         }

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -92,7 +92,7 @@ contract EtherFiNode is IEtherFiNode {
         uint256[] memory depositShares = new uint256[](1);
         depositShares[0] = amount;
         IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = IStrategy(address(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0));
+        strategies[0] = IStrategy(BEACON_ETH_STRATEGY_ADDRESS);
 
         IDelegationManagerTypes.QueuedWithdrawalParams[] memory paramsArray = new IDelegationManagerTypes.QueuedWithdrawalParams[](1);
         paramsArray[0] = IDelegationManagerTypes.QueuedWithdrawalParams({

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -48,6 +48,7 @@ contract EtherFiNodesManager is
     bytes32 public constant CONSOLIDATION_REQUEST_LIMIT_ID = keccak256("CONSOLIDATION_REQUEST_LIMIT_ID");
     // maximum exitable balance in gwei
     uint256 public constant FULL_EXIT_GWEI = 2_048_000_000_000;
+    uint256 public constant VALIDATOR_PUBKEY_LENGTH = 48;
 
     //-------------------------------------------------------------------------
     //-----------------------------  Admin  -----------------------------------
@@ -324,7 +325,7 @@ contract EtherFiNodesManager is
 
     ///@notice Calculates the pubkey hash of a validator's pubkey as per SSZ spec
     function calculateValidatorPubkeyHash(bytes memory pubkey) public pure returns (bytes32) {
-        if (pubkey.length != 48) revert InvalidPubKeyLength();
+        if (pubkey.length != VALIDATOR_PUBKEY_LENGTH) revert InvalidPubKeyLength();
         return sha256(abi.encodePacked(pubkey, bytes16(0)));
     }
 

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -219,7 +219,7 @@ contract EtherFiNodesManager is
      *        - amountGwei: 0 for full exit, >0 for partial to pod
      * @custom:fee Send EXACT ETH to cover sum of (feePerPod * requestsForPod).
      */
-    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable onlyConsolidationExecutor whenNotPaused nonReentrant {
+    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable nonReentrant onlyConsolidationExecutor whenNotPaused {
         if (requests.length == 0) revert EmptyWithdrawalsRequest();
 
         // rate limit the amount of the that can be withdrawn from beacon chain
@@ -263,7 +263,7 @@ contract EtherFiNodesManager is
      * @dev EigenLayer validates that validators belong to the pod automatically.
      * @custom:fee Send EXACT ETH to cover consolidation fees.
      */
-    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable onlyConsolidationExecutor whenNotPaused nonReentrant {
+    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable nonReentrant onlyConsolidationExecutor whenNotPaused {
         if (requests.length == 0) revert EmptyConsolidationRequest();
 
         // rate limit consolidation requests - each request could affect up to FULL_EXIT_GWEI

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -308,14 +308,14 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         emit ConsensusVersionUpdated(_consensusVersion);
     }
 
-    function unpublishReport(OracleReport calldata _report, uint32 _lastPublishedReportRefSlot, uint32 _lastPublishedReportRefBlock) public onlyOperations {
+    function unpublishReport(OracleReport calldata _report) public onlyOperations {
         bytes32 _hash = generateReportHash(_report);
         if (!consensusStates[_hash].consensusReached) revert ConsensusNotReached();
         if (_report.refSlotTo <= etherFiAdmin.lastHandledReportRefSlot()) revert ReportExecuted();
         consensusStates[_hash].support = 0;
         consensusStates[_hash].consensusReached = false;
-        lastPublishedReportRefSlot = _lastPublishedReportRefSlot;
-        lastPublishedReportRefBlock = _lastPublishedReportRefBlock;
+        lastPublishedReportRefSlot = _report.refSlotFrom - 1;
+        lastPublishedReportRefBlock = _report.refBlockFrom - 1;
         emit ReportUnpublished(_hash);
     }
 

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -307,13 +307,6 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         emit ConsensusVersionUpdated(_consensusVersion);
     }
 
-    function unpublishReport(bytes32 _hash) external onlyOperations {
-        if (!consensusStates[_hash].consensusReached) revert ConsensusNotReached();
-        consensusStates[_hash].support = 0;
-        consensusStates[_hash].consensusReached = false;
-        emit ReportUnpublished(_hash);
-    }
-
     function pauseContract() external onlyOperations {
         _pause();
     }

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -39,6 +39,8 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     IEtherFiAdmin public immutable etherFiAdmin;
     IRoleRegistry public immutable roleRegistry;
 
+    uint32 public immutable minQuorumSize;
+
     event CommitteeMemberAdded(address indexed member);
     event CommitteeMemberRemoved(address indexed member);
     event CommitteeMemberUpdated(address indexed member, bool enabled);
@@ -72,7 +74,8 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     error InvalidQuorum();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _etherFiAdmin, address _roleRegistry) {
+    constructor(uint32 _minQuorumSize, address _etherFiAdmin, address _roleRegistry) {
+        minQuorumSize = _minQuorumSize;
         etherFiAdmin = IEtherFiAdmin(_etherFiAdmin);
         roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
@@ -284,6 +287,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     }
 
     function setQuorumSize(uint32 _quorumSize) public onlyAdmin {
+        if (_quorumSize < minQuorumSize) revert InvalidQuorum();
         quorumSize = _quorumSize;
         _checkQuorum();
         emit QuorumUpdated(_quorumSize);

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -67,6 +67,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     error WrongBlockTo();
     error ReportBlockTooOld();
     error ConsensusNotReached();
+    error ReportExecuted();
     error AlreadyRegistered();
     error AlreadyInTargetState();
     error InvalidReportPeriod();
@@ -305,6 +306,17 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         consensusVersion = _consensusVersion;
 
         emit ConsensusVersionUpdated(_consensusVersion);
+    }
+
+    function unpublishReport(OracleReport calldata _report, uint32 _lastPublishedReportRefSlot, uint32 _lastPublishedReportRefBlock) public onlyOperations {
+        bytes32 _hash = generateReportHash(_report);
+        if (!consensusStates[_hash].consensusReached) revert ConsensusNotReached();
+        if (_report.refSlotTo <= etherFiAdmin.lastHandledReportRefSlot()) revert ReportExecuted();
+        consensusStates[_hash].support = 0;
+        consensusStates[_hash].consensusReached = false;
+        lastPublishedReportRefSlot = _lastPublishedReportRefSlot;
+        lastPublishedReportRefBlock = _lastPublishedReportRefBlock;
+        emit ReportUnpublished(_hash);
     }
 
     function pauseContract() external onlyOperations {

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -147,7 +147,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param receiver The address to receive the redeemed outputToken.
      * @param outputToken The token to redeem to (ETH or stETH).
      */
-    function redeemEEth(uint256 eEthAmount, address receiver, address outputToken) public whenNotPaused nonReentrant nonBlacklisted(receiver) {
+    function redeemEEth(uint256 eEthAmount, address receiver, address outputToken) public nonReentrant whenNotPaused nonBlacklisted(receiver) {
         _redeemEEth(eEthAmount, receiver, outputToken);
     }
 
@@ -157,7 +157,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param receiver The address to receive the redeemed outputToken.
      * @param outputToken The token to redeem to (ETH or stETH).
      */
-    function redeemWeEth(uint256 weEthAmount, address receiver, address outputToken) public whenNotPaused nonReentrant nonBlacklisted(receiver) {
+    function redeemWeEth(uint256 weEthAmount, address receiver, address outputToken) public nonReentrant whenNotPaused nonBlacklisted(receiver) {
         _redeemWeEth(weEthAmount, receiver, outputToken);
     }
 
@@ -168,7 +168,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param permit The permit params.
      * @param outputToken The token to redeem to (ETH or stETH).
      */
-    function redeemEEthWithPermit(uint256 eEthAmount, address receiver, IeETH.PermitInput calldata permit, address outputToken) external whenNotPaused nonReentrant nonBlacklisted(receiver) {
+    function redeemEEthWithPermit(uint256 eEthAmount, address receiver, IeETH.PermitInput calldata permit, address outputToken) external nonReentrant whenNotPaused nonBlacklisted(receiver) {
         try eEth.permit(msg.sender, address(this), permit.value, permit.deadline, permit.v, permit.r, permit.s) {} catch {}
         _redeemEEth(eEthAmount, receiver, outputToken);
     }
@@ -180,7 +180,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param permit The permit params.
      * @param outputToken The token to redeem to (ETH or stETH).
      */
-    function redeemWeEthWithPermit(uint256 weEthAmount, address receiver, IWeETH.PermitInput calldata permit, address outputToken) external whenNotPaused nonReentrant nonBlacklisted(receiver) {
+    function redeemWeEthWithPermit(uint256 weEthAmount, address receiver, IWeETH.PermitInput calldata permit, address outputToken) external nonReentrant whenNotPaused nonBlacklisted(receiver) {
         try weEth.permit(msg.sender, address(this), permit.value, permit.deadline, permit.v, permit.r, permit.s)  {} catch {}
         _redeemWeEth(weEthAmount, receiver, outputToken);
     }

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -189,7 +189,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         uint256 feeShareToStakers
     ) internal {
         uint256 prevBalance = address(this).balance;
-        uint256 prevLpBalance = address(liquidityPool).balance;
+        uint256 prevLpBalance = liquidityPool.totalValueInLp();
         uint256 totalEEthShare = eEth.totalShares();
 
         // Withdraw ETH from the liquidity pool
@@ -205,7 +205,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         if (!success) revert TransferFailed();
 
         // Make sure the liquidity pool balance is correct && total shares are correct
-        if (address(liquidityPool).balance != prevLpBalance - ethReceived) revert InvalidLpBalance();
+        if (liquidityPool.totalValueInLp() != prevLpBalance - ethReceived) revert InvalidLpBalance();
     }
 
     /**
@@ -280,7 +280,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         if(token == ETH_ADDRESS) {
             // Post-escrow-migration, locked ETH has physically left LP into the holder
             // contracts, so LP.balance already excludes it. No further subtraction needed.
-            return address(liquidityPool).balance;
+            return liquidityPool.totalValueInLp();
         } else if (token == address(lido)) {
             return lido.balanceOf(address(etherFiRestaker));
         }

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -72,7 +72,6 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
 
     error InvalidAmount();
     error InvalidOutputToken();
-    error BlacklistedUser();
     error InvalidBps();
     error ExceedsMaxExitFee();
     error ExceedsMaxLowWatermark();

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -45,6 +45,10 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     uint256 private constant BUCKET_UNIT_SCALE = 1e12;
     uint256 private constant BASIS_POINT_SCALE = 1e4;
 
+    /// @dev Suggested gas stipend for contract receiving ETH to perform a few
+    /// storage reads and writes, but low enough to prevent griefing.
+    uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
+
     address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     address public immutable treasury;
@@ -201,7 +205,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         if (eEth.totalShares() < 1 gwei || eEth.totalShares() != totalEEthShare - (sharesToBurn + feeShareToStakers)) revert InvalidTotalShares();
 
         // To Receiver by transferring ETH, using gas 10k for additional safety
-        (bool success, ) = receiver.call{value: ethReceived, gas: 10_000}("");
+        (bool success, ) = receiver.call{value: ethReceived, gas: GAS_STIPEND_NO_GRIEF}("");
         if (!success) revert TransferFailed();
 
         // Make sure the liquidity pool balance is correct && total shares are correct

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -47,6 +47,10 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     bytes32 public constant QUEUE_WITHDRAWALS_LIMIT_ID        = keccak256("QUEUE_WITHDRAWALS_LIMIT_ID");
     bytes32 public constant DEPOSIT_INTO_STRATEGY_LIMIT_ID    = keccak256("DEPOSIT_INTO_STRATEGY_LIMIT_ID");
 
+    /// @dev Suggested gas stipend for contract receiving ETH to perform a few
+    /// storage reads and writes, but low enough to prevent griefing.
+    uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
+
     LiquidityPool private DEPRECATED_liquidityPool;
     Liquifier private DEPRECATED_liquifier;
     ILidoWithdrawalQueue private DEPRECATED_lidoWithdrawalQueue;
@@ -193,7 +197,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     function _withdrawEther() internal {
         uint256 amountToLiquidityPool = _min(address(this).balance, liquidityPool.totalValueOutOfLp());
-        (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: 20000}("");
+        (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: GAS_STIPEND_NO_GRIEF}("");
         if (!sent) revert EthTransferFailed();
     }
 

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -235,7 +235,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
         rateLimiter.consume(DEPOSIT_INTO_STRATEGY_LIMIT_ID, _amountToGwei(amount));
 
-        IERC20(token).safeApprove(address(eigenLayerStrategyManager), amount);
+        IERC20(token).safeIncreaseAllowance(address(eigenLayerStrategyManager), amount);
 
         IStrategy strategy = tokenInfos[token].elStrategy;
         uint256 shares = eigenLayerStrategyManager.depositIntoStrategy(strategy, IERC20(token), amount);

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -166,7 +166,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
             reqAmounts[numReqs - 1] = minAmount;
         }
 
-        lido.approve(address(lidoWithdrawalQueue), _amount);
+        IERC20(lido).safeIncreaseAllowance(address(lidoWithdrawalQueue), _amount);
         uint256[] memory reqIds = lidoWithdrawalQueue.requestWithdrawals(reqAmounts, address(this));
 
         emit QueuedStEthWithdrawals(reqIds);

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -74,11 +74,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     error IncorrectRole();
     error NotEnoughBalance();
     error IncorrectAmount();
-    error StrategyShareNotEnough();
     error EthTransferFailed();
-    error AlreadyRegistered();
-    error NotRegistered();
-    error WrongOutput();
     error IncorrectCaller();
     error InsufficientBalance();
     error NotTheOwner();
@@ -101,7 +97,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         liquifier = ILiquifier(payable(_liquifier));
         lido = liquifier.lido();
         lidoWithdrawalQueue = liquifier.lidoWithdrawalQueue();
-        eigenLayerStrategyManager = IStrategyManager(_eigenLayerStrategyManager); 
+        eigenLayerStrategyManager = IStrategyManager(_eigenLayerStrategyManager);
         eigenLayerDelegationManager = IDelegationManager(_eigenLayerDelegationManager);
         rewardsCoordinator = IRewardsCoordinator(_rewardsCoordinator);
         etherFiRedemptionManager = _etherFiRedemptionManager;

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -554,10 +554,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _setPauseUntilDuration(_pauseUntilDuration);
     }
 
-    // Deprecated, just existing not to touch EtherFiAdmin contract
-    function setStakingTargetWeights(uint32 _eEthWeight, uint32 _etherFanWeight) external {
-    }
-
     /// @notice Locks ETH for finalized NFT withdrawals by transferring from LP to WithdrawRequestNFT. TVL preserved by InLp/OutOfLp rebalance; share rate unchanged.
     function addEthAmountLockedForWithdrawal(uint128 _amount) external {
         if (msg.sender != address(etherFiAdminContract) && msg.sender != address(withdrawRequestNFT)) revert IncorrectCaller();

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -232,14 +232,14 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Used by eETH staking flow
-    function deposit(address _referral) public payable whenNotPaused nonReentrant nonBlacklisted returns (uint256) {
+    function deposit(address _referral) public payable nonReentrant whenNotPaused nonBlacklisted returns (uint256) {
         emit Deposit(msg.sender, msg.value, SourceOfFunds.EETH, _referral);
 
         return _deposit(msg.sender, msg.value, 0);
     }
 
     // Used by eETH staking flow through Liquifier contract; deVamp or to pay protocol fees
-    function depositToRecipient(address _recipient, uint256 _amount, address _referral) public whenNotPaused nonReentrant returns (uint256) {
+    function depositToRecipient(address _recipient, uint256 _amount, address _referral) public nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(liquifier) && msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_recipient);
 
@@ -249,7 +249,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Used by ether.fan staking flow
-    function deposit(address _user, address _referral) external payable whenNotPaused nonReentrant returns (uint256) {
+    function deposit(address _user, address _referral) external payable nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_user);
 
@@ -312,7 +312,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @param recipient address that will be issued the NFT
     /// @param amount requested amount to withdraw from contract
     /// @return uint256 requestId of the WithdrawRequestNFT
-    function requestWithdraw(address recipient, uint256 amount) public whenNotPaused nonReentrant nonBlacklisted returns (uint256) {
+    function requestWithdraw(address recipient, uint256 amount) public nonReentrant whenNotPaused nonBlacklisted returns (uint256) {
         blacklister.nonBlacklisted(recipient);
         if (amount == 0) revert InvalidWithdrawalAmount();
         if (amount < MIN_WITHDRAW_AMOUNT || amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
@@ -351,7 +351,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @param amount requested amount to withdraw from contract
     /// @param fee the burn fee to be paid by the recipient when the withdrawal is claimed (WithdrawRequestNFT.claimWithdraw)
     /// @return uint256 requestId of the WithdrawRequestNFT
-    function requestMembershipNFTWithdraw(address recipient, uint256 amount, uint256 fee) public whenNotPaused nonReentrant returns (uint256) {
+    function requestMembershipNFTWithdraw(address recipient, uint256 amount, uint256 fee) public nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         uint256 share = sharesForAmount(amount);
         if (amount > type(uint96).max || amount == 0 || share == 0) revert InvalidAmount();
@@ -392,7 +392,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         IStakingManager.DepositData[] calldata _depositData,
         uint256[] calldata _bidIds,
         address _etherFiNode
-    ) external whenNotPaused nonReentrant {
+    ) external nonReentrant whenNotPaused {
         if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
 
         // liquidity pool supplies 1 eth per validator
@@ -409,7 +409,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         uint256[] memory _validatorIds,
         bytes[] calldata _pubkeys,
         bytes[] calldata _signatures
-    ) external whenNotPaused nonReentrant {
+    ) external nonReentrant whenNotPaused {
         if (msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
         if (validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
         if (_validatorIds.length == 0 || _validatorIds.length != _pubkeys.length || _validatorIds.length != _signatures.length) revert InvalidArrayLengths();
@@ -452,7 +452,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     function confirmAndFundBeaconValidators(
         IStakingManager.DepositData[] calldata _depositData,
         uint256 _validatorSizeWei
-    ) external whenNotPaused nonReentrant {
+    ) external nonReentrant whenNotPaused {
         if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
         if (_validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || _validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
 

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -94,7 +94,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-    uint256 public constant MIN_WITHDRAW_AMOUNT = 0.01 ether;
+    uint256 public constant MIN_WITHDRAW_AMOUNT = 0.001 ether;
     uint256 public constant MAX_WITHDRAW_AMOUNT = 1000 ether;
     uint256 public constant SHARE_UNIT = 1e18;
 
@@ -312,8 +312,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     function requestWithdraw(address recipient, uint256 amount) public whenNotPaused nonReentrant nonBlacklisted returns (uint256) {
         blacklister.nonBlacklisted(recipient);
         if (amount == 0) revert InvalidWithdrawalAmount();
-        if (amount < MIN_WITHDRAW_AMOUNT && amount != IERC20(address(eETH)).balanceOf(msg.sender)) revert InvalidWithdrawalAmount();
-        if (amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
+        if (amount < MIN_WITHDRAW_AMOUNT || amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
         uint256 share = sharesForAmount(amount);
         if (share == 0) revert InvalidShareAmount();
 

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -72,6 +72,8 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
     IRoleRegistry private DEPRECATED_roleRegistry;
     uint256 public validatorSizeWei;
+    uint256 public maxWithdrawAmount;
+    uint256 public minWithdrawAmount;
     bool public escrowMigrationCompleted;
 
     //--------------------------------------------------------------------------------------
@@ -94,8 +96,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-    uint256 public constant MIN_WITHDRAW_AMOUNT = 0.001 ether;
-    uint256 public constant MAX_WITHDRAW_AMOUNT = 1000 ether;
     uint256 public constant SHARE_UNIT = 1e18;
 
     //--------------------------------------------------------------------------------------
@@ -122,6 +122,8 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     event ProtocolFeePaid(uint128 protocolFees);
     event WhitelistStatusUpdated(bool value);
     event ValidatorExitRequested(uint256 indexed validatorId);
+    event MinWithdrawAmountSet(uint256 minWithdrawAmount);
+    event MaxWithdrawAmountSet(uint256 maxWithdrawAmount);
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
@@ -312,7 +314,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     function requestWithdraw(address recipient, uint256 amount) public nonReentrant whenNotPaused nonBlacklisted returns (uint256) {
         blacklister.nonBlacklisted(recipient);
         if (amount == 0) revert InvalidWithdrawalAmount();
-        if (amount < MIN_WITHDRAW_AMOUNT || amount > MAX_WITHDRAW_AMOUNT) revert InvalidWithdrawalAmount();
+        if (amount < minWithdrawAmount || amount > maxWithdrawAmount) revert InvalidWithdrawalAmount();
         uint256 share = sharesForAmount(amount);
         if (share == 0) revert InvalidShareAmount();
 
@@ -552,6 +554,17 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @notice Sets the pause duration for the contract
     function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
         _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
+    function setMinWithdrawAmount(uint256 _minWithdrawAmount) external onlyOperations {
+        minWithdrawAmount = _minWithdrawAmount;
+        emit MinWithdrawAmountSet(_minWithdrawAmount);
+    }
+
+    function setMaxWithdrawAmount(uint256 _maxWithdrawAmount) external onlyOperations {
+        if (_maxWithdrawAmount ==0 || _maxWithdrawAmount < minWithdrawAmount) revert InvalidAmount();
+        maxWithdrawAmount = _maxWithdrawAmount;
+        emit MaxWithdrawAmountSet(_maxWithdrawAmount);
     }
 
     /// @notice Locks ETH for finalized NFT withdrawals by transferring from LP to WithdrawRequestNFT. TVL preserved by InLp/OutOfLp rebalance; share rate unchanged.

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -319,7 +319,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         // transfer shares to WithdrawRequestNFT contract from this contract
         IERC20(address(eETH)).safeTransferFrom(msg.sender, address(withdrawRequestNFT), amount);
 
-        uint256 requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient, 0);
+        uint256 requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient);
        
         emit Withdraw(msg.sender, recipient, amount, SourceOfFunds.EETH);
 
@@ -346,7 +346,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @dev Transfers the amount of eETH from MembershipManager to the WithdrawRequestNFT contract & mints an NFT to the recipient
     /// @param recipient address that will be issued the NFT
     /// @param amount requested amount to withdraw from contract
-    /// @param fee the burn fee to be paid by the recipient when the withdrawal is claimed (WithdrawRequestNFT.claimWithdraw)
+    /// @param fee fee amount not used anymore, only kept to maintain compatibility with existing code
     /// @return uint256 requestId of the WithdrawRequestNFT
     function requestMembershipNFTWithdraw(address recipient, uint256 amount, uint256 fee) public nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
@@ -356,7 +356,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         // transfer shares to WithdrawRequestNFT contract
         IERC20(address(eETH)).safeTransferFrom(msg.sender, address(withdrawRequestNFT), amount);
 
-        uint256 requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient, fee);
+        uint256 requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient);
 
         emit Withdraw(msg.sender, recipient, amount, SourceOfFunds.ETHER_FAN);
 

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -97,9 +97,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     uint256 public constant MIN_WITHDRAW_AMOUNT = 0.001 ether;
     uint256 public constant MAX_WITHDRAW_AMOUNT = 1000 ether;
     uint256 public constant SHARE_UNIT = 1e18;
-    uint256 public constant LP_INITIAL_VALIDATOR_DEPOSIT = 1 ether;
-    uint256 public constant MIN_VALIDATOR_SIZE_WEI = 32 ether;
-    uint256 public constant MAX_VALIDATOR_SIZE_WEI = 2048 ether;
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
@@ -396,7 +393,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
 
         // liquidity pool supplies 1 eth per validator
-        uint256 outboundEthAmountFromLp = LP_INITIAL_VALIDATOR_DEPOSIT * _bidIds.length;
+        uint256 outboundEthAmountFromLp = stakingManager.INITIAL_DEPOSIT_AMOUNT() * _bidIds.length;
         stakingManager.createBeaconValidators{value: outboundEthAmountFromLp}(_depositData, _bidIds, _etherFiNode);
 
         _accountForEthSentOut(outboundEthAmountFromLp);
@@ -411,7 +408,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         bytes[] calldata _signatures
     ) external nonReentrant whenNotPaused {
         if (msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
-        if (validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
+        if (validatorSizeWei < stakingManager.MIN_VALIDATOR_SIZE_WEI() || validatorSizeWei > stakingManager.MAX_VALIDATOR_SIZE_WEI()) revert InvalidValidatorSize();
         if (_validatorIds.length == 0 || _validatorIds.length != _pubkeys.length || _validatorIds.length != _signatures.length) revert InvalidArrayLengths();
 
         // we have already deposited the initial amount to create the validator on the beacon chain
@@ -454,7 +451,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         uint256 _validatorSizeWei
     ) external nonReentrant whenNotPaused {
         if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-        if (_validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || _validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
+        if (_validatorSizeWei < stakingManager.MIN_VALIDATOR_SIZE_WEI() || _validatorSizeWei > stakingManager.MAX_VALIDATOR_SIZE_WEI()) revert InvalidValidatorSize();
 
         // we have already deposited the initial amount to create the validator on the beacon chain
         uint256 remainingEthPerValidator = _validatorSizeWei - stakingManager.INITIAL_DEPOSIT_AMOUNT();
@@ -469,7 +466,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     ///   In a future upgrade this will be a parameter to that call but was done like this to
     ///   to limit changes to other dependent contracts
     function setValidatorSizeWei(uint256 _validatorSizeWei) external onlyAdmin {
-        if (_validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || _validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
+        if (_validatorSizeWei < stakingManager.MIN_VALIDATOR_SIZE_WEI() || _validatorSizeWei > stakingManager.MAX_VALIDATOR_SIZE_WEI()) revert InvalidValidatorSize();
         validatorSizeWei = _validatorSizeWei;
     }
 

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -415,7 +415,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         if (_validatorIds.length == 0 || _validatorIds.length != _pubkeys.length || _validatorIds.length != _signatures.length) revert InvalidArrayLengths();
 
         // we have already deposited the initial amount to create the validator on the beacon chain
-        uint256 remainingEthPerValidator = validatorSizeWei - stakingManager.initialDepositAmount();
+        uint256 remainingEthPerValidator = validatorSizeWei - stakingManager.INITIAL_DEPOSIT_AMOUNT();
 
         // In order to maintain compatibility with current callers in this upgrade
         // need to construct data from old format
@@ -457,7 +457,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         if (_validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || _validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
 
         // we have already deposited the initial amount to create the validator on the beacon chain
-        uint256 remainingEthPerValidator = _validatorSizeWei - stakingManager.initialDepositAmount();
+        uint256 remainingEthPerValidator = _validatorSizeWei - stakingManager.INITIAL_DEPOSIT_AMOUNT();
 
         uint256 outboundEthAmountFromLp = remainingEthPerValidator * _depositData.length;
         stakingManager.confirmAndFundBeaconValidators{value: outboundEthAmountFromLp}(_depositData, _validatorSizeWei);

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -97,6 +97,9 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     uint256 public constant MIN_WITHDRAW_AMOUNT = 0.001 ether;
     uint256 public constant MAX_WITHDRAW_AMOUNT = 1000 ether;
     uint256 public constant SHARE_UNIT = 1e18;
+    uint256 public constant LP_INITIAL_VALIDATOR_DEPOSIT = 1 ether;
+    uint256 public constant MIN_VALIDATOR_SIZE_WEI = 32 ether;
+    uint256 public constant MAX_VALIDATOR_SIZE_WEI = 2048 ether;
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
@@ -393,7 +396,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
 
         // liquidity pool supplies 1 eth per validator
-        uint256 outboundEthAmountFromLp = 1 ether * _bidIds.length;
+        uint256 outboundEthAmountFromLp = LP_INITIAL_VALIDATOR_DEPOSIT * _bidIds.length;
         stakingManager.createBeaconValidators{value: outboundEthAmountFromLp}(_depositData, _bidIds, _etherFiNode);
 
         _accountForEthSentOut(outboundEthAmountFromLp);
@@ -408,7 +411,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         bytes[] calldata _signatures
     ) external whenNotPaused nonReentrant {
         if (msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
-        if (validatorSizeWei < 32 ether || validatorSizeWei > 2048 ether) revert InvalidValidatorSize();
+        if (validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
         if (_validatorIds.length == 0 || _validatorIds.length != _pubkeys.length || _validatorIds.length != _signatures.length) revert InvalidArrayLengths();
 
         // we have already deposited the initial amount to create the validator on the beacon chain
@@ -451,7 +454,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         uint256 _validatorSizeWei
     ) external whenNotPaused nonReentrant {
         if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-        if (_validatorSizeWei < 32 ether || _validatorSizeWei > 2048 ether) revert InvalidValidatorSize();
+        if (_validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || _validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
 
         // we have already deposited the initial amount to create the validator on the beacon chain
         uint256 remainingEthPerValidator = _validatorSizeWei - stakingManager.initialDepositAmount();
@@ -466,7 +469,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     ///   In a future upgrade this will be a parameter to that call but was done like this to
     ///   to limit changes to other dependent contracts
     function setValidatorSizeWei(uint256 _validatorSizeWei) external onlyAdmin {
-        if (_validatorSizeWei < 32 ether || _validatorSizeWei > 2048 ether) revert InvalidValidatorSize();
+        if (_validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || _validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
         validatorSizeWei = _validatorSizeWei;
     }
 
@@ -721,7 +724,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     function _checkMinAmountForShare() internal view {
-        if (amountForShare(1 ether) < minAmountForShare) revert InvalidAmountForShare();
+        if (amountForShare(SHARE_UNIT) < minAmountForShare) revert InvalidAmountForShare();
     }
 
     function getImplementation() external view returns (address) {return _getImplementation();}

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -7,6 +7,7 @@ import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "./interfaces/ILiquifier.sol";
 import "./interfaces/ILiquidityPool.sol";
@@ -51,6 +52,7 @@ interface IERC20Burnable is IERC20 {
 /// Go wild, spread eETH/weETH to the world
 contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, PausableUntil, ReentrancyGuardUpgradeable, ILiquifier {
     using SafeERC20 for IERC20;
+    using Math for uint256;
 
     uint32 private DEPRECATED_eigenLayerWithdrawalClaimGasCost;
     uint32 public timeBoundCapRefreshInterval; // seconds
@@ -360,9 +362,9 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
                 (, int256 answer, , uint256 updatedAt,) = stEthPriceFeed.latestRoundData();
                 if (answer <= 0) revert InvalidPriceFeed();
                 if (updatedAt + stalePriceWindow < block.timestamp) revert StalePriceFeed();
-                uint256 pricefeedValue = (uint256(answer) * _amount) / SHARE_UNIT;
+                uint256 pricefeedValue = uint256(answer).mulDiv(_amount, SHARE_UNIT);
                 uint256 deviation = pricefeedValue > _marketValue ? pricefeedValue - _marketValue : _marketValue - pricefeedValue;
-                if (deviation * BASIS_POINT_SCALE / _marketValue > maxPriceDeviationInBps) revert InvalidStEthPrice();
+                if (deviation.mulDiv(BASIS_POINT_SCALE, _marketValue) > maxPriceDeviationInBps) revert InvalidStEthPrice();
             } else {
                 _marketValue = _amount; /// 1:1 from stETH to eETH
             }
@@ -378,7 +380,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     function quoteByDiscountedValue(address _token, uint256 _amount) public view returns (uint256) {
         uint256 marketValue = quoteByMarketValue(_token, _amount);
 
-        return (BASIS_POINT_SCALE - tokenInfos[_token].discountInBasisPoints) * marketValue / BASIS_POINT_SCALE;
+        return (BASIS_POINT_SCALE - tokenInfos[_token].discountInBasisPoints).mulDiv(marketValue, BASIS_POINT_SCALE);
     }
 
     function isTokenWhitelisted(address _token) public view returns (bool) {

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -91,6 +91,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     address private DEPRECATED_etherfiRestaker;
 
     uint256 public constant BASIS_POINT_SCALE = 10_000;
+    uint256 public constant SHARE_UNIT = 1e18;
     uint32 public constant MAX_TIME_BOUND_CAP_IN_ETHER = 500_000_000;
     uint32 public constant MAX_TOTAL_CAP_IN_ETHER = 2_000_000_000;
 
@@ -123,12 +124,8 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
 
     error NotSupportedToken();
     error EthTransferFailed();
-    error NotEnoughBalance();
     error AlreadyRegistered();
-    error NotRegistered();
-    error WrongOutput();
     error IncorrectCaller();
-    error IncorrectAmount();
     error IncorrectRole();
     error InvalidDiscountRate();
     error InvalidDepositCap();
@@ -361,7 +358,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
                 (, int256 answer, , uint256 updatedAt,) = stEthPriceFeed.latestRoundData();
                 if (answer <= 0) revert InvalidPriceFeed();
                 if (updatedAt + stalePriceWindow < block.timestamp) revert StalePriceFeed();
-                uint256 pricefeedValue = (uint256(answer) * _amount) / 1e18;
+                uint256 pricefeedValue = (uint256(answer) * _amount) / SHARE_UNIT;
                 uint256 deviation = pricefeedValue > _marketValue ? pricefeedValue - _marketValue : _marketValue - pricefeedValue;
                 if (deviation * BASIS_POINT_SCALE / _marketValue > maxPriceDeviationInBps) revert InvalidStEthPrice();
             } else {

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -144,6 +144,8 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     error InvalidStEthPrice();
     error NotAllowed();
     error Capped();
+    error AddressZero();
+    error InvalidTotalSupply();
 
     struct ConstructorAddresses {
         address liquidityPool;
@@ -268,7 +270,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         if (_timeBoundCapInEther > MAX_TIME_BOUND_CAP_IN_ETHER || _totalCapInEther > MAX_TOTAL_CAP_IN_ETHER) revert InvalidDepositCap();
         if (tokenInfos[_token].timeBoundCapClockStartTime != 0) revert AlreadyRegistered();
         if (_isL2Eth) {
-            if (_token == address(0) || _target != address(0)) revert();
+            if (_token == address(0) || _target != address(0)) revert AddressZero();
             dummies.push(IERC20(_token));
         } else {
             // _target = EigenLayer's Strategy contract
@@ -448,7 +450,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
 
     function _L2SanityChecks(address _token) internal view {
-        if (IERC20(_token).totalSupply() != IERC20(_token).balanceOf(address(this))) revert();
+        if (IERC20(_token).totalSupply() != IERC20(_token).balanceOf(address(this))) revert InvalidTotalSupply();
     }
 
     function _min(uint256 _a, uint256 _b) internal pure returns (uint256) {

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -206,7 +206,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     /// @param _referral The referral address
     /// @return mintedAmount the amount of eETH minted to the caller (= msg.sender)
     /// If the token is l2Eth, only the l2SyncPool can call this function
-    function depositWithERC20(address _token, uint256 _amount, address _referral) public whenNotPaused nonReentrant nonBlacklisted returns (uint256) {        
+    function depositWithERC20(address _token, uint256 _amount, address _referral) public nonReentrant whenNotPaused nonBlacklisted returns (uint256) {        
         if (!isTokenWhitelisted(_token) || (tokenInfos[_token].isL2Eth && msg.sender != l1SyncPool)) revert NotAllowed();
 
         // Measure actual amount received to handle stETH's 1-2 wei rounding issue

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -94,6 +94,10 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     uint32 public constant MAX_TIME_BOUND_CAP_IN_ETHER = 500_000_000;
     uint32 public constant MAX_TOTAL_CAP_IN_ETHER = 2_000_000_000;
 
+    /// @dev Suggested gas stipend for contract receiving ETH to perform a few
+    /// storage reads and writes, but low enough to prevent griefing.
+    uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
+
     ILiquidityPool public immutable liquidityPool;
     ILidoWithdrawalQueue public immutable lidoWithdrawalQueue;
     ILido public immutable lido;
@@ -243,7 +247,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     function withdrawEther() external {
         if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
         uint256 amountToLiquidityPool = _min(address(this).balance, liquidityPool.totalValueOutOfLp());
-        (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: 20000}("");
+        (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: GAS_STIPEND_NO_GRIEF}("");
         if (!sent) revert EthTransferFailed();
     }
 

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -281,6 +281,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         // The balance of MembershipManager contract is used to reward ether.fan stakers (not eETH stakers)
         // Eth Rewards Amount per NFT = (eETH share amount of the NFT) * (total rewards ETH amount) / (total eETH share amount in ether.fan)
         uint256 etherFanEEthShares = eETH.shares(address(this));
+        if (etherFanEEthShares == 0) return;
         uint256 thresholdAmount = fanBoostThresholdEthAmount();
         if (address(this).balance >= thresholdAmount) {
             uint256 mintedShare = liquidityPool.deposit{value: thresholdAmount}(address(this), address(0));

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.13;
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "./interfaces/IeETH.sol";
 import "./interfaces/IMembershipManager.sol";
@@ -18,6 +20,7 @@ import "./libraries/GlobalIndexLibrary.sol";
 import "forge-std/console.sol";
 
 contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgradeable, UUPSUpgradeable, IMembershipManager {
+    using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
@@ -172,7 +175,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         (uint256 totalBalance, uint256 feeAmount) = _withdrawAndBurn(_tokenId);
 
         // transfer 'eEthShares' of eETH to the owner
-        eETH.transfer(msg.sender, totalBalance - feeAmount);
+        IERC20(address(eETH)).safeTransfer(msg.sender, totalBalance - feeAmount);
 
         if (feeAmount > 0) {
             liquidityPool.withdraw(address(this), feeAmount);
@@ -225,7 +228,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         _applyUnwrapPenalty(_tokenId, prevAmount, _amount);
 
         // send EETH to recipient before requesting withdraw?
-        eETH.approve(address(liquidityPool), _amount);
+        IERC20(address(eETH)).safeIncreaseAllowance(address(liquidityPool), _amount);
         uint256 withdrawTokenId = liquidityPool.requestMembershipNFTWithdraw(address(msg.sender), _amount, uint64(0));
 
         _emitNftUpdateEvent(_tokenId);
@@ -245,7 +248,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
 
         (uint256 totalBalance, uint256 feeAmount) = _withdrawAndBurn(_tokenId);
 
-        eETH.approve(address(liquidityPool), totalBalance);
+        IERC20(address(eETH)).safeIncreaseAllowance(address(liquidityPool), totalBalance);
         uint256 withdrawTokenId = liquidityPool.requestMembershipNFTWithdraw(msg.sender, totalBalance, feeAmount);
         
         return withdrawTokenId;

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -75,6 +75,9 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
 
     bytes32 public constant MEMBERSHIP_MANAGER_OPERATIONS_ROLE = keccak256("MEMBERSHIP_MANAGER_OPERATIONS_ROLE");
 
+    uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
+    uint256 public constant FEE_UNIT = 0.001 ether;
+
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
@@ -101,9 +104,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     //--------------------------------------------------------------------------------------
 
     error Deprecated();
-    error DisallowZeroAddress();
     error WrongVersion();
-    error BlacklistedUser();
     error InvalidEAPRollover();
 
     /// @notice EarlyAdopterPool users can re-deposit and mint a membership NFT claiming their points & tiers
@@ -138,7 +139,6 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     }
 
     error InvalidDeposit();
-    error InvalidAllocation();
     error InvalidAmount();
     error InsufficientBalance();
 
@@ -148,7 +148,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     /// @param _amountForPoints amount of ETH to boost earnings of {loyalty, tier} points
     /// @return tokenId The ID of the minted membership NFT.
     function wrapEth(uint256 _amount, uint256 _amountForPoints, address _referral) public payable whenNotPaused nonBlacklisted returns (uint256) {
-        uint256 feeAmount = uint256(mintFee) * 0.001 ether;
+        uint256 feeAmount = uint256(mintFee) * FEE_UNIT;
         uint256 depositPerNFT = _amount + _amountForPoints;
         uint256 ethNeededPerNFT = depositPerNFT + feeAmount;
 
@@ -197,17 +197,12 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     }
 
     error ExceededMaxWithdrawal();
-    error InsufficientLiquidity();
-    error RequireTokenUnlocked();
     error InvalidCaller();
     error TierLimitExceeded();
     error OutOfBound();
     error WrongTokenMinted();
     error UnexpectedTier();
-    error NotEnoughReservedRewards();
-    error NotInV0();
     error OnlyTokenOwner();
-    error IntegerOverflow();
     error IncorrectRole();
 
     /// @notice Requests exchange of membership points tokens for ETH.
@@ -367,14 +362,14 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         _feeAmountSanityCheck(_mintFeeAmount);
         _feeAmountSanityCheck(_burnFeeAmount);
         _feeAmountSanityCheck(_upgradeFeeAmount);
-        mintFee = uint16(_mintFeeAmount / 0.001 ether);
-        burnFee = uint16(_burnFeeAmount / 0.001 ether);
-        upgradeFee = uint16(_upgradeFeeAmount / 0.001 ether);
+        mintFee = uint16(_mintFeeAmount / FEE_UNIT);
+        burnFee = uint16(_burnFeeAmount / FEE_UNIT);
+        upgradeFee = uint16(_upgradeFeeAmount / FEE_UNIT);
         burnFeeWaiverPeriodInDays = _burnFeeWaiverPeriodInDays;
     }
 
     function setFanBoostThresholdEthAmount(uint256 _fanBoostThresholdEthAmount) external onlyOperations {
-        fanBoostThreshold = uint16(_fanBoostThresholdEthAmount / 0.001 ether);
+        fanBoostThreshold = uint16(_fanBoostThresholdEthAmount / FEE_UNIT);
     }
 
     //Pauses the contract
@@ -428,7 +423,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         if (tokenData[_tokenId].version != 1) revert WrongVersion();
 
         // subtract fee from provided ether. Will revert if not enough eth provided
-        uint256 upgradeFeeAmount = uint256(upgradeFee) * 0.001 ether;
+        uint256 upgradeFeeAmount = uint256(upgradeFee) * FEE_UNIT;
         uint256 additionalDeposit = msg.value - upgradeFeeAmount;
         if (!canTopUp(_tokenId, additionalDeposit, _amount, _amountForPoints)) revert InvalidDeposit();
 
@@ -462,7 +457,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         uint8 tier = tokenData[_tokenId].tier;
         uint256 vaultShare = tokenData[_tokenId].vaultShare;
         uint256 ethAmount = ethAmountForVaultShare(tier, vaultShare);
-        uint256 feeAmount = hasMetBurnFeeWaiverPeriod(_tokenId) ? 0 : uint256(burnFee) * 0.001 ether;
+        uint256 feeAmount = hasMetBurnFeeWaiverPeriod(_tokenId) ? 0 : uint256(burnFee) * FEE_UNIT;
         if (ethAmount < feeAmount) revert InsufficientBalance();
 
         _withdraw(_tokenId, ethAmount);
@@ -649,7 +644,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     }
 
     function fanBoostThresholdEthAmount() public view returns (uint256) {
-        return uint256(fanBoostThreshold) * 0.001 ether;
+        return uint256(fanBoostThreshold) * FEE_UNIT;
     }
 
     function hasMetBurnFeeWaiverPeriod(uint256 _tokenId) public view returns (bool) {
@@ -666,7 +661,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     }
 
     function _feeAmountSanityCheck(uint256 _feeAmount) internal pure {
-        if (_feeAmount % 0.001 ether != 0 || _feeAmount / 0.001 ether > type(uint16).max) revert InvalidAmount();
+        if (_feeAmount % FEE_UNIT != 0 || _feeAmount / FEE_UNIT > type(uint16).max) revert InvalidAmount();
     }
 
     function _min(uint256 _a, uint256 _b) internal pure returns (uint256) {
@@ -691,8 +686,8 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         uint40 degradeTierPenalty = curTierPoints - tierData[prevTier].requiredTierPoints;
 
         // point deduction if scaled proportional to withdrawal amount
-        uint256 ratio = (10000 * _withdrawalAmount) / _prevAmount;
-        uint40 scaledTierPointsPenalty = uint40((ratio * curTierPoints) / 10000);
+        uint256 ratio = (BASIS_POINTS_DENOMINATOR * _withdrawalAmount) / _prevAmount;
+        uint40 scaledTierPointsPenalty = uint40((ratio * curTierPoints) / BASIS_POINTS_DENOMINATOR);
 
         uint40 penalty = uint40(_max(degradeTierPenalty, scaledTierPointsPenalty));
 
@@ -751,7 +746,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
 
     // returns (mintFeeAmount, burnFeeAmount, upgradeFeeAmount)
     function getFees() external view returns (uint256 mintFeeAmount, uint256 burnFeeAmount, uint256 upgradeFeeAmount) {
-        return (uint256(mintFee) * 0.001 ether, uint256(burnFee) * 0.001 ether, uint256(upgradeFee) * 0.001 ether);
+        return (uint256(mintFee) * FEE_UNIT, uint256(burnFee) * FEE_UNIT, uint256(upgradeFee) * FEE_UNIT);
     }
 
     function rewardsGlobalIndex(uint8 _tier) external view returns (uint256) {

--- a/src/MembershipNFT.sol
+++ b/src/MembershipNFT.sol
@@ -41,11 +41,12 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
 
+    uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
+
     event MerkleUpdated(bytes32, bytes32);
     event MintingPaused(bool isPaused);
     event TokenLocked(uint256 indexed _tokenId, uint256 until);
     
-    error DisallowZeroAddress();
     error MintingIsPaused();
     error InvalidEAPRollover();
     error RequireTokenUnlocked();
@@ -284,7 +285,7 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
 
         uint256 elapsed = _until - _since;
         uint256 effectiveBalanceForEarningPoints = shares;
-        uint256 earning = effectiveBalanceForEarningPoints * elapsed * pointsGrowthRate / 10000;
+        uint256 earning = effectiveBalanceForEarningPoints * elapsed * pointsGrowthRate / BASIS_POINTS_DENOMINATOR;
 
         // 0.001         ether   earns 1     wei   points per day
         // == 1          ether   earns 1     kwei  points per day

--- a/src/NodeOperatorManager.sol
+++ b/src/NodeOperatorManager.sol
@@ -63,37 +63,6 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
         __UUPSUpgradeable_init();
     }
 
-    /// @notice Migrates operator details from previous contract
-    /// @dev Our previous node operator contract was non upgradeable. We will be moving to an upgradeable version but need this
-    ///         function to migrate the data
-    function initializeOnUpgrade(
-        address[] memory _operator, 
-        bytes[] memory _ipfsHash,
-        uint64[] memory _totalKeys,
-        uint64[] memory _keysUsed
-    ) external onlyOwner {
-        if ((_operator.length != _ipfsHash.length) || (_operator.length != _totalKeys.length) || (_operator.length != _keysUsed.length)) revert InvalidLengths();
-        for(uint256 x = 0; x < _operator.length; x++) {
-            if (registered[_operator[x]]) revert AlreadyRegistered();
-
-            KeyData memory keyData = KeyData({
-                totalKeys: _totalKeys[x],
-                keysUsed: _keysUsed[x],
-                ipfsHash: abi.encodePacked(_ipfsHash[x])
-            });
-
-            addressToOperatorData[_operator[x]] = keyData;
-            registered[_operator[x]] = true;
-
-            emit OperatorRegistered(
-                _operator[x],
-                keyData.totalKeys,
-                keyData.keysUsed,
-                _ipfsHash[x]
-            );
-        }
-    }
-
     /// @notice Registers a user as a operator to allow them to bid
     /// @param _ipfsHash location of all IPFS data stored for operator
     /// @param _totalKeys The number of keys they have available, relates to how many validators they can run

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -115,6 +115,7 @@ contract PriorityWithdrawalQueue is
     error InsufficientLiquidity();
     error InsufficientEscrow();
     error EthTransferFailed();
+    error MigrationNotComplete();
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
@@ -334,7 +335,10 @@ contract PriorityWithdrawalQueue is
 
     /// @notice Request manager finalizes withdrawal requests after maturity.
     /// @dev Locks ETH per request by calling LP.transferLockedEthForPriority — escrowed in this contract until claim or cancel.
+    ///      Gated on escrowMigrationCompleted: receive() only bumps ethAmountLockedForPriorityWithdrawal post-migration,
+    ///      so finalizing before that would leave the lock counter at zero and brick the resulting requests.
     function fulfillRequests(WithdrawRequest[] calldata requests) external onlyRequestManager whenNotPaused {
+        if (!liquidityPool.escrowMigrationCompleted()) revert MigrationNotComplete();
         uint256 totalAmountToLock = 0;
 
         for (uint256 i = 0; i < requests.length; ++i) {

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -204,7 +204,7 @@ contract PriorityWithdrawalQueue is
     function requestWithdraw(
         uint96 amountOfEEth,
         uint96 amountWithFee
-    ) external whenNotPaused onlyWhitelisted nonReentrant returns (bytes32 requestId) {
+    ) external nonReentrant whenNotPaused onlyWhitelisted returns (bytes32 requestId) {
         if (amountOfEEth < MIN_AMOUNT || amountOfEEth > MAX_AMOUNT) revert InvalidAmount();
         (uint256 lpEthBefore, uint256 queueEEthSharesBefore,) = _snapshotBalances();
 
@@ -218,7 +218,7 @@ contract PriorityWithdrawalQueue is
         uint96 amountOfEEth,
         uint96 amountWithFee,
         PermitInput calldata permit
-    ) external whenNotPaused onlyWhitelisted nonReentrant returns (bytes32 requestId) {
+    ) external nonReentrant whenNotPaused onlyWhitelisted returns (bytes32 requestId) {
         if (amountOfEEth < MIN_AMOUNT || amountOfEEth > MAX_AMOUNT) revert InvalidAmount();
         (uint256 lpEthBefore, uint256 queueEEthSharesBefore,) = _snapshotBalances();
 
@@ -242,7 +242,7 @@ contract PriorityWithdrawalQueue is
     function requestWithdrawWithWeETH(
         uint96 weEthAmount,
         uint96 amountWithFee
-    ) external whenNotPaused onlyWhitelisted nonReentrant returns (bytes32 requestId) {
+    ) external nonReentrant whenNotPaused onlyWhitelisted returns (bytes32 requestId) {
         (uint256 lpEthBefore, uint256 queueEEthSharesBefore,) = _snapshotBalances();
 
         IERC20(address(weETH)).safeTransferFrom(msg.sender, address(this), weEthAmount);
@@ -263,7 +263,7 @@ contract PriorityWithdrawalQueue is
         uint96 weEthAmount,
         uint96 amountWithFee,
         PermitInput calldata permit
-    ) external whenNotPaused onlyWhitelisted nonReentrant returns (bytes32 requestId) {
+    ) external nonReentrant whenNotPaused onlyWhitelisted returns (bytes32 requestId) {
         (uint256 lpEthBefore, uint256 queueEEthSharesBefore,) = _snapshotBalances();
 
         try weETH.permit(msg.sender, address(this), permit.value, permit.deadline, permit.v, permit.r, permit.s) {} catch {
@@ -286,7 +286,7 @@ contract PriorityWithdrawalQueue is
     /// @return requestId The cancelled request ID
     function cancelWithdraw(
         WithdrawRequest calldata request
-    ) external whenNotPaused onlyRequestUser(request.user) nonReentrant returns (bytes32 requestId) {
+    ) external nonReentrant whenNotPaused onlyRequestUser(request.user) returns (bytes32 requestId) {
         if (request.creationTime + minDelay > block.timestamp) revert NotMatured();
         (uint256 lpEthBefore, uint256 queueEEthSharesBefore,) = _snapshotBalances();
         uint256 userEEthSharesBefore = eETH.shares(request.user);

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -476,7 +476,7 @@ contract PriorityWithdrawalQueue is
     /// @return queueEEthSharesBefore eETH shares held by this contract
     /// @return queueEthBefore ETH balance of this contract (used for claim verification)
     function _snapshotBalances() internal view returns (uint256 lpEthBefore, uint256 queueEEthSharesBefore, uint256 queueEthBefore) {
-        lpEthBefore = address(liquidityPool).balance;
+        lpEthBefore = liquidityPool.totalValueInLp();
         queueEEthSharesBefore = eETH.shares(address(this));
         queueEthBefore = address(this).balance;
     }
@@ -492,7 +492,7 @@ contract PriorityWithdrawalQueue is
     ) internal view {
         uint256 expectedSharesReceived = liquidityPool.sharesForAmount(amountOfEEth);
         if (eETH.shares(address(this)) != queueEEthSharesBefore + expectedSharesReceived) revert UnexpectedBalanceChange();
-        if (address(liquidityPool).balance != lpEthBefore) revert UnexpectedBalanceChange();
+        if (liquidityPool.totalValueInLp() != lpEthBefore) revert UnexpectedBalanceChange();
     }
 
     /// @dev Verify post-conditions after a cancel operation
@@ -508,7 +508,7 @@ contract PriorityWithdrawalQueue is
         address user,
         uint256 expectedLpEthDelta
     ) internal view {
-        if (address(liquidityPool).balance != lpEthBefore + expectedLpEthDelta) revert UnexpectedBalanceChange();
+        if (liquidityPool.totalValueInLp() != lpEthBefore + expectedLpEthDelta) revert UnexpectedBalanceChange();
         if (eETH.shares(address(this)) >= queueEEthSharesBefore) revert UnexpectedBalanceChange();
         if (eETH.shares(user) <= userEEthSharesBefore) revert UnexpectedBalanceChange();
     }
@@ -527,7 +527,7 @@ contract PriorityWithdrawalQueue is
         address user
     ) internal view {
         // LP ETH balance may increase by feeEth (returned from queue to LP via returnLockedEth).
-        if (address(liquidityPool).balance < lpEthBefore) revert UnexpectedBalanceChange();
+        if (liquidityPool.totalValueInLp() < lpEthBefore) revert UnexpectedBalanceChange();
         if (eETH.shares(address(this)) >= queueEEthSharesBefore) revert UnexpectedBalanceChange();
         // Queue paid ETH to the user (and optionally fee back to LP) from its own escrow balance.
         if (address(this).balance >= queueEthBefore) revert UnexpectedBalanceChange();

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -35,6 +35,7 @@ contract PriorityWithdrawalQueue is
     uint96 public constant MIN_AMOUNT = 0.01 ether;
     uint96 public constant MAX_AMOUNT = 1000 ether;
     uint256 private constant _BASIS_POINT_SCALE = 1e4;
+    uint256 private constant _TOLERANCE_BUFFER = 10; // in wei to account for rounding errors
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  ---------------------------------------
@@ -609,7 +610,7 @@ contract PriorityWithdrawalQueue is
         if (!_finalizedRequests.contains(requestId)) revert RequestNotFinalized();
 
         uint256 amountForShares = liquidityPool.amountForShare(request.shareOfEEth);
-        if (amountForShares < request.amountWithFee) revert InvalidOutputAmount();
+        if (amountForShares + _TOLERANCE_BUFFER < request.amountWithFee) revert InvalidOutputAmount();
 
         uint128 amountToWithdraw = request.amountWithFee;
 

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -110,7 +110,6 @@ contract PriorityWithdrawalQueue is
     error AddressZero();
     error BadInput();
     error IncorrectCaller();
-    error InvalidBurnedSharesAmount();
     error InvalidEEthSharesAfterRemainderHandling();
     error InvalidOutputAmount();
     error InsufficientLiquidity();
@@ -191,7 +190,7 @@ contract PriorityWithdrawalQueue is
         __ReentrancyGuard_init();
 
         nonce = 1;
-        shareRemainderSplitToTreasuryInBps = 10000; // 100%
+        shareRemainderSplitToTreasuryInBps = uint16(_BASIS_POINT_SCALE); // 100%
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -28,7 +28,7 @@ contract StakingManager is
 {
 
     address public immutable liquidityPool;
-    uint256 public constant initialDepositAmount = 1 ether;
+    uint256 public constant INITIAL_DEPOSIT_AMOUNT = 1 ether;
     uint256 public constant MIN_VALIDATOR_SIZE_WEI = 32 ether;
     uint256 public constant MAX_VALIDATOR_SIZE_WEI = 2048 ether;
     uint256 public constant VALIDATOR_PUBKEY_LENGTH = 48;
@@ -103,7 +103,7 @@ contract StakingManager is
             if (validatorCreationStatus[validatorCreationDataHash] != ValidatorCreationStatus.REGISTERED) revert InvalidValidatorCreationStatus();
 
             bytes memory withdrawalCredentials = etherFiNodesManager.addressToCompoundingWithdrawalCredentials(address(IEtherFiNode(etherFiNode).getEigenPod()));
-            bytes32 computedDataRoot = generateDepositDataRoot(d.publicKey, d.signature, withdrawalCredentials, initialDepositAmount);
+            bytes32 computedDataRoot = generateDepositDataRoot(d.publicKey, d.signature, withdrawalCredentials, INITIAL_DEPOSIT_AMOUNT);
             if (computedDataRoot != d.depositDataRoot) revert IncorrectBeaconRoot();
 
             validatorCreationStatus[validatorCreationDataHash] = ValidatorCreationStatus.CONFIRMED;
@@ -113,7 +113,7 @@ contract StakingManager is
             etherFiNodesManager.linkPubkeyToNode(d.publicKey, etherFiNode, bidIds[i]);
 
             // Deposit to the Beacon Chain
-            depositContractEth2.deposit{value: initialDepositAmount}(d.publicKey, withdrawalCredentials, d.signature, computedDataRoot);
+            depositContractEth2.deposit{value: INITIAL_DEPOSIT_AMOUNT}(d.publicKey, withdrawalCredentials, d.signature, computedDataRoot);
 
             bytes32 pubkeyHash = calculateValidatorPubkeyHash(d.publicKey);
             emit validatorCreated(pubkeyHash, etherFiNode, d.publicKey);
@@ -140,7 +140,7 @@ contract StakingManager is
 
             // verify deposit root
             bytes memory withdrawalCredentials = etherFiNodesManager.addressToCompoundingWithdrawalCredentials(address(IEtherFiNode(etherFiNode).getEigenPod()));
-            bytes32 computedDataRoot = generateDepositDataRoot(depositData[i].publicKey, depositData[i].signature, withdrawalCredentials, initialDepositAmount);
+            bytes32 computedDataRoot = generateDepositDataRoot(depositData[i].publicKey, depositData[i].signature, withdrawalCredentials, INITIAL_DEPOSIT_AMOUNT);
             if (computedDataRoot != depositData[i].depositDataRoot) revert IncorrectBeaconRoot();
 
             bytes32 validatorCreationDataHash = keccak256(abi.encode(depositData[i].publicKey, depositData[i].signature, depositData[i].depositDataRoot, depositData[i].ipfsHashForEncryptedValidatorKey, bidIds[i], etherFiNode));
@@ -161,7 +161,7 @@ contract StakingManager is
         if (validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
 
         // we already deposited the initial amount to create the validators in createBeaconValidators()
-        uint256 remainingDeposit = validatorSizeWei - initialDepositAmount;
+        uint256 remainingDeposit = validatorSizeWei - INITIAL_DEPOSIT_AMOUNT;
 
         for (uint256 i = 0; i < depositData.length; i++) {
 

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -29,6 +29,9 @@ contract StakingManager is
 
     address public immutable liquidityPool;
     uint256 public constant initialDepositAmount = 1 ether;
+    uint256 public constant MIN_VALIDATOR_SIZE_WEI = 32 ether;
+    uint256 public constant MAX_VALIDATOR_SIZE_WEI = 2048 ether;
+    uint256 public constant VALIDATOR_PUBKEY_LENGTH = 48;
     IEtherFiNodesManager public immutable etherFiNodesManager;
     IDepositContract public immutable depositContractEth2;
     IAuctionManager public immutable auctionManager;
@@ -155,7 +158,7 @@ contract StakingManager is
     ///   The caller can use generateDepositDataRoot() to generate a valid root.
     function confirmAndFundBeaconValidators(DepositData[] calldata depositData, uint256 validatorSizeWei) external payable {
         if (msg.sender != liquidityPool) revert InvalidCaller();
-        if (validatorSizeWei < 32 ether || validatorSizeWei > 2048 ether) revert InvalidValidatorSize();
+        if (validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
 
         // we already deposited the initial amount to create the validators in createBeaconValidators()
         uint256 remainingDeposit = validatorSizeWei - initialDepositAmount;
@@ -182,7 +185,7 @@ contract StakingManager is
 
     /// @notice Calculates the pubkey hash of a validator's pubkey as per SSZ spec
     function calculateValidatorPubkeyHash(bytes memory pubkey) public pure returns (bytes32) {
-        if (pubkey.length != 48) revert InvalidPubKeyLength();
+        if (pubkey.length != VALIDATOR_PUBKEY_LENGTH) revert InvalidPubKeyLength();
         return sha256(abi.encodePacked(pubkey, bytes16(0)));
     }
 

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -5,6 +5,7 @@ import "@openzeppelin-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./interfaces/IeETH.sol";
 import "./interfaces/ILiquidityPool.sol";
 import "./interfaces/IRateProvider.sol";
@@ -17,6 +18,7 @@ import "./interfaces/IEtherFiRateLimiter.sol";
 import "./libraries/RateLimitMath.sol";
 
 contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, ERC20PermitUpgradeable, IRateProvider, AssetRecovery {
+    using SafeERC20 for IERC20;
 
     IeETH public immutable eETH;
     ILiquidityPool public immutable liquidityPool;
@@ -88,7 +90,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         uint256 weEthAmount = liquidityPool.sharesForAmount(_eETHAmount);
         rateLimiter.consumeIfConfigured(WEETH_MINT_LIMIT_ID, RateLimitMath.toBucketUnit(weEthAmount));
         _mint(msg.sender, weEthAmount);
-        eETH.transferFrom(msg.sender, address(this), _eETHAmount);
+        IERC20(address(eETH)).safeTransferFrom(msg.sender, address(this), _eETHAmount);
         return weEthAmount;
     }
 
@@ -111,7 +113,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         uint256 eETHAmount = liquidityPool.amountForShare(_weETHAmount);
         rateLimiter.consumeIfConfigured(WEETH_BURN_LIMIT_ID, RateLimitMath.toBucketUnit(_weETHAmount));
         _burn(msg.sender, _weETHAmount);
-        eETH.transfer(msg.sender, eETHAmount);
+        IERC20(address(eETH)).safeTransfer(msg.sender, eETHAmount);
         return eETHAmount;
     }
 

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -139,16 +139,16 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _setPauseUntilDuration(_pauseUntilDuration);
     }
 
-    function recoverETH(address payable to, uint256 amount) external onlyOperations {
+    function recoverETH(address payable to, uint256 amount) external onlyAdmin {
         _recoverETH(to, amount);
     }
 
-    function recoverERC20(address token, address to, uint256 amount) external onlyOperations {
+    function recoverERC20(address token, address to, uint256 amount) external onlyAdmin {
         if (token == address(eETH)) revert CannotRecoverEETH();
         _recoverERC20(token, to, amount);
     }
 
-    function recoverERC721(address token, address to, uint256 tokenId) external onlyOperations {
+    function recoverERC721(address token, address to, uint256 tokenId) external onlyAdmin {
         _recoverERC721(token, to, tokenId);
     }
 

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -281,7 +281,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     // Seize the request simply by transferring it to another recipient
-    function seizeInvalidRequest(uint256 requestId, address recipient) external onlyAdmin {
+    function seizeInvalidRequest(uint256 requestId, address recipient) external onlyUpgradeTimelock {
         if (_requests[requestId].isValid) revert RequestValid();
         if (!_exists(requestId)) revert RequestNotFound();
 
@@ -466,6 +466,11 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     modifier onlyLiquidityPool() {
         if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
+        _;
+    }
+
+    modifier onlyUpgradeTimelock() {
+        roleRegistry.onlyUpgradeTimelock(msg.sender);
         _;
     }
 

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -108,12 +108,10 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     error AlreadyPaused();
     error NotPaused();
     error EETHAmountCannotBeZero();
-    error NotAllPrevRequestsHaveBeenScanned();
     error NotEnoughEEthRemainder();
     error FeeReturnFailed();
     error InvalidRequest();
     error ContractPaused();
-    error ScanCompleted();
     error RequestValid();
     error RequestNotValid();
     error RequestNotFound();

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -179,9 +179,8 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @param amountOfEEth amount of eETH requested for withdrawal
     /// @param shareOfEEth share of eETH requested for withdrawal
     /// @param recipient address to recieve with WithdrawRequestNFT
-    /// @param fee fee to be subtracted from amount when recipient calls claimWithdraw
     /// @return uint256 id of the withdraw request
-    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient, uint256 fee) external onlyLiquidityPool whenNotPaused returns (uint256) {
+    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient) external onlyLiquidityPool whenNotPaused returns (uint256) {
         uint256 requestId = nextRequestId++;
 
         _requests[requestId] = IWithdrawRequestNFT.WithdrawRequest(amountOfEEth, shareOfEEth, true, 0);

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -344,7 +344,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         if (_requests[requestId].isValid) revert RequestValid();
         if (requestId <= lastFinalizedRequestId) {
             uint256 amount = _requests[requestId].amountOfEEth;
-            if (amount > address(liquidityPool).balance) revert RequestAmountGreaterThanAvailableLiquidity();
+            if (amount > liquidityPool.totalValueInLp()) revert RequestAmountGreaterThanAvailableLiquidity();
             liquidityPool.addEthAmountLockedForWithdrawal(uint128(amount));
         }
         _requests[requestId].isValid = true;

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -74,7 +74,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     RoleRegistry private DEPRECATED_roleRegistry;
 
     uint128 public ethAmountLockedForWithdrawal;
-    uint256 public negativeRebaseStrandedETH;
 
     // (requestId upperBound => amountPerShareCeil(1e18) at finalize time).
     // A value of 0 marks a "legacy" range that pre-dates the share-rate-freeze upgrade;
@@ -184,28 +183,27 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     /// @return uint256 id of the withdraw request
     function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient, uint256 fee) external onlyLiquidityPool whenNotPaused returns (uint256) {
         uint256 requestId = nextRequestId++;
-        uint32 feeGwei = uint32(fee / 1 gwei);
 
-        _requests[requestId] = IWithdrawRequestNFT.WithdrawRequest(amountOfEEth, shareOfEEth, true, feeGwei);
+        _requests[requestId] = IWithdrawRequestNFT.WithdrawRequest(amountOfEEth, shareOfEEth, true, 0);
 
         _safeMint(recipient, requestId);
 
-        emit WithdrawRequestCreated(uint32(requestId), amountOfEEth, shareOfEEth, recipient, fee);
+        emit WithdrawRequestCreated(uint32(requestId), amountOfEEth, shareOfEEth, recipient, 0);
         return requestId;
     }
 
     function getClaimableAmount(uint256 tokenId) public view returns (uint256) {
-        (uint256 amountToTransfer, uint256 fee, ) = _getClaimableAmount(tokenId);
-        return amountToTransfer - fee;
+        (uint256 amountToTransfer, ) = _getClaimableAmount(tokenId);
+        return amountToTransfer;
     }
 
-    /// @dev Returns `(amountToTransfer, fee, frozenRate)`. `frozenRate` is the rate snapshotted
+    /// @dev Returns `(amountToTransfer, frozenRate)`. `frozenRate` is the rate snapshotted
     ///      at the request's finalize batch. For pre-upgrade legacy requests (covered only by the
     ///      sentinel checkpoint with value 0), the live rate from `LP.amountPerShareCeil()` is
     ///      substituted locally — preserving legacy claim semantics (live-rate at claim). The
     ///      returned `frozenRate` is therefore guaranteed non-zero, which is what `LP.withdraw`
     ///      now requires (`InvalidRate` reverts on zero).
-    function _getClaimableAmount(uint256 tokenId) internal view returns (uint256, uint256, uint224) {
+    function _getClaimableAmount(uint256 tokenId) internal view returns (uint256, uint224) {
         if (tokenId > lastFinalizedRequestId) revert RequestNotFinalized();
         if (ownerOf(tokenId) == address(0)) revert AlreadyClaimed();
 
@@ -226,12 +224,11 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
         // send the lesser value of the originally requested amount of eEth or the frozen-rate value of the shares
         uint256 amountToTransfer = Math.min(request.amountOfEEth, amountForShares);
-        uint256 fee = uint256(request.feeGwei) * 1 gwei;
-        return (amountToTransfer, fee, frozenRate);
+        return (amountToTransfer, frozenRate);
     }
 
     /// @notice called by the NFT owner to claim their ETH
-    /// @dev burns the NFT and transfers ETH from the liquidity pool to the owner minus any fee, withdraw request must be valid and finalized
+    /// @dev burns the NFT and transfers ETH from the liquidity pool to the owner, withdraw request must be valid and finalized
     /// @param tokenId the id of the withdraw request and associated NFT
     function claimWithdraw(uint256 tokenId) external nonReentrant nonBlacklisted {
         return _claimWithdraw(tokenId, ownerOf(tokenId));
@@ -247,15 +244,13 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
         if (!request.isValid) revert RequestNotValid();
 
-        (uint256 amountToTransfer, uint256 fee, uint224 frozenRate) = _getClaimableAmount(tokenId);
-        uint256 amountToWithdraw = amountToTransfer - fee;
+        (uint256 amountToWithdraw, uint224 frozenRate) = _getClaimableAmount(tokenId);
 
         _burn(tokenId);
         delete _requests[tokenId];
 
-        if (ethAmountLockedForWithdrawal < amountToTransfer) revert InsufficientEscrow();
-        ethAmountLockedForWithdrawal -= uint128(amountToTransfer);
-        if (amountToTransfer < request.amountOfEEth) negativeRebaseStrandedETH += request.amountOfEEth - amountToTransfer;
+        if (ethAmountLockedForWithdrawal < amountToWithdraw) revert InsufficientEscrow();
+        ethAmountLockedForWithdrawal -= uint128(request.amountOfEEth);
 
         uint256 burnedShares = liquidityPool.withdraw(amountToWithdraw, uint256(frozenRate));
         // When `amountToWithdraw` was computed at `frozenRate` (or live rate, for legacy), the
@@ -408,25 +403,16 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
         emit HandledRemainderOfClaimedWithdrawRequests(eEthAmountToTreasury, eEthAmountToBurn);
 
-        if (negativeRebaseStrandedETH > 0) {
-            ethAmountLockedForWithdrawal -= uint128(negativeRebaseStrandedETH);
-            (bool ok, ) = payable(address(treasury)).call{value: negativeRebaseStrandedETH}("");
-            if (!ok) revert EthTransferFailed();
-            negativeRebaseStrandedETH = 0;
-        }
-
-        // Sweep accumulated fee ETH (surplus over locked counter) back to LP.
-        // Fee ETH accrues because _claimWithdraw decrements by gross (amountOfEEth) but only
-        // sends net (amountToWithdraw = amountOfEEth - fee) to the recipient.
-        uint256 strandedFeeEth = address(this).balance > ethAmountLockedForWithdrawal
+        // Sweep accumulated ETH back to treasury
+        // In case of negative rebase, the ETH is stranded in the NFT contract
+        uint256 strandedEth = address(this).balance > ethAmountLockedForWithdrawal
             ? address(this).balance - uint256(ethAmountLockedForWithdrawal)
             : 0;
-        if (strandedFeeEth > 0) {
-            (bool ok, ) = payable(address(liquidityPool)).call{value: strandedFeeEth}("");
+        if (strandedEth > 0) {
+            (bool ok, ) = payable(address(treasury)).call{value: strandedEth}("");
             if (!ok) revert FeeReturnFailed();
+            _checkEthAmountLockedForWithdrawal();
         }
-
-        _checkEthAmountLockedForWithdrawal();
     }
 
     function getEEthRemainderAmount() public view returns (uint256) {

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -64,9 +64,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     uint16 public _unused_gap;
 
     // inclusive
-    uint32 public currentRequestIdToScanFromForShareRemainder;
-    uint32 public lastRequestIdToScanUntilForShareRemainder;
-    uint256 public aggregateSumOfEEthShare;
+    uint32 private DEPRECATED_currentRequestIdToScanFromForShareRemainder;
+    uint32 private DEPRECATED_lastRequestIdToScanUntilForShareRemainder;
+    uint256 private DEPRECATED_aggregateSumOfEEthShare;
 
     uint256 public totalRemainderEEthShares;
 
@@ -278,29 +278,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         }
     }
 
-    // This function is used to aggregate the sum of the eEth shares of the requests that have not been claimed yet.
-    // To be triggered during the upgrade to the new version of the contract.
-    function aggregateSumEEthShareAmount(uint256 _numReqsToScan) external {
-        if (isScanOfShareRemainderCompleted()) revert ScanCompleted();
-
-        // [scanFrom, scanUntil]
-        uint256 scanFrom = currentRequestIdToScanFromForShareRemainder;
-        uint256 scanUntil = Math.min(lastRequestIdToScanUntilForShareRemainder, scanFrom + _numReqsToScan - 1);
-
-        for (uint256 i = scanFrom; i <= scanUntil; i++) {
-            if (!_exists(i)) continue;
-            aggregateSumOfEEthShare += _requests[i].shareOfEEth;
-        }
-
-        currentRequestIdToScanFromForShareRemainder = uint32(scanUntil + 1);
-        
-        // When the scan is completed, update the `totalRemainderEEthShares` and reset the `aggregateSumOfEEthShare`
-        if (isScanOfShareRemainderCompleted()) {
-            totalRemainderEEthShares = eETH.shares(address(this)) - aggregateSumOfEEthShare;
-            aggregateSumOfEEthShare = 0; // gone
-        }
-    }
-
     // Seize the request simply by transferring it to another recipient
     function seizeInvalidRequest(uint256 requestId, address recipient) external onlyAdmin {
         if (_requests[requestId].isValid) revert RequestValid();
@@ -413,7 +390,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     function handleRemainder(uint256 _eEthAmount) external {
         if(!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
         if (_eEthAmount == 0) revert EETHAmountCannotBeZero(); 
-        if (!isScanOfShareRemainderCompleted()) revert NotAllPrevRequestsHaveBeenScanned();
         if (getEEthRemainderAmount() < _eEthAmount) revert NotEnoughEEthRemainder();
 
         uint256 beforeEEthShares = eETH.shares(address(this));
@@ -447,10 +423,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     function getEEthRemainderAmount() public view returns (uint256) {
         return liquidityPool.amountForShare(totalRemainderEEthShares);
-    }
-
-    function isScanOfShareRemainderCompleted() public view returns (bool) {
-        return currentRequestIdToScanFromForShareRemainder == (lastRequestIdToScanUntilForShareRemainder + 1);
     }
 
     // the withdraw request NFT is transferrable

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -74,6 +74,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     RoleRegistry private DEPRECATED_roleRegistry;
 
     uint128 public ethAmountLockedForWithdrawal;
+    uint256 public negativeRebaseStrandedETH;
 
     // (requestId upperBound => amountPerShareCeil(1e18) at finalize time).
     // A value of 0 marks a "legacy" range that pre-dates the share-rate-freeze upgrade;
@@ -256,6 +257,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
         if (ethAmountLockedForWithdrawal < amountToTransfer) revert InsufficientEscrow();
         ethAmountLockedForWithdrawal -= uint128(amountToTransfer);
+        if (amountToTransfer < request.amountOfEEth) negativeRebaseStrandedETH += request.amountOfEEth - amountToTransfer;
 
         uint256 burnedShares = liquidityPool.withdraw(amountToWithdraw, uint256(frozenRate));
         // When `amountToWithdraw` was computed at `frozenRate` (or live rate, for legacy), the
@@ -408,6 +410,13 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
         emit HandledRemainderOfClaimedWithdrawRequests(eEthAmountToTreasury, eEthAmountToBurn);
 
+        if (negativeRebaseStrandedETH > 0) {
+            ethAmountLockedForWithdrawal -= uint128(negativeRebaseStrandedETH);
+            (bool ok, ) = payable(address(treasury)).call{value: negativeRebaseStrandedETH}("");
+            if (!ok) revert EthTransferFailed();
+            negativeRebaseStrandedETH = 0;
+        }
+
         // Sweep accumulated fee ETH (surplus over locked counter) back to LP.
         // Fee ETH accrues because _claimWithdraw decrements by gross (amountOfEEth) but only
         // sends net (amountToWithdraw = amountOfEEth - fee) to the recipient.
@@ -417,8 +426,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         if (strandedFeeEth > 0) {
             (bool ok, ) = payable(address(liquidityPool)).call{value: strandedFeeEth}("");
             if (!ok) revert FeeReturnFailed();
-            _checkEthAmountLockedForWithdrawal();
         }
+
+        _checkEthAmountLockedForWithdrawal();
     }
 
     function getEEthRemainderAmount() public view returns (uint256) {

--- a/src/helpers/WeETHWithdrawAdapter.sol
+++ b/src/helpers/WeETHWithdrawAdapter.sol
@@ -125,7 +125,7 @@ contract WeETHWithdrawAdapter is
         uint256 eETHAmount = weETH.unwrap(weETHAmount);
         
         // Approve eETH to be spent by LiquidityPool
-        IERC20(address(eETH)).safeApprove(address(liquidityPool), eETHAmount);
+        IERC20(address(eETH)).safeIncreaseAllowance(address(liquidityPool), eETHAmount);
         
         // Create withdrawal request through LiquidityPool
         requestId = liquidityPool.requestWithdraw(recipient, eETHAmount);

--- a/src/interfaces/ILiquidityPool.sol
+++ b/src/interfaces/ILiquidityPool.sol
@@ -83,8 +83,6 @@ interface ILiquidityPool {
     function unPauseContract() external; 
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
-    function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
-
-    function setStakingTargetWeights(uint32 _eEthWeight, uint32 _etherFanWeight) external;  
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external; 
     function setValidatorSizeWei(uint256 _size) external;
 }

--- a/src/interfaces/IStakingManager.sol
+++ b/src/interfaces/IStakingManager.sol
@@ -20,6 +20,8 @@ interface IStakingManager {
         INVALIDATED
     }
 
+    function INITIAL_DEPOSIT_AMOUNT() external view returns (uint256);
+
     // deposit flow
     function registerBeaconValidators(DepositData[] calldata depositData, uint256[] calldata bidIds, address etherFiNode) external;
     function createBeaconValidators(DepositData[] calldata depositData, uint256[] calldata bidIds, address etherFiNode) external payable;

--- a/src/interfaces/IStakingManager.sol
+++ b/src/interfaces/IStakingManager.sol
@@ -26,7 +26,6 @@ interface IStakingManager {
     function invalidateRegisteredBeaconValidator(DepositData calldata depositData, uint256 bidId, address etherFiNode) external;
     function confirmAndFundBeaconValidators(DepositData[] calldata depositData, uint256 validatorSizeWei) external payable;
     function calculateValidatorPubkeyHash(bytes memory pubkey) external pure returns (bytes32);
-    function initialDepositAmount() external returns (uint256);
     function generateDepositDataRoot(bytes memory pubkey, bytes memory signature, bytes memory withdrawalCredentials, uint256 amount) external pure returns (bytes32);
 
     // EtherFiNode Beacon Proxy

--- a/src/interfaces/IStakingManager.sol
+++ b/src/interfaces/IStakingManager.sol
@@ -21,6 +21,8 @@ interface IStakingManager {
     }
 
     function INITIAL_DEPOSIT_AMOUNT() external view returns (uint256);
+    function MIN_VALIDATOR_SIZE_WEI() external view returns (uint256);
+    function MAX_VALIDATOR_SIZE_WEI() external view returns (uint256);
 
     // deposit flow
     function registerBeaconValidators(DepositData[] calldata depositData, uint256[] calldata bidIds, address etherFiNode) external;

--- a/src/interfaces/IWithdrawRequestNFT.sol
+++ b/src/interfaces/IWithdrawRequestNFT.sol
@@ -10,7 +10,7 @@ interface IWithdrawRequestNFT {
     }
 
     function initialize(address _liquidityPoolAddress, address _eEthAddress, address _membershipManager) external;
-    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester, uint256 fee) external returns (uint256);
+    function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address requester) external returns (uint256);
     function claimWithdraw(uint256 requestId) external;
 
     function getRequest(uint256 requestId) external view returns (WithdrawRequest memory);

--- a/test/CumulativeMerkleRewardsDistributor.t.sol
+++ b/test/CumulativeMerkleRewardsDistributor.t.sol
@@ -372,4 +372,64 @@ contract  CumulativeMerkleRewardsDistributorTest is TestSetup {
     // verifyContractByteCodeMatch(deployedImpl, address(cumulativeMerkleRewardsDistributorImplementation));
     // verifyContractByteCodeMatch(deployedProxy, address(cumulativeMerkleRewardsDistributorInstance));
    }
+
+    /// @dev M-07: contract added `receive() external payable {}` + AssetRecovery (recoverETH /
+    ///      recoverERC20) so any ETH airdropped to the contract can be swept by Operations.
+    ///      Pre-fix, plain ETH transfers would revert (no receive/fallback), trapping funds.
+    function test_receive_acceptsPlainEthTransfer() public {
+        address payable cmrd = payable(address(cumulativeMerkleRewardsDistributorInstance));
+        uint256 balBefore = cmrd.balance;
+
+        vm.deal(bob, 1 ether);
+        vm.prank(bob);
+        (bool ok, ) = cmrd.call{value: 1 ether}("");
+        assertTrue(ok, "plain ETH transfer should succeed via receive()");
+        assertEq(cmrd.balance - balBefore, 1 ether, "balance should reflect transfer");
+    }
+
+    function test_recoverETH_movesEthToRecipient() public {
+        address payable cmrd = payable(address(cumulativeMerkleRewardsDistributorInstance));
+        vm.deal(cmrd, 5 ether);
+
+        address payable to = payable(makeAddr("recipient"));
+        uint256 toBalBefore = to.balance;
+        uint256 cmrdBalBefore = cmrd.balance;
+
+        vm.prank(admin);
+        cumulativeMerkleRewardsDistributorInstance.recoverETH(to, 3 ether);
+
+        assertEq(to.balance - toBalBefore, 3 ether, "recipient should receive recovered ETH");
+        assertEq(cmrdBalBefore - cmrd.balance, 3 ether, "contract balance should drop by recovered amount");
+    }
+
+    function test_recoverETH_revertsForNonOperator() public {
+        address payable cmrd = payable(address(cumulativeMerkleRewardsDistributorInstance));
+        vm.deal(cmrd, 1 ether);
+
+        vm.prank(bob); // bob holds no roles
+        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
+        cumulativeMerkleRewardsDistributorInstance.recoverETH(payable(bob), 1 ether);
+    }
+
+    function test_recoverERC20_movesTokenToRecipient() public {
+        // setUp() already minted 1000 rETH to the distributor; recover 100.
+        address to = makeAddr("recipient");
+        uint256 cmrdBefore = rETH.balanceOf(address(cumulativeMerkleRewardsDistributorInstance));
+
+        vm.prank(admin);
+        cumulativeMerkleRewardsDistributorInstance.recoverERC20(address(rETH), to, 100 ether);
+
+        assertEq(rETH.balanceOf(to), 100 ether, "recipient should receive recovered tokens");
+        assertEq(
+            cmrdBefore - rETH.balanceOf(address(cumulativeMerkleRewardsDistributorInstance)),
+            100 ether,
+            "contract balance should drop by recovered amount"
+        );
+    }
+
+    function test_recoverERC20_revertsForNonOperator() public {
+        vm.prank(bob);
+        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
+        cumulativeMerkleRewardsDistributorInstance.recoverERC20(address(rETH), bob, 1 ether);
+    }
 }

--- a/test/CumulativeMerkleRewardsDistributor.t.sol
+++ b/test/CumulativeMerkleRewardsDistributor.t.sol
@@ -407,7 +407,7 @@ contract  CumulativeMerkleRewardsDistributorTest is TestSetup {
         vm.deal(cmrd, 1 ether);
 
         vm.prank(bob); // bob holds no roles
-        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
+        vm.expectRevert(RoleRegistry.OnlyOperatingTimelock.selector);
         cumulativeMerkleRewardsDistributorInstance.recoverETH(payable(bob), 1 ether);
     }
 
@@ -429,7 +429,7 @@ contract  CumulativeMerkleRewardsDistributorTest is TestSetup {
 
     function test_recoverERC20_revertsForNonOperator() public {
         vm.prank(bob);
-        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
+        vm.expectRevert(RoleRegistry.OnlyOperatingTimelock.selector);
         cumulativeMerkleRewardsDistributorInstance.recoverERC20(address(rETH), bob, 1 ether);
     }
 }

--- a/test/DepositAdapter.t.sol
+++ b/test/DepositAdapter.t.sol
@@ -137,8 +137,8 @@ contract DepositAdapterTest is TestSetup {
         uint256 eETHAmountFromWstETH = liquifierInstance.quoteByDiscountedValue(address(stEth), 5 ether);
         depositAdapterInstance.depositWstETHForWeETHWithPermit(wstETHAmount, bob, liquifierPermitInput);
         assertEq(wstETHmainnet.balanceOf(address(alice)), 0);
-        assertApproxEqAbs(weEthInstance.balanceOf(address(alice)), weEthInstance.getWeETHByeETH(eETHAmountFromWstETH), 4);
-        assertApproxEqAbs(stEth.balanceOf(address(etherFiRestakerInstance)), protocolSeETHBeforeDeposit + 5 ether, 4);
+        assertApproxEqAbs(weEthInstance.balanceOf(address(alice)), weEthInstance.getWeETHByeETH(eETHAmountFromWstETH), 5);
+        assertApproxEqAbs(stEth.balanceOf(address(etherFiRestakerInstance)), protocolSeETHBeforeDeposit + 5 ether, 5);
 
         // deposit with insufficient balance
         permitInput = createPermitInput(2, address(depositAdapterInstance), 1 ether, wstETHmainnet.nonces(alice), 2**256 - 1, wstETHmainnet.DOMAIN_SEPARATOR());

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1530,25 +1530,6 @@ contract EtherFiOracleTest is TestSetup {
         assertEq(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal(), lockedBefore + 6 ether);
     }
 
-    // The flip side of the balance-based check: if the LP's actual ETH falls
-    // below what totalValueInLp would suggest, the check reverts even though
-    // the accounting says the withdrawal fits.
-    function test_executeTasks_revertsWhenFinalizedWithdrawalExceedsLpBalance() public {
-        vm.deal(alice, 10 ether);
-        vm.prank(alice);
-        liquidityPoolInstance.deposit{value: 10 ether}();
-
-        // Knock the LP's ETH balance below its accounting so the two diverge.
-        vm.deal(address(liquidityPoolInstance), 4 ether);
-        assertGt(liquidityPoolInstance.totalValueInLp(), address(liquidityPoolInstance).balance);
-
-        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
-        report.finalizedWithdrawalAmount = 5 ether; // <= totalValueInLp (10), > balance (4)
-
-        _moveClock(1 days / 12);
-        _executeAdminTasks(report, "EtherFiAdmin: finalized withdrawal exceeds LP liquidity");
-    }
-
     // =====================================================================
     // canExecuteTasks unit tests
     //
@@ -2227,10 +2208,10 @@ contract EtherFiOracleTest is TestSetup {
         _seedLp(10 ether);
         _makeWithdrawRequest(5 ether);
 
-        // Drain the LP balance below the request amount; the staleness function
-        // reads `address(liquidityPool).balance` directly, so this is the only
-        // knob that matters for the liquidity check.
-        vm.deal(address(liquidityPoolInstance), 1 ether);
+        // Drain totalValueInLp below the request amount; the staleness function
+        // reads `liquidityPool.totalValueInLp()`, so we have to drop both
+        // accounting and balance to make the liquidity check fail.
+        _forceLpBalanceAndTVIL(1 ether);
 
         _advanceToStaleBoundary();
 
@@ -2368,8 +2349,8 @@ contract EtherFiOracleTest is TestSetup {
         _makeWithdrawRequest(5 ether);
 
         _invalidateRequest(r1);
-        // LP balance below the next (valid) request's amount.
-        vm.deal(address(liquidityPoolInstance), 1 ether);
+        // totalValueInLp below the next (valid) request's amount.
+        _forceLpBalanceAndTVIL(1 ether);
 
         _advanceToStaleBoundary();
 

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1455,6 +1455,44 @@ contract EtherFiOracleTest is TestSetup {
         _executeAdminTasks(report, "EtherFiAdmin: finalized withdrawal amount exceeds max");
     }
 
+    // EtherFiAdmin gained `maxNumberOfRequestsToFinalizePerReport` (configured to 1000 in
+    // setUpTests). A report claiming to finalize a range larger than that must be rejected
+    // even when every other gate (per-day cap, LP liquidity, ascending id) is satisfied.
+    // No actual requests need to exist — the cap check sits BEFORE the sum-of-requests loop.
+    function test_executeTasks_revertsWhenRequestRangeExceedsCap() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        // delta from lastFinalizedRequestId(=0) = 1001 > cap(1000)
+        report.lastFinalizedWithdrawalRequestId = 1001;
+
+        _moveClock(1 days / 12);
+        _executeAdminTasks(report, "EtherFiAdmin: number of requests to finalize exceeds max");
+    }
+
+    // Boundary check: a report with delta == cap (1000) must pass the new range gate.
+    // We pin the gate by submitting delta = 1000 and a single real request — finalizeRequests
+    // is happy because the underlying share rate is in range, and the validation loop walks
+    // requests [1, 1000] where only id=1 has non-zero amount (matches finalizedWithdrawalAmount).
+    function test_executeTasks_passesRangeCapAtBoundary() public {
+        _unpauseWithdrawNFT();
+        _seedLp(200 ether);
+        uint256 requestId = _makeWithdrawRequest(1 ether);
+        assertEq(requestId, 1);
+
+        // Move the next-request cursor up so report can point at id=1000 (delta = 1000 == cap).
+        bytes32 slot306 = vm.load(address(withdrawRequestNFTInstance), bytes32(uint256(306)));
+        uint256 cleared = uint256(slot306) & ~uint256(0xffffffff);          // clear nextRequestId
+        uint256 patched = cleared | uint256(1001);                           // nextRequestId = 1001
+        vm.store(address(withdrawRequestNFTInstance), bytes32(uint256(306)), bytes32(patched));
+
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.lastFinalizedWithdrawalRequestId = 1000;       // delta = 1000 - 0 == cap
+        report.finalizedWithdrawalAmount = 1 ether;           // backed by request #1 only
+
+        _moveClock(1 days / 12);
+        _executeAdminTasks(report);
+        assertEq(withdrawRequestNFTInstance.lastFinalizedRequestId(), 1000);
+    }
+
     function test_executeTasks_revertsWhenValidatorApprovalsExceedCap() public {
         IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
         report.validatorsToApprove = new uint256[](400); // > 200/day cap

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -2422,6 +2422,19 @@ contract EtherFiOracleTest is TestSetup {
         assertEq(withdrawRequestNFTInstance.lastFinalizedRequestId(), uint32(requestId));
     }
 
+    function test_finalizeWithdrawalsWhenStale_revertsWhenCooldownPeriodNotElapsed() public {
+        _unpauseWithdrawNFT();
+        _seedLp(10 ether);
+        _makeWithdrawRequest(1 ether);
+
+        _advanceToStaleBoundary();
+        
+        etherFiAdminInstance.finalizeWithdrawalsWhenStale();
+
+        vm.expectRevert(EtherFiAdmin.StaleReportFinalizationCooldown.selector);
+        etherFiAdminInstance.finalizeWithdrawalsWhenStale();
+    }
+
     // Calling twice back-to-back: second call has nothing new to finalize so
     // it reverts with NoWithdrawalsToFinalize (not OracleReportNotStale —
     // staleness is still satisfied, the inner loop just finds nothing).
@@ -2434,13 +2447,15 @@ contract EtherFiOracleTest is TestSetup {
 
         etherFiAdminInstance.finalizeWithdrawalsWhenStale();
 
+        vm.warp(block.timestamp + etherFiAdminInstance.STALE_REPORT_FINALIZATION_COOLDOWN() + 1);
+
         vm.expectRevert(EtherFiAdmin.NoWithdrawalsToFinalize.selector);
         etherFiAdminInstance.finalizeWithdrawalsWhenStale();
     }
 
     // A partial-fill call followed by another after liquidity replenishes:
     // the second call picks up the leftover request that the first one
-    // couldn't cover.
+    // couldn't cover after cooldown period.
     function test_finalizeWithdrawalsWhenStale_resumesAfterLiquidityReplenishes() public {
         _unpauseWithdrawNFT();
         _seedLp(20 ether);
@@ -2459,6 +2474,8 @@ contract EtherFiOracleTest is TestSetup {
         // Bump totalValueInLp via a deposit so addEthAmountLockedForWithdrawal
         // doesn't trip its own InsufficientLiquidity guard.
         _seedLp(10 ether);
+
+        vm.warp(block.timestamp + etherFiAdminInstance.STALE_REPORT_FINALIZATION_COOLDOWN() + 1);
 
         etherFiAdminInstance.finalizeWithdrawalsWhenStale();
         assertEq(withdrawRequestNFTInstance.lastFinalizedRequestId(), uint32(r2));

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -392,35 +392,6 @@ contract EtherFiOracleTest is TestSetup {
         etherFiOracleInstance.submitReport(reportAtSlot4287);
     }
 
-    function test_unpublishReport() public {
-        vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
-
-        // period 2
-        _moveClock(1024 + 2 * slotsPerEpoch);
-
-        uint32 lastPublishedReportRefSlot = etherFiOracleInstance.lastPublishedReportRefSlot();
-        uint32 lastPublishedReportRefBlock = etherFiOracleInstance.lastPublishedReportRefBlock();
-
-        // Oracle accidentally generated an wrong report
-        bytes32 reportHash = etherFiOracleInstance.generateReportHash(reportAtPeriod2A);
-        vm.prank(alice);
-        bool consensusReached = etherFiOracleInstance.submitReport(reportAtPeriod2A);
-        assertEq(consensusReached, true);
-
-        assertEq(etherFiOracleInstance.lastPublishedReportRefSlot(), reportAtPeriod2A.refSlotTo);
-        assertEq(etherFiOracleInstance.lastPublishedReportRefBlock(), reportAtPeriod2A.refBlockTo);
-
-        // Owner performs manual operations to undo the published report
-        vm.startPrank(owner);
-        etherFiOracleInstance.unpublishReport(reportHash);
-        vm.stopPrank();
-        _setLastPublishedBlockStamps(uint32(lastPublishedReportRefSlot), uint32(lastPublishedReportRefBlock));
-
-        assertEq(etherFiOracleInstance.lastPublishedReportRefSlot(), lastPublishedReportRefSlot);
-        assertEq(etherFiOracleInstance.lastPublishedReportRefBlock(), lastPublishedReportRefBlock);
-    }
-
     function test_pause() public {
         _moveClock(1024 + 2 * slotsPerEpoch);
         
@@ -812,33 +783,6 @@ contract EtherFiOracleTest is TestSetup {
         vm.prank(owner);
         etherFiOracleInstance.setConsensusVersion(5);
         assertEq(etherFiOracleInstance.consensusVersion(), 5);
-    }
-
-    function test_unpublishReport_edgeCases() public {
-        vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
-
-        _moveClock(1024 + 2 * slotsPerEpoch);
-
-        bytes32 reportHash = etherFiOracleInstance.generateReportHash(reportAtPeriod2A);
-        
-        // Test: cannot unpublish report that hasn't reached consensus
-        vm.prank(owner);
-        vm.expectRevert(EtherFiOracle.ConsensusNotReached.selector);
-        etherFiOracleInstance.unpublishReport(reportHash);
-
-        // Submit report to reach consensus
-        vm.prank(alice);
-        etherFiOracleInstance.submitReport(reportAtPeriod2A);
-
-        // Now unpublish should work
-        vm.prank(owner);
-        etherFiOracleInstance.unpublishReport(reportHash);
-
-        // Verify consensus is reset
-        (uint32 support, bool consensusReached,) = etherFiOracleInstance.consensusStates(reportHash);
-        assertEq(support, 0);
-        assertEq(consensusReached, false);
     }
 
     function test_shouldSubmitReport_reportSlotNotStarted() public {

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -2466,7 +2466,7 @@ contract EtherFiOracleTest is TestSetup {
 
         etherFiAdminInstance.finalizeWithdrawalsWhenStale();
 
-        vm.warp(block.timestamp + etherFiAdminInstance.STALE_REPORT_FINALIZATION_COOLDOWN() + 1);
+        vm.roll(block.number + etherFiAdminInstance.STALE_REPORT_FINALIZATION_COOLDOWN() + 1);
 
         vm.expectRevert(EtherFiAdmin.NoWithdrawalsToFinalize.selector);
         etherFiAdminInstance.finalizeWithdrawalsWhenStale();
@@ -2494,7 +2494,7 @@ contract EtherFiOracleTest is TestSetup {
         // doesn't trip its own InsufficientLiquidity guard.
         _seedLp(10 ether);
 
-        vm.warp(block.timestamp + etherFiAdminInstance.STALE_REPORT_FINALIZATION_COOLDOWN() + 1);
+        vm.roll(block.number + etherFiAdminInstance.STALE_REPORT_FINALIZATION_COOLDOWN() + 1);
 
         etherFiAdminInstance.finalizeWithdrawalsWhenStale();
         assertEq(withdrawRequestNFTInstance.lastFinalizedRequestId(), uint32(r2));

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -941,6 +941,12 @@ contract EtherFiOracleTest is TestSetup {
     // The check runs after every add/remove/manage/setQuorum mutation, so each
     // mutation needs to leave the (members, quorum) pair inside the valid band.
 
+    function test_setQuorumSize_revertsWhenBelowMinQuorumSize() public {
+        vm.prank(owner);
+        vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
+        etherFiOracleInstance.setQuorumSize(0);
+    }
+
     function test_setQuorumSize_revertsWhenAboveActiveMembers() public {
         // numActive = 2 (alice, bob); quorum = 3 violates numActive < quorum
         vm.prank(owner);

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1034,52 +1034,52 @@ contract EtherFiOracleTest is TestSetup {
     }
 
     function test_constructor_maxValidatorTaskBatchSize_guardrail() public {
-        EtherFiAdmin nonZeroValue = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 500);
+        EtherFiAdmin nonZeroValue = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 500, 1000);
         assertEq(nonZeroValue.maxValidatorTaskBatchSize(), 1_000);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidValidatorTaskBatchSize.selector);
-        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 0, 7200, 100_000 ether, 500);
+        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 0, 7200, 100_000 ether, 500, 1000);
     }
 
     function test_constructor_maxAcceptableRebaseAprInBps_guardrail() public {
-        EtherFiAdmin validValue = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 500);
+        EtherFiAdmin validValue = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 500, 1000);
         assertEq(validValue.maxAcceptableRebaseAprInBps(), 500);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 0, 1_000, 7200, 100_000 ether, 500);
+        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 0, 1_000, 7200, 100_000 ether, 500, 1000);
 
         // negative values revert
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), -1, 1_000, 7200, 100_000 ether, 500);
+        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), -1, 1_000, 7200, 100_000 ether, 500, 1000);
 
         // values above 10_000 revert
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableRebaseApr.selector);
-        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 10_001, 1_000, 7200, 100_000 ether, 500);
+        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 10_001, 1_000, 7200, 100_000 ether, 500, 1000);
     }
 
     function test_constructor_staleOracleReportBlockWindow_guardrail() public {
-        EtherFiAdmin validValue = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 500);
+        EtherFiAdmin validValue = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 500, 1000);
         assertEq(validValue.staleOracleReportBlockWindow(), 7200);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidStaleOracleReportBlockWindow.selector);
-        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 0, 100_000 ether, 500);
+        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 0, 100_000 ether, 500, 1000);
     }
 
     function test_constructor_maxAcceptableFinalizedWithdrawalAmountPerDay_guardrail() public {
-        EtherFiAdmin validValue = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 500);
+        EtherFiAdmin validValue = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 500, 1000);
         assertEq(validValue.maxAcceptableFinalizedWithdrawalAmountPerDay(), 100_000 ether);
 
         // value 0 reverts
         vm.expectRevert(EtherFiAdmin.InvalidMaxAcceptableFinalizedWithdrawalAmount.selector);
-        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 0, 500);
+        new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 0, 500, 1000);
     }
 
     function test_constructor_maxAcceptableNumValidatorsToApprovePerDay_zero_is_allowed() public {
         // _maxAcceptableNumValidatorsToApprovePerDay = 0 signals "pause new validators"
-        EtherFiAdmin zeroAllowed = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 0);
+        EtherFiAdmin zeroAllowed = new EtherFiAdmin(_defaultEtherFiAdminCtorAddrs(), 500, 1_000, 7200, 100_000 ether, 0, 1000);
         assertEq(zeroAllowed.maxAcceptableNumValidatorsToApprovePerDay(), 0);
     }
 

--- a/test/EtherFiRateLimiter.t.sol
+++ b/test/EtherFiRateLimiter.t.sol
@@ -822,7 +822,10 @@ contract EtherFiRateLimiterTest is TestSetup {
         bytes32 limitId
     ) public {
         vm.assume(limitId != bytes32(0)); // Avoid zero limit ID
-        
+        // TestSetup pre-creates eETH/weETH mint/burn/transfer limiters; skip any
+        // fuzzer pick that collides with an already-registered ID.
+        vm.assume(!rateLimiter.limitExists(limitId));
+
         vm.prank(admin);
         rateLimiter.createNewLimiter(limitId, capacity, refillRate);
         

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -2316,7 +2316,7 @@ contract LiquidityPoolTest is TestSetup {
     //--------------------------------------------------------------------------------------
 
     function test_constants_minMaxWithdrawAmount() public view {
-        assertEq(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT(), 0.01 ether, "MIN_WITHDRAW_AMOUNT mismatch");
+        assertEq(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT(), 0.001 ether, "MIN_WITHDRAW_AMOUNT mismatch");
         assertEq(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT(), 1000 ether, "MAX_WITHDRAW_AMOUNT mismatch");
     }
 
@@ -2408,9 +2408,9 @@ contract LiquidityPoolTest is TestSetup {
 
     /// @dev Contrast with `requestMembershipNFTWithdraw`, which accepts both dust
     ///      and whale amounts unchanged. Via the user-facing `requestWithdraw`:
-    ///        - dust (< MIN) is rewritten to the caller's full eETH balance
+    ///        - dust (< MIN) reverts with InvalidWithdrawalAmount
     ///        - large (> MAX) still reverts with InvalidWithdrawalAmount
-    function test_requestWithdraw_userFlow_dustWithdrawsFullBalance_largeReverts() public {
+    function test_requestWithdraw_userFlow_dustRevertsWithInvalidWithdrawalAmount_largeRevertsWithInvalidWithdrawalAmount() public {
         uint256 dust = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() - 1;
         uint256 large = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT() + 1 ether;
 
@@ -2420,9 +2420,8 @@ contract LiquidityPoolTest is TestSetup {
         uint256 balance = eETHInstance.balanceOf(bob);
         eETHInstance.approve(address(liquidityPoolInstance), balance);
 
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, dust);
-        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
-        assertEq(request.amountOfEEth, balance, "dust request should withdraw bob's full balance");
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, dust);
 
         vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
         liquidityPoolInstance.requestWithdraw(bob, large);

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -1984,10 +1984,10 @@ contract LiquidityPoolTest is TestSetup {
         // escrowMigrationCompleted is at slot 226, byte offset 0 (bool).
         // It should already be false after initializeTestingFork; no-op write to be safe.
         {
-            bytes32 slot226 = bytes32(uint256(226));
-            bytes32 current = vm.load(address(liquidityPoolInstance), slot226);
+            bytes32 slot228 = bytes32(uint256(228));
+            bytes32 current = vm.load(address(liquidityPoolInstance), slot228);
             bytes32 newVal  = current & bytes32(~uint256(0xff)); // clear byte 0
-            vm.store(address(liquidityPoolInstance), slot226, newVal);
+            vm.store(address(liquidityPoolInstance), slot228, newVal);
         }
         assertFalse(liquidityPoolInstance.escrowMigrationCompleted());
 
@@ -2287,10 +2287,10 @@ contract LiquidityPoolTest is TestSetup {
     function test_addEthAmountLockedForWithdrawal_revertsIfMigrationIncomplete() public {
         // setUp already ran initializeOnUpgradeV2. Reset the flag to simulate pre-migration state.
         {
-            bytes32 slot226 = bytes32(uint256(226));
-            bytes32 current = vm.load(address(liquidityPoolInstance), slot226);
+            bytes32 slot228 = bytes32(uint256(228));
+            bytes32 current = vm.load(address(liquidityPoolInstance), slot228);
             bytes32 newVal  = current & bytes32(~uint256(0xff)); // clear byte 0 (the bool)
-            vm.store(address(liquidityPoolInstance), slot226, newVal);
+            vm.store(address(liquidityPoolInstance), slot228, newVal);
         }
         assertFalse(liquidityPoolInstance.escrowMigrationCompleted(), "pre-condition: migration flag reset");
 
@@ -2315,13 +2315,8 @@ contract LiquidityPoolTest is TestSetup {
     //----------------------  MIN / MAX WITHDRAW AMOUNT TESTS  -----------------------------
     //--------------------------------------------------------------------------------------
 
-    function test_constants_minMaxWithdrawAmount() public view {
-        assertEq(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT(), 0.001 ether, "MIN_WITHDRAW_AMOUNT mismatch");
-        assertEq(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT(), 1000 ether, "MAX_WITHDRAW_AMOUNT mismatch");
-    }
-
     function test_requestWithdraw_atMin_succeeds() public {
-        uint96 amt = uint96(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT());
+        uint96 amt = uint96(liquidityPoolInstance.minWithdrawAmount());
 
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 1 ether}();
@@ -2330,11 +2325,11 @@ contract LiquidityPoolTest is TestSetup {
         vm.stopPrank();
 
         WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
-        assertEq(request.amountOfEEth, amt, "MIN_WITHDRAW_AMOUNT request should be created");
+        assertEq(request.amountOfEEth, amt, "minWithdrawAmount request should be created");
     }
 
     function test_requestWithdraw_belowMin_amountNotEqualToBalance_reverts() public {
-        uint96 amt = uint96(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT()) - 1;
+        uint96 amt = uint96(liquidityPoolInstance.minWithdrawAmount()) - 1;
 
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 1 ether}();
@@ -2344,7 +2339,7 @@ contract LiquidityPoolTest is TestSetup {
     }
 
     function test_requestWithdraw_atMax_succeeds() public {
-        uint96 amt = uint96(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT());
+        uint96 amt = uint96(liquidityPoolInstance.maxWithdrawAmount());
 
         vm.deal(bob, uint256(amt) + 1 ether);
         vm.startPrank(bob);
@@ -2354,11 +2349,11 @@ contract LiquidityPoolTest is TestSetup {
         vm.stopPrank();
 
         WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
-        assertEq(request.amountOfEEth, amt, "MAX_WITHDRAW_AMOUNT request should be created");
+        assertEq(request.amountOfEEth, amt, "maxWithdrawAmount request should be created");
     }
 
     function test_requestWithdraw_aboveMax_reverts() public {
-        uint96 amt = uint96(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT()) + 1;
+        uint96 amt = uint96(liquidityPoolInstance.maxWithdrawAmount()) + 1;
 
         vm.deal(bob, uint256(amt) + 1 ether);
         vm.startPrank(bob);
@@ -2381,7 +2376,7 @@ contract LiquidityPoolTest is TestSetup {
         vm.startPrank(address(membershipManagerInstance));
         liquidityPoolInstance.deposit{value: 1 ether}(address(membershipManagerInstance), address(0));
 
-        uint256 dust = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() - 1; // below user cap
+        uint256 dust = liquidityPoolInstance.minWithdrawAmount() - 1; // below user cap
         eETHInstance.approve(address(liquidityPoolInstance), dust);
         uint256 reqId = liquidityPoolInstance.requestMembershipNFTWithdraw(alice, dust, 0);
         vm.stopPrank();
@@ -2391,7 +2386,7 @@ contract LiquidityPoolTest is TestSetup {
     }
 
     function test_requestMembershipNFTWithdraw_aboveMax_succeeds() public {
-        uint256 large = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT() + 1 ether; // above user cap
+        uint256 large = liquidityPoolInstance.maxWithdrawAmount() + 1 ether; // above user cap
 
         // Seed the MembershipManager with enough eETH to cover the large request.
         vm.deal(address(membershipManagerInstance), large + 1 ether);
@@ -2411,8 +2406,8 @@ contract LiquidityPoolTest is TestSetup {
     ///        - dust (< MIN) reverts with InvalidWithdrawalAmount
     ///        - large (> MAX) still reverts with InvalidWithdrawalAmount
     function test_requestWithdraw_userFlow_dustRevertsWithInvalidWithdrawalAmount_largeRevertsWithInvalidWithdrawalAmount() public {
-        uint256 dust = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() - 1;
-        uint256 large = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT() + 1 ether;
+        uint256 dust = liquidityPoolInstance.minWithdrawAmount() - 1;
+        uint256 large = liquidityPoolInstance.maxWithdrawAmount() + 1 ether;
 
         vm.deal(bob, dust);
         vm.startPrank(bob);

--- a/test/MembershipManager.t.sol
+++ b/test/MembershipManager.t.sol
@@ -1413,4 +1413,37 @@ contract MembershipManagerTest is TestSetup {
 //         assertEq(eETHInstance.balanceOf(address(membershipManagerV1Instance)), 0 ether);
 //         assertEq(eETHInstance.balanceOf(alice), 0.5 ether);
 //     }
+
+    function setUp() public {
+        setUpTests();
+    }
+
+    /// @dev M-06: rebase() must early-return when the MembershipManager holds zero eETH shares.
+    /// Pre-fix, the `1 ether * thresholdAmount / etherFanEEthShares` expression panicked with
+    /// division-by-zero whenever the fan-boost branch was entered and shares were zero
+    /// (e.g. fresh deployment, or after every NFT exited ether.fan).
+    function test_rebase_earlyReturnsWhenEtherFanSharesAreZero() public {
+        // Sanity: fresh deployment → MembershipManager has 0 eETH shares.
+        assertEq(eETHInstance.shares(address(membershipManagerInstance)), 0, "precondition: no fan shares");
+
+        // Send a small ETH balance to the MM so the fan-boost branch (`balance >= threshold`)
+        // would otherwise enter and divide by zero. `fanBoostThreshold` is 0 in fresh setup,
+        // so balance >= threshold even with 0 wei — but pump 1 wei to be safe across configs.
+        vm.deal(address(membershipManagerInstance), 1 wei);
+
+        // Seed LP with some pool funds so rebase math doesn't fail upstream.
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 5 ether}();
+        vm.stopPrank();
+
+        // rebase must succeed (no division-by-zero) AND the underlying LP rebase must apply.
+        uint256 tvolBefore = liquidityPoolInstance.totalValueOutOfLp();
+        vm.prank(address(etherFiAdminInstance));
+        membershipManagerInstance.rebase(1 ether);
+        assertEq(
+            liquidityPoolInstance.totalValueOutOfLp(),
+            tvolBefore + 1 ether,
+            "LP rebase still applied even on early-return"
+        );
+    }
 }

--- a/test/NodeOperatorManager.t.sol
+++ b/test/NodeOperatorManager.t.sol
@@ -50,63 +50,6 @@ contract NodeOperatorManagerTest is TestSetup {
         );
     }
 
-    function test_RegisterNodeOperatorInMigration() public {
-
-        address[] memory operators = new address[](2);
-        operators[0] = address(bob);
-        operators[1] = address(alice);
-
-        bytes[] memory hashes = new bytes[](2);
-        hashes[0] = bobIPFS_Hash;
-        hashes[1] = aliceIPFS_Hash;
-
-        uint64[] memory totalKeys = new uint64[](2);
-        totalKeys[0] = 10;
-        totalKeys[1] = 15;
-
-        uint64[] memory keysUsed = new uint64[](2);
-        keysUsed[0] = 5;
-        keysUsed[1] = 1;
-
-        vm.prank(bob);
-        vm.expectRevert("Ownable: caller is not the owner");
-        nodeOperatorManagerInstance.initializeOnUpgrade(
-            operators,
-            hashes,
-            totalKeys,
-            keysUsed
-        );
-
-        vm.prank(owner);
-        nodeOperatorManagerInstance.initializeOnUpgrade(
-            operators,
-            hashes,
-            totalKeys,
-            keysUsed
-        );
-
-        (
-            uint64 totalKeysUser,
-            uint64 keysUsedUser,
-            bytes memory bobHash
-        ) = nodeOperatorManagerInstance.addressToOperatorData(bob);
-
-        assertEq(bobHash, abi.encodePacked(bobIPFS_Hash));
-        assertEq(totalKeysUser, 10);
-        assertEq(keysUsedUser, 5);
-
-        assertEq(nodeOperatorManagerInstance.registered(bob), true);
-
-        vm.prank(owner);
-        vm.expectRevert(NodeOperatorManager.AlreadyRegistered.selector);
-        nodeOperatorManagerInstance.initializeOnUpgrade(
-            operators,
-            hashes,
-            totalKeys,
-            keysUsed
-        );
-    }
-
     function test_CanAddAddressToWhitelist() public {
         vm.startPrank(alice);
         nodeOperatorManagerInstance.registerNodeOperator(

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -742,6 +742,32 @@ contract PriorityWithdrawalQueueTest is TestSetup {
         priorityQueue.fulfillRequests(requests);
     }
 
+    function test_fulfillRequests_revertWhenMigrationNotComplete() public {
+        uint96 withdrawAmount = 10 ether;
+
+        (, IPriorityWithdrawalQueue.WithdrawRequest memory request) =
+            _createWithdrawRequest(vipUser, withdrawAmount);
+
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory requests = new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+        requests[0] = request;
+
+        // Simulate the LP pre-migration state. Without the fulfillRequests guard,
+        // the request would still get finalized and ethAmountLockedForPriorityWithdrawal
+        // would stay at zero (since receive() also gates on this flag), bricking later
+        // claims and cancels via uint128 underflow.
+        vm.mockCall(
+            address(liquidityPoolInstance),
+            abi.encodeWithSelector(ILiquidityPool.escrowMigrationCompleted.selector),
+            abi.encode(false)
+        );
+
+        vm.prank(requestManager);
+        vm.expectRevert(PriorityWithdrawalQueue.MigrationNotComplete.selector);
+        priorityQueue.fulfillRequests(requests);
+
+        vm.clearMockedCalls();
+    }
+
     //--------------------------------------------------------------------------------------
     //------------------------------  CLAIM TESTS  -----------------------------------------
     //--------------------------------------------------------------------------------------

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -1662,14 +1662,16 @@ contract PriorityWithdrawalQueueTest is TestSetup {
         priorityQueue.claimWithdraw(request);
 
         uint256 remainderAmount = priorityQueue.getRemainderAmount();
-        
-        // Only test if there are remainder shares
+
+        // Only test if there are remainder shares. The remainder is just a few wei on mainnet
+        // fork (rounding dust), so halving it can round `sharesForAmount(eEthAmount)` to zero
+        // and leave `totalRemainderShares` untouched. Sweep the full remainder so the share
+        // delta is non-zero and the post-condition can fire.
         if (remainderAmount > 0) {
-            uint256 amountToHandle = remainderAmount / 2;
             uint256 remainderBefore = priorityQueue.totalRemainderShares();
 
             vm.prank(alice);
-            priorityQueue.handleRemainder(amountToHandle);
+            priorityQueue.handleRemainder(remainderAmount);
 
             assertLt(priorityQueue.totalRemainderShares(), remainderBefore, "Remainder should decrease");
         }

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -96,6 +96,9 @@ contract PriorityWithdrawalQueueTest is TestSetup {
             liquidityPoolInstance.initializeOnUpgradeV2();
         }
 
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
+        liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
+
         // Grant roles — consolidated to the 8-tier model.
         // PWQ admin → OPERATION_TIMELOCK_ROLE; pauser → OPERATION_MULTISIG_ROLE;
         // whitelist manager → HOUSEKEEPING_OPERATIONS_ROLE; request manager → ORACLE_OPERATIONS_ROLE; IMPLICIT_FEE_CLAIMER → HOUSEKEEPING_OPERATIONS_ROLE.

--- a/test/StakingManager.t.sol
+++ b/test/StakingManager.t.sol
@@ -1324,7 +1324,7 @@ contract StakingManagerTest is TestSetup {
     //---------------------------------------------------------------------------
 
     function test_initialDepositAmount() public view {
-        assertEq(stakingManagerInstance.initialDepositAmount(), 1 ether);
+        assertEq(stakingManagerInstance.INITIAL_DEPOSIT_AMOUNT(), 1 ether);
     }
 
     function test_calculateValidatorPubkeyHash() public view {

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1024,7 +1024,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // CumulativeMerkleRewardsDistributor (no circular deps)
         cumulativeMerkleRewardsDistributorImplementation = new CumulativeMerkleRewardsDistributor(address(roleRegistryInstance));
         cumulativeMerkleRewardsDistributorProxy = new UUPSProxy(address(cumulativeMerkleRewardsDistributorImplementation), "");
-        cumulativeMerkleRewardsDistributorInstance = CumulativeMerkleRewardsDistributor(address(cumulativeMerkleRewardsDistributorProxy));
+        cumulativeMerkleRewardsDistributorInstance = CumulativeMerkleRewardsDistributor(payable(address(cumulativeMerkleRewardsDistributorProxy)));
         cumulativeMerkleRewardsDistributorInstance.initialize();
 
         // CumulativeMerkleRewardsDistributor admin/claim-delay-setter consolidated into EXECUTOR_OPERATIONS_ROLE

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1031,7 +1031,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryInstance.grantRole(roleRegistryInstance.EXECUTOR_OPERATIONS_ROLE(), admin);
 
         // EtherFiOracle
-        etherFiOracleImplementation = new EtherFiOracle(address(etherFiAdminProxy), address(roleRegistryInstance));
+        etherFiOracleImplementation = new EtherFiOracle(1, address(etherFiAdminProxy), address(roleRegistryInstance));
         etherFiOracleInstance.upgradeTo(address(etherFiOracleImplementation));
 
         // EtherFiRestaker — constructor reads from liquifier, which is initialized above
@@ -1331,7 +1331,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function _upgradeOracleAndAdminForFork() internal {
-        address newOracleImpl = address(new EtherFiOracle(address(etherFiAdminInstance), address(roleRegistryInstance)));
+        address newOracleImpl = address(new EtherFiOracle(1, address(etherFiAdminInstance), address(roleRegistryInstance)));
         vm.prank(etherFiOracleInstance.owner());
         etherFiOracleInstance.upgradeTo(newOracleImpl);
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1205,6 +1205,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         vm.startPrank(alice);
         etherFiAdminInstance.setValidatorTaskBatchSize(100);
         liquidityPoolInstance.setValidatorSizeWei(32 ether);
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
+        liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
         // Pause WithdrawRequestNFT so existing tests that unPauseContract in their
         // own setUp continue to find it paused (initializeOnUpgrade used to set this).
         withdrawRequestNFTInstance.pauseContract();

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1017,7 +1017,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 roleRegistry: address(roleRegistryInstance),
                 priorityWithdrawalQueue: address(priorityQueueProxy)
             }),
-            10_000, 1_000, 7200, 100_000 ether, 500
+            10_000, 1_000, 7200, 100_000 ether, 500, 1000
         );
         etherFiAdminInstance.upgradeTo(address(etherFiAdminImplementation));
 
@@ -1323,7 +1323,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 priorityWithdrawalQueue: address(priorityQueueInstance)
             }),
             10_000, 1_000, 7200
-        , 100_000 ether, 500));
+        , 100_000 ether, 500, 1000));
         vm.prank(etherFiAdminInstance.owner());
         etherFiAdminInstance.upgradeTo(newAdminImpl);
     }
@@ -1346,7 +1346,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 priorityWithdrawalQueue: address(priorityQueueInstance)
             }),
             10_000, 1_000, 7200
-        , 100_000 ether, 500));
+        , 100_000 ether, 500, 1000));
         vm.prank(roleRegistryInstance.owner());
         etherFiAdminInstance.upgradeTo(newAdminImpl);
     }

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -847,7 +847,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         TNFTInstance.initializeOnUpgrade(address(managerInstance));
 
         // BNFT — fresh proxy; constructor immutables wired to predeployed proxies
-        BNFTImplementation = new BNFT(address(stakingManagerProxy), address(etherFiNodeManagerProxy));
+        BNFTImplementation = new BNFT();
         BNFTProxy = new UUPSProxy(address(BNFTImplementation), "");
         BNFTInstance = BNFT(address(BNFTProxy));
         BNFTInstance.initialize(address(stakingManagerInstance));

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1108,9 +1108,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         withdrawRequestNFTInstance.initialize(payable(address(liquidityPoolProxy)), payable(address(eETHProxy)), payable(address(membershipManagerProxy)));
         // initializeOnUpgrade now reverts (checks immutable roleRegistry == 0). Set the
-        // share-remainder split + paused state it used to bootstrap directly. Also seed
-        // the scan cursor (current = 1, last = 0) so isScanOfShareRemainderCompleted()
-        // is true from the start, matching post-initializeOnUpgrade behaviour.
+        // share-remainder split + paused state it used to bootstrap directly.
         withdrawRequestNFTInstance.updateShareRemainderSplitToTreasuryInBps(1000);
         {
             // Slot 306 packs (nextRequestId, lastFinalizedRequestId, shareRemainderSplit,

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -263,7 +263,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         
     }
 
-    // Sub-wei rounding scenario from the original SD-6 report. The MIN_WITHDRAW_AMOUNT
+    // Sub-wei rounding scenario from the original SD-6 report. The minWithdrawAmount
     // gate on the LiquidityPool rewrites any below-MIN request if amount is equal to the 
     // caller's full eETH balance instead of reverting. Pin the new behavior: a below-MIN
     // request reverts with InvalidWithdrawalAmount.
@@ -365,9 +365,9 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     function testFuzz_RequestWithdraw(uint96 depositAmount, uint96 withdrawAmount, address recipient) public {
-        // Assume valid conditions — withdraw amount must satisfy [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT].
+        // Assume valid conditions — withdraw amount must satisfy [minWithdrawAmount, maxWithdrawAmount].
         vm.assume(depositAmount >= 1 ether && depositAmount <= 1000 ether);
-        vm.assume(withdrawAmount >= liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() && withdrawAmount <= depositAmount);
+        vm.assume(withdrawAmount >= liquidityPoolInstance.minWithdrawAmount() && withdrawAmount <= depositAmount);
         vm.assume(recipient != address(0) && recipient != address(liquidityPoolInstance));
         // Filter out contracts that don't implement IERC721Receiver - only allow EOAs
         vm.assume(recipient.code.length == 0);
@@ -397,8 +397,8 @@ contract WithdrawRequestNFTTest is TestSetup {
         assertEq(eETHInstance.balanceOf(address(withdrawRequestNFTInstance)), withdrawAmount, "Incorrect contract eETH balance");
         assertEq(withdrawRequestNFTInstance.nextRequestId(), requestId + 1, "Incorrect next request ID");
 
-        uint256 minAmount = liquidityPoolInstance.MIN_WITHDRAW_AMOUNT();
-        uint256 maxAmount = liquidityPoolInstance.MAX_WITHDRAW_AMOUNT();
+        uint256 minAmount = liquidityPoolInstance.minWithdrawAmount();
+        uint256 maxAmount = liquidityPoolInstance.maxWithdrawAmount();
         if (eETHInstance.balanceOf(bob) >= minAmount) {
             uint256 reqAmount = eETHInstance.balanceOf(bob);
             if (reqAmount > maxAmount) reqAmount = maxAmount;
@@ -418,11 +418,11 @@ contract WithdrawRequestNFTTest is TestSetup {
         address recipient
     ) public {
         // Bound to valid ranges. withdrawAmount is bounded against the new
-        // [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT] gate; without bound() the cascading
+        // [minWithdrawAmount, maxWithdrawAmount] gate; without bound() the cascading
         // vm.assume calls hit forge's input-rejection cap at low probability.
         depositAmount = uint96(bound(depositAmount, 1 ether, 1e6 ether));
-        uint96 maxWithdraw = uint96(liquidityPoolInstance.MAX_WITHDRAW_AMOUNT());
-        uint96 minWithdraw = uint96(liquidityPoolInstance.MIN_WITHDRAW_AMOUNT());
+        uint96 maxWithdraw = uint96(liquidityPoolInstance.maxWithdrawAmount());
+        uint96 minWithdraw = uint96(liquidityPoolInstance.minWithdrawAmount());
         uint96 withdrawCeil = depositAmount < maxWithdraw ? depositAmount : maxWithdraw;
         withdrawAmount = uint96(bound(withdrawAmount, minWithdraw, withdrawCeil));
         rebaseAmount = uint96(bound(rebaseAmount, 0.5 ether, depositAmount));
@@ -553,9 +553,9 @@ contract WithdrawRequestNFTTest is TestSetup {
     }
 
     function testFuzz_InvalidateRequest(uint96 depositAmount, uint96 withdrawAmount, address recipient) public {
-        // Assume valid conditions — withdraw amount must satisfy [MIN_WITHDRAW_AMOUNT, MAX_WITHDRAW_AMOUNT].
+        // Assume valid conditions — withdraw amount must satisfy [minWithdrawAmount, maxWithdrawAmount].
         vm.assume(depositAmount >= 1 ether && depositAmount <= 1000 ether);
-        vm.assume(withdrawAmount >= liquidityPoolInstance.MIN_WITHDRAW_AMOUNT() && withdrawAmount <= depositAmount);
+        vm.assume(withdrawAmount >= liquidityPoolInstance.minWithdrawAmount() && withdrawAmount <= depositAmount);
         vm.assume(recipient != address(0) && recipient != address(liquidityPoolInstance) && recipient != alice && recipient != admin && recipient != (address(etherFiAdminInstance)) && recipient != roleRegistryInstance.owner());
         // Filter out contracts that don't implement IERC721Receiver - only allow EOAs
         vm.assume(recipient.code.length == 0);

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -30,6 +30,29 @@ contract WithdrawRequestNFTTest is TestSetup {
         setUpTests();
         vm.prank(admin);
         withdrawRequestNFTInstance.unPauseContract();
+
+        // seizeInvalidRequest is now gated by onlyUpgradeTimelock (audit L-02).
+        // Grant the role to the NFT contract's owner so tests calling
+        // `vm.prank(withdrawRequestNFTInstance.owner())` can still invoke it.
+        // Cache view-call results before the prank — each external call (even view)
+        // consumes a single `vm.prank`.
+        address roleOwner = roleRegistryInstance.owner();
+        address nftOwner = withdrawRequestNFTInstance.owner();
+        bytes32 upgradeRole = roleRegistryInstance.UPGRADE_TIMELOCK_ROLE();
+        vm.prank(roleOwner);
+        roleRegistryInstance.grantRole(upgradeRole, nftOwner);
+    }
+
+    // Drops totalValueInLp (and balance, to preserve the LP invariant) to `target`.
+    // LiquidityPool storage layout: slot 207 packs totalValueOutOfLp (low 128)
+    // and totalValueInLp (high 128). vm.deal alone would skew accounting.
+    function _forceLpBalanceAndTVIL(uint128 target) internal {
+        bytes32 slot = bytes32(uint256(207));
+        bytes32 raw = vm.load(address(liquidityPoolInstance), slot);
+        uint128 outOf = uint128(uint256(raw));
+        bytes32 packed = bytes32((uint256(target) << 128) | uint256(outOf));
+        vm.store(address(liquidityPoolInstance), slot, packed);
+        vm.deal(address(liquidityPoolInstance), uint256(target));
     }
 
     function test_finalizeRequests() public {
@@ -727,7 +750,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     /// @dev When the LP can no longer cover the request amount (drained between
     ///      invalidate and re-validate), `validateRequest` must revert before
     ///      touching state. We stage the same finalized-but-invalid setup and
-    ///      then `vm.deal(LP, 0)` to force the precondition to fail.
+    ///      then drop totalValueInLp to 0 (the check now reads tVIL, not balance).
     function test_validateRequest_finalized_revertsOnInsufficientLpBalance() public {
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 10 ether}();
@@ -740,8 +763,8 @@ contract WithdrawRequestNFTTest is TestSetup {
         withdrawRequestNFTInstance.invalidateRequest(reqA);
         _finalizeWithdrawalRequest(reqB);
 
-        // Drain LP so it can't cover the 1 ETH request.
-        vm.deal(address(liquidityPoolInstance), 0);
+        // Drop LP accounting (and balance) so it can't cover the 1 ETH request.
+        _forceLpBalanceAndTVIL(0);
 
         vm.prank(admin);
         vm.expectRevert(WithdrawRequestNFT.RequestAmountGreaterThanAvailableLiquidity.selector);

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -1119,140 +1119,186 @@ contract WithdrawRequestNFTTest is TestSetup {
         assertGe(remainderAmount, 0, "Remainder amount should be >= 0");
     }
 
-    function test_requestWithdrawWithFee() public {
+    /// @dev L-01: After a negative rebase between request and finalize, the request was locked
+    ///      at the original (higher) amount but the frozen rate at finalize values the shares lower.
+    ///      The delta sits in the NFT as stranded ETH (locked > amountToWithdraw). handleRemainder
+    ///      must sweep that stranded ETH to the treasury (NOT back to LP — that would inflate the
+    ///      LP and double-count the shares already burned during claim).
+    function test_handleRemainder_sweepsNegativeRebaseStrandedEthToTreasury() public {
+        // Pure negative-rebase claims burn the full request.shareOfEEth → no share remainder,
+        // so handleRemainder cannot be invoked stand-alone. Pair the strand-prone request with
+        // a positive-rebase request that DOES leave share remainder, so handleRemainder has fuel
+        // for its first half and the new sweep block fires at the end.
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+        vm.stopPrank();
+
+        // First positive rebase pumps TVOL so we have headroom to rebase negative later.
+        // After: TPE=15, shares=10e18, rate=1.5
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(5 ether);
+
+        // Request A — priced at rate=1.5; another positive rebase before finalize leaves share
+        // remainder during claim (burnedShares = ceil(amountOfEEth/frozenRate) < shareOfEEth).
+        vm.prank(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), 2 ether);
+        vm.prank(bob);
+        uint256 reqA = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+
+        // Second positive rebase: rate climbs to ~2.0
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(5 ether);
+
+        _finalizeWithdrawalRequest(reqA);
+        vm.prank(bob);
+        withdrawRequestNFTInstance.claimWithdraw(reqA);
+
+        assertGt(
+            withdrawRequestNFTInstance.totalRemainderEEthShares(),
+            0,
+            "claim A should leave eETH share remainder"
+        );
+
+        // Request B at current (high) rate, then drop TVOL so finalize-rate < request-rate.
+        // request.shareOfEEth priced at the high rate, finalize-rate values them less → claim
+        // sends < amountOfEEth, the unspent ETH sits in NFT as stranded.
+        vm.prank(bob);
+        uint256 reqB = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(-int128(int256(7 ether)));
+
+        _finalizeWithdrawalRequest(reqB);
+
+        uint256 treasuryEthBefore = address(treasuryInstance).balance;
+        uint128 lockedBefore = withdrawRequestNFTInstance.ethAmountLockedForWithdrawal();
+
+        vm.prank(bob);
+        withdrawRequestNFTInstance.claimWithdraw(reqB);
+
+        // NFT.balance now carries the stranded ETH delta (locked - amountToWithdraw).
+        uint256 strandedEth = address(withdrawRequestNFTInstance).balance;
+        assertGt(strandedEth, 0, "stranded ETH should exist after negative-rebase claim");
+        assertEq(
+            withdrawRequestNFTInstance.ethAmountLockedForWithdrawal(),
+            lockedBefore - 1 ether,
+            "lock counter decremented by gross request amount"
+        );
+
+        // Sweep via handleRemainder.
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), admin);
+        vm.stopPrank();
+
+        uint256 remainderAmount = withdrawRequestNFTInstance.getEEthRemainderAmount();
+        assertGt(remainderAmount, 0, "remainder must remain to drive handleRemainder");
+
+        vm.prank(admin);
+        withdrawRequestNFTInstance.handleRemainder(remainderAmount);
+
+        // Stranded ETH must have flowed to the treasury, NOT back to LP.
+        assertEq(address(withdrawRequestNFTInstance).balance, 0, "NFT balance should be zero after sweep");
+        assertEq(
+            address(treasuryInstance).balance - treasuryEthBefore,
+            strandedEth,
+            "treasury should receive the full stranded ETH"
+        );
+    }
+
+    /// @dev Counter-case: when there is no rebase divergence, claim consumes the full locked ETH
+    ///      and no stranded ETH remains. handleRemainder must complete without doing an ETH sweep.
+    function test_handleRemainder_noStrandedEthWhenNoRebase() public {
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 10 ether}();
         vm.stopPrank();
 
         vm.prank(bob);
         eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
+        vm.prank(bob);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
-        uint256 fee = 0.01 ether; // 1% fee
-        
-        // Direct call to requestWithdraw with fee (simulating MembershipManager)
-        vm.prank(address(liquidityPoolInstance));
-        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(1 ether, 1 ether, bob, fee);
+        _finalizeWithdrawalRequest(requestId);
 
-        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
-        assertEq(request.feeGwei, uint32(fee / 1 gwei), "Fee should be stored correctly");
+        vm.prank(bob);
+        withdrawRequestNFTInstance.claimWithdraw(requestId);
+
+        assertEq(address(withdrawRequestNFTInstance).balance, 0, "no stranded ETH expected");
     }
 
-    function test_claimWithdrawWithFee() public {
+    /// @dev L-01: handleRemainder must not touch ethAmountLockedForWithdrawal — the sweep
+    ///      decrements only the surplus above the lock counter. Pin this so future refactors
+    ///      can't accidentally double-debit the escrow accounting.
+    function test_handleRemainder_doesNotTouchLockedCounter() public {
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 10 ether}();
         vm.stopPrank();
 
-        uint256 amount = 1 ether;
-        uint256 fee = 0.01 ether; // 1% fee
-
-        vm.prank(bob);
-        eETHInstance.approve(address(liquidityPoolInstance), amount);
-
-        // Transfer eETH to contract first (simulating what liquidity pool does)
-        vm.prank(bob);
-        eETHInstance.transfer(address(withdrawRequestNFTInstance), amount);
-
-        // Create request with fee via direct call
-        vm.prank(address(liquidityPoolInstance));
-        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(uint96(amount), uint96(amount), bob, fee);
-
-        // Add more liquidity to ensure withdrawal can be fulfilled
-        vm.deal(alice, 10 ether);
-        vm.prank(alice);
-        liquidityPoolInstance.deposit{value: 5 ether}();
-
-        // Rebase to increase value
+        // Seed TVOL so the later negative rebase has headroom (rebase touches TVOL, not TVIL).
         vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(5 ether);
+        liquidityPoolInstance.rebase(10 ether);
 
-        _finalizeWithdrawalRequest(requestId);
-
-        uint256 bobBalanceBefore = address(bob).balance;
-        uint256 claimableAmount = withdrawRequestNFTInstance.getClaimableAmount(requestId);
-        
+        // Two requests — finalize+claim one to generate remainder shares while the other
+        // keeps `ethAmountLockedForWithdrawal` non-zero.
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
-
-        uint256 bobBalanceAfter = address(bob).balance;
-        uint256 receivedAmount = bobBalanceAfter - bobBalanceBefore;
-        
-        // Received amount should be claimable amount (which already has fee deducted)
-        assertApproxEqAbs(receivedAmount, claimableAmount, 0.001 ether, "Bob should receive amount minus fee");
-    }
-
-    /// @dev Verifies that fee ETH stranded in the NFT after a fee-bearing claim is swept back to LP
-    ///      when handleRemainder is called, and that ethAmountLockedForWithdrawal is unchanged by it.
-    function test_handleRemainder_returnsFeeEthToLP() public {
-        uint256 amount = 1 ether;
-        uint256 fee    = 0.1 ether; // 10% fee
-
-        // --- setup: deposit liquidity ---
-        startHoax(bob);
-        liquidityPoolInstance.deposit{value: 10 ether}();
-        vm.stopPrank();
-
-        // Transfer eETH into NFT contract (simulates what LP does in the real requestWithdraw path)
+        eETHInstance.approve(address(liquidityPoolInstance), 2 ether);
         vm.prank(bob);
-        eETHInstance.transfer(address(withdrawRequestNFTInstance), amount);
+        uint256 reqA = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+        vm.prank(bob);
+        uint256 reqB = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
-        // Create a fee-bearing withdraw request directly (simulating MembershipManager)
-        vm.prank(address(liquidityPoolInstance));
-        uint256 requestId = withdrawRequestNFTInstance.requestWithdraw(
-            uint96(amount), uint96(amount), bob, fee
-        );
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(-8 ether);
 
-        // Add more liquidity and finalize
-        vm.deal(alice, 10 ether);
-        vm.prank(alice);
-        liquidityPoolInstance.deposit{value: 5 ether}();
-
-        _finalizeWithdrawalRequest(requestId);
-
-        // Bob claims — NFT sends net (amount - fee) to bob, but received gross from LP at finalize.
-        // After claim: NFT.balance should equal fee (stranded), counter should be 0.
-        uint256 nftBalBefore  = address(withdrawRequestNFTInstance).balance;
-        uint256 lpBalBefore   = address(liquidityPoolInstance).balance;
+        _finalizeWithdrawalRequest(reqA);
+        _finalizeWithdrawalRequest(reqB);
 
         vm.prank(bob);
-        withdrawRequestNFTInstance.claimWithdraw(requestId);
+        withdrawRequestNFTInstance.claimWithdraw(reqA);
 
-        // Counter must be zero (decremented by gross).
-        assertEq(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal(), 0, "counter should be 0 after gross decrement");
-
-        // NFT balance should equal the stranded fee.
-        uint256 strandedFee = address(withdrawRequestNFTInstance).balance;
-        assertGt(strandedFee, 0, "fee ETH should be stranded in NFT");
-        assertApproxEqAbs(strandedFee, fee, 0.001 ether, "stranded amount should equal fee");
-
-        // --- trigger handleRemainder to sweep fee ETH back to LP ---
-        // First get some eETH remainder to satisfy the non-zero _eEthAmount requirement.
-        // After claim, totalRemainderEEthShares > 0 due to share-rate drift from rebase.
-        uint256 remainderAmount = withdrawRequestNFTInstance.getEEthRemainderAmount();
+        uint128 lockedBefore = withdrawRequestNFTInstance.ethAmountLockedForWithdrawal();
+        assertGt(lockedBefore, 0, "reqB lock should still cover the remaining request");
 
         vm.startPrank(owner);
         roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), admin);
         vm.stopPrank();
 
-        uint256 lpBalAfterClaim  = address(liquidityPoolInstance).balance;
-        uint256 nftBalAfterClaim = address(withdrawRequestNFTInstance).balance;
-
-        vm.prank(admin);
+        uint256 remainderAmount = withdrawRequestNFTInstance.getEEthRemainderAmount();
         if (remainderAmount > 0) {
+            vm.prank(admin);
             withdrawRequestNFTInstance.handleRemainder(remainderAmount);
         }
 
-        // LP balance must have increased by the stranded fee ETH.
-        assertGe(
-            address(liquidityPoolInstance).balance,
-            lpBalAfterClaim + strandedFee,
-            "LP should receive stranded fee ETH on handleRemainder"
+        assertEq(
+            withdrawRequestNFTInstance.ethAmountLockedForWithdrawal(),
+            lockedBefore,
+            "handleRemainder must not mutate ethAmountLockedForWithdrawal"
         );
+    }
 
-        // NFT balance must now be zero (or only residual dust).
-        assertEq(address(withdrawRequestNFTInstance).balance, 0, "NFT balance should be zero after sweep");
+    /// @dev L-02: seizeInvalidRequest is now gated by UPGRADE_TIMELOCK_ROLE (was the operating
+    ///      timelock via onlyAdmin). Any caller without UPGRADE_TIMELOCK_ROLE must revert.
+    function test_seizeInvalidRequest_revertsForNonUpgradeTimelock() public {
+        startHoax(bob);
+        liquidityPoolInstance.deposit{value: 10 ether}();
+        vm.stopPrank();
 
-        // Counter is still zero — handleRemainder does not touch it.
-        assertEq(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal(), 0, "counter must remain 0 after handleRemainder");
+        vm.prank(bob);
+        eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
+        vm.prank(bob);
+        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
+
+        vm.prank(admin);
+        withdrawRequestNFTInstance.invalidateRequest(requestId);
+
+        // admin holds the operating-timelock role but NOT the upgrade-timelock role.
+        vm.prank(admin);
+        vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
+        withdrawRequestNFTInstance.seizeInvalidRequest(requestId, alice);
+
+        // bob (no roles) also reverts.
+        vm.prank(bob);
+        vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
+        withdrawRequestNFTInstance.seizeInvalidRequest(requestId, alice);
     }
 
     function test_seizeInvalidRequest_EdgeCases() public {

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -15,11 +15,6 @@ contract WithdrawRequestNFTIntrusive is WithdrawRequestNFT {
     // so a zero immutable would brick the swap-back step in updateParam.
     constructor(address _roleRegistry) WithdrawRequestNFT(address(0), address(0), address(0), address(0), _roleRegistry, address(0), address(0), 1, 4e18) {}
 
-    function updateParam(uint32 _currentRequestIdToScanFromForShareRemainder, uint32 _lastRequestIdToScanUntilForShareRemainder) external {
-        currentRequestIdToScanFromForShareRemainder = _currentRequestIdToScanFromForShareRemainder;
-        lastRequestIdToScanUntilForShareRemainder = _lastRequestIdToScanUntilForShareRemainder;
-    }
-
     /// @dev Test-only: advance `lastFinalizedRequestId` without going through `finalizeRequests`,
     ///      simulating the pre-upgrade state where no rate snapshot was captured.
     function setLastFinalizedRequestIdForTest(uint32 _id) external {
@@ -35,14 +30,6 @@ contract WithdrawRequestNFTTest is TestSetup {
         setUpTests();
         vm.prank(admin);
         withdrawRequestNFTInstance.unPauseContract();
-    }
-
-    function updateParam(uint32 _currentRequestIdToScanFromForShareRemainder, uint32 _lastRequestIdToScanUntilForShareRemainder) internal {
-        address cur_impl = withdrawRequestNFTInstance.getImplementation();
-        address new_impl = address(new WithdrawRequestNFTIntrusive(address(roleRegistryInstance)));
-        withdrawRequestNFTInstance.upgradeTo(new_impl);
-        WithdrawRequestNFTIntrusive(payable(address(withdrawRequestNFTInstance))).updateParam(_currentRequestIdToScanFromForShareRemainder, _lastRequestIdToScanUntilForShareRemainder);
-        withdrawRequestNFTInstance.upgradeTo(cur_impl);
     }
 
     function test_finalizeRequests() public {
@@ -1000,40 +987,6 @@ contract WithdrawRequestNFTTest is TestSetup {
         withdrawRequestNFTInstance.setPauseUntilDuration(aboveMax);
     }
 
-    // The scan-of-share-remainder gate was removed from unPauseContract / unpauseContractUntil.
-    // Unpausing must succeed even when isScanOfShareRemainderCompleted() returns false.
-    function test_unPauseContract_worksWhenScanIncomplete() public {
-        // Force scan-incomplete state: scanFrom < scanUntil + 1
-        vm.startPrank(withdrawRequestNFTInstance.owner());
-        updateParam(1, 5);
-        vm.stopPrank();
-        assertFalse(withdrawRequestNFTInstance.isScanOfShareRemainderCompleted(), "scan should be incomplete");
-
-        vm.prank(admin);
-        withdrawRequestNFTInstance.pauseContract();
-        assertTrue(withdrawRequestNFTInstance.paused());
-
-        vm.prank(admin);
-        withdrawRequestNFTInstance.unPauseContract();
-        assertFalse(withdrawRequestNFTInstance.paused(), "Contract should unpause regardless of scan state");
-    }
-
-    function test_unpauseContractUntil_worksWhenScanIncomplete() public {
-        vm.startPrank(withdrawRequestNFTInstance.owner());
-        updateParam(1, 5);
-        vm.stopPrank();
-        assertFalse(withdrawRequestNFTInstance.isScanOfShareRemainderCompleted(), "scan should be incomplete");
-
-        _grantWrPauseUntilRoles();
-        vm.prank(wrPauseUntilPauser);
-        withdrawRequestNFTInstance.pauseContractUntil();
-        assertEq(_wrPausedUntil(), block.timestamp + withdrawRequestNFTInstance.MAX_PAUSE_DURATION());
-
-        vm.prank(wrUnpauseUntilUnpauser);
-        withdrawRequestNFTInstance.unpauseContractUntil();
-        assertEq(_wrPausedUntil(), 0, "pause-until should clear regardless of scan state");
-    }
-
     // --- each gated function (whenNotPaused → blocked by pause-until too) ---
 
     function test_requestWithdraw_blockedByPauseContractUntil() public {
@@ -1146,67 +1099,6 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         uint256 remainderAmount = withdrawRequestNFTInstance.getEEthRemainderAmount();
         assertGe(remainderAmount, 0, "Remainder amount should be >= 0");
-    }
-
-    function test_isScanOfShareRemainderCompleted() public {
-        // Initially should be completed (no requests to scan)
-        assertTrue(withdrawRequestNFTInstance.isScanOfShareRemainderCompleted(), "Scan should be completed initially");
-
-        startHoax(bob);
-        liquidityPoolInstance.deposit{value: 10 ether}();
-        vm.stopPrank();
-
-        vm.prank(bob);
-        eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
-
-        vm.prank(bob);
-        liquidityPoolInstance.requestWithdraw(bob, 1 ether);
-
-        // Still completed because scan range hasn't been set
-        assertTrue(withdrawRequestNFTInstance.isScanOfShareRemainderCompleted(), "Scan should still be completed");
-    }
-
-    function test_aggregateSumEEthShareAmount() public {
-        // Setup scan parameters (needs owner to upgrade)
-        uint32 startId = 1;
-        uint32 endId = 5;
-        vm.startPrank(withdrawRequestNFTInstance.owner());
-        updateParam(startId, endId);
-        vm.stopPrank();
-
-        startHoax(bob);
-        liquidityPoolInstance.deposit{value: 50 ether}();
-        vm.stopPrank();
-
-        // Create multiple requests
-        uint256[] memory requestIds = new uint256[](5);
-        for (uint256 i = 0; i < 5; i++) {
-            vm.prank(bob);
-            eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
-            vm.prank(bob);
-            requestIds[i] = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
-        }
-
-        // Initially scan is not completed
-        assertFalse(withdrawRequestNFTInstance.isScanOfShareRemainderCompleted(), "Scan should not be completed");
-
-        uint256 initialAggregateSum = withdrawRequestNFTInstance.aggregateSumOfEEthShare();
-        
-        // Aggregate first 3 requests
-        withdrawRequestNFTInstance.aggregateSumEEthShareAmount(3);
-        
-        uint256 aggregateSumAfter = withdrawRequestNFTInstance.aggregateSumOfEEthShare();
-        assertGt(aggregateSumAfter, initialAggregateSum, "Aggregate sum should increase");
-
-        // Aggregate remaining requests
-        withdrawRequestNFTInstance.aggregateSumEEthShareAmount(10);
-        
-        // Scan should be completed now
-        assertTrue(withdrawRequestNFTInstance.isScanOfShareRemainderCompleted(), "Scan should be completed");
-        
-        // Cannot aggregate again after completion
-        vm.expectRevert(WithdrawRequestNFT.ScanCompleted.selector);
-        withdrawRequestNFTInstance.aggregateSumEEthShareAmount(1);
     }
 
     function test_requestWithdrawWithFee() public {

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -242,10 +242,9 @@ contract WithdrawRequestNFTTest is TestSetup {
 
     // Sub-wei rounding scenario from the original SD-6 report. The MIN_WITHDRAW_AMOUNT
     // gate on the LiquidityPool rewrites any below-MIN request if amount is equal to the 
-    // caller's full eETH balance instead of reverting. Pin the new behavior: a legacy 9-wei
-    // request mints a single request for bob's full eETH balance, leaving no dust behind to
-    // round around.
-    function test_SD_6_requestBelowMin_withdrawsFullBalance() public {
+    // caller's full eETH balance instead of reverting. Pin the new behavior: a below-MIN
+    // request reverts with InvalidWithdrawalAmount.
+    function test_SD_6_requestBelowMin_revertsWithInvalidWithdrawalAmount() public {
         vm.deal(bob, 9);
 
         vm.startPrank(bob);
@@ -258,12 +257,8 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.startPrank(bob);
         uint256 balance = eETHInstance.balanceOf(bob);
         eETHInstance.approve(address(liquidityPoolInstance), balance);
-        uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, balance);
-        vm.stopPrank();
-
-        WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
-        assertEq(request.amountOfEEth, balance, "below-MIN request should withdraw bob's full balance");
-        assertEq(eETHInstance.balanceOf(bob), 0, "bob should have no eETH dust left");
+        vm.expectRevert(LiquidityPool.InvalidWithdrawalAmount.selector);
+        liquidityPoolInstance.requestWithdraw(bob, balance);
     }
 
 

--- a/test/fork-tests/RoleMigrationStorageIntegrity.t.sol
+++ b/test/fork-tests/RoleMigrationStorageIntegrity.t.sol
@@ -79,7 +79,7 @@ contract RoleMigrationStorageIntegrityTest is Test, Deployed {
         bytes32[] memory preOracle = _snapshot(ETHERFI_ORACLE);
         bytes32[] memory preNOM    = _snapshot(NODE_OPERATOR_MANAGER);
 
-        address newOracle = address(new EtherFiOracle(ETHERFI_ADMIN, ROLE_REGISTRY));
+        address newOracle = address(new EtherFiOracle(1, ETHERFI_ADMIN, ROLE_REGISTRY));
         address newNOM    = address(new NodeOperatorManager(ROLE_REGISTRY, AUCTION_MANAGER));
 
         _upgradeProxy(ETHERFI_ORACLE,        newOracle);

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -70,9 +70,6 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         uint32 nextId;
         uint32 lastFin;
         uint16 split;
-        uint32 scanFrom;
-        uint32 scanTo;
-        uint256 agg;
         uint256 remainder;
         bool paused;
     }
@@ -104,9 +101,6 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         s.nextId = wrn.nextRequestId();
         s.lastFin = wrn.lastFinalizedRequestId();
         s.split = wrn.shareRemainderSplitToTreasuryInBps();
-        s.scanFrom = wrn.currentRequestIdToScanFromForShareRemainder();
-        s.scanTo = wrn.lastRequestIdToScanUntilForShareRemainder();
-        s.agg = wrn.aggregateSumOfEEthShare();
         s.remainder = wrn.totalRemainderEEthShares();
         s.paused = wrn.paused();
     }
@@ -134,9 +128,6 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         assertEq(a.nextId,     b.nextId,     "WRN.nextRequestId");
         assertEq(a.lastFin,    b.lastFin,    "WRN.lastFinalizedRequestId");
         assertEq(a.split,      b.split,      "WRN.split");
-        assertEq(a.scanFrom,   b.scanFrom,   "WRN.scanFrom");
-        assertEq(a.scanTo,     b.scanTo,     "WRN.scanTo");
-        assertEq(a.agg,        b.agg,        "WRN.aggregateSum");
         assertEq(a.remainder,  b.remainder,  "WRN.remainder");
         assertEq(a.paused,     b.paused,     "WRN.paused");
     }

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -684,7 +684,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
                 pubkey,
                 signature,
                 withdrawalCreds,
-                stakingManager.initialDepositAmount()
+                stakingManager.INITIAL_DEPOSIT_AMOUNT()
             );
 
             depositData[i] = IStakingManager.DepositData({

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -66,6 +66,11 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
             liquidityPoolInstance.initializeOnUpgradeV2();
         }
 
+        vm.startPrank(owner);
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
+        liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
+        vm.stopPrank();
+
         // Admin-gated setters on WithdrawRequestNFT (e.g. updateShareRemainderSplitToTreasuryInBps)
         // route through OPERATION_TIMELOCK_ROLE. Grant it to `admin` so the test can drive them.
         // Resolve every argument before vm.prank so unrelated view calls don't consume it.

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -184,7 +184,7 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         bytes memory signature = vm.randomBytes(96);
         bytes memory withdrawalCredentials = managerInstance.addressToCompoundingWithdrawalCredentials(eigenPod);
         bytes32 depositDataRoot =
-            depositDataRootGenerator.generateDepositDataRoot(pubkey, signature, withdrawalCredentials, stakingManagerInstance.initialDepositAmount());
+            depositDataRootGenerator.generateDepositDataRoot(pubkey, signature, withdrawalCredentials, stakingManagerInstance.INITIAL_DEPOSIT_AMOUNT());
 
         depositData = IStakingManager.DepositData({
             publicKey: pubkey,
@@ -296,6 +296,6 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         etherFiAdminInstance.executeTasks(report);
         (bool completed, bool exists) = _executeValidatorApprovalTask(report, pubkeys, signatures);
         uint256 LiquidityPoolBalanceAfter = address(liquidityPoolInstance).balance;
-        assertApproxEqAbs(LiquidityPoolBalanceAfter, LiquidityPoolBalanceBefore - liquidityPoolInstance.validatorSizeWei() + stakingManagerInstance.initialDepositAmount(), 1e3);
+        assertApproxEqAbs(LiquidityPoolBalanceAfter, LiquidityPoolBalanceBefore - liquidityPoolInstance.validatorSizeWei() + stakingManagerInstance.INITIAL_DEPOSIT_AMOUNT(), 1e3);
     }
 }

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -354,9 +354,9 @@ contract WithdrawEscrowE2ETest is TestSetup {
         // User received ETH from NFT's balance; LP raw ETH unchanged (segregated path)
         // share-rate rounding artifact: claimable may be up to 2 wei less than raw withdrawAmt
         // (deposit→share→amountForShare round-trip can drop 2 wei at the live mainnet share rate)
-        assertApproxEqAbs(user.balance, userEthPre + withdrawAmt, 4,
+        assertApproxEqAbs(user.balance, userEthPre + withdrawAmt, 5,
             "step4: user raw ETH after claim");
-        assertApproxEqAbs(address(withdrawRequestNFTInstance).balance, preNft.rawEth - withdrawAmt, 4,
+        assertApproxEqAbs(address(withdrawRequestNFTInstance).balance, preNft.rawEth - withdrawAmt, 5,
             "step4: NFT raw ETH after claim");
         assertEq(address(liquidityPoolInstance).balance, preLp.rawEth,
             "step4: LP raw ETH unchanged at claim");
@@ -365,7 +365,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
         // totalValueOutOfLp decrements by claimable (the actual ETH paid), not raw withdrawAmt
         // — share-rate round-trip can drift by 2 wei at the live mainnet share rate
         assertApproxEqAbs(liquidityPoolInstance.totalValueOutOfLp(),
-            preLp.outLp - uint128(withdrawAmt), 4,
+            preLp.outLp - uint128(withdrawAmt), 5,
             "step4: totalValueOutOfLp after claim");
         assertEq(eETHInstance.totalShares(),
             preTotalShares - expectedSharesBurned,
@@ -374,15 +374,15 @@ contract WithdrawEscrowE2ETest is TestSetup {
         assertApproxEqAbs(
             eETHInstance.balanceOf(address(withdrawRequestNFTInstance)),
             preNft.eEthBal - withdrawAmt,
-            4,
-            "step4: NFT eETH after claim (2-wei tolerance for share-rate rounding)"); // share-rate rounding artifact
+            5,
+            "step4: NFT eETH after claim"); // share-rate rounding artifact
         // ethAmountLockedForWithdrawal decrements by claimable (NFT._claimWithdraw path)
         // — share-rate rounding artifact: claimable can be up to 2 wei less than withdrawAmt
         assertApproxEqAbs(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal(),
-            preLocked - uint128(withdrawAmt), 4,
+            preLocked - uint128(withdrawAmt), 5,
             "step4: ethAmountLockedForWithdrawal after claim");
         assertApproxEqAbs(liquidityPoolInstance.getTotalPooledEther(),
-            preLp.totalPooled - withdrawAmt, 4,
+            preLp.totalPooled - withdrawAmt, 5,
             "step4: getTotalPooledEther after claim");
         // NFT burned — ownerOf must revert
         vm.expectRevert();

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -79,6 +79,8 @@ contract WithdrawEscrowE2ETest is TestSetup {
         if (!liquidityPoolInstance.escrowMigrationCompleted()) {
             liquidityPoolInstance.initializeOnUpgradeV2();
         }
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
+        liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
         _grantRoles();
         vm.stopPrank();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core protocol paths (oracle report handling, withdrawal finalization/claiming, and liquidity accounting) and changes access control for asset recovery, so mistakes could impact redemption safety or governance permissions despite added guardrails/tests.
> 
> **Overview**
> Hardens several *core protocol* flows around oracle reporting and withdrawals. `EtherFiAdmin.finalizeWithdrawalsWhenStale` now keys off `EtherFiOracle.lastPublishedReportRefBlock()`, adds a cooldown, caps the number of requests finalized per call/report, and switches liquidity checks to `liquidityPool.totalValueInLp()`; report validation also adds the same request-range cap and updates math to use `Math` helpers.
> 
> Withdrawal mechanics are adjusted for the escrow-migration model: `LiquidityPool` replaces fixed MIN/MAX withdrawal constants with operator-set `minWithdrawAmount`/`maxWithdrawAmount`, and `WithdrawRequestNFT` removes fee handling from requests/claims, tightens escrow accounting, adds a small tolerance buffer when validating outputs, gates `fulfillRequests` on `escrowMigrationCompleted`, and restricts `seizeInvalidRequest` to the upgrade timelock.
> 
> Across the codebase, ERC20 interactions are made safer via `SafeERC20` (e.g., `DepositAdapter`, `WeETH`, `MembershipManager`, `EtherFiRestaker`), multiple ETH forwarding sites increase gas stipends to a shared no-grief constant, and `BucketRateLimiter` switches to `ceilDiv` with an explicit `RATE_PRECISION`. Finally, `CumulativeMerkleRewardsDistributor` gains `receive()` plus admin-only `recoverETH`/`recoverERC20`, and `EETH`/`WeETH` recovery functions are tightened from operations to admin; migration-only initializers are removed from `AuctionManager` and `NodeOperatorManager`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449fa983442163c009a685c730db50b1c7a39990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->