### PR TITLE
yash/fix/misc-changes

### DIFF
--- a/script/DeployHoodiContracts.s.sol
+++ b/script/DeployHoodiContracts.s.sol
@@ -45,8 +45,7 @@ contract DeployHoodiContracts is Script {
             liquidityPoolProxy,
             etherFiNodesManagerProxy,
             eigenPodManagerProxy,
-            delegationManagerProxy,
-            roleRegistryProxy
+            delegationManagerProxy
         );
         console.log("EtherFiNode deployed at:", address(newNode));
 

--- a/script/VerifyV3Upgrade.s.sol
+++ b/script/VerifyV3Upgrade.s.sol
@@ -182,7 +182,7 @@ contract VerifyV3Upgrade is Script {
             protocolUpgrader != address(0),
             "Protocol upgrader (RoleRegistry owner) is set"
         );
-        try roleRegistry.onlyProtocolUpgrader(protocolUpgrader) {
+        try roleRegistry.onlyUpgradeTimelock(protocolUpgrader) {
             checkCondition(true, "Protocol upgrader is owner");
         } catch {
             checkCondition(false, "Protocol upgrader is not owner");

--- a/script/VerifyV3Upgrade.s.sol
+++ b/script/VerifyV3Upgrade.s.sol
@@ -123,18 +123,8 @@ contract VerifyV3Upgrade is Script {
             "EtherFiNodesManager has correct RoleRegistry"
         );
 
-        // Check a sample EtherFiNode implementation has correct RoleRegistry
-        console2.log("Checking EtherFiNode implementation RoleRegistry...");
-        address beacon = stakingManager.getEtherFiNodeBeacon();
-        address etherFiNodeImpl = getImplementation(beacon);
-        if (etherFiNodeImpl != address(0)) {
-            // Create a temporary instance to check the roleRegistry
-            EtherFiNode nodeImpl = EtherFiNode(payable(etherFiNodeImpl));
-            checkCondition(
-                address(nodeImpl.roleRegistry()) == address(roleRegistry),
-                "EtherFiNode implementation has correct RoleRegistry"
-            );
-        }
+        // EtherFiNode no longer holds a direct roleRegistry reference after the roles refactor;
+        // role checks now live on EtherFiNodesManager via the shared RolesLibrary.
 
         // Check LiquidityPool has correct RoleRegistry
         console2.log("Checking LiquidityPool RoleRegistry...");

--- a/script/el-exits/PectraUpgradeBytecode.s.sol
+++ b/script/el-exits/PectraUpgradeBytecode.s.sol
@@ -55,7 +55,7 @@ contract PectraUpgradeBytecode is Script {
         address deployedEtherFiNodesManager = address(0x0f366dF7af5003fC7C6524665ca58bDeAdDC3745);
         address deployedStakingManager = address(0xa38d03ea42F8bc31892336E1F42523e94FB91a7A);
 
-        EtherFiNode etherFiNodeImplementation = new EtherFiNode(address(liquidityPoolProxy), address(etherFiNodesManagerProxy), address(eigenPodManager), address(delegationManager), address(roleRegistryProxy));
+        EtherFiNode etherFiNodeImplementation = new EtherFiNode(address(liquidityPoolProxy), address(etherFiNodesManagerProxy), address(eigenPodManager), address(delegationManager));
         EtherFiNodesManager etherFiNodesManagerImplementation = new EtherFiNodesManager(address(stakingManagerProxy), address(roleRegistryProxy), address(rateLimiterProxy));
         StakingManager stakingManagerImplementation = new StakingManager(address(liquidityPoolProxy), address(etherFiNodesManagerProxy), address(stakingDepositContract), address(auctionManager), address(etherFiNodeBeacon), address(roleRegistryProxy));
         EtherFiRateLimiter rateLimiterImplementation = new EtherFiRateLimiter(address(roleRegistryProxy));

--- a/script/upgrades/CrossPodApproval/transactions.s.sol
+++ b/script/upgrades/CrossPodApproval/transactions.s.sol
@@ -187,7 +187,7 @@ contract CrossPodApprovalScript is Script, Deployed, Utils {
         bytes[] memory pubkeys = new bytes[](1);
         pubkeys[0] = hex"8f9c0aab19ee7586d3d470f132842396af606947a0589382483308fdffdaf544078c3be24210677a9c471ce70b3b4c2c";
 
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         vm.prank(OPERATING_TIMELOCK);
         EtherFiNodesManager(payable(ETHERFI_NODES_MANAGER)).linkLegacyValidatorIds(validatorIds, pubkeys);
     

--- a/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
+++ b/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
@@ -202,7 +202,7 @@ contract ReauditFixesTransactions is Utils {
         console2.log("=== Verifying Deployed Bytecode ===");
         console2.log("");
 
-        EtherFiNode newEtherFiNodeImplementation = new EtherFiNode(address(LIQUIDITY_POOL), address(ETHERFI_NODES_MANAGER), address(EIGENLAYER_POD_MANAGER), address(EIGENLAYER_DELEGATION_MANAGER), address(ROLE_REGISTRY));
+        EtherFiNode newEtherFiNodeImplementation = new EtherFiNode(address(LIQUIDITY_POOL), address(ETHERFI_NODES_MANAGER), address(EIGENLAYER_POD_MANAGER), address(EIGENLAYER_DELEGATION_MANAGER));
         EtherFiRedemptionManager newEtherFiRedemptionManagerImplementation = new EtherFiRedemptionManager(address(LIQUIDITY_POOL), address(EETH), address(WEETH), address(TREASURY), address(ROLE_REGISTRY), address(ETHERFI_RESTAKER), address(0x0), address(0x0), 10_000, 100, 10_000);
         EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(LIQUIDITY_POOL), address(LIQUIFIER), address(EIGENLAYER_REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER), address(ROLE_REGISTRY), address(ETHERFI_RATE_LIMITER), address(EIGENLAYER_STRATEGY_MANAGER), address(EIGENLAYER_DELEGATION_MANAGER));
         EtherFiRewardsRouter newEtherFiRewardsRouterImplementation = new EtherFiRewardsRouter(address(LIQUIDITY_POOL), address(TREASURY), address(ROLE_REGISTRY));

--- a/script/validator-key-gen/verify.s.sol
+++ b/script/validator-key-gen/verify.s.sol
@@ -157,12 +157,12 @@ contract VerifyValidatorKeyGen is Script {
 
         // Verify that the new functionality is exists and is role restricted
         {
-            vm.expectRevert(IStakingManager.IncorrectRole.selector);
+            vm.expectRevert(RoleRegistry.OnlyOracleOperations.selector);
             liquidityPool.batchCreateBeaconValidators(depositDataArray, new uint256[](1), etherFiNode);
         }
 
         {
-            vm.expectRevert(IStakingManager.IncorrectRole.selector);
+            vm.expectRevert(RoleRegistry.OnlyOracleOperations.selector);
             stakingManager.invalidateRegisteredBeaconValidator(depositDataArray[0], 1, etherFiNode);
 
             vm.expectRevert(IStakingManager.InvalidCaller.selector);

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -287,9 +287,7 @@ contract AuctionManager is
         super._requireNotPaused();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //--------------------------------------  GETTER  --------------------------------------

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -216,23 +216,6 @@ contract AuctionManager is
         emit BidReEnteredAuction(_bidId);
     }
 
-    /// @notice Transfer the auction fee received from the node operator to the membership NFT contract when above the threshold
-    /// @dev Called by registerValidator() in StakingManager.sol
-    /// @param _bidId the ID of the validator
-    function processAuctionFeeTransfer(
-        uint256 _bidId
-    ) external onlyStakingManagerContract {
-        uint256 amount = bids[_bidId].amount;
-        uint256 newAccumulatedRevenue = accumulatedRevenue + amount;
-        if (newAccumulatedRevenue >= accumulatedRevenueThreshold) {
-            accumulatedRevenue = 0;
-            (bool sent, ) = membershipManagerContractAddress.call{value: newAccumulatedRevenue}("");
-            if (!sent) revert EtherTransferFailed();
-        } else {
-            accumulatedRevenue = uint128(newAccumulatedRevenue);
-        }
-    }
-
     function transferAccumulatedRevenue() external onlyHousekeepingOperations {
         uint256 transferAmount = accumulatedRevenue;
         accumulatedRevenue = 0;

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import "./interfaces/IAuctionManager.sol";
-import "./interfaces/INodeOperatorManager.sol";
-import "./interfaces/IProtocolRevenueManager.sol";
-import "./interfaces/IRoleRegistry.sol";
-import "./interfaces/IBlacklister.sol";
-import "./utils/PausableUntil.sol";
 import "@openzeppelin-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import "./interfaces/IAuctionManager.sol";
+import "./interfaces/INodeOperatorManager.sol";
+import "./interfaces/IProtocolRevenueManager.sol";
+import "./interfaces/IBlacklister.sol";
+import "./utils/PausableUntil.sol";
+import "./utils/RolesLibrary.sol";
 
 contract AuctionManager is
     Initializable,
@@ -18,6 +19,7 @@ contract AuctionManager is
     PausableUpgradeable,
     OwnableUpgradeable,
     PausableUntil,
+    RolesLibrary,
     ReentrancyGuardUpgradeable,
     UUPSUpgradeable
 {
@@ -49,7 +51,6 @@ contract AuctionManager is
     mapping(address => bool) private DEPRECATED_admins;
 
     // Immutables are not part of proxy storage; stored in implementation bytecode only.
-    IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
     INodeOperatorManager public immutable nodeOperatorManager;
     address public immutable stakingManagerContractAddress;
@@ -80,11 +81,9 @@ contract AuctionManager is
     error InvalidMaxBid();
     error InvalidWhitelistAmount();
     error IncorrectCaller();
-    error IncorrectRole();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _roleRegistry, address _blacklister, address _nodeOperatorManagerContract, address _stakingManagerContractAddress, address _membershipManagerContractAddress, address _treasury) {
-        roleRegistry = IRoleRegistry(_roleRegistry);
+    constructor(address _roleRegistry, address _blacklister, address _nodeOperatorManagerContract, address _stakingManagerContractAddress, address _membershipManagerContractAddress, address _treasury) RolesLibrary(_roleRegistry) {
         blacklister = IBlacklister(_blacklister);
         nodeOperatorManager = INodeOperatorManager(_nodeOperatorManagerContract);
         stakingManagerContractAddress = _stakingManagerContractAddress;
@@ -234,8 +233,7 @@ contract AuctionManager is
         }
     }
 
-    function transferAccumulatedRevenue() external {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function transferAccumulatedRevenue() external onlyHousekeepingOperations {
         uint256 transferAmount = accumulatedRevenue;
         accumulatedRevenue = 0;
         (bool sent, ) = treasury.call{value: transferAmount}("");
@@ -244,25 +242,25 @@ contract AuctionManager is
 
     /// @notice Disables the whitelisting phase of the bidding
     /// @dev Allows both regular users and whitelisted users to bid
-    function disableWhitelist() public onlyOperations {
+    function disableWhitelist() public onlyOperatingMultisig {
         whitelistEnabled = false;
         emit WhitelistDisabled(whitelistEnabled);
     }
 
     /// @notice Enables the whitelisting phase of the bidding
     /// @dev Only users who are on a whitelist can bid
-    function enableWhitelist() public onlyOperations {
+    function enableWhitelist() public onlyOperatingMultisig {
         whitelistEnabled = true;
         emit WhitelistEnabled(whitelistEnabled);
     }
 
     //Pauses the contract
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
     //Unpauses the contract
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -272,7 +270,7 @@ contract AuctionManager is
     }
 
     // Unpauses contract from pauseUntil
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -307,7 +305,7 @@ contract AuctionManager is
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     //--------------------------------------------------------------------------------------
@@ -340,7 +338,7 @@ contract AuctionManager is
 
     /// @notice Updates the minimum bid price for a non-whitelisted bidder
     /// @param _newMinBidAmount the new amount to set the minimum bid price as
-    function setMinBidPrice(uint64 _newMinBidAmount) external onlyOperations {
+    function setMinBidPrice(uint64 _newMinBidAmount) external onlyOperatingMultisig {
         if (_newMinBidAmount >= maxBidAmount) revert InvalidMinBid();
         if (_newMinBidAmount < whitelistBidAmount) revert InvalidMinBid();
         minBidAmount = _newMinBidAmount;
@@ -348,14 +346,14 @@ contract AuctionManager is
 
     /// @notice Updates the maximum bid price for both whitelisted and non-whitelisted bidders
     /// @param _newMaxBidAmount the new amount to set the maximum bid price as
-    function setMaxBidPrice(uint64 _newMaxBidAmount) external onlyOperations {
+    function setMaxBidPrice(uint64 _newMaxBidAmount) external onlyOperatingMultisig {
         if (_newMaxBidAmount <= minBidAmount) revert InvalidMaxBid();
         maxBidAmount = _newMaxBidAmount;
     }
 
     /// @notice Updates the accumulated revenue threshold that will trigger a transfer to MembershipNFT contract
     /// @param _newThreshold the new threshold to set
-    function setAccumulatedRevenueThreshold(uint128 _newThreshold) external onlyOperations {
+    function setAccumulatedRevenueThreshold(uint128 _newThreshold) external onlyOperatingMultisig {
         accumulatedRevenueThreshold = _newThreshold;
     }
 
@@ -363,7 +361,7 @@ contract AuctionManager is
     /// @param _newAmount the new amount to set the minimum bid price as
     function updateWhitelistMinBidAmount(
         uint128 _newAmount
-    ) external onlyOperations {
+    ) external onlyOperatingMultisig {
         if (_newAmount >= minBidAmount || _newAmount == 0) revert InvalidWhitelistAmount();
         whitelistBidAmount = _newAmount;
     }
@@ -374,21 +372,6 @@ contract AuctionManager is
 
     modifier onlyStakingManagerContract() {
         if (msg.sender != stakingManagerContractAddress) revert IncorrectCaller();
-        _;
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
         _;
     }
 

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -54,6 +54,7 @@ contract AuctionManager is
     INodeOperatorManager public immutable nodeOperatorManager;
     address public immutable stakingManagerContractAddress;
     address public immutable membershipManagerContractAddress;
+    address public immutable treasury;
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
@@ -79,14 +80,16 @@ contract AuctionManager is
     error InvalidMaxBid();
     error InvalidWhitelistAmount();
     error IncorrectCaller();
+    error IncorrectRole();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _roleRegistry, address _blacklister, address _nodeOperatorManagerContract, address _stakingManagerContractAddress, address _membershipManagerContractAddress) {
+    constructor(address _roleRegistry, address _blacklister, address _nodeOperatorManagerContract, address _stakingManagerContractAddress, address _membershipManagerContractAddress, address _treasury) {
         roleRegistry = IRoleRegistry(_roleRegistry);
         blacklister = IBlacklister(_blacklister);
         nodeOperatorManager = INodeOperatorManager(_nodeOperatorManagerContract);
         stakingManagerContractAddress = _stakingManagerContractAddress;
         membershipManagerContractAddress = _membershipManagerContractAddress;
+        treasury = _treasury;
         _disableInitializers();
     }
 
@@ -231,10 +234,11 @@ contract AuctionManager is
         }
     }
 
-    function transferAccumulatedRevenue() external onlyOperations {
+    function transferAccumulatedRevenue() external {
+        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
         uint256 transferAmount = accumulatedRevenue;
         accumulatedRevenue = 0;
-        (bool sent, ) = membershipManagerContractAddress.call{value: transferAmount}("");
+        (bool sent, ) = treasury.call{value: transferAmount}("");
         if (!sent) revert EtherTransferFailed();
     }
 

--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -334,12 +334,6 @@ contract AuctionManager is
         maxBidAmount = _newMaxBidAmount;
     }
 
-    /// @notice Updates the accumulated revenue threshold that will trigger a transfer to MembershipNFT contract
-    /// @param _newThreshold the new threshold to set
-    function setAccumulatedRevenueThreshold(uint128 _newThreshold) external onlyOperatingMultisig {
-        accumulatedRevenueThreshold = _newThreshold;
-    }
-
     /// @notice Updates the minimum bid price for a whitelisted address
     /// @param _newAmount the new amount to set the minimum bid price as
     function updateWhitelistMinBidAmount(

--- a/src/BucketRateLimiter.sol
+++ b/src/BucketRateLimiter.sol
@@ -102,7 +102,5 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
         return _getImplementation();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 }

--- a/src/BucketRateLimiter.sol
+++ b/src/BucketRateLimiter.sol
@@ -7,10 +7,10 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "src/interfaces/IRateLimiter.sol";
-import "src/interfaces/IRoleRegistry.sol";
 import "lib/BucketLimiter.sol";
+import "./utils/RolesLibrary.sol";
 
-contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, OwnableUpgradeable, UUPSUpgradeable {
+contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, OwnableUpgradeable, UUPSUpgradeable, RolesLibrary {
     using Math for uint256;
 
     error IncorrectCaller();
@@ -27,12 +27,8 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
 
     mapping(address => BucketLimiter.Limit) public limitsPerToken;
 
-    // Immutables are not part of proxy storage; stored in implementation bytecode only.
-    IRoleRegistry public immutable roleRegistry;
-
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _roleRegistry) {
-        roleRegistry = IRoleRegistry(_roleRegistry);
+    constructor(address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
     }
 
@@ -94,11 +90,11 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
         consumer = _consumer;
     }
 
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -106,17 +102,7 @@ contract BucketRateLimiter is IRateLimiter, Initializable, PausableUpgradeable, 
         return _getImplementation();
     }
 
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 }

--- a/src/CumulativeMerkleRewardsDistributor.sol
+++ b/src/CumulativeMerkleRewardsDistributor.sol
@@ -169,9 +169,7 @@ using SafeERC20 for IERC20;
     //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
     //--------------------------------------------------------------------------------------
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function _verifyAsm(bytes32[] calldata proof, bytes32 root, bytes32 leaf) private pure returns (bool valid) {
         if(proof.length > 1000) revert InvalidProof();

--- a/src/CumulativeMerkleRewardsDistributor.sol
+++ b/src/CumulativeMerkleRewardsDistributor.sol
@@ -5,11 +5,11 @@ import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/Saf
 import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {AssetRecovery} from "./AssetRecovery.sol";
-import {IRoleRegistry} from "./interfaces/IRoleRegistry.sol";
 import {PausableUntil} from "./utils/PausableUntil.sol";
+import {RolesLibrary} from "./utils/RolesLibrary.sol";
 import {ICumulativeMerkleRewardsDistributor}  from "./interfaces/ICumulativeMerkleRewardsDistributor.sol";
 
-contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, OwnableUpgradeable, UUPSUpgradeable, PausableUntil, AssetRecovery {
+contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, OwnableUpgradeable, UUPSUpgradeable, PausableUntil, AssetRecovery, RolesLibrary {
 using SafeERC20 for IERC20;
 
 
@@ -29,19 +29,17 @@ using SafeERC20 for IERC20;
 
 
     //--------------------------------------------------------------------------------------
-    //-------------------------------------  ROLES  ---------------------------------------
+    //-------------------------------------  CONSTANTS  -------------------------------------
     //--------------------------------------------------------------------------------------
 
     address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    IRoleRegistry public immutable roleRegistry;
 
 //--------------------------------------------------------------------------------------
 //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
 //--------------------------------------------------------------------------------------
 
-    constructor(address _roleRegistry) {
+    constructor(address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
-        roleRegistry = IRoleRegistry(_roleRegistry);
     }
 
     receive() external payable {}
@@ -64,8 +62,7 @@ using SafeERC20 for IERC20;
 * @param _token Address of the reward token (use ETH_ADDRESS for ETH rewards)
 * @param _merkleRoot New Merkle root containing the reward data
 **/
-    function setPendingMerkleRoot(address _token, bytes32 _merkleRoot) external whenNotPaused {
-        if(!roleRegistry.hasRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function setPendingMerkleRoot(address _token, bytes32 _merkleRoot) external whenNotPaused onlyExecutorOperations {
         pendingMerkleRoots[_token] = _merkleRoot;
         lastPendingMerkleUpdatedToTimestamp[_token] = block.timestamp;
         emit PendingMerkleRootUpdated(_token, _merkleRoot);
@@ -78,8 +75,7 @@ using SafeERC20 for IERC20;
 * @param _token Address of the reward token (use ETH_ADDRESS for ETH rewards)
 * @param _finalizedBlock Block number up to which rewards are calculated
 */
-    function finalizeMerkleRoot(address _token, uint256 _finalizedBlock) external whenNotPaused {
-        if(!roleRegistry.hasRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function finalizeMerkleRoot(address _token, uint256 _finalizedBlock) external whenNotPaused onlyExecutorOperations {
         if(!(block.timestamp >= lastPendingMerkleUpdatedToTimestamp[_token] + claimDelay)) revert InsufficentDelay();
         if(_finalizedBlock < lastRewardsCalculatedToBlock[_token] || _finalizedBlock > block.number) revert InvalidFinalizedBlock();
         bytes32 oldClaimableMerkleRoot = claimableMerkleRoots[_token];
@@ -136,12 +132,12 @@ using SafeERC20 for IERC20;
         emit RecipientStatusUpdated(user, isWhitelisted);
     }
 
-    function pause() external onlyOperations {
+    function pause() external onlyOperatingMultisig {
         paused = true;
         emit Paused(msg.sender);
     }
 
-    function unpause() external onlyOperations {
+    function unpause() external onlyOperatingMultisig {
         paused = false;
         emit UnPaused(msg.sender);
     }
@@ -150,7 +146,7 @@ using SafeERC20 for IERC20;
         _pauseUntil();
     }
 
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -174,7 +170,7 @@ using SafeERC20 for IERC20;
     //--------------------------------------------------------------------------------------
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function _verifyAsm(bytes32[] calldata proof, bytes32 root, bytes32 leaf) private pure returns (bool valid) {
@@ -213,21 +209,6 @@ using SafeERC20 for IERC20;
     modifier whenNotPaused() {
         _requireNotPaused();
         _requireNotPausedUntil();
-        _;
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
         _;
     }
 }

--- a/src/CumulativeMerkleRewardsDistributor.sol
+++ b/src/CumulativeMerkleRewardsDistributor.sol
@@ -53,7 +53,7 @@ using SafeERC20 for IERC20;
         claimDelay = 2 days; // 48 hours
     }
 
-    function setClaimDelay(uint256 _claimDelay) external onlyOperations {
+    function setClaimDelay(uint256 _claimDelay) external onlyAdmin {
         claimDelay = _claimDelay;
         emit ClaimDelayUpdated(claimDelay);
     }
@@ -131,7 +131,7 @@ using SafeERC20 for IERC20;
         emit Claimed(token, account, amount);
     }
 
-    function updateWhitelistedRecipient(address user, bool isWhitelisted) external onlyOperations {
+    function updateWhitelistedRecipient(address user, bool isWhitelisted) external onlyAdmin {
         whitelistedRecipient[user] = isWhitelisted;
         emit RecipientStatusUpdated(user, isWhitelisted);
     }

--- a/src/DepositAdapter.sol
+++ b/src/DepositAdapter.sol
@@ -151,9 +151,7 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
         return weEthAmount;
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);

--- a/src/DepositAdapter.sol
+++ b/src/DepositAdapter.sol
@@ -13,10 +13,10 @@ import "./interfaces/IeETH.sol";
 import "./interfaces/IWeETH.sol";
 import "./interfaces/IWETH.sol";
 import "./interfaces/IwstETH.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IBlacklister.sol";
+import "./utils/RolesLibrary.sol";
 
-contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
+contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
 
     ILiquidityPool public immutable liquidityPool;
@@ -26,7 +26,6 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
     IWETH public immutable wETH;
     IERC20Upgradeable public immutable stETH;
     IwstETH public immutable wstETH;
-    IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
 
      enum SourceOfFunds {
@@ -43,7 +42,7 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
     error PermitExpired();
     error EthTransfersNotAccepted();
 
-    constructor(address _liquidityPool, address _liquifier, address _weETH, address _eETH, address _wETH, address _stETH, address _wstETH, address _roleRegistry, address _blacklister) {
+    constructor(address _liquidityPool, address _liquifier, address _weETH, address _eETH, address _wETH, address _stETH, address _wstETH, address _roleRegistry, address _blacklister) RolesLibrary(_roleRegistry) {
         liquidityPool = ILiquidityPool(_liquidityPool);
         liquifier = ILiquifier(_liquifier);
         eETH = IeETH(_eETH);
@@ -51,7 +50,6 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
         wETH = IWETH(_wETH);
         stETH = IERC20Upgradeable(_stETH);
         wstETH = IwstETH(_wstETH);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         blacklister = IBlacklister(_blacklister);
 
         _disableInitializers();
@@ -154,7 +152,7 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable {
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     modifier nonBlacklisted() {

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -12,13 +12,13 @@ import "@openzeppelin-upgradeable/contracts/utils/cryptography/ECDSAUpgradeable.
 import "./interfaces/IeETH.sol";
 import "./interfaces/ILiquidityPool.sol";
 import "./AssetRecovery.sol";
-import "./interfaces/IRoleRegistry.sol";
+import "./utils/RolesLibrary.sol";
 import "./interfaces/IBlacklister.sol";
 import "./interfaces/IEtherFiRateLimiter.sol";
 import "./libraries/RateLimitMath.sol";
 import "./utils/PausableUntil.sol";
 
-contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, IERC20PermitUpgradeable, IeETH, AssetRecovery {
+contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, IERC20PermitUpgradeable, IeETH, AssetRecovery, RolesLibrary {
     using CountersUpgradeable for CountersUpgradeable.Counter;
     ILiquidityPool private DEPRECATED_liquidityPool;
 
@@ -41,7 +41,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     bytes32 private immutable _TYPE_HASH;
 
     ILiquidityPool public immutable liquidityPool;
-    IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
     IEtherFiRateLimiter public immutable rateLimiter;
 
@@ -63,7 +62,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     error TransferAmountExceedsBalance();
     error ContractPaused();
 
-    constructor(address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter) {
+    constructor(address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter) RolesLibrary(_roleRegistry) {
         bytes32 hashedName = keccak256("EETH");
         bytes32 hashedVersion = keccak256("1");
         bytes32 typeHash = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
@@ -76,7 +75,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
 
         if (_liquidityPool == address(0) || _roleRegistry == address(0) || _blacklister == address(0)) revert AddressZero();
         liquidityPool = ILiquidityPool(_liquidityPool);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         blacklister = IBlacklister(_blacklister);
         rateLimiter = IEtherFiRateLimiter(_rateLimiter);
 
@@ -157,12 +155,12 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return true;
     }
 
-    function pause() external onlyOperations {
+    function pause() external onlyOperatingMultisig {
         paused = true;
         emit Paused();
     }
 
-    function unpause() external onlyOperations {
+    function unpause() external onlyOperatingMultisig {
         paused = false;
         emit Unpaused();
     }
@@ -171,7 +169,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _pauseUntil();
     }
 
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -243,7 +241,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     function _authorizeUpgrade(
         address /* newImplementation */
     ) internal view override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function _useNonce(address owner) internal virtual returns (uint256 current) {
@@ -300,26 +298,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     // [MODIFIERS]
     modifier onlyPoolContract() {
         if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
-        _;
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlySuperGuardian() {
-        roleRegistry.onlySuperGuardian(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
         _;
     }
 

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -73,7 +73,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _CACHED_THIS = address(this);
         _TYPE_HASH = typeHash;
 
-        if (_liquidityPool == address(0) || _roleRegistry == address(0) || _blacklister == address(0)) revert AddressZero();
+        if (_liquidityPool == address(0) || _blacklister == address(0)) revert AddressZero();
         liquidityPool = ILiquidityPool(_liquidityPool);
         blacklister = IBlacklister(_blacklister);
         rateLimiter = IEtherFiRateLimiter(_rateLimiter);

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -238,11 +238,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit TransferShares(_sender, _recipient, _sharesAmount);
     }
 
-    function _authorizeUpgrade(
-        address /* newImplementation */
-    ) internal view override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function _useNonce(address owner) internal virtual returns (uint256 current) {
         CountersUpgradeable.Counter storage nonce = _nonces[owner];

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -422,7 +422,5 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         return _getImplementation();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 }

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -5,23 +5,22 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
-import "./RoleRegistry.sol";
-
 import "./interfaces/IEtherFiOracle.sol";
 import "./interfaces/IStakingManager.sol";
 import "./interfaces/IAuctionManager.sol";
 import "./interfaces/IEtherFiNodesManager.sol";
 import "./interfaces/ILiquidityPool.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IMembershipManager.sol";
 import "./interfaces/IWithdrawRequestNFT.sol";
 import "./interfaces/IPriorityWithdrawalQueue.sol";
+
+import "./utils/RolesLibrary.sol";
 
 interface IEtherFiPausable {
     function paused() external view returns (bool);
 }
 
-contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
+contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, RolesLibrary {
     using Math for uint256;
 
     struct TaskStatus {
@@ -53,7 +52,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     mapping(bytes32 => TaskStatus) public validatorApprovalTaskStatus;
     uint16 validatorTaskBatchSize;
 
-    RoleRegistry private DEPRECATED_roleRegistry;
+    address private DEPRECATED_roleRegistry;
 
     uint256 public lastStaleReportFinalizationBlock;
     uint256 public maxFinalizedWithdrawalAmountPerDay;
@@ -71,7 +70,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     ILiquidityPool public immutable liquidityPool;
     IMembershipManager public immutable membershipManager;
     IWithdrawRequestNFT public immutable withdrawRequestNft;
-    IRoleRegistry public immutable roleRegistry;
     IPriorityWithdrawalQueue public immutable priorityWithdrawalQueue;
 
     int256 public immutable maxAcceptableRebaseAprInBps;
@@ -100,7 +98,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     event ValidatorApprovalTaskCompleted(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
     event ValidatorApprovalTaskInvalidated(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
 
-    error IncorrectRole();
     error InvalidMaxAcceptableFinalizedWithdrawalAmount();
     error InvalidMaxNumberOfRequestsToFinalizePerReport();
     error InvalidMaxFinalizedWithdrawalAmountPerDay();
@@ -127,7 +124,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         uint256 _maxAcceptableFinalizedWithdrawalAmountPerDay,
         uint256 _maxAcceptableNumValidatorsToApprovePerDay,
         uint256 _maxNumberOfRequestsToFinalizePerReport
-    ) {
+    ) RolesLibrary(_constructorAddresses.roleRegistry) {
         if (_maxAcceptableRebaseAprInBps <= 0 || _maxAcceptableRebaseAprInBps > int256(BASIS_POINTS_DENOMINATOR)) revert InvalidMaxAcceptableRebaseApr();
         if (_maxValidatorTaskBatchSize == 0) revert InvalidValidatorTaskBatchSize();
         if (_staleOracleReportBlockWindow == 0) revert InvalidStaleOracleReportBlockWindow();
@@ -141,7 +138,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         liquidityPool = ILiquidityPool(_constructorAddresses.liquidityPool);
         membershipManager = IMembershipManager(_constructorAddresses.membershipManager);
         withdrawRequestNft = IWithdrawRequestNFT(_constructorAddresses.withdrawRequestNft);
-        roleRegistry = IRoleRegistry(_constructorAddresses.roleRegistry);
         priorityWithdrawalQueue = IPriorityWithdrawalQueue(_constructorAddresses.priorityWithdrawalQueue);
 
         maxAcceptableRebaseAprInBps = _maxAcceptableRebaseAprInBps;
@@ -199,9 +195,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         emit AdminOperationsExecuted(msg.sender, reportHash);
     }
 
-    function executeValidatorApprovalTask(bytes32 _reportHash, uint256[] calldata _validators, bytes[] calldata _pubKeys, bytes[] calldata _signatures) external {
-        if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-
+    function executeValidatorApprovalTask(bytes32 _reportHash, uint256[] calldata _validators, bytes[] calldata _pubKeys, bytes[] calldata _signatures) external onlyOracleOperations {
         if (!etherFiOracle.isConsensusReached(_reportHash)) revert ConsensusNotReached();
         bytes32 taskHash = keccak256(abi.encode(_reportHash, _validators));
         if (!validatorApprovalTaskStatus[taskHash].exists) revert TaskDoesNotExist();
@@ -212,7 +206,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         emit ValidatorApprovalTaskCompleted(taskHash, _reportHash, _validators);
     }
 
-    function invalidateValidatorApprovalTask(bytes32 _reportHash, uint256[] calldata _validators) external onlyOperations {
+    function invalidateValidatorApprovalTask(bytes32 _reportHash, uint256[] calldata _validators) external onlyOperatingMultisig {
         bytes32 taskHash = keccak256(abi.encode(_reportHash, _validators));
         if (!validatorApprovalTaskStatus[taskHash].exists) revert TaskDoesNotExist();
         if (validatorApprovalTaskStatus[taskHash].completed) revert TaskAlreadyCompleted();
@@ -429,16 +423,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
+        _onlyProtocolUpgrader();
     }
 }

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -20,7 +20,6 @@ contract EtherFiNode is IEtherFiNode {
 
     ILiquidityPool public immutable liquidityPool;
     IEtherFiNodesManager public immutable etherFiNodesManager;
-    IRoleRegistry public immutable roleRegistry;
 
     // eigenlayer core contracts
     IEigenPodManager public immutable eigenPodManager;
@@ -47,7 +46,6 @@ contract EtherFiNode is IEtherFiNode {
         etherFiNodesManager = IEtherFiNodesManager(_etherFiNodesManager);
         eigenPodManager = IEigenPodManager(_eigenPodManager);
         delegationManager = IDelegationManager(_delegationManager);
-        roleRegistry = IRoleRegistry(_roleRegistry);
     }
 
     fallback() external payable {}

--- a/src/EtherFiNode.sol
+++ b/src/EtherFiNode.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.27;
 
 import {IEtherFiNode} from "../src/interfaces/IEtherFiNode.sol";
 import {IEtherFiNodesManager} from "../src/interfaces/IEtherFiNodesManager.sol";
-import {IRoleRegistry} from "../src/interfaces/IRoleRegistry.sol";
 import {ILiquidityPool} from "../src/interfaces/ILiquidityPool.sol";
 
 import {IDelegationManager} from "../src/eigenlayer-interfaces/IDelegationManager.sol";
@@ -41,7 +40,7 @@ contract EtherFiNode is IEtherFiNode {
     //-----------------------------  Admin  -----------------------------------
     //-------------------------------------------------------------------------
 
-    constructor(address _liquidityPool, address _etherFiNodesManager, address _eigenPodManager, address _delegationManager, address _roleRegistry) {
+    constructor(address _liquidityPool, address _etherFiNodesManager, address _eigenPodManager, address _delegationManager) {
         liquidityPool = ILiquidityPool(_liquidityPool);
         etherFiNodesManager = IEtherFiNodesManager(_etherFiNodesManager);
         eigenPodManager = IEigenPodManager(_eigenPodManager);

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -139,22 +139,22 @@ contract EtherFiNodesManager is
         verifyCheckpointProofs(etherfiNodeAddress(id), balanceContainerProof, proofs);
     }
 
-    function setProofSubmitter(address node, address proofSubmitter) public onlyEigenlayerAdmin whenNotPaused {
+    function setProofSubmitter(address node, address proofSubmitter) public onlyOperations whenNotPaused {
         _validateNode(node);
         IEtherFiNode(node).setProofSubmitter(proofSubmitter);
     }
     
-    function setProofSubmitter(uint256 id, address proofSubmitter) external onlyEigenlayerAdmin whenNotPaused {
+    function setProofSubmitter(uint256 id, address proofSubmitter) external onlyOperations whenNotPaused {
         setProofSubmitter(etherfiNodeAddress(id), proofSubmitter);
     }
 
-    function queueETHWithdrawal(address node, uint256 amount) public onlyEigenlayerAdmin whenNotPaused returns (bytes32 withdrawalRoot) {
+    function queueETHWithdrawal(address node, uint256 amount) public onlyConsolidationExecutor whenNotPaused returns (bytes32 withdrawalRoot) {
         _validateNode(node);
         rateLimiter.consume(UNRESTAKING_LIMIT_ID, SafeCast.toUint64(amount / 1 gwei));
         return IEtherFiNode(node).queueETHWithdrawal(amount);
     }
     
-    function queueETHWithdrawal(uint256 id, uint256 amount) external onlyEigenlayerAdmin whenNotPaused returns (bytes32 withdrawalRoot) {
+    function queueETHWithdrawal(uint256 id, uint256 amount) external onlyConsolidationExecutor whenNotPaused returns (bytes32 withdrawalRoot) {
         return queueETHWithdrawal(etherfiNodeAddress(id), amount);
     }
 

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -13,9 +13,9 @@ import "./interfaces/IEtherFiNode.sol";
 import "./interfaces/IEtherFiNodesManager.sol";
 import "./interfaces/IProtocolRevenueManager.sol";
 import "./interfaces/IStakingManager.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IEtherFiRateLimiter.sol";
 import "./utils/PausableUntil.sol";
+import "./utils/RolesLibrary.sol";
 
 contract EtherFiNodesManager is
     Initializable,
@@ -24,11 +24,11 @@ contract EtherFiNodesManager is
     PausableUpgradeable,
     PausableUntil,
     ReentrancyGuardUpgradeable,
-    UUPSUpgradeable
+    UUPSUpgradeable,
+    RolesLibrary
 {
 
     IStakingManager public immutable stakingManager;
-    IRoleRegistry public immutable roleRegistry;
     IEtherFiRateLimiter public immutable rateLimiter;
     address public constant BEACON_ETH_STRATEGY_ADDRESS = address(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
@@ -55,23 +55,22 @@ contract EtherFiNodesManager is
     //-------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _stakingManager, address _roleRegistry, address _rateLimiter) {
+    constructor(address _stakingManager, address _roleRegistry, address _rateLimiter) RolesLibrary(_roleRegistry) {
         stakingManager = IStakingManager(_stakingManager);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         rateLimiter = IEtherFiRateLimiter(_rateLimiter);
 
         _disableInitializers();
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -79,7 +78,7 @@ contract EtherFiNodesManager is
         _pauseUntil();
     }
 
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -89,7 +88,7 @@ contract EtherFiNodesManager is
 
     /// @dev under normal conditions ETH should not accumulate in the EtherFiNode. This will forward
     ///   the eth to the liquidity pool in the event of ETH being accidentally sent there
-    function sweepFunds(uint256 id) external onlyEigenlayerAdmin whenNotPaused {
+    function sweepFunds(uint256 id) external onlyHousekeepingOperations whenNotPaused {
         address nodeAddr = etherfiNodeAddress(id);
         uint256 balance = IEtherFiNode(nodeAddr).sweepFunds();
         if(balance > 0) {
@@ -121,44 +120,44 @@ contract EtherFiNodesManager is
         return getEigenPod(etherfiNodeAddress(id));
     }
 
-    function startCheckpoint(address node) public onlyPodProver whenNotPaused {
+    function startCheckpoint(address node) public onlyEigenpodOperations whenNotPaused {
         _validateNode(node);
         IEtherFiNode(node).startCheckpoint();
     }
     
-    function startCheckpoint(uint256 id) external onlyPodProver whenNotPaused {
+    function startCheckpoint(uint256 id) external onlyEigenpodOperations whenNotPaused {
         startCheckpoint(etherfiNodeAddress(id));
     }
 
-    function verifyCheckpointProofs(address node, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) public onlyPodProver whenNotPaused {
+    function verifyCheckpointProofs(address node, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) public onlyEigenpodOperations whenNotPaused {
         _validateNode(node);
         IEtherFiNode(node).verifyCheckpointProofs(balanceContainerProof, proofs);
     }
     
-    function verifyCheckpointProofs(uint256 id, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyPodProver whenNotPaused {
+    function verifyCheckpointProofs(uint256 id, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyEigenpodOperations whenNotPaused {
         verifyCheckpointProofs(etherfiNodeAddress(id), balanceContainerProof, proofs);
     }
 
-    function setProofSubmitter(address node, address proofSubmitter) public onlyOperations whenNotPaused {
+    function setProofSubmitter(address node, address proofSubmitter) public onlyOperatingMultisig whenNotPaused {
         _validateNode(node);
         IEtherFiNode(node).setProofSubmitter(proofSubmitter);
     }
     
-    function setProofSubmitter(uint256 id, address proofSubmitter) external onlyOperations whenNotPaused {
+    function setProofSubmitter(uint256 id, address proofSubmitter) external onlyOperatingMultisig whenNotPaused {
         setProofSubmitter(etherfiNodeAddress(id), proofSubmitter);
     }
 
-    function queueETHWithdrawal(address node, uint256 amount) public onlyConsolidationExecutor whenNotPaused returns (bytes32 withdrawalRoot) {
+    function queueETHWithdrawal(address node, uint256 amount) public onlyExecutorOperations whenNotPaused returns (bytes32 withdrawalRoot) {
         _validateNode(node);
         rateLimiter.consume(UNRESTAKING_LIMIT_ID, SafeCast.toUint64(amount / 1 gwei));
         return IEtherFiNode(node).queueETHWithdrawal(amount);
     }
     
-    function queueETHWithdrawal(uint256 id, uint256 amount) external onlyConsolidationExecutor whenNotPaused returns (bytes32 withdrawalRoot) {
+    function queueETHWithdrawal(uint256 id, uint256 amount) external onlyExecutorOperations whenNotPaused returns (bytes32 withdrawalRoot) {
         return queueETHWithdrawal(etherfiNodeAddress(id), amount);
     }
 
-    function completeQueuedETHWithdrawals(address node, bool receiveAsTokens) public onlyEigenlayerAdmin whenNotPaused {
+    function completeQueuedETHWithdrawals(address node, bool receiveAsTokens) public onlyHousekeepingOperations whenNotPaused {
         _validateNode(node);
         uint256 balance = IEtherFiNode(node).completeQueuedETHWithdrawals(receiveAsTokens);
         if(balance > 0) {
@@ -166,22 +165,22 @@ contract EtherFiNodesManager is
         }
     }
     
-    function completeQueuedETHWithdrawals(uint256 id, bool receiveAsTokens) external onlyEigenlayerAdmin whenNotPaused {
+    function completeQueuedETHWithdrawals(uint256 id, bool receiveAsTokens) external onlyHousekeepingOperations whenNotPaused {
         completeQueuedETHWithdrawals(etherfiNodeAddress(id), receiveAsTokens);
     }
 
-    function queueWithdrawals(address node, IDelegationManager.QueuedWithdrawalParams[] calldata params) public onlyEigenlayerAdmin whenNotPaused {
+    function queueWithdrawals(address node, IDelegationManager.QueuedWithdrawalParams[] calldata params) public onlyHousekeepingOperations whenNotPaused {
         _validateNode(node);
         // need to rate limit any beacon eth being withdrawn
         rateLimiter.consume(UNRESTAKING_LIMIT_ID, SafeCast.toUint64(sumRestakingETHWithdrawals(params) / 1 gwei));
         IEtherFiNode(node).queueWithdrawals(params);
     }
     
-    function queueWithdrawals(uint256 id, IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyEigenlayerAdmin whenNotPaused {
+    function queueWithdrawals(uint256 id, IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyHousekeepingOperations whenNotPaused {
         queueWithdrawals(etherfiNodeAddress(id), params);
     }
 
-    function completeQueuedWithdrawals(address node, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) public onlyEigenlayerAdmin whenNotPaused {
+    function completeQueuedWithdrawals(address node, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) public onlyHousekeepingOperations whenNotPaused {
         _validateNode(node);
         uint256 balance = IEtherFiNode(node).completeQueuedWithdrawals(withdrawals, tokens, receiveAsTokens);
         if (balance > 0) {
@@ -189,7 +188,7 @@ contract EtherFiNodesManager is
         }
     }
     
-    function completeQueuedWithdrawals(uint256 id, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external onlyEigenlayerAdmin whenNotPaused {
+    function completeQueuedWithdrawals(uint256 id, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external onlyHousekeepingOperations whenNotPaused {
         completeQueuedWithdrawals(etherfiNodeAddress(id), withdrawals, tokens, receiveAsTokens);
     }
 
@@ -219,7 +218,7 @@ contract EtherFiNodesManager is
      *        - amountGwei: 0 for full exit, >0 for partial to pod
      * @custom:fee Send EXACT ETH to cover sum of (feePerPod * requestsForPod).
      */
-    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable nonReentrant onlyConsolidationExecutor whenNotPaused {
+    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable nonReentrant onlyExecutorOperations whenNotPaused {
         if (requests.length == 0) revert EmptyWithdrawalsRequest();
 
         // rate limit the amount of the that can be withdrawn from beacon chain
@@ -263,7 +262,7 @@ contract EtherFiNodesManager is
      * @dev EigenLayer validates that validators belong to the pod automatically.
      * @custom:fee Send EXACT ETH to cover consolidation fees.
      */
-    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable nonReentrant onlyConsolidationExecutor whenNotPaused {
+    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable nonReentrant onlyExecutorOperations whenNotPaused {
         if (requests.length == 0) revert EmptyConsolidationRequest();
 
         // rate limit consolidation requests - each request could affect up to FULL_EXIT_GWEI
@@ -374,7 +373,7 @@ contract EtherFiNodesManager is
 
     /// @dev this method is for linking our old legacy validator ids that were created before
     ///    we started tracking the pubkeys onchain. We can delete this method once we have linked all of our legacy validators
-    function linkLegacyValidatorIds(uint256[] calldata validatorIds, bytes[] calldata pubkeys) external onlyConsolidationExecutor {
+    function linkLegacyValidatorIds(uint256[] calldata validatorIds, bytes[] calldata pubkeys) external onlyExecutorOperations {
         if (validatorIds.length != pubkeys.length) revert LengthMismatch();
         for (uint256 i = 0; i < validatorIds.length; i++) {
 
@@ -416,7 +415,7 @@ contract EtherFiNodesManager is
     }
 
     /// @notice forward a whitelisted call to a whitelisted external contract with the EtherFiNode as the caller
-    function forwardExternalCall(address[] calldata nodes, bytes[] calldata data, address target) external onlyPodProver whenNotPaused returns (bytes[] memory returnData) {
+    function forwardExternalCall(address[] calldata nodes, bytes[] calldata data, address target) external onlyEigenpodOperations whenNotPaused returns (bytes[] memory returnData) {
         if (nodes.length != data.length) revert InvalidForwardedCall();
 
         returnData = new bytes[](nodes.length);
@@ -436,7 +435,7 @@ contract EtherFiNodesManager is
 
     /// @notice forward a whitelisted call to the associated eigenPod of the EtherFiNode with the EtherFiNode as the caller.
     ///   This serves to allow us to support minor eigenlayer upgrades without needing to immediately upgrade our contracts.
-    function forwardEigenPodCall(address[] calldata nodes, bytes[] calldata data) external onlyPodProver whenNotPaused returns (bytes[] memory returnData) {
+    function forwardEigenPodCall(address[] calldata nodes, bytes[] calldata data) external onlyEigenpodOperations whenNotPaused returns (bytes[] memory returnData) {
         if (nodes.length != data.length) revert InvalidForwardedCall();
 
         returnData = new bytes[](nodes.length);
@@ -465,36 +464,6 @@ contract EtherFiNodesManager is
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
-        _;
-    }
-
-    modifier onlyEigenlayerAdmin() {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-        _;
-    }
-
-    modifier onlyConsolidationExecutor() {
-        if (!roleRegistry.hasRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-        _;
-    }
-
-    modifier onlyPodProver() {
-        if (!roleRegistry.hasRole(roleRegistry.EIGENPOD_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-        _;
-    }
 
     /// @dev Route OZ's whenNotPaused through the pause-until check as well, so any function
     ///      gated by whenNotPaused is automatically blocked during a timed pause too.

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -62,9 +62,7 @@ contract EtherFiNodesManager is
         _disableInitializers();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function pauseContract() external onlyOperatingMultisig {
         _pause();

--- a/src/EtherFiNodesManager.sol
+++ b/src/EtherFiNodesManager.sol
@@ -169,14 +169,14 @@ contract EtherFiNodesManager is
         completeQueuedETHWithdrawals(etherfiNodeAddress(id), receiveAsTokens);
     }
 
-    function queueWithdrawals(address node, IDelegationManager.QueuedWithdrawalParams[] calldata params) public onlyHousekeepingOperations whenNotPaused {
+    function queueWithdrawals(address node, IDelegationManager.QueuedWithdrawalParams[] calldata params) public onlyExecutorOperations whenNotPaused {
         _validateNode(node);
         // need to rate limit any beacon eth being withdrawn
         rateLimiter.consume(UNRESTAKING_LIMIT_ID, SafeCast.toUint64(sumRestakingETHWithdrawals(params) / 1 gwei));
         IEtherFiNode(node).queueWithdrawals(params);
     }
     
-    function queueWithdrawals(uint256 id, IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyHousekeepingOperations whenNotPaused {
+    function queueWithdrawals(uint256 id, IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyExecutorOperations whenNotPaused {
         queueWithdrawals(etherfiNodeAddress(id), params);
     }
 

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -332,7 +332,5 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         if (numActiveCommitteeMembers < quorumSize || numActiveCommitteeMembers > 2 * quorumSize) revert InvalidQuorum();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 }

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -7,10 +7,10 @@ import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 
 import "./interfaces/IEtherFiOracle.sol";
 import "./interfaces/IEtherFiAdmin.sol";
-import "./interfaces/IRoleRegistry.sol";
+import "./utils/RolesLibrary.sol";
 
 
-contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable, UUPSUpgradeable, IEtherFiOracle {
+contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable, UUPSUpgradeable, IEtherFiOracle, RolesLibrary {
 
     mapping(address => IEtherFiOracle.CommitteeMemberState) public committeeMemberStates; // committee member wallet address to its State
     mapping(bytes32 => IEtherFiOracle.ConsensusState) public consensusStates; // report's hash -> Consensus State
@@ -37,8 +37,6 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
 
     // Immutables are not part of proxy storage; stored in implementation bytecode only.
     IEtherFiAdmin public immutable etherFiAdmin;
-    IRoleRegistry public immutable roleRegistry;
-
     uint32 public immutable minQuorumSize;
 
     event CommitteeMemberAdded(address indexed member);
@@ -75,10 +73,9 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     error InvalidQuorum();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(uint32 _minQuorumSize, address _etherFiAdmin, address _roleRegistry) {
+    constructor(uint32 _minQuorumSize, address _etherFiAdmin, address _roleRegistry) RolesLibrary(_roleRegistry) {
         minQuorumSize = _minQuorumSize;
         etherFiAdmin = IEtherFiAdmin(_etherFiAdmin);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
     }
 
@@ -274,7 +271,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         emit CommitteeMemberRemoved(_address);
     }
 
-    function manageCommitteeMember(address _address, bool _enabled) public onlyOperations {
+    function manageCommitteeMember(address _address, bool _enabled) public onlyOperatingMultisig {
         if (!committeeMemberStates[_address].registered) revert NotRegistered();
         if (committeeMemberStates[_address].enabled == _enabled) revert AlreadyInTargetState();
         committeeMemberStates[_address].enabled = _enabled;
@@ -308,7 +305,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         emit ConsensusVersionUpdated(_consensusVersion);
     }
 
-    function unpublishReport(OracleReport calldata _report) public onlyOperations {
+    function unpublishReport(OracleReport calldata _report) public onlyOperatingMultisig {
         bytes32 _hash = generateReportHash(_report);
         if (!consensusStates[_hash].consensusReached) revert ConsensusNotReached();
         if (_report.refSlotTo <= etherFiAdmin.lastHandledReportRefSlot()) revert ReportExecuted();
@@ -319,11 +316,11 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         emit ReportUnpublished(_hash);
     }
 
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -336,16 +333,6 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
+        _onlyProtocolUpgrader();
     }
 }

--- a/src/EtherFiRateLimiter.sol
+++ b/src/EtherFiRateLimiter.sol
@@ -5,12 +5,10 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 
 import "./interfaces/IEtherFiRateLimiter.sol";
-import "./interfaces/IRoleRegistry.sol";
+import "./utils/RolesLibrary.sol";
 import "lib/BucketLimiter.sol";
 
-contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeable, PausableUpgradeable {
-
-    IRoleRegistry public immutable roleRegistry;
+contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeable, PausableUpgradeable, RolesLibrary {
 
     //---------------------------------------------------------------------------
     //---------------------------  Storage  -------------------------------------
@@ -21,8 +19,7 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     //-------------------------------------------------------------------------
     //-------------------------  Deployment  ----------------------------------
     //-------------------------------------------------------------------------
-    constructor(address _roleRegistry) {
-        roleRegistry = IRoleRegistry(_roleRegistry);
+    constructor(address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
     }
 
@@ -32,7 +29,7 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     //-------------------------------------------------------------------------
@@ -91,12 +88,12 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     }
 
     /// @notice Pauses the contract, preventing consumption operations
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
     /// @notice Unpauses the contract, allowing consumption operations
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -182,19 +179,5 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     function limitExists(bytes32 id) public view returns (bool) {
         BucketLimiter.Limit memory limit = limits[id];
         return limit.capacity != 0 || limit.remaining != 0 || limit.lastRefill != 0 || limit.refillRate != 0;
-    }
-
-    //--------------------------------------------------------------------------------------
-    //-----------------------------------  MODIFIERS  --------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
     }
 }

--- a/src/EtherFiRateLimiter.sol
+++ b/src/EtherFiRateLimiter.sol
@@ -28,9 +28,7 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
         __Pausable_init();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //-------------------------------------------------------------------------
     //-----------------------------  Admin  -----------------------------------

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -16,12 +16,12 @@ import "./interfaces/ILiquidityPool.sol";
 import "./interfaces/IeETH.sol";
 import "./interfaces/IWeETH.sol";
 import "./interfaces/ILiquifier.sol";
+import "./interfaces/IEtherFiRestaker.sol";
 import "./utils/PausableUntil.sol";
-import "./EtherFiRestaker.sol";
+import "./utils/RolesLibrary.sol";
 
 import "lib/BucketLimiter.sol";
 
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IPriorityWithdrawalQueue.sol";
 import "./interfaces/IBlacklister.sol";
 
@@ -38,7 +38,7 @@ struct RedemptionInfo {
     uint16 lowWatermarkInBpsOfTvl;
 }
 
-contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, PausableUntil, ReentrancyGuardUpgradeable, UUPSUpgradeable {
+contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, PausableUntil, ReentrancyGuardUpgradeable, UUPSUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
     using Math for uint256;
 
@@ -52,11 +52,10 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     address public immutable treasury;
-    IRoleRegistry public immutable roleRegistry;
     IeETH public immutable eEth;
     IWeETH public immutable weEth;
     ILiquidityPool public immutable liquidityPool;
-    EtherFiRestaker public immutable etherFiRestaker;
+    IEtherFiRestaker public immutable etherFiRestaker;
     ILido public immutable lido;
     IPriorityWithdrawalQueue public immutable priorityWithdrawalQueue;
     IBlacklister public immutable blacklister;
@@ -101,17 +100,17 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         uint256 _maxExitFeeSplitToTreasuryInBps, 
         uint256 _maxExitFeeInBps, 
         uint256 _maxLowWatermarkInBpsOfTvl)
+        RolesLibrary(_roleRegistry)
     {
         if (_maxExitFeeSplitToTreasuryInBps > BASIS_POINT_SCALE || _maxExitFeeInBps > BASIS_POINT_SCALE || _maxLowWatermarkInBpsOfTvl > BASIS_POINT_SCALE) revert InvalidAmount();
         maxExitFeeSplitToTreasuryInBps = _maxExitFeeSplitToTreasuryInBps;
         maxExitFeeInBps = _maxExitFeeInBps;
         maxLowWatermarkInBpsOfTvl = _maxLowWatermarkInBpsOfTvl;
-        roleRegistry = IRoleRegistry(_roleRegistry);
         treasury = _treasury;
         liquidityPool = ILiquidityPool(payable(_liquidityPool));
         eEth = IeETH(_eEth);
         weEth = IWeETH(_weEth); 
-        etherFiRestaker = EtherFiRestaker(payable(_etherFiRestaker));
+        etherFiRestaker = IEtherFiRestaker(payable(_etherFiRestaker));
         lido = etherFiRestaker.lido();
         priorityWithdrawalQueue = IPriorityWithdrawalQueue(_priorityWithdrawalQueue);
         blacklister = IBlacklister(_blacklister);
@@ -367,11 +366,11 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         tokenToRedemptionInfo[token].exitFeeSplitToTreasuryInBps = _exitFeeSplitToTreasuryInBps;
     }
 
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -379,7 +378,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         _pauseUntil();
     }
 
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -451,26 +450,11 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function getImplementation() external view returns (address) {
         return _getImplementation();
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
-        _;
     }
 
     modifier nonBlacklisted(address receiver) {

--- a/src/EtherFiRedemptionManager.sol
+++ b/src/EtherFiRedemptionManager.sol
@@ -449,9 +449,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         return assets.mulDiv(feeBasisPoints, BASIS_POINT_SCALE, Math.Rounding.Up);
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function getImplementation() external view returns (address) {
         return _getImplementation();

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import "./Liquifier.sol";
 import "./LiquidityPool.sol";
+import "./utils/RolesLibrary.sol";
 
 import "./eigenlayer-interfaces/IStrategyManager.sol";
 import "./eigenlayer-interfaces/IDelegationManager.sol";
@@ -18,10 +19,9 @@ import "./eigenlayer-interfaces/IRewardsCoordinator.sol";
 
 import "./interfaces/ILiquifier.sol";
 import "./interfaces/ILiquidityPool.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IEtherFiRateLimiter.sol";
 
-contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
@@ -40,7 +40,6 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     ILido public immutable lido;
     IDelegationManager public immutable eigenLayerDelegationManager;
     IStrategyManager public immutable eigenLayerStrategyManager;
-    IRoleRegistry public immutable roleRegistry;
     IEtherFiRateLimiter public immutable rateLimiter;
 
     bytes32 public constant STETH_REQUEST_WITHDRAWAL_LIMIT_ID = keccak256("STETH_REQUEST_WITHDRAWAL_LIMIT_ID");
@@ -71,7 +70,6 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     event CompletedStEthQueuedWithdrawals(uint256[] _reqIds);
     event CompletedQueuedWithdrawal(bytes32 _withdrawalRoot);
 
-    error IncorrectRole();
     error NotEnoughBalance();
     error IncorrectAmount();
     error EthTransferFailed();
@@ -92,7 +90,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         address _rateLimiter,
         address _eigenLayerStrategyManager,
         address _eigenLayerDelegationManager
-    ) {
+    ) RolesLibrary(_roleRegistry) {
         liquidityPool = ILiquidityPool(payable(_liquidityPool));
         liquifier = ILiquifier(payable(_liquifier));
         lido = liquifier.lido();
@@ -101,7 +99,6 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         eigenLayerDelegationManager = IDelegationManager(_eigenLayerDelegationManager);
         rewardsCoordinator = IRewardsCoordinator(_rewardsCoordinator);
         etherFiRedemptionManager = _etherFiRedemptionManager;
-        roleRegistry = IRoleRegistry(_roleRegistry);
         rateLimiter = IEtherFiRateLimiter(_rateLimiter);
         _disableInitializers();
     }
@@ -142,8 +139,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     /// @notice Request for a specific amount of stETH holdings
     /// @param _amount the amount of stETH to request
-    function stEthRequestWithdrawal(uint256 _amount) public returns (uint256[] memory) {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function stEthRequestWithdrawal(uint256 _amount) public onlyHousekeepingOperations returns (uint256[] memory) {
         rateLimiter.consume(STETH_REQUEST_WITHDRAWAL_LIMIT_ID, _amountToGwei(_amount));
 
         uint256 minAmount = lidoWithdrawalQueue.MIN_STETH_WITHDRAWAL_AMOUNT();
@@ -177,8 +173,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// @notice Claim a batch of withdrawal requests if they are finalized sending the ETH to the this contract back
     /// @param _requestIds array of request ids to claim
     /// @param _hints checkpoint hint for each id. Can be obtained with `findCheckpointHints()`
-    function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external onlyHousekeepingOperations {
         lidoWithdrawalQueue.claimWithdrawals(_requestIds, _hints);
 
         _withdrawEther();
@@ -187,8 +182,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     // Send the ETH back to the liquidity pool
-    function withdrawEther() public {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function withdrawEther() public onlyHousekeepingOperations {
         _withdrawEther();
     }
 
@@ -212,12 +206,12 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         address operator,
         IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry,
         bytes32 approverSalt
-    ) external onlyOperations {
+    ) external onlyOperatingMultisig {
         eigenLayerDelegationManager.delegateTo(operator, approverSignatureAndExpiry, approverSalt);
     }
 
     // undelegate from the current AVS operator & un-restake all
-    function undelegate() external onlyOperations returns (bytes32[] memory) {
+    function undelegate() external onlyOperatingMultisig returns (bytes32[] memory) {
         bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.undelegate(address(this));
 
         for (uint256 i = 0; i < withdrawalRoots.length; i++) {
@@ -232,8 +226,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     // deposit the token in holding into the restaking strategy
-    function depositIntoStrategy(address token, uint256 amount) external returns (uint256) {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function depositIntoStrategy(address token, uint256 amount) external onlyHousekeepingOperations returns (uint256) {
         rateLimiter.consume(DEPOSIT_INTO_STRATEGY_LIMIT_ID, _amountToGwei(amount));
 
         IERC20(token).safeIncreaseAllowance(address(eigenLayerStrategyManager), amount);
@@ -248,8 +241,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// Made easy for operators
     /// @param token the token to withdraw
     /// @param amount the amount of token to withdraw
-    function queueWithdrawals(address token, uint256 amount) public returns (bytes32[] memory) {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function queueWithdrawals(address token, uint256 amount) public onlyHousekeepingOperations returns (bytes32[] memory) {
         rateLimiter.consume(QUEUE_WITHDRAWALS_LIMIT_ID, _amountToGwei(amount));
 
         uint256 shares = getEigenLayerRestakingStrategy(token).underlyingToSharesView(amount);
@@ -269,8 +261,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     function completeQueuedWithdrawals(
         IDelegationManager.Withdrawal[] memory _queuedWithdrawals,
         IERC20[][] memory _tokens
-    ) external {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    ) external onlyHousekeepingOperations {
         uint256 num = _queuedWithdrawals.length;
         bool[] memory receiveAsTokens = new bool[](num);
         for (uint256 i = 0; i < num; i++) {
@@ -388,12 +379,12 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     // Pauses the contract
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
     // Unpauses the contract
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -429,17 +420,6 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
-    }
-
-    /* MODIFIERS */
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
+        _onlyProtocolUpgrader();
     }
 }

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -419,7 +419,5 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return (_a > _b) ? _b : _a;
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 }

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -178,7 +178,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// @param _requestIds array of request ids to claim
     /// @param _hints checkpoint hint for each id. Can be obtained with `findCheckpointHints()`
     function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external {
-        if (!roleRegistry.hasRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
         lidoWithdrawalQueue.claimWithdrawals(_requestIds, _hints);
 
         _withdrawEther();
@@ -187,7 +187,8 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     // Send the ETH back to the liquidity pool
-    function withdrawEther() public onlyOperations {
+    function withdrawEther() public {
+        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
         _withdrawEther();
     }
 
@@ -202,7 +203,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     // |--------------------------------------------------------------------------------------------|
 
     /// Set the claimer of the restaking rewards of this contract
-    function setRewardsClaimer(address _claimer) external onlyOperations {
+    function setRewardsClaimer(address _claimer) external onlyAdmin {
         rewardsCoordinator.setClaimerFor(_claimer);
     }
 
@@ -269,7 +270,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         IDelegationManager.Withdrawal[] memory _queuedWithdrawals,
         IERC20[][] memory _tokens
     ) external {
-        if (!roleRegistry.hasRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
         uint256 num = _queuedWithdrawals.length;
         bool[] memory receiveAsTokens = new bool[](num);
         for (uint256 i = 0; i < num; i++) {
@@ -432,6 +433,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     /* MODIFIERS */
+    modifier onlyAdmin() {
+        roleRegistry.onlyOperatingTimelock(msg.sender);
+        _;
+    }
+
     modifier onlyOperations() {
         roleRegistry.onlyOperatingMultisig(msg.sender);
         _;

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -139,7 +139,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     /// @notice Request for a specific amount of stETH holdings
     /// @param _amount the amount of stETH to request
-    function stEthRequestWithdrawal(uint256 _amount) public onlyHousekeepingOperations returns (uint256[] memory) {
+    function stEthRequestWithdrawal(uint256 _amount) public onlyExecutorOperations returns (uint256[] memory) {
         rateLimiter.consume(STETH_REQUEST_WITHDRAWAL_LIMIT_ID, _amountToGwei(_amount));
 
         uint256 minAmount = lidoWithdrawalQueue.MIN_STETH_WITHDRAWAL_AMOUNT();
@@ -226,7 +226,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     // deposit the token in holding into the restaking strategy
-    function depositIntoStrategy(address token, uint256 amount) external onlyHousekeepingOperations returns (uint256) {
+    function depositIntoStrategy(address token, uint256 amount) external onlyExecutorOperations returns (uint256) {
         rateLimiter.consume(DEPOSIT_INTO_STRATEGY_LIMIT_ID, _amountToGwei(amount));
 
         IERC20(token).safeIncreaseAllowance(address(eigenLayerStrategyManager), amount);
@@ -241,7 +241,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// Made easy for operators
     /// @param token the token to withdraw
     /// @param amount the amount of token to withdraw
-    function queueWithdrawals(address token, uint256 amount) public onlyHousekeepingOperations returns (bytes32[] memory) {
+    function queueWithdrawals(address token, uint256 amount) public onlyExecutorOperations returns (bytes32[] memory) {
         rateLimiter.consume(QUEUE_WITHDRAWALS_LIMIT_ID, _amountToGwei(amount));
 
         uint256 shares = getEigenLayerRestakingStrategy(token).underlyingToSharesView(amount);

--- a/src/EtherFiRewardsRouter.sol
+++ b/src/EtherFiRewardsRouter.sol
@@ -64,9 +64,7 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable, RolesLibra
         emit Erc721Sent(msg.sender, _token, _tokenId);
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function getImplementation() external view returns (address) {
         return _getImplementation();

--- a/src/EtherFiRewardsRouter.sol
+++ b/src/EtherFiRewardsRouter.sol
@@ -6,15 +6,14 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import "./interfaces/IRoleRegistry.sol";
+import "./utils/RolesLibrary.sol";
 import "./interfaces/ILiquidityPool.sol";
 
-contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
+contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
 
     address public immutable treasury;
     address public immutable liquidityPool;
-    IRoleRegistry public immutable roleRegistry;
 
     event EthReceived(address indexed from, uint256 value);
     event EthSent(address indexed from, address indexed to, uint256 value);
@@ -25,11 +24,10 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
     error ContractBalanceIsZero();
     error EthTransferFailed();
 
-    constructor(address _liquidityPool, address _treasury, address _roleRegistry) {
+    constructor(address _liquidityPool, address _treasury, address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
         liquidityPool = _liquidityPool;
         treasury = _treasury;
-        roleRegistry = IRoleRegistry(_roleRegistry);
     }
 
     receive() external payable {
@@ -53,13 +51,13 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
         emit EthSent(address(this), liquidityPool, balance);
     }
 
-    function recoverERC20(address _token, uint256 _amount) external onlyOperations {
+    function recoverERC20(address _token, uint256 _amount) external onlyOperatingMultisig {
         IERC20(_token).safeTransfer(treasury, _amount);
 
         emit Erc20Sent(msg.sender, _token, _amount);
     }
 
-    function recoverERC721(address _token, uint256 _tokenId) external onlyOperations {
+    function recoverERC721(address _token, uint256 _tokenId) external onlyOperatingMultisig {
 
         IERC721(_token).transferFrom(address(this), treasury, _tokenId);
 
@@ -67,15 +65,10 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable  {
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function getImplementation() external view returns (address) {
         return _getImplementation();
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
     }
 }

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -196,7 +196,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     /// @notice One-shot post-upgrade migration that sweeps existing locked ETH from LP to WithdrawRequestNFT and PriorityWithdrawalQueue.
-    function initializeOnUpgradeV2() external onlyOwner {
+    function initializeOnUpgradeV2() external onlyUpgradeTimelock {
         if (escrowMigrationCompleted) revert AlreadyMigrated();
 
         uint128 nftLocked   = DEPRECATED_ethAmountLockedForWithdrawal;
@@ -664,9 +664,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _checkMinAmountForShare();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //------------------------------------  GETTERS  ---------------------------------------

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -557,12 +557,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     function setMinWithdrawAmount(uint256 _minWithdrawAmount) external onlyOperations {
+        if (_minWithdrawAmount > maxWithdrawAmount) revert InvalidAmount();
         minWithdrawAmount = _minWithdrawAmount;
         emit MinWithdrawAmountSet(_minWithdrawAmount);
     }
 
     function setMaxWithdrawAmount(uint256 _maxWithdrawAmount) external onlyOperations {
-        if (_maxWithdrawAmount ==0 || _maxWithdrawAmount < minWithdrawAmount) revert InvalidAmount();
+        if (_maxWithdrawAmount == 0 || _maxWithdrawAmount < minWithdrawAmount) revert InvalidAmount();
         maxWithdrawAmount = _maxWithdrawAmount;
         emit MaxWithdrawAmountSet(_maxWithdrawAmount);
     }

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -7,7 +7,6 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 
-import "./utils/PausableUntil.sol";
 import "./interfaces/IeETH.sol";
 import "./interfaces/IStakingManager.sol";
 import "./interfaces/IWithdrawRequestNFT.sol";
@@ -16,12 +15,13 @@ import "./interfaces/ILiquifier.sol";
 import "./interfaces/IEtherFiNode.sol";
 import "./interfaces/IEtherFiNodesManager.sol";
 import "./interfaces/IEtherFiRedemptionManager.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IPriorityWithdrawalQueue.sol";
 import "./interfaces/IBlacklister.sol";
 import "./utils/ReentrancyGuardNamespaced.sol";
+import "./utils/RolesLibrary.sol";
+import "./utils/PausableUntil.sol";
 
-contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuardNamespaced, PausableUntil, ILiquidityPool {
+contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuardNamespaced, PausableUntil, RolesLibrary, ILiquidityPool {
     using SafeERC20 for IERC20;
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
@@ -86,7 +86,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     IWithdrawRequestNFT public immutable withdrawRequestNFT;
     ILiquifier public immutable liquifier;
     IEtherFiRedemptionManager public immutable etherFiRedemptionManager;
-    IRoleRegistry public immutable roleRegistry;
     IPriorityWithdrawalQueue public immutable priorityWithdrawalQueue;
     IBlacklister public immutable blacklister;
     address public immutable etherFiAdminContract;
@@ -136,7 +135,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     error DataNotSet();
     error InsufficientLiquidity();
     error SendFail();
-    error IncorrectRole();
     error InvalidValidatorSize();
     error InvalidArrayLengths();
     error InvalidAmountForShare();
@@ -166,14 +164,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minAmountForShare) {
+    constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minAmountForShare) RolesLibrary(_constructorAddresses.roleRegistry) {
         stakingManager = IStakingManager(_constructorAddresses.stakingManager);
         nodesManager = IEtherFiNodesManager(_constructorAddresses.nodesManager);
         eETH = IeETH(_constructorAddresses.eETH);
         withdrawRequestNFT = IWithdrawRequestNFT(_constructorAddresses.withdrawRequestNFT);
         liquifier = ILiquifier(_constructorAddresses.liquifier);
         etherFiRedemptionManager = IEtherFiRedemptionManager(payable(_constructorAddresses.etherFiRedemptionManager));
-        roleRegistry = IRoleRegistry(_constructorAddresses.roleRegistry);
         priorityWithdrawalQueue = IPriorityWithdrawalQueue(_constructorAddresses.priorityWithdrawalQueue);
         blacklister = IBlacklister(_constructorAddresses.blacklister);
         etherFiAdminContract = _constructorAddresses.etherFiAdminContract;
@@ -391,9 +388,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         IStakingManager.DepositData[] calldata _depositData,
         uint256[] calldata _bidIds,
         address _etherFiNode
-    ) external nonReentrant whenNotPaused {
-        if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-
+    ) external nonReentrant whenNotPaused onlyOracleOperations {
         // liquidity pool supplies 1 eth per validator
         uint256 outboundEthAmountFromLp = stakingManager.INITIAL_DEPOSIT_AMOUNT() * _bidIds.length;
         stakingManager.createBeaconValidators{value: outboundEthAmountFromLp}(_depositData, _bidIds, _etherFiNode);
@@ -451,8 +446,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     function confirmAndFundBeaconValidators(
         IStakingManager.DepositData[] calldata _depositData,
         uint256 _validatorSizeWei
-    ) external nonReentrant whenNotPaused {
-        if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    ) external nonReentrant whenNotPaused onlyOracleOperations {
         if (_validatorSizeWei < stakingManager.MIN_VALIDATOR_SIZE_WEI() || _validatorSizeWei > stakingManager.MAX_VALIDATOR_SIZE_WEI()) revert InvalidValidatorSize();
 
         // we have already deposited the initial amount to create the validator on the beacon chain
@@ -484,7 +478,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
     /// @notice Removes a Validator Spawner
     /// @param _user the address of the Validator Spawner to remove
-    function unregisterValidatorSpawner(address _user) external onlyOperations {
+    function unregisterValidatorSpawner(address _user) external onlyOperatingMultisig {
         if (!validatorSpawner[_user].registered) revert NotRegistered();
 
         delete validatorSpawner[_user];
@@ -526,7 +520,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Pauses the contract
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         if (paused) revert("Pausable: already paused");
 
         paused = true;
@@ -534,7 +528,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Unpauses the contract
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         if (!paused) revert("Pausable: not paused");
 
         paused = false;
@@ -547,7 +541,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Unpauses contract from pauseUntil
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -556,13 +550,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _setPauseUntilDuration(_pauseUntilDuration);
     }
 
-    function setMinWithdrawAmount(uint256 _minWithdrawAmount) external onlyOperations {
+    function setMinWithdrawAmount(uint256 _minWithdrawAmount) external onlyOperatingMultisig {
         if (_minWithdrawAmount > maxWithdrawAmount) revert InvalidAmount();
         minWithdrawAmount = _minWithdrawAmount;
         emit MinWithdrawAmountSet(_minWithdrawAmount);
     }
 
-    function setMaxWithdrawAmount(uint256 _maxWithdrawAmount) external onlyOperations {
+    function setMaxWithdrawAmount(uint256 _maxWithdrawAmount) external onlyOperatingMultisig {
         if (_maxWithdrawAmount == 0 || _maxWithdrawAmount < minWithdrawAmount) revert InvalidAmount();
         maxWithdrawAmount = _maxWithdrawAmount;
         emit MaxWithdrawAmountSet(_maxWithdrawAmount);
@@ -671,7 +665,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     //--------------------------------------------------------------------------------------
@@ -756,22 +750,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
-        _;
-    }
-
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
         _;
     }
 

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -421,9 +421,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         return (_a > _b) ? _b : _a;
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function _requireNotPaused() internal override view {
         _requireNotPausedUntil();

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -104,7 +104,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     error InvalidLidoWithdrawalQueue();
     error InvalidLido();
     error InvalidStEth_Eth_Pool();
-    error InvalidRoleRegistry();
     error InvalidPriceFeed();
     error InvalidBlacklister();
     error InvalidEtherfiRestaker();

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -18,37 +18,6 @@ import "./utils/PausableUntil.sol";
 import "./eigenlayer-interfaces/IStrategyManager.sol";
 import "./eigenlayer-interfaces/IDelegationManager.sol";
 
-
-/// @title Router token swapping functionality
-/// @notice Functions for swapping tokens via PancakeSwap V3
-interface IPancackeV3SwapRouter {
-    function WETH9() external returns (address);
-
-    struct ExactInputSingleParams {
-        address tokenIn;
-        address tokenOut;
-        uint24 fee;
-        address recipient;
-        uint256 deadline;
-        uint256 amountIn;
-        uint256 amountOutMinimum;
-        uint160 sqrtPriceLimitX96;
-    }
-
-    /// @notice Swaps `amountIn` of one token for as much as possible of another token
-    /// @dev Setting `amountIn` to 0 will cause the contract to look up its own balance,
-    /// and swap the entire amount, enabling contracts to send tokens before calling this function.
-    /// @param params The parameters necessary for the swap, encoded as `ExactInputSingleParams` in calldata
-    /// @return amountOut The amount of the received token
-    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
-
-    function unwrapWETH9(uint256 amountMinimum, address recipient) external payable;
-}
-
-interface IERC20Burnable is IERC20 {
-    function burn(uint256 amount) external;
-}
-
 /// Go wild, spread eETH/weETH to the world
 contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, PausableUntil, ReentrancyGuardUpgradeable, ILiquifier {
     using SafeERC20 for IERC20;
@@ -281,7 +250,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         tokenInfos[_token] = TokenInfo(0, 0, IStrategy(_target), _isWhitelisted, _discountInBasisPoints, uint32(block.timestamp), _timeBoundCapInEther, _totalCapInEther, 0, 0, _isL2Eth);
     }
 
-    function updateTimeBoundCapRefreshInterval(uint32 _timeBoundCapRefreshInterval) external onlyOperations {
+    function updateTimeBoundCapRefreshInterval(uint32 _timeBoundCapRefreshInterval) external onlyAdmin {
         timeBoundCapRefreshInterval = _timeBoundCapRefreshInterval;
     }
 
@@ -290,7 +259,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         tokenInfos[_token].discountInBasisPoints = _discountInBasisPoints;
     }
 
-    function updateQuoteStEthWithCurve(bool _quoteStEthWithCurve) external onlyOperations {
+    function updateQuoteStEthWithCurve(bool _quoteStEthWithCurve) external onlyAdmin {
         quoteStEthWithCurve = _quoteStEthWithCurve;
     }
 

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -11,15 +11,15 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "./interfaces/ILiquifier.sol";
 import "./interfaces/ILiquidityPool.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IBlacklister.sol";
 import "./utils/PausableUntil.sol";
+import "./utils/RolesLibrary.sol";
 
 import "./eigenlayer-interfaces/IStrategyManager.sol";
 import "./eigenlayer-interfaces/IDelegationManager.sol";
 
 /// Go wild, spread eETH/weETH to the world
-contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, PausableUntil, ReentrancyGuardUpgradeable, ILiquifier {
+contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, PausableUntil, ReentrancyGuardUpgradeable, ILiquifier, RolesLibrary {
     using SafeERC20 for IERC20;
     using Math for uint256;
 
@@ -74,7 +74,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     ILidoWithdrawalQueue public immutable lidoWithdrawalQueue;
     ILido public immutable lido;
     ICurvePool public immutable stEth_Eth_Pool;
-    IRoleRegistry public immutable roleRegistry;
     AggregatorV3Interface public immutable stEthPriceFeed;
     IBlacklister public immutable blacklister;
 
@@ -97,7 +96,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     error EthTransferFailed();
     error AlreadyRegistered();
     error IncorrectCaller();
-    error IncorrectRole();
     error InvalidDiscountRate();
     error InvalidDepositCap();
     error InvalidPriceWindow();
@@ -131,7 +129,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minDiscountInBasisPoints, uint256 _stalePriceWindow, uint256 _maxPriceDeviationInBps) {
+    constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minDiscountInBasisPoints, uint256 _stalePriceWindow, uint256 _maxPriceDeviationInBps) RolesLibrary(_constructorAddresses.roleRegistry) {
         if (_minDiscountInBasisPoints == 0 || _minDiscountInBasisPoints > BASIS_POINT_SCALE) revert InvalidDiscountRate();
         if (_stalePriceWindow == 0) revert InvalidPriceWindow();
         if (_maxPriceDeviationInBps == 0 || _maxPriceDeviationInBps > BASIS_POINT_SCALE) revert InvalidMaxPriceDeviationInBps();
@@ -139,7 +137,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         if (_constructorAddresses.lidoWithdrawalQueue == address(0)) revert InvalidLidoWithdrawalQueue();
         if (_constructorAddresses.lido == address(0)) revert InvalidLido();
         if (_constructorAddresses.stEth_Eth_Pool == address(0)) revert InvalidStEth_Eth_Pool();
-        if (_constructorAddresses.roleRegistry == address(0)) revert InvalidRoleRegistry();
         if (_constructorAddresses.stEthPriceFeed == address(0)) revert InvalidPriceFeed();
         if (_constructorAddresses.blacklister == address(0)) revert InvalidBlacklister();
         if (_constructorAddresses.etherfiRestaker == address(0)) revert InvalidEtherfiRestaker();
@@ -148,7 +145,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         lidoWithdrawalQueue = ILidoWithdrawalQueue(_constructorAddresses.lidoWithdrawalQueue);
         lido = ILido(_constructorAddresses.lido);
         stEth_Eth_Pool = ICurvePool(_constructorAddresses.stEth_Eth_Pool);
-        roleRegistry = IRoleRegistry(_constructorAddresses.roleRegistry);
         stEthPriceFeed = AggregatorV3Interface(_constructorAddresses.stEthPriceFeed);
         blacklister = IBlacklister(_constructorAddresses.blacklister);
         etherfiRestaker = _constructorAddresses.etherfiRestaker;
@@ -214,15 +210,13 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
 
     // Send the redeemed ETH back to the liquidity pool & Send the fee to Treasury
-    function withdrawEther() external {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function withdrawEther() external onlyHousekeepingOperations {
         uint256 amountToLiquidityPool = _min(address(this).balance, liquidityPool.totalValueOutOfLp());
         (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: GAS_STIPEND_NO_GRIEF}("");
         if (!sent) revert EthTransferFailed();
     }
 
-    function sendToEtherFiRestaker(address _token, uint256 _amount) external {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function sendToEtherFiRestaker(address _token, uint256 _amount) external onlyHousekeepingOperations {
         IERC20(_token).safeTransfer(etherfiRestaker, _amount);
     }
 
@@ -264,12 +258,12 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
 
     //Pauses the contract
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
     //Unpauses the contract
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -279,7 +273,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
 
     /// @notice Unpauses the contract from pauseUntil
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -429,32 +423,12 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function _requireNotPaused() internal override view {
         _requireNotPausedUntil();
         super._requireNotPaused();
-    }
-
-    modifier onlyUpgradeTimelock() {
-        roleRegistry.onlyUpgradeTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
-        _;
     }
 
     modifier nonBlacklisted() {

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -76,8 +76,6 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
 
-    bytes32 public constant MEMBERSHIP_MANAGER_OPERATIONS_ROLE = keccak256("MEMBERSHIP_MANAGER_OPERATIONS_ROLE");
-
     uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
     uint256 public constant FEE_UNIT = 0.001 ether;
 
@@ -770,7 +768,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     }
 
     modifier onlyOperations() {
-        if (!roleRegistry.hasRole(MEMBERSHIP_MANAGER_OPERATIONS_ROLE, msg.sender)) revert IncorrectRole();
+        roleRegistry.onlyOperatingMultisig(msg.sender);
         _;
     }
 }

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -734,9 +734,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         return uint256(1 gwei) * minDepositGwei;
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //--------------------------------------  GETTER  --------------------------------------

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -12,14 +12,14 @@ import "./interfaces/IMembershipManager.sol";
 import "./interfaces/IMembershipNFT.sol";
 import "./interfaces/ILiquidityPool.sol";
 import "./interfaces/IEtherFiAdmin.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IBlacklister.sol";
+import "./utils/RolesLibrary.sol";
 
 import "./libraries/GlobalIndexLibrary.sol";
 
 import "forge-std/console.sol";
 
-contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgradeable, UUPSUpgradeable, IMembershipManager {
+contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgradeable, UUPSUpgradeable, IMembershipManager, RolesLibrary {
     using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------
@@ -73,7 +73,6 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     ILiquidityPool public immutable liquidityPool;
     IMembershipNFT public immutable membershipNFT;
     IEtherFiAdmin public immutable etherFiAdmin;
-    IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
 
     uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
@@ -88,12 +87,11 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     event NftUnwrappedForEEth(address indexed _user, uint256 indexed _tokenId, uint256 _amountOfEEth, uint40 _loyaltyPoints, uint256 _feeAmount);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _eETH, address _liquidityPool, address _membershipNFT, address _etherFiAdmin, address _roleRegistry, address _blacklister) {
+    constructor(address _eETH, address _liquidityPool, address _membershipNFT, address _etherFiAdmin, address _roleRegistry, address _blacklister) RolesLibrary(_roleRegistry) {
         eETH = IeETH(_eETH);
         liquidityPool = ILiquidityPool(_liquidityPool);
         membershipNFT = IMembershipNFT(_membershipNFT);
         etherFiAdmin = IEtherFiAdmin(_etherFiAdmin);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         blacklister = IBlacklister(_blacklister);
         _disableInitializers();
     }
@@ -204,7 +202,6 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     error WrongTokenMinted();
     error UnexpectedTier();
     error OnlyTokenOwner();
-    error IncorrectRole();
 
     /// @notice Requests exchange of membership points tokens for ETH.
     /// @dev decrements the amount of eETH backing the membership NFT and calls requestWithdraw on the liquidity pool
@@ -311,13 +308,13 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         }
     }
 
-    function addNewTier(uint40 _requiredTierPoints, uint24 _weight) external onlyOperations {
+    function addNewTier(uint40 _requiredTierPoints, uint24 _weight) external onlyOperatingMultisig {
         if (tierData.length >= type(uint8).max) revert TierLimitExceeded();
         tierData.push(TierData(0, _requiredTierPoints, _weight, 0));
         tierVaults.push(TierVault(0, 0));
     }
 
-    function updateTier(uint8 _tier, uint40 _requiredTierPoints, uint24 _weight) external onlyOperations {
+    function updateTier(uint8 _tier, uint40 _requiredTierPoints, uint24 _weight) external onlyOperatingMultisig {
         if (_tier >= tierData.length) revert OutOfBound();
         tierData[_tier].requiredTierPoints = _requiredTierPoints;
         tierData[_tier].weight = _weight;
@@ -328,38 +325,38 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     /// @param _tokenId The ID of the membership NFT.
     /// @param _loyaltyPoints The number of loyalty points to set for the specified NFT.
     /// @param _tierPoints The number of tier points to set for the specified NFT.
-    function setPoints(uint256 _tokenId, uint40 _loyaltyPoints, uint40 _tierPoints) public onlyOperations {
+    function setPoints(uint256 _tokenId, uint40 _loyaltyPoints, uint40 _tierPoints) public onlyOperatingMultisig {
         _claimStakingRewards(_tokenId);
         _setPoints(_tokenId, _loyaltyPoints, _tierPoints);
         _claimTier(_tokenId);
         _emitNftUpdateEvent(_tokenId);
     }
 
-    function updatePointsParams(uint16 _newPointsBoostFactor, uint16 _newPointsGrowthRate) external onlyOperations {
+    function updatePointsParams(uint16 _newPointsBoostFactor, uint16 _newPointsGrowthRate) external onlyOperatingMultisig {
         pointsBoostFactor = _newPointsBoostFactor;
         pointsGrowthRate = _newPointsGrowthRate;
     }
 
     /// @dev set how many blocks a token is locked from trading for after withdrawing
-    function setWithdrawalLockBlocks(uint32 _blocks) external onlyOperations {
+    function setWithdrawalLockBlocks(uint32 _blocks) external onlyOperatingMultisig {
         withdrawalLockBlocks = _blocks;
     }
 
     /// @notice Updates minimum valid deposit
     /// @param _minDepositGwei minimum deposit in wei
     /// @param _maxDepositTopUpPercent integer percentage value
-    function setDepositAmountParams(uint56 _minDepositGwei, uint8 _maxDepositTopUpPercent) external onlyOperations {
+    function setDepositAmountParams(uint56 _minDepositGwei, uint8 _maxDepositTopUpPercent) external onlyOperatingMultisig {
         minDepositGwei = _minDepositGwei;
         maxDepositTopUpPercent = _maxDepositTopUpPercent;
     }
 
     /// @notice Updates the time a user must wait between top ups
     /// @param _newWaitTime the new time to wait between top ups
-    function setTopUpCooltimePeriod(uint32 _newWaitTime) external onlyOperations {
+    function setTopUpCooltimePeriod(uint32 _newWaitTime) external onlyOperatingMultisig {
         topUpCooltimePeriod = _newWaitTime;
     }
 
-    function setFeeAmounts(uint256 _mintFeeAmount, uint256 _burnFeeAmount, uint256 _upgradeFeeAmount, uint16 _burnFeeWaiverPeriodInDays) external onlyOperations {
+    function setFeeAmounts(uint256 _mintFeeAmount, uint256 _burnFeeAmount, uint256 _upgradeFeeAmount, uint16 _burnFeeWaiverPeriodInDays) external onlyOperatingMultisig {
         _feeAmountSanityCheck(_mintFeeAmount);
         _feeAmountSanityCheck(_burnFeeAmount);
         _feeAmountSanityCheck(_upgradeFeeAmount);
@@ -369,17 +366,17 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
         burnFeeWaiverPeriodInDays = _burnFeeWaiverPeriodInDays;
     }
 
-    function setFanBoostThresholdEthAmount(uint256 _fanBoostThresholdEthAmount) external onlyOperations {
+    function setFanBoostThresholdEthAmount(uint256 _fanBoostThresholdEthAmount) external onlyOperatingMultisig {
         fanBoostThreshold = uint16(_fanBoostThresholdEthAmount / FEE_UNIT);
     }
 
     //Pauses the contract
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
     //Unpauses the contract
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -738,7 +735,7 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     //--------------------------------------------------------------------------------------
@@ -764,11 +761,6 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
 
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
         _;
     }
 }

--- a/src/MembershipNFT.sol
+++ b/src/MembershipNFT.sol
@@ -10,12 +10,12 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./interfaces/IMembershipManager.sol";
 import "./interfaces/IMembershipNFT.sol";
 import "./interfaces/ILiquidityPool.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IBlacklister.sol";
+import "./utils/RolesLibrary.sol";
 
 import "forge-std/console.sol";
 
-contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ERC1155Upgradeable, IMembershipNFT {
+contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ERC1155Upgradeable, IMembershipNFT, RolesLibrary {
 
     IMembershipManager private DEPRECATED_membershipManager;
     uint32 public nextMintTokenId;
@@ -38,7 +38,6 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
 
     ILiquidityPool public immutable liquidityPool;
     IMembershipManager public immutable membershipManager;
-    IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
 
     uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
@@ -53,10 +52,9 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     error OnlyMembershipManagerContract();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister) {
+    constructor(address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister) RolesLibrary(_roleRegistry) {
         liquidityPool = ILiquidityPool(_liquidityPool);
         membershipManager = IMembershipManager(_membershipManager);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         blacklister = IBlacklister(_blacklister);
         _disableInitializers();
     }
@@ -104,21 +102,21 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     //--------------------------------------  SETTER  --------------------------------------
     //--------------------------------------------------------------------------------------
 
-    function setMaxTokenId(uint32 _maxTokenId) external onlyOperations {
+    function setMaxTokenId(uint32 _maxTokenId) external onlyOperatingMultisig {
         maxTokenId = _maxTokenId;
     }
 
     /// @notice Set up for EAP migration; Updates the merkle root, Set the required loyalty points per tier
     /// @param _newMerkleRoot new merkle root used to verify the EAP user data (deposits, points)
     /// @param _requiredEapPointsPerEapDeposit required EAP points per deposit for each tier
-    function setUpForEap(bytes32 _newMerkleRoot, uint64[] calldata _requiredEapPointsPerEapDeposit) external onlyOperations {
+    function setUpForEap(bytes32 _newMerkleRoot, uint64[] calldata _requiredEapPointsPerEapDeposit) external onlyOperatingMultisig {
         bytes32 oldMerkleRoot = eapMerkleRoot;
         eapMerkleRoot = _newMerkleRoot;
         requiredEapPointsPerEapDeposit = _requiredEapPointsPerEapDeposit;
         emit MerkleUpdated(oldMerkleRoot, _newMerkleRoot);
     }
     
-    function setMintingPaused(bool _paused) external onlyOperations {
+    function setMintingPaused(bool _paused) external onlyOperatingMultisig {
         mintingPaused = _paused;
         emit MintingPaused(_paused);
     }
@@ -128,7 +126,7 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     //--------------------------------------------------------------------------------------
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
 
@@ -371,33 +369,28 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     }
 
     /// @dev opensea contract-level metadata
-    function setContractMetadataURI(string calldata _newURI) external onlyOperations {
+    function setContractMetadataURI(string calldata _newURI) external onlyOperatingMultisig {
         contractMetadataURI = _newURI;
     }
 
     /// @dev erc1155 metadata extension
-    function setMetadataURI(string calldata _newURI) external onlyOperations {
+    function setMetadataURI(string calldata _newURI) external onlyOperatingMultisig {
         _setURI(_newURI);
     }
 
     /// @dev alert opensea to a metadata update
-    function alertMetadataUpdate(uint256 id) public onlyOperations {
+    function alertMetadataUpdate(uint256 id) public onlyOperatingMultisig {
         emit MetadataUpdate(id);
     }
 
     /// @dev alert opensea to a metadata update
-    function alertBatchMetadataUpdate(uint256 startID, uint256 endID) public onlyOperations {
+    function alertBatchMetadataUpdate(uint256 startID, uint256 endID) public onlyOperatingMultisig {
         emit BatchMetadataUpdate(startID, endID);
     }
 
     //--------------------------------------------------------------------------------------
     //------------------------------------  MODIFIER  --------------------------------------
     //--------------------------------------------------------------------------------------
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
 
     modifier onlyMembershipManagerContract() {
         if (msg.sender != address(membershipManager)) revert OnlyMembershipManagerContract();

--- a/src/MembershipNFT.sol
+++ b/src/MembershipNFT.sol
@@ -125,9 +125,7 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
     //---------------------------------  INTERNAL FUNCTIONS  -------------------------------
     //--------------------------------------------------------------------------------------
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
 
     function _beforeTokenTransfer(

--- a/src/NodeOperatorManager.sol
+++ b/src/NodeOperatorManager.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import "../src/interfaces/INodeOperatorManager.sol";
-import "../src/interfaces/IAuctionManager.sol";
-import "../src/interfaces/IRoleRegistry.sol";
-import "../src/LiquidityPool.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
+import "./interfaces/INodeOperatorManager.sol";
+import "./interfaces/IAuctionManager.sol";
+import "./interfaces/ILiquidityPool.sol";
+import "./utils/RolesLibrary.sol";
+
 /// Contract which helps us control our node operators and their permissions in different aspects of the protocol
-contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgradeable, PausableUpgradeable, OwnableUpgradeable {
+contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgradeable, PausableUpgradeable, OwnableUpgradeable, RolesLibrary {
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
@@ -43,16 +44,14 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
 
     // Immutables are not part of proxy storage; stored in implementation bytecode only.
     address public immutable auctionManagerContractAddress;
-    IRoleRegistry public immutable roleRegistry;
 
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _roleRegistry, address _auctionManagerContractAddress) {
+    constructor(address _roleRegistry, address _auctionManagerContractAddress) RolesLibrary(_roleRegistry) {
         auctionManagerContractAddress = _auctionManagerContractAddress;
-        roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
     }
 
@@ -116,7 +115,7 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
         address[] memory _users, 
         LiquidityPool.SourceOfFunds[] memory _approvedTags, 
         bool[] memory _approvals
-    ) external onlyOperations {
+    ) external onlyOperatingMultisig {
         if ((_users.length != _approvedTags.length) || (_users.length != _approvals.length)) revert InvalidArrayLengths();
 
         for(uint256 x; x < _approvedTags.length; x++) {
@@ -127,7 +126,7 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
 
     /// @notice Adds an address to the whitelist
     /// @param _address Address of the user to add
-    function addToWhitelist(address _address) external onlyOperations {
+    function addToWhitelist(address _address) external onlyOperatingMultisig {
         whitelistedAddresses[_address] = true;
 
         emit AddedToWhitelist(_address);
@@ -135,19 +134,19 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
 
     /// @notice Removed an address from the whitelist
     /// @param _address Address of the user to remove
-    function removeFromWhitelist(address _address) external onlyOperations {
+    function removeFromWhitelist(address _address) external onlyOperatingMultisig {
         whitelistedAddresses[_address] = false;
 
         emit RemovedFromWhitelist(_address);
     }
 
     //Pauses the contract
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         _pause();
     }
 
     //Unpauses the contract
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         _unpause();
     }
 
@@ -205,7 +204,7 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
     function _authorizeUpgrade(
         address newImplementation
     ) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     //--------------------------------------------------------------------------------------
@@ -214,11 +213,6 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
 
     modifier onlyAuctionManagerContract() {
         if (msg.sender != auctionManagerContractAddress) revert IncorrectCaller();
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
         _;
     }
 }

--- a/src/NodeOperatorManager.sol
+++ b/src/NodeOperatorManager.sol
@@ -201,11 +201,7 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
     //-------------------------------  INTERNAL FUNCTIONS   --------------------------------
     //--------------------------------------------------------------------------------------
 
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -11,8 +11,8 @@ import "./interfaces/IPriorityWithdrawalQueue.sol";
 import "./interfaces/ILiquidityPool.sol";
 import "./interfaces/IeETH.sol";
 import "./interfaces/IWeETH.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./utils/PausableUntil.sol";
+import "./utils/RolesLibrary.sol";
 
 /// @title PriorityWithdrawalQueue
 /// @notice Manages priority withdrawals for whitelisted users
@@ -22,6 +22,7 @@ contract PriorityWithdrawalQueue is
     UUPSUpgradeable, 
     ReentrancyGuardUpgradeable,
     PausableUntil,
+    RolesLibrary,
     IPriorityWithdrawalQueue
 {
     using SafeERC20 for IERC20;
@@ -44,7 +45,6 @@ contract PriorityWithdrawalQueue is
     ILiquidityPool public immutable liquidityPool;
     IeETH public immutable eETH;
     IWeETH public immutable weETH;
-    IRoleRegistry public immutable roleRegistry;
     address public immutable treasury;
     uint32 public immutable minDelay;
 
@@ -99,7 +99,6 @@ contract PriorityWithdrawalQueue is
     error RequestNotFinalized();
     error RequestAlreadyFinalized();
     error NotRequestOwner();
-    error IncorrectRole();
     error ContractPaused();
     error ContractNotPaused();
     error NotMatured();
@@ -132,26 +131,6 @@ contract PriorityWithdrawalQueue is
         _;
     }
 
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
-        _;
-    }
-
-    modifier onlyRequestManager() {
-        if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-        _;
-    }
-
     modifier onlyRequestUser(address requestUser) {
         if (requestUser != msg.sender) revert NotRequestOwner();
         _;
@@ -162,15 +141,14 @@ contract PriorityWithdrawalQueue is
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _liquidityPool, address _eETH, address _weETH, address _roleRegistry, address _treasury, uint32 _minDelay) {
-        if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _roleRegistry == address(0) || _treasury == address(0)) {
+    constructor(address _liquidityPool, address _eETH, address _weETH, address _roleRegistry, address _treasury, uint32 _minDelay) RolesLibrary(_roleRegistry) {
+        if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _treasury == address(0)) {
             revert AddressZero();
         }
         
         liquidityPool = ILiquidityPool(_liquidityPool);
         eETH = IeETH(_eETH);
         weETH = IWeETH(_weETH);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         treasury = _treasury;
         minDelay = _minDelay;
 
@@ -337,7 +315,7 @@ contract PriorityWithdrawalQueue is
     /// @dev Locks ETH per request by calling LP.transferLockedEthForPriority — escrowed in this contract until claim or cancel.
     ///      Gated on escrowMigrationCompleted: receive() only bumps ethAmountLockedForPriorityWithdrawal post-migration,
     ///      so finalizing before that would leave the lock counter at zero and brick the resulting requests.
-    function fulfillRequests(WithdrawRequest[] calldata requests) external onlyRequestManager whenNotPaused {
+    function fulfillRequests(WithdrawRequest[] calldata requests) external onlyOracleOperations whenNotPaused {
         if (!liquidityPool.escrowMigrationCompleted()) revert MigrationNotComplete();
         uint256 totalAmountToLock = 0;
 
@@ -373,7 +351,7 @@ contract PriorityWithdrawalQueue is
         emit WhitelistUpdated(user, true);
     }
 
-    function removeFromWhitelist(address user) external onlyOperations {
+    function removeFromWhitelist(address user) external onlyOperatingMultisig {
         isWhitelisted[user] = false;
         emit WhitelistUpdated(user, false);
     }
@@ -392,7 +370,7 @@ contract PriorityWithdrawalQueue is
     ///      For finalized requests, this also prevents subsequent claims.
     /// @param requests Array of requests to invalidate
     /// @return invalidatedRequestIds Array of request IDs that were invalidated
-    function invalidateRequests(WithdrawRequest[] calldata requests) external onlyRequestManager returns (bytes32[] memory invalidatedRequestIds) {
+    function invalidateRequests(WithdrawRequest[] calldata requests) external onlyOracleOperations returns (bytes32[] memory invalidatedRequestIds) {
         invalidatedRequestIds = new bytes32[](requests.length);
         for (uint256 i = 0; i < requests.length; ++i) {
             bytes32 requestId = keccak256(abi.encode(requests[i]));
@@ -410,8 +388,7 @@ contract PriorityWithdrawalQueue is
     ///      - Treasury: gets a percentage of the remainder based on shareRemainderSplitToTreasuryInBps
     ///      - Burn: the rest of the remainder is burned
     /// @param eEthAmount Amount of eETH remainder to handle
-    function handleRemainder(uint256 eEthAmount) external {
-        if (!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function handleRemainder(uint256 eEthAmount) external onlyHousekeepingOperations {
         if (eEthAmount == 0) revert BadInput();
         if (eEthAmount > liquidityPool.amountForShare(totalRemainderShares)) revert BadInput();
 
@@ -442,13 +419,13 @@ contract PriorityWithdrawalQueue is
         emit ShareRemainderSplitUpdated(_shareRemainderSplitToTreasuryInBps);
     }
 
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         if (paused) revert ContractPaused();
         paused = true;
         emit Paused(msg.sender);
     }
 
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         if (!paused) revert ContractNotPaused();
         paused = false;
         emit Unpaused(msg.sender);
@@ -458,7 +435,7 @@ contract PriorityWithdrawalQueue is
         _pauseUntil();
     }
 
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -645,7 +622,7 @@ contract PriorityWithdrawalQueue is
     }
 
     function _authorizeUpgrade(address) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/PriorityWithdrawalQueue.sol
+++ b/src/PriorityWithdrawalQueue.sol
@@ -621,9 +621,7 @@ contract PriorityWithdrawalQueue is
         if (ethAmountLockedForPriorityWithdrawal > address(this).balance) revert InsufficientLiquidity();
     }
 
-    function _authorizeUpgrade(address) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //------------------------------------  GETTERS  ---------------------------------------

--- a/src/RestakingRewardsRouter.sol
+++ b/src/RestakingRewardsRouter.sol
@@ -5,14 +5,13 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import "./interfaces/IRoleRegistry.sol";
+import "./utils/RolesLibrary.sol";
 
-contract RestakingRewardsRouter is UUPSUpgradeable {
+contract RestakingRewardsRouter is UUPSUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
 
     address public immutable liquidityPool;
     address public immutable rewardTokenAddress;
-    IRoleRegistry public immutable roleRegistry;
 
     address public recipientAddress;
 
@@ -27,20 +26,17 @@ contract RestakingRewardsRouter is UUPSUpgradeable {
     error InvalidAddress();
     error NoRecipientSet();
     error TransferFailed();
-    error IncorrectRole();
 
     constructor(
         address _roleRegistry,
         address _rewardTokenAddress,
         address _liquidityPool
-    ) {
+    ) RolesLibrary(_roleRegistry) {
         _disableInitializers();
         if (
             _rewardTokenAddress == address(0) ||
-            _liquidityPool == address(0) ||
-            _roleRegistry == address(0)
+            _liquidityPool == address(0)
         ) revert InvalidAddress();
-        roleRegistry = IRoleRegistry(_roleRegistry);
         rewardTokenAddress = _rewardTokenAddress;
         liquidityPool = _liquidityPool;
     }
@@ -62,13 +58,7 @@ contract RestakingRewardsRouter is UUPSUpgradeable {
     }
 
     /// @dev Manual transfer function to recover reward tokens that may have accumulated in the contract
-    function recoverERC20() external {
-        if (
-            !roleRegistry.hasRole(
-                roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(),
-                msg.sender
-            )
-        ) revert IncorrectRole();
+    function recoverERC20() external onlyHousekeepingOperations {
         if (recipientAddress == address(0)) revert NoRecipientSet();
 
         uint256 balance = IERC20(rewardTokenAddress).balanceOf(address(this));
@@ -85,15 +75,10 @@ contract RestakingRewardsRouter is UUPSUpgradeable {
     function _authorizeUpgrade(
         address /* newImplementation */
     ) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function getImplementation() external view returns (address) {
         return _getImplementation();
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
     }
 }

--- a/src/RestakingRewardsRouter.sol
+++ b/src/RestakingRewardsRouter.sol
@@ -72,11 +72,7 @@ contract RestakingRewardsRouter is UUPSUpgradeable, RolesLibrary {
         }
     }
 
-    function _authorizeUpgrade(
-        address /* newImplementation */
-    ) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function getImplementation() external view returns (address) {
         return _getImplementation();

--- a/src/RoleRegistry.sol
+++ b/src/RoleRegistry.sol
@@ -22,7 +22,6 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     bytes32 public constant EXECUTOR_OPERATIONS_ROLE = keccak256("EXECUTOR_OPERATIONS_ROLE"); // Executor operations role
     bytes32 public constant EIGENPOD_OPERATIONS_ROLE = keccak256("EIGENPOD_OPERATIONS_ROLE"); // Eigenpod operations role
 
-    error OnlyProtocolUpgrader();
     error OnlyUpgradeTimelock();
     error OnlyOperatingTimelock();
     error OnlyOperatingMultisig();
@@ -104,10 +103,6 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
         return roleHolders(uint256(role));
     }
 
-    function onlyProtocolUpgrader(address account) public view {
-        if (owner() != account) revert OnlyProtocolUpgrader();
-    }
-
     function onlyUpgradeTimelock(address account) public view {
         if (!hasRole(UPGRADE_TIMELOCK_ROLE, account)) revert OnlyUpgradeTimelock();
     }
@@ -153,6 +148,6 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        onlyProtocolUpgrader(msg.sender);
+        onlyUpgradeTimelock(msg.sender);
     }
 }

--- a/src/RoleRegistry.sol
+++ b/src/RoleRegistry.sol
@@ -4,14 +4,23 @@ pragma solidity ^0.8.24;
 import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable, Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {EnumerableRoles} from "solady/auth/EnumerableRoles.sol";
-import {RolesLibrary} from "./utils/RolesLibrary.sol";
 
 /// @title RoleRegistry - An upgradeable role-based access control system
 /// @notice Provides functionality for managing and querying roles with enumeration capabilities
 /// @dev Implements UUPS upgradeability pattern and uses Solady's EnumerableRoles for efficient role management
 /// @author EtherFi
-contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, EnumerableRoles, RolesLibrary {
+contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, EnumerableRoles {
     address public immutable revokeAdmin;
+
+    bytes32 public constant UPGRADE_TIMELOCK_ROLE = keccak256("UPGRADE_TIMELOCK_ROLE"); // 10 day timelock
+    bytes32 public constant OPERATION_TIMELOCK_ROLE = keccak256("OPERATION_TIMELOCK_ROLE"); // 2 day timelock
+    bytes32 public constant OPERATION_MULTISIG_ROLE = keccak256("OPERATION_MULTISIG_ROLE"); // 4 of 7 multisig
+    bytes32 public constant SUPER_GUARDIAN_ROLE = keccak256("SUPER_GUARDIAN_ROLE"); // Guardian role for pausing eeth/weeth token transfers
+    bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE"); // hypernative and EOA keys for emergency pausing and blacklisting
+    bytes32 public constant ORACLE_OPERATIONS_ROLE = keccak256("ORACLE_OPERATIONS_ROLE"); // Oracle operations role
+    bytes32 public constant HOUSEKEEPING_OPERATIONS_ROLE = keccak256("HOUSEKEEPING_OPERATIONS_ROLE"); // Housekeeping operations role
+    bytes32 public constant EXECUTOR_OPERATIONS_ROLE = keccak256("EXECUTOR_OPERATIONS_ROLE"); // Executor operations role
+    bytes32 public constant EIGENPOD_OPERATIONS_ROLE = keccak256("EIGENPOD_OPERATIONS_ROLE"); // Eigenpod operations role
 
     error OnlyProtocolUpgrader();
     error OnlyUpgradeTimelock();
@@ -19,6 +28,10 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     error OnlyOperatingMultisig();
     error OnlySuperGuardian();
     error OnlyGuardian();
+    error OnlyOracleOperations();
+    error OnlyHousekeepingOperations();
+    error OnlyExecutorOperations();
+    error OnlyEigenpodOperations();
     error OnlyRevokeAdmin();
     error InvalidRoleToRevoke();
 
@@ -113,6 +126,22 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
 
     function onlyGuardian(address account) public view {
         if (!hasRole(GUARDIAN_ROLE, account)) revert OnlyGuardian();
+    }
+
+    function onlyOracleOperations(address account) public view {
+        if (!hasRole(ORACLE_OPERATIONS_ROLE, account)) revert OnlyOracleOperations();
+    }
+
+    function onlyHousekeepingOperations(address account) public view {
+        if (!hasRole(HOUSEKEEPING_OPERATIONS_ROLE, account)) revert OnlyHousekeepingOperations();
+    }
+
+    function onlyExecutorOperations(address account) public view {
+        if (!hasRole(EXECUTOR_OPERATIONS_ROLE, account)) revert OnlyExecutorOperations();
+    }
+
+    function onlyEigenpodOperations(address account) public view {
+        if (!hasRole(EIGENPOD_OPERATIONS_ROLE, account)) revert OnlyEigenpodOperations();
     }
 
     function __revertEnumerableRolesUnauthorized() private pure {

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -67,9 +67,7 @@ contract StakingManager is
         _disableInitializers();
     }
 
-    function _authorizeUpgrade(address _newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //---------------------------------------------------------------------------
     //------------------------- Deposit Flow ------------------------------------
@@ -194,8 +192,7 @@ contract StakingManager is
 
     /// @notice Upgrades the etherfi node
     /// @param _newImplementation The new address of the etherfi node
-    function upgradeEtherFiNode(address _newImplementation) external {
-        _onlyProtocolUpgrader();
+    function upgradeEtherFiNode(address _newImplementation) external onlyUpgradeTimelock {
         if (_newImplementation == address(0)) revert InvalidUpgrade();
 
         etherFiNodeBeacon.upgradeTo(_newImplementation);

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -72,13 +72,6 @@ contract StakingManager is
         roleRegistry.onlyProtocolUpgrader(msg.sender);
     }
 
-    function pauseContract() external onlyOperations {
-        _pause();
-    }
-    function unPauseContract() external onlyOperations {
-        _unpause();
-    }
-
     //---------------------------------------------------------------------------
     //------------------------- Deposit Flow ------------------------------------
     //---------------------------------------------------------------------------

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -1,14 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import "./interfaces/IRoleRegistry.sol";
-import "./interfaces/IAuctionManager.sol";
-import "./interfaces/IStakingManager.sol";
-import "./interfaces/IDepositContract.sol";
-import "./interfaces/IEtherFiNode.sol";
-import "./interfaces/IEtherFiNodesManager.sol";
-import "./libraries/DepositDataRootGenerator.sol";
-
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/beacon/IBeaconUpgradeable.sol";
@@ -17,6 +9,14 @@ import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
+import "./interfaces/IAuctionManager.sol";
+import "./interfaces/IStakingManager.sol";
+import "./interfaces/IDepositContract.sol";
+import "./interfaces/IEtherFiNode.sol";
+import "./interfaces/IEtherFiNodesManager.sol";
+import "./libraries/DepositDataRootGenerator.sol";
+import "./utils/RolesLibrary.sol";
+
 contract StakingManager is
     Initializable,
     IStakingManager,
@@ -24,7 +24,8 @@ contract StakingManager is
     OwnableUpgradeable,
     PausableUpgradeable,
     ReentrancyGuardUpgradeable,
-    UUPSUpgradeable
+    UUPSUpgradeable,
+    RolesLibrary
 {
 
     address public immutable liquidityPool;
@@ -36,7 +37,6 @@ contract StakingManager is
     IDepositContract public immutable depositContractEth2;
     IAuctionManager public immutable auctionManager;
     UpgradeableBeacon public immutable etherFiNodeBeacon;
-    IRoleRegistry public immutable roleRegistry;
 
     //---------------------------------------------------------------------------
     //-----------------------------  Storage  -----------------------------------
@@ -57,27 +57,25 @@ contract StakingManager is
         address _auctionManager,
         address _etherFiNodeBeacon,
         address _roleRegistry
-    ) {
+    ) RolesLibrary(_roleRegistry) {
         liquidityPool = _liquidityPool;
         etherFiNodesManager = IEtherFiNodesManager(_etherFiNodesManager);
         depositContractEth2 = IDepositContract(_ethDepositContract);
         auctionManager = IAuctionManager(_auctionManager);
         etherFiNodeBeacon = UpgradeableBeacon(_etherFiNodeBeacon);
-        roleRegistry = IRoleRegistry(_roleRegistry);
 
         _disableInitializers();
     }
 
     function _authorizeUpgrade(address _newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     //---------------------------------------------------------------------------
     //------------------------- Deposit Flow ------------------------------------
     //---------------------------------------------------------------------------
     
-    function invalidateRegisteredBeaconValidator(DepositData calldata depositData, uint256 bidId, address etherFiNode) external {
-        if (!roleRegistry.hasRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function invalidateRegisteredBeaconValidator(DepositData calldata depositData, uint256 bidId, address etherFiNode) external onlyOracleOperations {
         bytes32 validatorCreationDataHash = keccak256(abi.encode(depositData.publicKey, depositData.signature, depositData.depositDataRoot, depositData.ipfsHashForEncryptedValidatorKey, bidId, etherFiNode));
         if (validatorCreationStatus[validatorCreationDataHash] != ValidatorCreationStatus.REGISTERED) revert InvalidValidatorCreationStatus();
         validatorCreationStatus[validatorCreationDataHash] = ValidatorCreationStatus.INVALIDATED;
@@ -197,7 +195,7 @@ contract StakingManager is
     /// @notice Upgrades the etherfi node
     /// @param _newImplementation The new address of the etherfi node
     function upgradeEtherFiNode(address _newImplementation) external {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
         if (_newImplementation == address(0)) revert InvalidUpgrade();
 
         etherFiNodeBeacon.upgradeTo(_newImplementation);
@@ -216,9 +214,7 @@ contract StakingManager is
 
     /// @dev create a new proxy instance of the etherFiNode withdrawal safe contract.
     /// @param _createEigenPod whether or not to create an associated eigenPod contract.
-    function instantiateEtherFiNode(bool _createEigenPod) external returns (address) {
-        if (!roleRegistry.hasRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
-
+    function instantiateEtherFiNode(bool _createEigenPod) external onlyExecutorOperations returns (address) {
         BeaconProxy proxy = new BeaconProxy(address(etherFiNodeBeacon), "");
         address node = address(proxy);
 
@@ -234,7 +230,7 @@ contract StakingManager is
 
     /// @dev this method is for backfilling the addresses of etherFiNodes the protocol has previously deployed
     ///    Once this data has been backfilled we can delete this method
-    function backfillExistingEtherFiNodes(address[] calldata nodes) external onlyOperations {
+    function backfillExistingEtherFiNodes(address[] calldata nodes) external onlyOperatingMultisig {
         for (uint256 i = 0; i < nodes.length; i++) {
             address node = nodes[i];
             if (deployedEtherFiNodes[node]) continue; // already linked
@@ -243,14 +239,4 @@ contract StakingManager is
             emit EtherFiNodeDeployed(node);
         }
     }
-
-    //--------------------------------------------------------------------------------------
-    //-----------------------------------  MODIFIERS  --------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
 }

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -12,17 +12,16 @@ import "./interfaces/IRateProvider.sol";
 
 import "./AssetRecovery.sol";
 import "./utils/PausableUntil.sol";
-import "./interfaces/IRoleRegistry.sol";
+import "./utils/RolesLibrary.sol";
 import "./interfaces/IBlacklister.sol";
 import "./interfaces/IEtherFiRateLimiter.sol";
 import "./libraries/RateLimitMath.sol";
 
-contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, ERC20PermitUpgradeable, IRateProvider, AssetRecovery {
+contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, ERC20PermitUpgradeable, IRateProvider, AssetRecovery, RolesLibrary {
     using SafeERC20 for IERC20;
 
     IeETH public immutable eETH;
     ILiquidityPool public immutable liquidityPool;
-    IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
     IEtherFiRateLimiter public immutable rateLimiter;
 
@@ -58,11 +57,10 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _eETH, address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter) {
-        if(_eETH == address(0) || _liquidityPool == address(0) || _roleRegistry == address(0) || _blacklister == address(0) || _rateLimiter == address(0)) revert AddressZero();
+    constructor(address _eETH, address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter) RolesLibrary(_roleRegistry) {
+        if(_eETH == address(0) || _liquidityPool == address(0) || _blacklister == address(0) || _rateLimiter == address(0)) revert AddressZero();
         eETH = IeETH(_eETH);
         liquidityPool = ILiquidityPool(_liquidityPool);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         blacklister = IBlacklister(_blacklister);
         rateLimiter = IEtherFiRateLimiter(_rateLimiter);
         _disableInitializers();
@@ -117,12 +115,12 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return eETHAmount;
     }
 
-    function pause() external onlyOperations {
+    function pause() external onlyOperatingMultisig {
         paused = true;
         emit Paused();
     }
 
-    function unpause() external onlyOperations {
+    function unpause() external onlyOperatingMultisig {
         paused = false;
         emit Unpaused();
     }
@@ -131,7 +129,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _pauseUntil();
     }
 
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -159,7 +157,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     function _authorizeUpgrade(
         address /* newImplementation */
     ) internal view override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function _beforeTokenTransfer(
@@ -202,25 +200,5 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
 
     function getImplementation() external view returns (address) {
         return _getImplementation();
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlySuperGuardian() {
-        roleRegistry.onlySuperGuardian(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
-        _;
     }
 }

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -154,11 +154,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //-------------------------------  INTERNAL FUNCTIONS  ---------------------------------
     //--------------------------------------------------------------------------------------
 
-    function _authorizeUpgrade(
-        address /* newImplementation */
-    ) internal view override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function _beforeTokenTransfer(
         address from,

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -6,7 +6,6 @@ import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 
 import "./interfaces/IeETH.sol";
 import "./interfaces/ILiquidityPool.sol";
-import "./interfaces/IRoleRegistry.sol";
 import "./interfaces/IWithdrawRequestNFT.sol";
 import "./interfaces/IMembershipManager.sol";
 import "./interfaces/IBlacklister.sol";
@@ -14,11 +13,9 @@ import "./interfaces/IBlacklister.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/Checkpoints.sol";
-import "./RoleRegistry.sol";
 import "./utils/ReentrancyGuardNamespaced.sol";
 import "./utils/PausableUntil.sol";
-
-
+import "./utils/RolesLibrary.sol";
 
 /// @title WithdrawRequestNFT — share-rate-freeze invariants
 /// @notice
@@ -41,7 +38,7 @@ import "./utils/PausableUntil.sol";
 ///      `shareOfEEth * rate / 1e18 >= LP.amountForShare(shareOfEEth)` and
 ///      `ceil(amount * 1e18 / rate) <= shareOfEEth`. These keep solvency checks and
 ///      the share burn within the request's own share allocation.
-contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardNamespaced, PausableUntil, IWithdrawRequestNFT {
+contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardNamespaced, PausableUntil, RolesLibrary, IWithdrawRequestNFT {
     using Math for uint256;
     using SafeERC20 for IERC20;
     using Checkpoints for Checkpoints.Trace224;
@@ -71,7 +68,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     uint256 public totalRemainderEEthShares;
 
     bool public paused;
-    RoleRegistry private DEPRECATED_roleRegistry;
+    address private DEPRECATED_roleRegistry;
 
     uint128 public ethAmountLockedForWithdrawal;
 
@@ -84,7 +81,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     ILiquidityPool public immutable liquidityPool;
     IeETH public immutable eETH;
     IMembershipManager public immutable membershipManager;
-    IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
 
     uint256 public immutable minAcceptableShareRate;
@@ -101,7 +97,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     event Paused();
     event Unpaused();
 
-    error IncorrectRole();
     error IncorrectCaller();
     error AddressZero();
     error AlreadyPaused();
@@ -133,14 +128,13 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     error InvalidEEthShares();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _treasury, address _eETH, address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister,  address _etherFiAdmin, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) {
+    constructor(address _treasury, address _eETH, address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister,  address _etherFiAdmin, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) RolesLibrary(_roleRegistry) {
         if (_minAcceptableShareRate == 0) revert InvalidMinAcceptableShareRate();
         if (_maxAcceptableShareRate <= _minAcceptableShareRate) revert InvalidMinMaxAcceptableShareRate();
         treasury = _treasury;
         eETH = IeETH(_eETH);
         liquidityPool = ILiquidityPool(_liquidityPool);
         membershipManager = IMembershipManager(_membershipManager);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         blacklister = IBlacklister(_blacklister);
         etherFiAdmin = _etherFiAdmin;
         minAcceptableShareRate = _minAcceptableShareRate;
@@ -307,7 +301,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     function finalizeRequests(uint256 requestId) external {
-        if (msg.sender != address(etherFiAdmin)) revert IncorrectRole();
+        if (msg.sender != address(etherFiAdmin)) revert IncorrectCaller();
         if (requestId < lastFinalizedRequestId) revert CannotUndoFinalization();
         if (requestId >= nextRequestId) revert CannotFinalizeFutureRequests();
 
@@ -349,13 +343,13 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         shareRemainderSplitToTreasuryInBps = _shareRemainderSplitToTreasuryInBps;
     }
 
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         if (paused) revert AlreadyPaused();
         paused = true;
         emit Paused();
     }
 
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         if (!paused) revert NotPaused();
 
 
@@ -367,7 +361,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         _pauseUntil();
     }
 
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -381,8 +375,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     ///  - Treasury: treasury gets a split of the remainder
     ///   - Burn: the rest of the remainder is burned
     /// @param _eEthAmount: the remainder of the eEth amount
-    function handleRemainder(uint256 _eEthAmount) external {
-        if(!roleRegistry.hasRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), msg.sender)) revert IncorrectRole();
+    function handleRemainder(uint256 _eEthAmount) external onlyHousekeepingOperations {
         if (_eEthAmount == 0) revert EETHAmountCannotBeZero(); 
         if (getEEthRemainderAmount() < _eEthAmount) revert NotEnoughEEthRemainder();
 
@@ -436,7 +429,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function getImplementation() external view returns (address) {
@@ -449,26 +442,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     modifier onlyLiquidityPool() {
         if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
-        _;
-    }
-
-    modifier onlyUpgradeTimelock() {
-        roleRegistry.onlyUpgradeTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
         _;
     }
 

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -61,7 +61,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     uint32 public nextRequestId;
     uint32 public lastFinalizedRequestId;
     uint16 public shareRemainderSplitToTreasuryInBps;
-    uint16 public _unused_gap;
+    uint16 private _unused_gap;
 
     // inclusive
     uint32 private DEPRECATED_currentRequestIdToScanFromForShareRemainder;

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -157,7 +157,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     ///      path resolves locally to the live rate via `LP.amountPerShareCeil()` — preserving
     ///      legacy behavior for requests finalized before this upgrade. New finalizations push
     ///      real rate snapshots, so post-upgrade tokenIds always resolve to a non-zero rate.
-    function initializeShareRateFreezeUpgrade() external onlyOwner {
+    function initializeShareRateFreezeUpgrade() external onlyUpgradeTimelock {
         if (_finalizationRates.length() != 0) revert AlreadyInitialized();
         _finalizationRates.push(uint32(lastFinalizedRequestId), 0);
     }
@@ -428,9 +428,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         if (address(this).balance < ethAmountLockedForWithdrawal) revert InsufficientEscrow();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function getImplementation() external view returns (address) {
         return _getImplementation();

--- a/src/helpers/Blacklister.sol
+++ b/src/helpers/Blacklister.sol
@@ -9,6 +9,8 @@ import "../interfaces/IRoleRegistry.sol";
 contract Blacklister is Initializable, UUPSUpgradeable {
     IRoleRegistry public immutable roleRegistry;
 
+    uint256 public constant BLACKLIST_DURATION = 3 days;
+
     mapping(address => uint256) public blacklistedUntil;
 
     error BlacklistedUser(address user);
@@ -33,8 +35,8 @@ contract Blacklister is Initializable, UUPSUpgradeable {
 
     function blacklistUserUntil(address user) external onlyGuardian {
         if (blacklistedUntil[user] > block.timestamp) revert UserAlreadyBlacklisted(user);
-        blacklistedUntil[user] = block.timestamp + 1 days;
-        emit UserBlacklistedUntil(user, block.timestamp + 1 days);
+        blacklistedUntil[user] = block.timestamp + BLACKLIST_DURATION;
+        emit UserBlacklistedUntil(user, block.timestamp + BLACKLIST_DURATION);
     }
 
     function setBlacklistUntil(address user, uint256 until) external onlyOperations {

--- a/src/helpers/Blacklister.sol
+++ b/src/helpers/Blacklister.sol
@@ -4,10 +4,9 @@ pragma solidity ^0.8.27;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
-import "../interfaces/IRoleRegistry.sol";
+import "../utils/RolesLibrary.sol";
 
-contract Blacklister is Initializable, UUPSUpgradeable {
-    IRoleRegistry public immutable roleRegistry;
+contract Blacklister is Initializable, UUPSUpgradeable, RolesLibrary {
 
     uint256 public constant BLACKLIST_DURATION = 3 days;
 
@@ -20,8 +19,7 @@ contract Blacklister is Initializable, UUPSUpgradeable {
     event UserUnblacklisted(address user);
     event UserBlacklistedUntil(address user, uint256 until);
 
-    constructor(address _roleRegistry) {
-        roleRegistry = IRoleRegistry(_roleRegistry);
+    constructor(address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
     }
 
@@ -30,7 +28,7 @@ contract Blacklister is Initializable, UUPSUpgradeable {
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     function blacklistUserUntil(address user) external onlyGuardian {
@@ -39,17 +37,17 @@ contract Blacklister is Initializable, UUPSUpgradeable {
         emit UserBlacklistedUntil(user, block.timestamp + BLACKLIST_DURATION);
     }
 
-    function setBlacklistUntil(address user, uint256 until) external onlyOperations {
+    function setBlacklistUntil(address user, uint256 until) external onlyOperatingMultisig {
         blacklistedUntil[user] = block.timestamp + until;
         emit UserBlacklistedUntil(user, block.timestamp + until);
     }
 
-    function blacklistUser(address user) external onlyOperations {
+    function blacklistUser(address user) external onlyOperatingMultisig {
         blacklistedUntil[user] = type(uint256).max;
         emit UserBlacklisted(user);
     }
 
-    function unblacklistUser(address user) external onlyOperations {
+    function unblacklistUser(address user) external onlyOperatingMultisig {
         blacklistedUntil[user] = 0;
         emit UserUnblacklisted(user);
     }
@@ -60,15 +58,5 @@ contract Blacklister is Initializable, UUPSUpgradeable {
 
     function getImplementation() external view returns (address) { 
         return _getImplementation(); 
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
-        _;
     }
 }

--- a/src/helpers/Blacklister.sol
+++ b/src/helpers/Blacklister.sol
@@ -27,9 +27,7 @@ contract Blacklister is Initializable, UUPSUpgradeable, RolesLibrary {
         __UUPSUpgradeable_init();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function blacklistUserUntil(address user) external onlyGuardian {
         if (blacklistedUntil[user] > block.timestamp) revert UserAlreadyBlacklisted(user);

--- a/src/helpers/RevokeAdmin.sol
+++ b/src/helpers/RevokeAdmin.sol
@@ -4,13 +4,11 @@ pragma solidity ^0.8.27;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
-import "../interfaces/IRoleRegistry.sol";
+import "../utils/RolesLibrary.sol";
 
-contract RevokeAdmin is Initializable, UUPSUpgradeable {
-    IRoleRegistry public immutable roleRegistry;
+contract RevokeAdmin is Initializable, UUPSUpgradeable, RolesLibrary {
 
-    constructor(address _roleRegistry) {
-        roleRegistry = IRoleRegistry(_roleRegistry);
+    constructor(address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
     }
 
@@ -19,31 +17,30 @@ contract RevokeAdmin is Initializable, UUPSUpgradeable {
     }
 
     function _authorizeUpgrade(address newImplementation) internal override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
-    function revokeGuardianRole(address account) external onlyOperations {
-        roleRegistry.revokeFast(roleRegistry.GUARDIAN_ROLE(), account);
+    function revokeGuardianRole(address account) external onlyOperatingMultisig {
+        _revokeFast(roleRegistry.GUARDIAN_ROLE(), account);
     }
 
-    function revokeOracleOperationsRole(address account) external onlyOperations {
-        roleRegistry.revokeFast(roleRegistry.ORACLE_OPERATIONS_ROLE(), account);
+    function revokeOracleOperationsRole(address account) external onlyOperatingMultisig {
+        _revokeFast(roleRegistry.ORACLE_OPERATIONS_ROLE(), account);
     }
 
-    function revokeHousekeepingOperationsRole(address account) external onlyOperations {
-        roleRegistry.revokeFast(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), account);
+    function revokeHousekeepingOperationsRole(address account) external onlyOperatingMultisig {
+        _revokeFast(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), account);
     }
 
-    function revokeExecutorOperationsRole(address account) external onlyOperations {
-        roleRegistry.revokeFast(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), account);
+    function revokeExecutorOperationsRole(address account) external onlyOperatingMultisig {
+        _revokeFast(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), account);
     }
 
-    function revokeEigenpodOperationsRole(address account) external onlyOperations {
-        roleRegistry.revokeFast(roleRegistry.EIGENPOD_OPERATIONS_ROLE(), account);
+    function revokeEigenpodOperationsRole(address account) external onlyOperatingMultisig {
+        _revokeFast(roleRegistry.EIGENPOD_OPERATIONS_ROLE(), account);
     }
 
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
+    function _revokeFast(bytes32 role, address account) internal {
+        roleRegistry.revokeFast(role, account);
     }
 }

--- a/src/helpers/RevokeAdmin.sol
+++ b/src/helpers/RevokeAdmin.sol
@@ -16,9 +16,7 @@ contract RevokeAdmin is Initializable, UUPSUpgradeable, RolesLibrary {
         __UUPSUpgradeable_init();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     function revokeGuardianRole(address account) external onlyOperatingMultisig {
         _revokeFast(roleRegistry.GUARDIAN_ROLE(), account);

--- a/src/helpers/RevokeAdmin.sol
+++ b/src/helpers/RevokeAdmin.sol
@@ -26,19 +26,19 @@ contract RevokeAdmin is Initializable, UUPSUpgradeable {
         roleRegistry.revokeFast(roleRegistry.GUARDIAN_ROLE(), account);
     }
 
-    function revokeEOA1Role(address account) external onlyOperations {
+    function revokeOracleOperationsRole(address account) external onlyOperations {
         roleRegistry.revokeFast(roleRegistry.ORACLE_OPERATIONS_ROLE(), account);
     }
 
-    function revokeEOA2Role(address account) external onlyOperations {
+    function revokeHousekeepingOperationsRole(address account) external onlyOperations {
         roleRegistry.revokeFast(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), account);
     }
 
-    function revokeEOA3Role(address account) external onlyOperations {
+    function revokeExecutorOperationsRole(address account) external onlyOperations {
         roleRegistry.revokeFast(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), account);
     }
 
-    function revokeEOA4Role(address account) external onlyOperations {
+    function revokeEigenpodOperationsRole(address account) external onlyOperations {
         roleRegistry.revokeFast(roleRegistry.EIGENPOD_OPERATIONS_ROLE(), account);
     }
 

--- a/src/helpers/WeETHWithdrawAdapter.sol
+++ b/src/helpers/WeETHWithdrawAdapter.sol
@@ -12,9 +12,9 @@ import {IWeETH} from "../interfaces/IWeETH.sol";
 import {IeETH} from "../interfaces/IeETH.sol";
 import {ILiquidityPool} from "../interfaces/ILiquidityPool.sol";
 import {IWithdrawRequestNFT} from "../interfaces/IWithdrawRequestNFT.sol";
-import {IRoleRegistry} from "../interfaces/IRoleRegistry.sol";
 import {IBlacklister} from "../interfaces/IBlacklister.sol";
 import {PausableUntil} from "../utils/PausableUntil.sol";
+import {RolesLibrary} from "../utils/RolesLibrary.sol";
 
 /**
  * @title WeETHWithdrawAdapter
@@ -26,6 +26,7 @@ contract WeETHWithdrawAdapter is
     UUPSUpgradeable, 
     OwnableUpgradeable, 
     PausableUntil,
+    RolesLibrary,
     IWeETHWithdrawAdapter 
 {
     using SafeERC20 for IERC20;
@@ -38,7 +39,6 @@ contract WeETHWithdrawAdapter is
     IeETH public immutable eETH;
     ILiquidityPool public immutable liquidityPool;
     IWithdrawRequestNFT public immutable withdrawRequestNFT;
-    IRoleRegistry public immutable roleRegistry;
     IBlacklister public immutable blacklister;
 
     bool public paused;
@@ -71,12 +71,11 @@ contract WeETHWithdrawAdapter is
         address _withdrawRequestNFT,
         address _roleRegistry,
         address _blacklister
-    ) {
+    ) RolesLibrary(_roleRegistry) {
         if (_weETH == address(0) ||
             _eETH == address(0) ||
             _liquidityPool == address(0) ||
             _withdrawRequestNFT == address(0) ||
-            _roleRegistry == address(0) ||
             _blacklister == address(0)) {
             revert ZeroAddress();
         }
@@ -85,7 +84,6 @@ contract WeETHWithdrawAdapter is
         eETH = IeETH(_eETH);
         liquidityPool = ILiquidityPool(_liquidityPool);
         withdrawRequestNFT = IWithdrawRequestNFT(_withdrawRequestNFT);
-        roleRegistry = IRoleRegistry(_roleRegistry);
         blacklister = IBlacklister(_blacklister);
 
         _disableInitializers();
@@ -169,7 +167,7 @@ contract WeETHWithdrawAdapter is
     /**
      * @notice Pause the contract
      */
-    function pauseContract() external onlyOperations {
+    function pauseContract() external onlyOperatingMultisig {
         if (paused) revert("Pausable: already paused");
 
         paused = true;
@@ -179,7 +177,7 @@ contract WeETHWithdrawAdapter is
     /**
      * @notice Unpause the contract
      */
-    function unPauseContract() external onlyOperations {
+    function unPauseContract() external onlyOperatingMultisig {
         if (!paused) revert("Pausable: not paused");
 
         paused = false;
@@ -196,7 +194,7 @@ contract WeETHWithdrawAdapter is
     /**
      * @notice Unpause the contract from pauseUntil
      */
-    function unpauseContractUntil() external onlyOperations {
+    function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
@@ -237,7 +235,7 @@ contract WeETHWithdrawAdapter is
      * @notice Authorize contract upgrades
      */
     function _authorizeUpgrade(address /* newImplementation */) internal view override {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
+        _onlyProtocolUpgrader();
     }
 
     /**
@@ -259,21 +257,6 @@ contract WeETHWithdrawAdapter is
 
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
-        _;
-    }
-
-    modifier onlyAdmin() {
-        roleRegistry.onlyOperatingTimelock(msg.sender);
-        _;
-    }
-
-    modifier onlyOperations() {
-        roleRegistry.onlyOperatingMultisig(msg.sender);
-        _;
-    }
-
-    modifier onlyGuardian() {
-        roleRegistry.onlyGuardian(msg.sender);
         _;
     }
 }

--- a/src/helpers/WeETHWithdrawAdapter.sol
+++ b/src/helpers/WeETHWithdrawAdapter.sol
@@ -234,9 +234,7 @@ contract WeETHWithdrawAdapter is
     /**
      * @notice Authorize contract upgrades
      */
-    function _authorizeUpgrade(address /* newImplementation */) internal view override {
-        _onlyProtocolUpgrader();
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     /**
      * @notice Check if contract is not paused

--- a/src/interfaces/IAuctionManager.sol
+++ b/src/interfaces/IAuctionManager.sol
@@ -30,8 +30,6 @@ interface IAuctionManager {
 
     function updateSelectedBidInformation(uint256 _bidId) external;
 
-    function setAccumulatedRevenueThreshold(uint128 _newThreshold) external;
-
     function pauseContract() external;
     function unPauseContract() external;
     

--- a/src/interfaces/IAuctionManager.sol
+++ b/src/interfaces/IAuctionManager.sol
@@ -30,8 +30,6 @@ interface IAuctionManager {
 
     function updateSelectedBidInformation(uint256 _bidId) external;
 
-    function processAuctionFeeTransfer(uint256 _validatorId) external;
-
     function setAccumulatedRevenueThreshold(uint128 _newThreshold) external;
 
     function pauseContract() external;

--- a/src/interfaces/ICumulativeMerkleRewardsDistributor.sol
+++ b/src/interfaces/ICumulativeMerkleRewardsDistributor.sol
@@ -13,7 +13,6 @@ interface ICumulativeMerkleRewardsDistributor {
     event Paused(address account);
     event UnPaused(address account);
 
-    error IncorrectRole();
     error InsufficentDelay();
     error InvalidFinalizedBlock();
     error InvalidProof();

--- a/src/interfaces/IEtherFiNode.sol
+++ b/src/interfaces/IEtherFiNode.sol
@@ -90,7 +90,6 @@ interface IEtherFiNode {
     //--------------------------------------------------------------------------
 
     error TransferFailed();
-    error IncorrectRole();
     error ForwardedCallNotAllowed();
     error InvalidForwardedCall();
     error InvalidCaller();

--- a/src/interfaces/IEtherFiNodesManager.sol
+++ b/src/interfaces/IEtherFiNodesManager.sol
@@ -141,7 +141,6 @@ interface IEtherFiNodesManager {
     error InvalidPubKeyLength();
     error LengthMismatch();
     error InvalidCaller();
-    error IncorrectRole();
     error ForwardedCallNotAllowed();
     error InvalidForwardedCall();
     error EmptyWithdrawalsRequest();

--- a/src/interfaces/IEtherFiRateLimiter.sol
+++ b/src/interfaces/IEtherFiRateLimiter.sol
@@ -38,7 +38,6 @@ interface IEtherFiRateLimiter {
     //--------------------------------------------------------------------------
     //-----------------------------  Errors  -----------------------------------
     //--------------------------------------------------------------------------
-    error IncorrectRole();
     error InvalidConsumer();
     error LimitAlreadyExists();
     error LimitExceeded();

--- a/src/interfaces/IEtherFiRestaker.sol
+++ b/src/interfaces/IEtherFiRestaker.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "./ILiquifier.sol";
+
+interface IEtherFiRestaker {
+    function stEthRequestWithdrawal(uint256 _amount) external returns (uint256[] memory);
+    function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external;
+    function depositIntoStrategy(address token, uint256 amount) external returns (uint256);
+    function queueWithdrawals(address token, uint256 amount) external returns (bytes32[] memory);
+    function undelegate() external returns (bytes32[] memory);
+    function transferStETH(address recipient, uint256 amount) external;
+    function lido() external view returns (ILido);
+    function pauseContract() external;
+    function unPauseContract() external;
+}

--- a/src/interfaces/ILiquifier.sol
+++ b/src/interfaces/ILiquifier.sol
@@ -46,6 +46,36 @@ interface ILido is IERC20 {
     function DOMAIN_SEPARATOR() external view returns (bytes32);
 }
 
+/// @title Router token swapping functionality
+/// @notice Functions for swapping tokens via PancakeSwap V3
+interface IPancackeV3SwapRouter {
+    function WETH9() external returns (address);
+
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another token
+    /// @dev Setting `amountIn` to 0 will cause the contract to look up its own balance,
+    /// and swap the entire amount, enabling contracts to send tokens before calling this function.
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputSingleParams` in calldata
+    /// @return amountOut The amount of the received token
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+    function unwrapWETH9(uint256 amountMinimum, address recipient) external payable;
+}
+
+interface IERC20Burnable is IERC20 {
+    function burn(uint256 amount) external;
+}
+
 // mainnet: 0x858646372CC42E1A627fcE94aa7A7033e7CF075A
 interface IEigenLayerStrategyManager is IStrategyManager {
     function withdrawalRootPending(bytes32 _withdrawalRoot) external view returns (bool);

--- a/src/interfaces/ILiquifier.sol
+++ b/src/interfaces/ILiquifier.sol
@@ -164,6 +164,4 @@ interface ILiquifier {
     function pauseContractUntil() external;
     function unpauseContractUntil() external;
     function setPauseUntilDuration(uint256 _pauseUntilDuration) external;
-
-    function roleRegistry() external view returns (IRoleRegistry);
 }

--- a/src/interfaces/IRoleRegistry.sol
+++ b/src/interfaces/IRoleRegistry.sol
@@ -117,6 +117,34 @@ interface IRoleRegistry {
     function onlyGuardian(address account) external view;
 
     /**
+     * @notice Checks if an account is the oracle operations
+     * @dev Reverts if the account is not the oracle operations
+     * @param account The address to check
+     */
+    function onlyOracleOperations(address account) external view;
+
+    /**
+     * @notice Checks if an account is the housekeeping operations
+     * @dev Reverts if the account is not the housekeeping operations
+     * @param account The address to check
+     */
+    function onlyHousekeepingOperations(address account) external view;
+
+    /**
+     * @notice Checks if an account is the executor operations
+     * @dev Reverts if the account is not the executor operations
+     * @param account The address to check
+     */
+    function onlyExecutorOperations(address account) external view;
+
+    /**
+     * @notice Checks if an account is the eigenpod operations
+     * @dev Reverts if the account is not the eigenpod operations
+     * @param account The address to check
+     */
+    function onlyEigenpodOperations(address account) external view;
+
+    /**
      * @notice Returns the current owner of the contract
      * @return The address of the current owner
      */

--- a/src/interfaces/IRoleRegistry.sol
+++ b/src/interfaces/IRoleRegistry.sol
@@ -14,6 +14,11 @@ interface IRoleRegistry {
     error OnlyProtocolUpgrader();
 
     /**
+     * @dev Error thrown when a function is called by an account without the upgrade timelock role
+     */
+    error OnlyUpgradeTimelock();
+
+    /**
      * @notice Returns the maximum allowed role value
      * @dev This is used by EnumerableRoles._validateRole to ensure roles are within valid range
      * @return The maximum role value

--- a/src/interfaces/IStakingManager.sol
+++ b/src/interfaces/IStakingManager.sol
@@ -101,7 +101,6 @@ interface IStakingManager {
     error InactiveBid();
     error InvalidEtherFiNode();
     error InvalidValidatorSize();
-    error IncorrectRole();
     error InvalidUpgrade();
     error InvalidValidatorCreationStatus();
 

--- a/src/interfaces/IStakingManager.sol
+++ b/src/interfaces/IStakingManager.sol
@@ -37,10 +37,6 @@ interface IStakingManager {
     function getEtherFiNodeBeacon() external view returns (address);
     function deployedEtherFiNodes(address etherFiNode) external view returns (bool);
 
-    // protocol
-    function pauseContract() external;
-    function unPauseContract() external;
-
     // prevent storage shift on upgrade
     struct LegacyStakingManagerState {
         uint256[14] legacyState;

--- a/src/utils/RolesLibrary.sol
+++ b/src/utils/RolesLibrary.sol
@@ -54,8 +54,4 @@ abstract contract RolesLibrary {
         roleRegistry.onlyEigenpodOperations(msg.sender);
         _;
     }
-
-    function _onlyProtocolUpgrader() internal view {
-        roleRegistry.onlyProtocolUpgrader(msg.sender);
-    }
 }

--- a/src/utils/RolesLibrary.sol
+++ b/src/utils/RolesLibrary.sol
@@ -1,14 +1,61 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
+import "../interfaces/IRoleRegistry.sol";
+
 abstract contract RolesLibrary {
-    bytes32 public constant UPGRADE_TIMELOCK_ROLE = keccak256("UPGRADE_TIMELOCK_ROLE"); // 10 day timelock
-    bytes32 public constant OPERATION_TIMELOCK_ROLE = keccak256("OPERATION_TIMELOCK_ROLE"); // 2 day timelock
-    bytes32 public constant OPERATION_MULTISIG_ROLE = keccak256("OPERATION_MULTISIG_ROLE"); // 4 of 7 multisig
-    bytes32 public constant SUPER_GUARDIAN_ROLE = keccak256("SUPER_GUARDIAN_ROLE"); // Guardian role for pausing eeth/weeth token transfers
-    bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE"); // hypernative and EOA keys for emergency pausing and blacklisting
-    bytes32 public constant ORACLE_OPERATIONS_ROLE = keccak256("ORACLE_OPERATIONS_ROLE"); // Oracle operations role
-    bytes32 public constant HOUSEKEEPING_OPERATIONS_ROLE = keccak256("HOUSEKEEPING_OPERATIONS_ROLE"); // Housekeeping operations role
-    bytes32 public constant EXECUTOR_OPERATIONS_ROLE = keccak256("EXECUTOR_OPERATIONS_ROLE"); // Executor operations role
-    bytes32 public constant EIGENPOD_OPERATIONS_ROLE = keccak256("EIGENPOD_OPERATIONS_ROLE"); // Eigenpod operations role
+    IRoleRegistry public immutable roleRegistry;
+
+    constructor(address _roleRegistry) {
+        roleRegistry = IRoleRegistry(_roleRegistry);
+    }
+
+    modifier onlyUpgradeTimelock() {
+        roleRegistry.onlyUpgradeTimelock(msg.sender);
+        _;
+    }
+
+    modifier onlyAdmin() {
+        roleRegistry.onlyOperatingTimelock(msg.sender);
+        _;
+    }
+
+    modifier onlyOperatingMultisig() {
+        roleRegistry.onlyOperatingMultisig(msg.sender);
+        _;
+    }
+
+    modifier onlySuperGuardian() {
+        roleRegistry.onlySuperGuardian(msg.sender);
+        _;
+    }
+
+    modifier onlyGuardian() {
+        roleRegistry.onlyGuardian(msg.sender);
+        _;
+    }
+
+    modifier onlyOracleOperations() {
+        roleRegistry.onlyOracleOperations(msg.sender);
+        _;
+    }
+
+    modifier onlyHousekeepingOperations() {
+        roleRegistry.onlyHousekeepingOperations(msg.sender);
+        _;
+    }
+
+    modifier onlyExecutorOperations() {
+        roleRegistry.onlyExecutorOperations(msg.sender);
+        _;
+    }
+
+    modifier onlyEigenpodOperations() {
+        roleRegistry.onlyEigenpodOperations(msg.sender);
+        _;
+    }
+
+    function _onlyProtocolUpgrader() internal view {
+        roleRegistry.onlyProtocolUpgrader(msg.sender);
+    }
 }

--- a/test/AddressProvider.t.sol
+++ b/test/AddressProvider.t.sol
@@ -9,8 +9,9 @@ contract AuctionManagerV2Test is AuctionManager {
         address _blacklister,
         address _nodeOperatorManagerContract,
         address _stakingManagerContractAddress,
-        address _membershipManagerContractAddress
-    ) AuctionManager(_roleRegistry, _blacklister, _nodeOperatorManagerContract, _stakingManagerContractAddress, _membershipManagerContractAddress) {}
+        address _membershipManagerContractAddress,
+        address _treasury
+    ) AuctionManager(_roleRegistry, _blacklister, _nodeOperatorManagerContract, _stakingManagerContractAddress, _membershipManagerContractAddress, _treasury) {}
     function isUpgraded() public pure returns(bool){
         return true;
     }
@@ -142,7 +143,8 @@ contract AddressProviderTest is TestSetup {
             address(blacklisterInstance),
             address(nodeOperatorManagerInstance),
             address(stakingManagerInstance),
-            address(membershipManagerInstance)
+            address(membershipManagerInstance),
+            address(treasuryInstance)
         );
         auctionInstance.upgradeTo(address(auctionManagerV2Implementation));
 

--- a/test/AuctionManager.t.sol
+++ b/test/AuctionManager.t.sol
@@ -840,21 +840,6 @@ contract AuctionManagerTest is TestSetup {
         auctionInstance.cancelBid(bidIds[0]);      
     }
 
-    function test_SetAccumulatedRevenueThreshold() public {
-        vm.prank(bob);
-        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
-        auctionInstance.setAccumulatedRevenueThreshold(0.005 ether);
-
-        // TODO: consider if 0 is an invalid threshold amount
-        // vm.prank(alice);
-        // vm.expectRevert("Invalid Amount");
-        // auctionInstance.updateAccumulatedRevenueThreshold(0);
-
-        vm.prank(alice);
-        auctionInstance.setAccumulatedRevenueThreshold(2 ether);
-        assertEq(auctionInstance.accumulatedRevenueThreshold(), 2 ether);
-    }
-
     /*
     function test_AccumulateAuctionRevenue() public {
         vm.startPrank(0xCd5EBC2dD4Cb3dc52ac66CEEcc72c838B40A5931);

--- a/test/Blacklist.t.sol
+++ b/test/Blacklist.t.sol
@@ -332,30 +332,30 @@ contract BlacklistTest is TestSetup {
         roleRegistryInstance.grantRole(role, who);
     }
 
-    function test_blacklistUserUntil_default_sets_one_day_window() public {
+    function test_blacklistUserUntil_default_sets_three_days_window() public {
         _grantBlacklistUntilRoleTo(owner);
 
         uint256 t0 = block.timestamp;
         vm.prank(owner);
         blacklisterInstance.blacklistUserUntil(tempBlacklisted);
 
-        assertEq(blacklisterInstance.blacklistedUntil(tempBlacklisted), t0 + 1 days);
+        assertEq(blacklisterInstance.blacklistedUntil(tempBlacklisted), t0 + 3 days);
 
         // Inside the window: gate closed.
         _expectBlacklistedRevert(tempBlacklisted);
         blacklisterInstance.nonBlacklisted(tempBlacklisted);
 
         // One second before expiry: still closed.
-        vm.warp(t0 + 1 days - 1);
+        vm.warp(t0 + 3 days - 1);
         _expectBlacklistedRevert(tempBlacklisted);
         blacklisterInstance.nonBlacklisted(tempBlacklisted);
 
         // At expiry (strict `>` check): gate opens.
-        vm.warp(t0 + 1 days);
+        vm.warp(t0 + 3 days);
         blacklisterInstance.nonBlacklisted(tempBlacklisted);
 
         // After expiry: still open.
-        vm.warp(t0 + 1 days + 1);
+        vm.warp(t0 + 3 days + 1);
         blacklisterInstance.nonBlacklisted(tempBlacklisted);
     }
 
@@ -371,7 +371,7 @@ contract BlacklistTest is TestSetup {
         _grantBlacklistUntilRoleTo(owner);
 
         vm.expectEmit(false, false, false, true, address(blacklisterInstance));
-        emit Blacklister.UserBlacklistedUntil(tempBlacklisted, block.timestamp + 1 days);
+        emit Blacklister.UserBlacklistedUntil(tempBlacklisted, block.timestamp + 3 days);
 
         vm.prank(owner);
         blacklisterInstance.blacklistUserUntil(tempBlacklisted);

--- a/test/BucketRaterLimiter.t.sol
+++ b/test/BucketRaterLimiter.t.sol
@@ -30,6 +30,8 @@ contract BucketRateLimiterTest is Test {
 
         roleRegistry.grantRole(roleRegistry.OPERATION_TIMELOCK_ROLE(), owner);
         roleRegistry.grantRole(roleRegistry.OPERATION_MULTISIG_ROLE(), owner);
+        // `_authorizeUpgrade` now defers to `onlyUpgradeTimelock`.
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), owner);
 
         limiter.updateConsumer(owner);
         limiter.setCapacity(200 ether);
@@ -1167,7 +1169,7 @@ contract BucketRateLimiterTest is Test {
         BucketRateLimiter newImpl = new BucketRateLimiter(address(roleRegistry));
 
         vm.prank(nonOwner);
-        vm.expectRevert(RoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
         limiter.upgradeTo(address(newImpl));
     }
 

--- a/test/ContractCodeChecker.t.sol
+++ b/test/ContractCodeChecker.t.sol
@@ -21,7 +21,7 @@ contract ContractCodeCheckerTest is TestSetup {
         EtherFiNodesManager etherFiNodesManagerImplementation = new EtherFiNodesManager(address(0x0), address(0x0), address(0x0));
         address etherFiNodesManagerImplAddress = address(0xE9EE6923D41Cf5F964F11065436BD90D4577B5e4);
 
-        EtherFiNode etherFiNodeImplementation = new EtherFiNode(address(0x0), address(0x0), address(0x0), address(0x0), address(0x0));
+        EtherFiNode etherFiNodeImplementation = new EtherFiNode(address(0x0), address(0x0), address(0x0), address(0x0));
         address etherFiNodeImplAddress = address(0xc5F2764383f93259Fba1D820b894B1DE0d47937e);
 
         EtherFiRestaker etherFiRestakerImplementation = new EtherFiRestaker(address(liquidityPoolInstance), address(liquifierInstance), address(eigenLayerRewardsCoordinator), address(0x0), address(0x0), address(0x0), address(eigenLayerStrategyManager), address(eigenLayerDelegationManager));

--- a/test/CumulativeMerkleRewardsDistributor.t.sol
+++ b/test/CumulativeMerkleRewardsDistributor.t.sol
@@ -166,7 +166,7 @@ contract  CumulativeMerkleRewardsDistributorTest is TestSetup {
    }
    function test_upgrading() public {
     vm.prank(chad);
-    vm.expectRevert(RoleRegistry.OnlyProtocolUpgrader.selector);
+    vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
     cumulativeMerkleRewardsDistributorInstance.upgradeTo(address(0x555));
     CumulativeMerkleRewardsDistributor newImpl = new CumulativeMerkleRewardsDistributor(address(roleRegistryInstance)); 
     vm.prank(roleRegistryInstance.owner());

--- a/test/CumulativeMerkleRewardsDistributor.t.sol
+++ b/test/CumulativeMerkleRewardsDistributor.t.sol
@@ -108,7 +108,7 @@ contract  CumulativeMerkleRewardsDistributorTest is TestSetup {
    }
 
    function test_whitelisting() public {
-    vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
+    vm.expectRevert(RoleRegistry.OnlyOperatingTimelock.selector);
     cumulativeMerkleRewardsDistributorInstance.updateWhitelistedRecipient(accounts[0], false);
    }
 

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -339,18 +339,18 @@ contract EtherFiNodesManagerTest is TestSetup {
     
     function test_setProofSubmitter_byAddress() public {
         address newSubmitter = address(0x123);
-        vm.prank(eigenlayerAdmin);
+        vm.prank(owner);
         managerInstance.setProofSubmitter(testNode, newSubmitter);
     }
     
     function test_setProofSubmitter_byId() public {
         address newSubmitter = address(0x123);
-        vm.prank(eigenlayerAdmin);
+        vm.prank(owner);
         managerInstance.setProofSubmitter(testLegacyId, newSubmitter);
     }
     
     function test_setProofSubmitter_unauthorized() public {
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
         vm.prank(bob);
         managerInstance.setProofSubmitter(testNode, address(0x123));
     }
@@ -987,7 +987,7 @@ contract EtherFiNodesManagerTest is TestSetup {
         _grantNmPauseUntilRoles();
         _pauseUntil();
         _expectPausedUntilRevert();
-        vm.prank(eigenlayerAdmin);
+        vm.prank(owner);
         managerInstance.setProofSubmitter(testNode, bob);
     }
 
@@ -995,7 +995,7 @@ contract EtherFiNodesManagerTest is TestSetup {
         _grantNmPauseUntilRoles();
         _pauseUntil();
         _expectPausedUntilRevert();
-        vm.prank(eigenlayerAdmin);
+        vm.prank(owner);
         managerInstance.setProofSubmitter(testLegacyId, bob);
     }
 
@@ -1003,7 +1003,7 @@ contract EtherFiNodesManagerTest is TestSetup {
         _grantNmPauseUntilRoles();
         _pauseUntil();
         _expectPausedUntilRevert();
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         managerInstance.queueETHWithdrawal(testNode, 1 ether);
     }
 
@@ -1011,7 +1011,7 @@ contract EtherFiNodesManagerTest is TestSetup {
         _grantNmPauseUntilRoles();
         _pauseUntil();
         _expectPausedUntilRevert();
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         managerInstance.queueETHWithdrawal(testLegacyId, 1 ether);
     }
 

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -91,8 +91,7 @@ contract EtherFiNodesManagerTest is TestSetup {
             address(liquidityPoolInstance),
             address(managerInstance),
             address(eigenLayerEigenPodManager),
-            address(eigenLayerDelegationManager),
-            address(roleRegistryInstance)
+            address(eigenLayerDelegationManager)
         );
         vm.prank(stakingManagerInstance.owner());
         stakingManagerInstance.upgradeEtherFiNode(address(nodeImpl));

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -380,7 +380,7 @@ contract EtherFiNodesManagerTest is TestSetup {
             __deprecated_withdrawer: testNode
         });
         
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         managerInstance.queueWithdrawals(testNode, params);
     }
     
@@ -397,7 +397,7 @@ contract EtherFiNodesManagerTest is TestSetup {
             __deprecated_withdrawer: testNode
         });
         
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         managerInstance.queueWithdrawals(testLegacyId, params);
     }
     
@@ -1037,7 +1037,7 @@ contract EtherFiNodesManagerTest is TestSetup {
 
         IDelegationManager.QueuedWithdrawalParams[] memory params;
         _expectPausedUntilRevert();
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         managerInstance.queueWithdrawals(testNode, params);
     }
 
@@ -1047,7 +1047,7 @@ contract EtherFiNodesManagerTest is TestSetup {
 
         IDelegationManager.QueuedWithdrawalParams[] memory params;
         _expectPausedUntilRevert();
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         managerInstance.queueWithdrawals(testLegacyId, params);
     }
 

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -247,12 +247,12 @@ contract EtherFiNodesManagerTest is TestSetup {
     }
 
     function test_sweepFunds_unauthorized() public {
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         vm.prank(bob);
         managerInstance.sweepFunds(testLegacyId);
 
         // ADMIN_ROLE alone is not enough — sweepFunds requires EIGENLAYER_ADMIN_ROLE.
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         vm.prank(admin);
         managerInstance.sweepFunds(testLegacyId);
     }
@@ -323,7 +323,7 @@ contract EtherFiNodesManagerTest is TestSetup {
     }
     
     function test_startCheckpoint_unauthorized() public {
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
         vm.prank(bob);
         managerInstance.startCheckpoint(testNode);
     }
@@ -356,13 +356,13 @@ contract EtherFiNodesManagerTest is TestSetup {
     }
             
     function test_queueETHWithdrawal_unauthorized() public {
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         vm.prank(bob);
         managerInstance.queueETHWithdrawal(testNode, 1 ether);
     }
-    
+
     function test_completeQueuedETHWithdrawals_unauthorized() public {
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         vm.prank(bob);
         managerInstance.completeQueuedETHWithdrawals(testNode, true);
     }
@@ -510,7 +510,7 @@ contract EtherFiNodesManagerTest is TestSetup {
     }
     
     function test_forwardExternalCall_unauthorized() public {
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
         vm.prank(bob);
         address[] memory nodes = new address[](1);
         bytes[] memory data = new bytes[](1);
@@ -629,7 +629,7 @@ contract EtherFiNodesManagerTest is TestSetup {
             amountGwei: 0
         });
         
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         vm.prank(bob);
         managerInstance.requestExecutionLayerTriggeredWithdrawal(requests);
     }
@@ -710,7 +710,7 @@ contract EtherFiNodesManagerTest is TestSetup {
             targetPubkey: testPubkey
         });
         
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         vm.prank(bob);
         managerInstance.requestConsolidation(requests);
     }

--- a/test/EtherFiRateLimiter.t.sol
+++ b/test/EtherFiRateLimiter.t.sol
@@ -731,7 +731,7 @@ contract EtherFiRateLimiterTest is TestSetup {
     function test_upgradeability() public {
         // Verify upgrade authorization
         vm.prank(unauthorizedUser);
-        vm.expectRevert(RoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
         rateLimiter.upgradeTo(address(0x1));
 
         // Owner is the protocol upgrader; passes role check but reverts for other reasons

--- a/test/EtherFiRewardsRouter.t.sol
+++ b/test/EtherFiRewardsRouter.t.sol
@@ -67,6 +67,8 @@ contract EtherFiRewardsRouterTest is Test {
         
         // Grant admin role
         roleRegistry.grantRole(roleRegistry.OPERATION_MULTISIG_ROLE(), admin);
+        // `_authorizeUpgrade` now requires UPGRADE_TIMELOCK_ROLE.
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), owner);
         vm.stopPrank();
         
         // Deploy proxy and initialize (outside prank so owner is address(this))

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -788,7 +788,7 @@ contract LiquidityPoolTest is TestSetup {
 
     function test_Upgrade2_49_onlyRoleRegistryOwnerCanUpgrade() public {
         liquidityPool = address(new LiquidityPool(_lpCtorAddrs(address(0x0), address(blacklisterInstance)), 0));
-        vm.expectRevert(RoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
         vm.prank(address(100));
         liquidityPoolInstance.upgradeTo(liquidityPool);
 

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -383,7 +383,7 @@ contract LiquifierTest is TestSetup {
 
         // bob has no roles; sendToEtherFiRestaker now requires HOUSEKEEPING_OPERATIONS_ROLE
         vm.prank(bob);
-        vm.expectRevert(Liquifier.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         liquifierInstance.sendToEtherFiRestaker(address(stEth), 1);
 
         // chad has only the consolidated admin role — sender path requires HOUSEKEEPING_OPERATIONS_ROLE
@@ -391,7 +391,7 @@ contract LiquifierTest is TestSetup {
         roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), chad);
         vm.stopPrank();
         vm.prank(chad);
-        vm.expectRevert(Liquifier.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         liquifierInstance.sendToEtherFiRestaker(address(stEth), 1);
     }
 

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -1857,7 +1857,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
 
     function test_revert_handleRemainderNotFeeClaimer() public {
         vm.prank(regularUser);
-        vm.expectRevert(PriorityWithdrawalQueue.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         priorityQueue.handleRemainder(1 ether);
     }
 
@@ -1894,7 +1894,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
         requests[0] = request;
 
         vm.prank(regularUser);
-        vm.expectRevert(PriorityWithdrawalQueue.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyOracleOperations.selector);
         priorityQueue.fulfillRequests(requests);
     }
 

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -96,8 +96,8 @@ contract PriorityWithdrawalQueueTest is TestSetup {
             liquidityPoolInstance.initializeOnUpgradeV2();
         }
 
-        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
         liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
 
         // Grant roles — consolidated to the 8-tier model.
         // PWQ admin → OPERATION_TIMELOCK_ROLE; pauser → OPERATION_MULTISIG_ROLE;

--- a/test/RestakingRewardsRouter.t.sol
+++ b/test/RestakingRewardsRouter.t.sol
@@ -129,15 +129,6 @@ contract RestakingRewardsRouterTest is Test {
         );
     }
 
-    function test_constructor_revertsWithZeroRoleRegistry() public {
-        vm.expectRevert(RestakingRewardsRouter.InvalidAddress.selector);
-        new RestakingRewardsRouter(
-            address(0),
-            address(rewardToken),
-            address(liquidityPool)
-        );
-    }
-
     function test_constructor_disablesInitializers() public {
         vm.expectRevert();
         routerImpl.initialize();
@@ -324,7 +315,7 @@ contract RestakingRewardsRouterTest is Test {
         rewardToken.mint(address(router), amount);
 
         vm.prank(unauthorizedUser);
-        vm.expectRevert(RestakingRewardsRouter.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         router.recoverERC20();
 
         // Should still have tokens since transfer failed

--- a/test/RestakingRewardsRouter.t.sol
+++ b/test/RestakingRewardsRouter.t.sol
@@ -93,6 +93,8 @@ contract RestakingRewardsRouterTest is Test {
         // Grant transfer role — ETHERFI_REWARDS_ROUTER_ERC20_TRANSFER_ROLE consolidated into HOUSEKEEPING_OPERATIONS_ROLE.
         roleRegistry.grantRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), admin);
         roleRegistry.grantRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), transferRoleUser);
+        // `_authorizeUpgrade` now requires UPGRADE_TIMELOCK_ROLE.
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), owner);
         vm.stopPrank();
 
         // Deploy proxy and initialize (outside prank so owner is address(this))

--- a/test/RoleRegistry.t.sol
+++ b/test/RoleRegistry.t.sol
@@ -16,6 +16,7 @@ contract RoleRegistryTest is Test {
 
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+    bytes32 public constant UPGRADE_TIMELOCK_ROLE = keccak256("UPGRADE_TIMELOCK_ROLE");
 
    event RoleSet(address indexed holder, uint256 indexed role, bool indexed active);
 
@@ -40,6 +41,9 @@ contract RoleRegistryTest is Test {
         );
 
         registry = RoleRegistry(address(proxy));
+
+        vm.prank(owner);
+        registry.grantRole(UPGRADE_TIMELOCK_ROLE, owner);
     }
     
     function test_Initialization() public {
@@ -132,7 +136,7 @@ contract RoleRegistryTest is Test {
         
         // Only owner can upgrade
         vm.prank(user1);
-        vm.expectRevert(RoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
         registry.upgradeTo(address(newImplementation));
         
         // Owner can upgrade

--- a/test/StakingManager.t.sol
+++ b/test/StakingManager.t.sol
@@ -1432,29 +1432,6 @@ contract StakingManagerTest is TestSetup {
         stakingManagerInstance.backfillExistingEtherFiNodes(nodes);
     }
 
-    function test_unPauseContract() public {
-        // StakingManager pause/unpause is gated by onlyAdmin (OPERATION_MULTISIG_ROLE).
-        address pauser = roleRegistryInstance.roleHolders(roleRegistryInstance.OPERATION_MULTISIG_ROLE())[0];
-        vm.startPrank(pauser);
-        stakingManagerInstance.pauseContract();
-        vm.stopPrank();
-        assertTrue(stakingManagerInstance.paused());
-
-        vm.prank(pauser);
-        stakingManagerInstance.unPauseContract();
-        assertFalse(stakingManagerInstance.paused());
-    }
-
-    function test_unPauseContractFailsIfNotAuthorized() public {
-        address pauser = roleRegistryInstance.roleHolders(roleRegistryInstance.OPERATION_MULTISIG_ROLE())[0];
-        vm.prank(pauser);
-        stakingManagerInstance.pauseContract();
-
-        vm.prank(bob);
-        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
-        stakingManagerInstance.unPauseContract();
-    }
-
     function test_upgradeEtherFiNode() public {
         address newImpl = address(new EtherFiNode(address(0), address(0), address(0), address(0), address(roleRegistryInstance)));
         

--- a/test/StakingManager.t.sol
+++ b/test/StakingManager.t.sol
@@ -1387,7 +1387,7 @@ contract StakingManagerTest is TestSetup {
     }
     
     function test_instantiateEtherFiNodeFailsIfNotAuthorized() public {
-        vm.expectRevert(IStakingManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         stakingManagerInstance.instantiateEtherFiNode(false);
     }
 

--- a/test/StakingManager.t.sol
+++ b/test/StakingManager.t.sol
@@ -1444,8 +1444,8 @@ contract StakingManagerTest is TestSetup {
 
     function test_upgradeEtherFiNodeFailsIfNotAuthorized() public {
         address newImpl = address(new EtherFiNode(address(0), address(0), address(0), address(0)));
-        
-        vm.expectRevert(IRoleRegistry.OnlyProtocolUpgrader.selector);
+
+        vm.expectRevert(IRoleRegistry.OnlyUpgradeTimelock.selector);
         stakingManagerInstance.upgradeEtherFiNode(newImpl);
     }
 

--- a/test/StakingManager.t.sol
+++ b/test/StakingManager.t.sol
@@ -1433,7 +1433,7 @@ contract StakingManagerTest is TestSetup {
     }
 
     function test_upgradeEtherFiNode() public {
-        address newImpl = address(new EtherFiNode(address(0), address(0), address(0), address(0), address(roleRegistryInstance)));
+        address newImpl = address(new EtherFiNode(address(0), address(0), address(0), address(0)));
         
         address roleRegistryOwner = roleRegistryInstance.owner();
         
@@ -1443,7 +1443,7 @@ contract StakingManagerTest is TestSetup {
     }
 
     function test_upgradeEtherFiNodeFailsIfNotAuthorized() public {
-        address newImpl = address(new EtherFiNode(address(0), address(0), address(0), address(0), address(roleRegistryInstance)));
+        address newImpl = address(new EtherFiNode(address(0), address(0), address(0), address(0)));
         
         vm.expectRevert(IRoleRegistry.OnlyProtocolUpgrader.selector);
         stakingManagerInstance.upgradeEtherFiNode(newImpl);

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -815,7 +815,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(blacklisterInstance),
             address(nodeOperatorManagerProxy),
             address(stakingManagerProxy),
-            address(membershipManagerProxy)
+            address(membershipManagerProxy),
+            address(treasuryInstance)
         );
         auctionInstance.upgradeTo(address(auctionImplementation));
         auctionInstance.initialize(address(nodeOperatorManagerInstance));

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1205,8 +1205,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         vm.startPrank(alice);
         etherFiAdminInstance.setValidatorTaskBatchSize(100);
         liquidityPoolInstance.setValidatorSizeWei(32 ether);
-        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
         liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
         // Pause WithdrawRequestNFT so existing tests that unPauseContract in their
         // own setUp continue to find it paused (initializeOnUpgrade used to set this).
         withdrawRequestNFTInstance.pauseContract();

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -800,8 +800,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(liquidityPoolProxy),
             address(etherFiNodeManagerProxy),
             address(eigenLayerEigenPodManager),
-            address(eigenLayerDelegationManager),
-            address(roleRegistryInstance)
+            address(eigenLayerDelegationManager)
         );
 
         // NodeOperatorManager
@@ -2012,7 +2011,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         address liquidityPool;
         address etherFiNodesManager;
 
-        EtherFiNode etherFiNode = new EtherFiNode(liquidityPool, etherFiNodesManager, eigenPodManager, delegationManager, address(roleRegistryInstance));
+        EtherFiNode etherFiNode = new EtherFiNode(liquidityPool, etherFiNodesManager, eigenPodManager, delegationManager);
         address newImpl = address(etherFiNode);
         vm.prank(stakingManagerInstance.owner());
         stakingManagerInstance.upgradeEtherFiNode(newImpl);

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -484,43 +484,17 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         weEthWithdrawAdapterInstance = IWeETHWithdrawAdapter(deployed.WEETH_WITHDRAW_ADAPTER());
         etherFiRedemptionManagerInstance = EtherFiRedemptionManager(payable(address(liquidityPoolInstance.etherFiRedemptionManager())));
 
-        // Upgrade the live RoleRegistry to the local impl so newly-added role
-        // getters are reachable from any contract that is also being upgraded in this fork.
-        vm.prank(roleRegistryInstance.owner());
-        roleRegistryInstance.upgradeTo(address(new RoleRegistry(address(0))));
+        // NOTE: Do NOT upgrade RoleRegistry yet. The currently deployed proxies
+        // (StakingManager, EtherFiRedemptionManager, EtherFiRateLimiter, ...)
+        // authorize upgrades via `roleRegistry.onlyProtocolUpgrader`, which was
+        // removed from the new RoleRegistry impl. Upgrading RoleRegistry first
+        // would bork every subsequent `upgradeTo` against the live impls. The
+        // RoleRegistry swap + role grants happen AFTER the proxy upgrades below.
 
         // Deploy a fresh Blacklister on the fork — mainnet does not yet have one
         // deployed, but any upgraded impl now expects it as an immutable.
         blacklisterImplementation = new Blacklister(address(roleRegistryInstance));
         blacklisterInstance = Blacklister(address(new UUPSProxy(address(blacklisterImplementation), abi.encodeWithSelector(Blacklister.initialize.selector))));
-        // Resolve both arguments before vm.prank — every interleaved external
-        // call would otherwise consume the prank before grantRole executes.
-        bytes32 _blacklisterRole = roleRegistryInstance.OPERATION_MULTISIG_ROLE();
-        address _roleRegOwner = roleRegistryInstance.owner();
-        bytes32 _upgradeTimelockRole = roleRegistryInstance.UPGRADE_TIMELOCK_ROLE();
-        vm.startPrank(_roleRegOwner);
-        roleRegistryInstance.grantRole(_blacklisterRole, _roleRegOwner);
-        // `_authorizeUpgrade` now defers to `onlyUpgradeTimelock`, which checks
-        // UPGRADE_TIMELOCK_ROLE. Grant it to every proxy owner address that
-        // realistic-fork tests prank as for an upgradeTo call.
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, _roleRegOwner);
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, stakingManagerInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, depositAdapterInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, liquidityPoolInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, withdrawRequestNFTInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, managerInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiAdminInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiOracleInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, liquifierInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, auctionInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, weEthInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, eETHInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, membershipManagerInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, membershipNftInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, nodeOperatorManagerInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiRestakerInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, owner);
-        vm.stopPrank();
 
         // Deploy PriorityWithdrawalQueue for fork testing (mainnet LP has immutable address(0) for this)
         PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
@@ -529,6 +503,19 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
         );
         priorityQueueInstance = PriorityWithdrawalQueue(payable(address(priorityQueueProxy)));
+
+        // Also pre-upgrade the LIVE mainnet PriorityWithdrawalQueue proxy: a handful
+        // of integration tests dereference its deployed address directly and try to
+        // upgrade it themselves AFTER initializeRealisticFork has swapped RoleRegistry.
+        // Doing it here (before that swap) lets the legacy `onlyProtocolUpgrader`
+        // auth path succeed.
+        address mainnetPwqProxy = deployed.PRIORITY_WITHDRAWAL_QUEUE();
+        if (mainnetPwqProxy.code.length > 0) {
+            // Use the same impl bytecode as the fresh proxy above so subsequent
+            // upgradeTo calls in tests are no-ops storage-wise.
+            vm.prank(roleRegistryInstance.owner());
+            PriorityWithdrawalQueue(payable(mainnetPwqProxy)).upgradeTo(address(priorityQueueImplementation));
+        }
 
         // Upgrade StakingManager on the fork so it uses the consolidated role model
         // (the on-chain impl still calls PROTOCOL_PAUSER, which the upgraded RoleRegistry
@@ -591,6 +578,206 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         ));
         vm.prank(depositAdapterInstance.owner());
         depositAdapterInstance.upgradeTo(newDepositAdapterImpl);
+
+        // Upgrade LiquidityPool — deployed impl uses `onlyProtocolUpgrader`,
+        // which the new RoleRegistry impl no longer exposes. Doing this swap
+        // before the RoleRegistry upgrade lets the legacy auth path succeed;
+        // afterwards the new impl's `onlyUpgradeTimelock` takes over (and we
+        // grant the role to relevant addresses below).
+        address newLpImpl = address(new LiquidityPool(
+            LiquidityPool.ConstructorAddresses({
+                stakingManager: address(stakingManagerInstance),
+                nodesManager: address(managerInstance),
+                eETH: address(eETHInstance),
+                withdrawRequestNFT: address(withdrawRequestNFTInstance),
+                liquifier: address(liquifierInstance),
+                etherFiRedemptionManager: address(etherFiRedemptionManagerInstance),
+                roleRegistry: address(roleRegistryInstance),
+                priorityWithdrawalQueue: address(priorityQueueInstance),
+                blacklister: address(blacklisterInstance),
+                etherFiAdminContract: address(etherFiAdminInstance),
+                membershipManager: address(membershipManagerV1Instance)
+            }),
+            0
+        ));
+        vm.prank(liquidityPoolInstance.owner());
+        liquidityPoolInstance.upgradeTo(newLpImpl);
+
+        // Upgrade WithdrawRequestNFT — legacy `_authorizeUpgrade` is `onlyOwner`,
+        // so the call path is independent of RoleRegistry, but we still need the
+        // new impl in place for the consolidated role checks elsewhere.
+        address newWrnImpl = address(new WithdrawRequestNFT(
+            deployed.WITHDRAW_REQUEST_NFT_BUYBACK_SAFE(),
+            address(eETHInstance),
+            address(liquidityPoolInstance),
+            address(membershipManagerV1Instance),
+            address(roleRegistryInstance),
+            address(blacklisterInstance),
+            address(etherFiAdminInstance),
+            1,
+            4e18
+        ));
+        vm.prank(withdrawRequestNFTInstance.owner());
+        withdrawRequestNFTInstance.upgradeTo(newWrnImpl);
+
+        // Upgrade EtherFiNodesManager — deployed impl uses `onlyProtocolUpgrader`.
+        address newManagerImpl = address(new EtherFiNodesManager(
+            address(stakingManagerInstance),
+            address(roleRegistryInstance),
+            address(rateLimiterInstance)
+        ));
+        vm.prank(managerInstance.owner());
+        managerInstance.upgradeTo(newManagerImpl);
+
+        // Upgrade EtherFiAdmin — deployed impl uses `onlyProtocolUpgrader`. Tests
+        // that re-upgrade it later via `_upgradeOracleAndAdminForFork` will then
+        // route through the new impl's `onlyUpgradeTimelock`, which we grant
+        // below.
+        address newAdminImpl = address(new EtherFiAdmin(
+            EtherFiAdmin.ConstructorAddresses({
+                etherFiOracle: address(etherFiOracleInstance),
+                stakingManager: address(stakingManagerInstance),
+                auctionManager: address(auctionInstance),
+                etherFiNodesManager: address(managerInstance),
+                liquidityPool: address(liquidityPoolInstance),
+                membershipManager: address(membershipManagerV1Instance),
+                withdrawRequestNft: address(withdrawRequestNFTInstance),
+                roleRegistry: address(roleRegistryInstance),
+                priorityWithdrawalQueue: address(priorityQueueInstance)
+            }),
+            10_000, 1_000, 7200,
+            100_000 ether, 500, 1000
+        ));
+        vm.prank(roleRegistryInstance.owner());
+        etherFiAdminInstance.upgradeTo(newAdminImpl);
+
+        // Upgrade WeETH — deployed impl uses `onlyProtocolUpgrader`. Tests that
+        // call `setUpLiquifier` later re-upgrade weETH via `_upgrade_weETH`; pre-
+        // upgrading here ensures that path uses the new impl's `onlyUpgradeTimelock`
+        // (granted to `owner` below) instead of the removed legacy selector.
+        address newWeETHImpl = address(new WeETH(
+            address(eETHInstance),
+            address(liquidityPoolInstance),
+            address(roleRegistryInstance),
+            address(blacklisterInstance),
+            address(rateLimiterInstance)
+        ));
+        vm.prank(weEthInstance.owner());
+        weEthInstance.upgradeTo(newWeETHImpl);
+
+        // Upgrade Liquifier — legacy `_authorizeUpgrade` is `onlyOwner`, but we
+        // pre-upgrade here so the rest of the suite sees the new impl consistently.
+        // Need a price feed; mirror the defensive default from `setUpLiquifier`
+        // in case fork-specific wiring hasn't been set up yet.
+        if (stEthChainlinkFeed == address(0)) {
+            stEthChainlinkFeed = address(new MockChainlinkPriceFeed(int256(1 ether), 0));
+        }
+        address newLiquifierImpl = address(new Liquifier(
+            Liquifier.ConstructorAddresses({
+                liquidityPool: address(liquidityPoolInstance),
+                lidoWithdrawalQueue: address(lidoWithdrawalQueue),
+                lido: address(stEth),
+                stEth_Eth_Pool: address(stEth_Eth_Pool),
+                roleRegistry: address(roleRegistryInstance),
+                stEthPriceFeed: stEthChainlinkFeed,
+                blacklister: address(blacklisterInstance),
+                etherfiRestaker: address(etherFiRestakerInstance),
+                l1SyncPool: address(0xA6)
+            }),
+            100,
+            LIQUIFIER_STALE_WINDOW,
+            LIQUIFIER_MAX_PRICE_DEVIATION_BPS
+        ));
+        vm.prank(liquifierInstance.owner());
+        liquifierInstance.upgradeTo(newLiquifierImpl);
+
+        // Now that every live proxy that authorizes upgrades through the legacy
+        // `onlyProtocolUpgrader` path has been swapped to the new impl, it's
+        // safe to upgrade RoleRegistry. After this point, `onlyProtocolUpgrader`
+        // no longer exists; any further proxy upgrade must use UPGRADE_TIMELOCK_ROLE
+        // via `onlyUpgradeTimelock`.
+        vm.prank(roleRegistryInstance.owner());
+        roleRegistryInstance.upgradeTo(address(new RoleRegistry(address(0))));
+
+        // Resolve role identifiers before vm.prank — every interleaved external
+        // call would otherwise consume the prank before grantRole executes.
+        bytes32 _operatingMultisigRole = roleRegistryInstance.OPERATION_MULTISIG_ROLE();
+        bytes32 _operatingTimelockRole = roleRegistryInstance.OPERATION_TIMELOCK_ROLE();
+        bytes32 _upgradeTimelockRole = roleRegistryInstance.UPGRADE_TIMELOCK_ROLE();
+        address _roleRegOwner = roleRegistryInstance.owner();
+        address _operatingTimelockAddr = deployed.OPERATING_TIMELOCK();
+        vm.startPrank(_roleRegOwner);
+        roleRegistryInstance.grantRole(_operatingMultisigRole, _roleRegOwner);
+        // `_authorizeUpgrade` now defers to `onlyUpgradeTimelock`, which checks
+        // UPGRADE_TIMELOCK_ROLE. Grant it to every proxy owner address that
+        // realistic-fork tests prank as for an upgradeTo call.
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, _roleRegOwner);
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, stakingManagerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, depositAdapterInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, liquidityPoolInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, withdrawRequestNFTInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, managerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiAdminInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiOracleInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, liquifierInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, nodeOperatorManagerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiRestakerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, owner);
+
+        // Operational roles for test setUps. Pre-consolidation, these
+        // call paths were gated by per-contract admin maps or by addresses
+        // that previously held legacy admin roles. The consolidated model
+        // routes them through OPERATION_TIMELOCK / OPERATION_MULTISIG, so we
+        // mirror that historical access for the addresses tests prank as.
+        // Note: HOUSEKEEPING / GUARDIAN are intentionally NOT granted here —
+        // tests for sweepFunds & friends rely on `admin` lacking them.
+        roleRegistryInstance.grantRole(_operatingTimelockRole, owner);
+        roleRegistryInstance.grantRole(_operatingTimelockRole, alice);
+        roleRegistryInstance.grantRole(_operatingTimelockRole, admin);
+        roleRegistryInstance.grantRole(_operatingTimelockRole, _operatingTimelockAddr);
+        roleRegistryInstance.grantRole(_operatingMultisigRole, owner);
+        roleRegistryInstance.grantRole(_operatingMultisigRole, alice);
+        roleRegistryInstance.grantRole(_operatingMultisigRole, admin);
+        roleRegistryInstance.grantRole(_operatingMultisigRole, _operatingTimelockAddr);
+        vm.stopPrank();
+
+        // The freshly-upgraded LP introduces `minWithdrawAmount`/`maxWithdrawAmount`
+        // gates that weren't part of the deployed impl. Their default storage
+        // values are zero, which would reject every `requestWithdraw`. Set sane
+        // bounds here so generic fork tests don't trip the new checks. Tests
+        // that want to exercise the gates can override.
+        vm.startPrank(_roleRegOwner);
+        liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
+        vm.stopPrank();
+
+        // Run the one-shot escrow migration so `requestWithdraw` / `withdraw`
+        // (both gated by `escrowMigrationCompleted`) function on the upgraded
+        // LP. Idempotent: skip if already complete.
+        if (!liquidityPoolInstance.escrowMigrationCompleted()) {
+            vm.prank(_roleRegOwner);
+            liquidityPoolInstance.initializeOnUpgradeV2();
+        }
+
+        // The just-upgraded WeETH calls the rate limiter on mint/burn/transfer.
+        // Create its buckets with effectively unbounded capacity so generic fork
+        // tests that don't care about rate-limit behaviour don't revert on
+        // UnknownLimit. Done AFTER role grants because `createNewLimiter` is
+        // OPERATION_TIMELOCK-gated.
+        bytes32[3] memory weethRateIds = [
+            weEthInstance.WEETH_MINT_LIMIT_ID(),
+            weEthInstance.WEETH_BURN_LIMIT_ID(),
+            weEthInstance.WEETH_TRANSFER_LIMIT_ID()
+        ];
+        uint64 _rateMax = type(uint64).max;
+        vm.startPrank(owner);
+        for (uint256 i = 0; i < weethRateIds.length; i++) {
+            if (!rateLimiterInstance.limitExists(weethRateIds[i])) {
+                rateLimiterInstance.createNewLimiter(weethRateIds[i], _rateMax, _rateMax);
+            }
+            rateLimiterInstance.updateConsumers(weethRateIds[i], address(weEthInstance), true);
+        }
+        vm.stopPrank();
     }
 
     function updateShouldSetRoleRegistry(bool shouldSetup) public {
@@ -604,27 +791,12 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             stEthChainlinkFeed = address(new MockChainlinkPriceFeed(int256(1 ether), 0));
         }
 
-        // On fork, the live RoleRegistry impl may predate this PR and not expose PAUSE_UNTIL_ROLE().
-        // Upgrade in place so new role getters are reachable, then grant roles used by tests.
-        // Order matters: UPGRADE_TIMELOCK_ROLE must be granted to `owner` BEFORE the
-        // Liquifier upgrade below, because `_authorizeUpgrade` now requires that role.
-        vm.startPrank(roleRegistryInstance.owner());
+        // Upgrade Liquifier BEFORE swapping RoleRegistry: the live Liquifier impl
+        // still authorizes upgrades through `onlyProtocolUpgrader`, which the new
+        // RoleRegistry impl no longer exposes. `liquifierInstance.owner()` matches
+        // RoleRegistry.owner() on mainnet, so the OLD impl's owner check passes.
         if (forkEnum == MAINNET_FORK || forkEnum == TESTNET_FORK) {
-            roleRegistryInstance.upgradeTo(address(new RoleRegistry(address(0))));
-        }
-        roleRegistryInstance.grantRole(roleRegistryInstance.UPGRADE_TIMELOCK_ROLE(), owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), alice);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), alice);
-        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), alice);
-        roleRegistryInstance.grantRole(roleRegistryInstance.GUARDIAN_ROLE(), owner);
-        vm.stopPrank();
-
-        vm.startPrank(owner);
-
-        if (forkEnum == MAINNET_FORK || forkEnum == TESTNET_FORK) {
+            vm.prank(liquifierInstance.owner());
             liquifierInstance.upgradeTo(address(new Liquifier(Liquifier.ConstructorAddresses({
                 liquidityPool: address(liquidityPoolInstance),
                 lidoWithdrawalQueue: address(lidoWithdrawalQueue),
@@ -637,6 +809,20 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 l1SyncPool: address(0xA6)
             }), 100, LIQUIFIER_STALE_WINDOW, LIQUIFIER_MAX_PRICE_DEVIATION_BPS)));
         }
+
+        // Now swap RoleRegistry and grant roles used by tests.
+        vm.startPrank(roleRegistryInstance.owner());
+        if (forkEnum == MAINNET_FORK || forkEnum == TESTNET_FORK) {
+            roleRegistryInstance.upgradeTo(address(new RoleRegistry(address(0))));
+        }
+        roleRegistryInstance.grantRole(roleRegistryInstance.UPGRADE_TIMELOCK_ROLE(), owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), alice);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), alice);
+        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), alice);
+        roleRegistryInstance.grantRole(roleRegistryInstance.GUARDIAN_ROLE(), owner);
         vm.stopPrank();
 
         vm.startPrank(owner);

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -497,8 +497,30 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // call would otherwise consume the prank before grantRole executes.
         bytes32 _blacklisterRole = roleRegistryInstance.OPERATION_MULTISIG_ROLE();
         address _roleRegOwner = roleRegistryInstance.owner();
-        vm.prank(_roleRegOwner);
+        bytes32 _upgradeTimelockRole = roleRegistryInstance.UPGRADE_TIMELOCK_ROLE();
+        vm.startPrank(_roleRegOwner);
         roleRegistryInstance.grantRole(_blacklisterRole, _roleRegOwner);
+        // `_authorizeUpgrade` now defers to `onlyUpgradeTimelock`, which checks
+        // UPGRADE_TIMELOCK_ROLE. Grant it to every proxy owner address that
+        // realistic-fork tests prank as for an upgradeTo call.
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, _roleRegOwner);
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, stakingManagerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, depositAdapterInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, liquidityPoolInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, withdrawRequestNFTInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, managerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiAdminInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiOracleInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, liquifierInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, auctionInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, weEthInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, eETHInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, membershipManagerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, membershipNftInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, nodeOperatorManagerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiRestakerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, owner);
+        vm.stopPrank();
 
         // Deploy PriorityWithdrawalQueue for fork testing (mainnet LP has immutable address(0) for this)
         PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
@@ -582,6 +604,24 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             stEthChainlinkFeed = address(new MockChainlinkPriceFeed(int256(1 ether), 0));
         }
 
+        // On fork, the live RoleRegistry impl may predate this PR and not expose PAUSE_UNTIL_ROLE().
+        // Upgrade in place so new role getters are reachable, then grant roles used by tests.
+        // Order matters: UPGRADE_TIMELOCK_ROLE must be granted to `owner` BEFORE the
+        // Liquifier upgrade below, because `_authorizeUpgrade` now requires that role.
+        vm.startPrank(roleRegistryInstance.owner());
+        if (forkEnum == MAINNET_FORK || forkEnum == TESTNET_FORK) {
+            roleRegistryInstance.upgradeTo(address(new RoleRegistry(address(0))));
+        }
+        roleRegistryInstance.grantRole(roleRegistryInstance.UPGRADE_TIMELOCK_ROLE(), owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), alice);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), alice);
+        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), alice);
+        roleRegistryInstance.grantRole(roleRegistryInstance.GUARDIAN_ROLE(), owner);
+        vm.stopPrank();
+
         vm.startPrank(owner);
 
         if (forkEnum == MAINNET_FORK || forkEnum == TESTNET_FORK) {
@@ -597,22 +637,6 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 l1SyncPool: address(0xA6)
             }), 100, LIQUIFIER_STALE_WINDOW, LIQUIFIER_MAX_PRICE_DEVIATION_BPS)));
         }
-        vm.stopPrank();
-
-        // On fork, the live RoleRegistry impl may predate this PR and not expose PAUSE_UNTIL_ROLE().
-        // Upgrade in place so new role getters are reachable, then grant roles used by tests.
-        vm.startPrank(roleRegistryInstance.owner());
-        if (forkEnum == MAINNET_FORK || forkEnum == TESTNET_FORK) {
-            roleRegistryInstance.upgradeTo(address(new RoleRegistry(address(0))));
-        }
-        roleRegistryInstance.grantRole(roleRegistryInstance.UPGRADE_TIMELOCK_ROLE(), owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), alice);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), alice);
-        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), alice);
-        roleRegistryInstance.grantRole(roleRegistryInstance.GUARDIAN_ROLE(), owner);
         vm.stopPrank();
 
         vm.startPrank(owner);
@@ -683,6 +707,12 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryImplementation = new RoleRegistry(address(0));
         roleRegistryProxy = new UUPSProxy(address(roleRegistryImplementation), abi.encodeWithSelector(RoleRegistry.initialize.selector, owner));
         roleRegistryInstance = RoleRegistry(address(roleRegistryProxy));
+
+        // Grant UPGRADE_TIMELOCK_ROLE to `owner` up-front so every later upgradeTo
+        // pranked as `owner` (and the proxy-owner pranks below, which also resolve
+        // to `owner` here) passes the new `onlyUpgradeTimelock` check on
+        // `_authorizeUpgrade`.
+        roleRegistryInstance.grantRole(roleRegistryInstance.UPGRADE_TIMELOCK_ROLE(), owner);
 
         rateLimiterImplementation = new EtherFiRateLimiter(address(roleRegistryInstance));
         rateLimiterProxy = new UUPSProxy(address(rateLimiterImplementation), "");

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -1414,9 +1414,9 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.expectRevert(WithdrawRequestNFT.CannotUndoFinalization.selector);
         withdrawRequestNFTInstance.finalizeRequests(requestId - 1);
 
-        // Non-admin cannot finalize — reverts with IncorrectRole() (not the legacy admin string).
+        // Non-admin cannot finalize — only etherFiAdmin may call finalizeRequests.
         vm.prank(bob);
-        vm.expectRevert(WithdrawRequestNFT.IncorrectRole.selector);
+        vm.expectRevert(WithdrawRequestNFT.IncorrectCaller.selector);
         withdrawRequestNFTInstance.finalizeRequests(requestId + 1);
     }
 

--- a/test/behaviour-tests/ELExitsForkTestingDeployment.t.sol
+++ b/test/behaviour-tests/ELExitsForkTestingDeployment.t.sol
@@ -149,8 +149,7 @@ contract ELExitsForkTestingDeploymentTest is Test {
             address(liquidityPool),
             address(etherFiNodesManager),
             eigenPodManager,
-            delegationManager,
-            address(roleRegistry)
+            delegationManager
         );
         console2.log("New EtherFiNode implementation:", address(newEtherFiNodeImpl));
         console2.log("");

--- a/test/behaviour-tests/pectra-fork-tests/EL-withdrawals.t.sol
+++ b/test/behaviour-tests/pectra-fork-tests/EL-withdrawals.t.sol
@@ -34,6 +34,15 @@ contract ELExitsTest is TestSetup {
 
     function setUp() public {
         initializeRealisticFork(MAINNET_FORK);
+
+        // `requestExecutionLayerTriggeredWithdrawal` is gated by
+        // `onlyExecutorOperations`. On mainnet, `realElExiter` held the legacy
+        // STAKING_MANAGER_NODE_CREATOR_ROLE; in the consolidated model that
+        // maps to EXECUTOR_OPERATIONS_ROLE, which isn't auto-migrated.
+        bytes32 execRole = roleRegistryInstance.EXECUTOR_OPERATIONS_ROLE();
+        address rrOwner = roleRegistryInstance.owner();
+        vm.prank(rrOwner);
+        roleRegistryInstance.grantRole(execRole, realElExiter);
     }
 
     function _resolvePod(bytes memory pubkey) internal view returns (IEtherFiNode etherFiNode, IEigenPod pod) {

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -128,8 +128,7 @@ contract PreludeTest is Test, ArrayTestHelper {
             address(liquidityPool),
             address(etherFiNodesManager),
             eigenPodManager,
-            delegationManager,
-            address(roleRegistry)
+            delegationManager
         );
         vm.prank(stakingManager.owner());
         stakingManager.upgradeEtherFiNode(address(etherFiNodeImpl));
@@ -939,7 +938,7 @@ contract PreludeTest is Test, ArrayTestHelper {
 
 
         // only protocolUpgrader can upgrade etherFiNode
-        EtherFiNode nodeImpl = new EtherFiNode(address(0), address(0), address(0), address(0), address(0));
+        EtherFiNode nodeImpl = new EtherFiNode(address(0), address(0), address(0), address(0));
         vm.prank(admin);
         vm.expectRevert(IRoleRegistry.OnlyProtocolUpgrader.selector);
         stakingManager.upgradeEtherFiNode(address(nodeImpl));

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -390,10 +390,10 @@ contract PreludeTest is Test, ArrayTestHelper {
         // user with no role should not be able to forward calls
         vm.startPrank(user);
         {
-            vm.expectRevert(IEtherFiNode.IncorrectRole.selector);
+            vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
             etherFiNodesManager.forwardEigenPodCall(toArray(etherFiNode), toArray_bytes(""));
 
-            vm.expectRevert(IEtherFiNode.IncorrectRole.selector);
+            vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
             etherFiNodesManager.forwardExternalCall(toArray(etherFiNode), toArray_bytes(""), address(0));
         }
         vm.stopPrank();
@@ -710,12 +710,12 @@ contract PreludeTest is Test, ArrayTestHelper {
         // Random caller: revert.
         address rando = makeAddr("rando");
         vm.prank(rando);
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         etherFiNodesManager.sweepFunds(nodeId);
 
         // ADMIN_ROLE alone (held by `admin`) no longer satisfies sweep.
         vm.prank(admin);
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         etherFiNodesManager.sweepFunds(nodeId);
 
         // EIGENLAYER_ADMIN_ROLE can sweep (no-op when node has no balance).
@@ -864,7 +864,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
         etherFiNodesManager.setProofSubmitter(nodeId, address(0));
 
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
         etherFiNodesManager.startCheckpoint(nodeId);
 
         BeaconChainProofs.BalanceProof[] memory balanceProofs = new BeaconChainProofs.BalanceProof[](1);
@@ -872,36 +872,36 @@ contract PreludeTest is Test, ArrayTestHelper {
             balanceContainerRoot: bytes32(uint256(1)),
             proof: ""
         });
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
         etherFiNodesManager.verifyCheckpointProofs(nodeId, containerProof, balanceProofs);
 
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         etherFiNodesManager.queueETHWithdrawal(nodeId, 1 ether);
 
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         etherFiNodesManager.completeQueuedETHWithdrawals(nodeId, true);
 
         IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         etherFiNodesManager.queueWithdrawals(nodeId, params);
 
         IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
         IERC20[][] memory tokens = new IERC20[][](1);
         bool[] memory receiveAsTokens = new bool[](1);
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         etherFiNodesManager.completeQueuedWithdrawals(nodeId, withdrawals, tokens, receiveAsTokens);
 
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
         etherFiNodesManager.sweepFunds(nodeId);
 
         // normal user should fail for all call forwarding
         address[] memory nodes = new address[](1);
         bytes[] memory data = new bytes[](1);
 
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
         etherFiNodesManager.forwardEigenPodCall(nodes, data);
 
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
         etherFiNodesManager.forwardExternalCall(nodes, data, address(0));
 
         vm.stopPrank();
@@ -1029,7 +1029,7 @@ contract PreludeTest is Test, ArrayTestHelper {
 
         // only POD_PROVER can start checkpoint
         vm.prank(eigenlayerAdmin);
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyEigenpodOperations.selector);
         etherFiNodesManager.startCheckpoint(uint256(val.pubkeyHash));
 
         // initiate a checkpoint
@@ -1053,7 +1053,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         pubkeys[2] = vm.randomBytes(48);
 
         // should fail if not admin
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         vm.prank(elExiter);
@@ -1599,7 +1599,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         assertEq(remaining, 25_000_000_000);
         
         // Test that unauthorized access is blocked by the access control
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         vm.prank(user);
         etherFiNodesManager.queueETHWithdrawal(uint256(val1.pubkeyHash), 10 ether);
         

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -882,7 +882,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         etherFiNodesManager.completeQueuedETHWithdrawals(nodeId, true);
 
         IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
-        vm.expectRevert(RoleRegistry.OnlyHousekeepingOperations.selector);
+        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
         etherFiNodesManager.queueWithdrawals(nodeId, params);
 
         IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
@@ -1429,13 +1429,13 @@ contract PreludeTest is Test, ArrayTestHelper {
         params[0].__deprecated_withdrawer = address(0);
 
         // First withdrawal within limit should succeed
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueWithdrawals(uint256(val.pubkeyHash), params);
 
         // Second withdrawal exceeding limit should fail (15 + 10 > 20)
         shares[0] = 10 ether;
         vm.expectRevert(abi.encodeWithSignature("LimitExceeded()"));
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueWithdrawals(uint256(val.pubkeyHash), params);
     }
 

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -689,7 +689,7 @@ contract PreludeTest is Test, ArrayTestHelper {
             .with_key(etherFiNodeAddress)
             .checked_write_int(int256(10_000 ether));
 
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(pubkeyHash), 1 ether);
 
         uint256 startingBalance = address(liquidityPool).balance;
@@ -745,7 +745,7 @@ contract PreludeTest is Test, ArrayTestHelper {
             .with_key(nodeAddr)
             .checked_write_int(int256(10_000 ether));
 
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         bytes32 root = etherFiNodesManager.queueETHWithdrawal(uint256(pubkeyHash), 1 ether);
 
         // build the explicit Withdrawal struct that mirrors what the node queued
@@ -861,7 +861,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.startPrank(user);
 
         // Normal user should fail for all eigenlayer functions
-        vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
         etherFiNodesManager.setProofSubmitter(nodeId, address(0));
 
         vm.expectRevert(IEtherFiNodesManager.IncorrectRole.selector);
@@ -982,7 +982,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         IEtherFiNode newNode = IEtherFiNode(stakingManager.instantiateEtherFiNode(/*createEigenPod=*/true));
         address newSubmitter = vm.addr(0xabc123);
 
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.setProofSubmitter(address(newNode), newSubmitter);
 
         IEigenPod pod = newNode.getEigenPod();
@@ -1091,7 +1091,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         uint256 startingLPBalance = address(liquidityPool).balance;
 
         // should be able to withdraw arbitrary amounts not tied to any particular validator
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val1.pubkeyHash), 1234 ether);
 
         // need to fast forward so that withdrawal is claimable
@@ -1120,11 +1120,11 @@ contract PreludeTest is Test, ArrayTestHelper {
         TestValidator memory val = helper_createValidator(params);
 
         // queue up multiple withdrawals
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 1 ether);
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 1 ether);
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 1 ether);
 
         // need to fast forward so that withdrawal is claimable
@@ -1392,16 +1392,16 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.stopPrank();
 
         // First withdrawal within limit should succeed
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 5 ether);
 
         // Second withdrawal within limit should succeed
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 4 ether);
 
         // Third withdrawal exceeding limit should fail
         vm.expectRevert();
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 2 ether);
     }
 
@@ -1513,7 +1513,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.stopPrank();
 
         // Test consuming within capacity - should succeed
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 30 ether);
         
         // Check remaining capacity is reduced
@@ -1522,11 +1522,11 @@ contract PreludeTest is Test, ArrayTestHelper {
         
         // Test consuming more than remaining capacity - should fail
         vm.expectRevert(abi.encodeWithSignature("LimitExceeded()"));
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 25 ether);
         
         // Test consuming exactly remaining capacity - should succeed
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val.pubkeyHash), 20 ether);
         
         // Verify capacity is now exhausted
@@ -1585,13 +1585,13 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.stopPrank();
 
         // Test multiple consumption attempts within capacity - all should succeed
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val1.pubkeyHash), 25 ether);
         
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val2.pubkeyHash), 30 ether);
         
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val3.pubkeyHash), 20 ether);
         
         // Check remaining capacity after multiple consumptions (100 - 25 - 30 - 20 = 25 ETH)
@@ -1609,11 +1609,11 @@ contract PreludeTest is Test, ArrayTestHelper {
         
         // Test final consumption that would exceed remaining capacity should fail
         vm.expectRevert(abi.encodeWithSignature("LimitExceeded()"));
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val1.pubkeyHash), 30 ether);
         
         // Test final consumption within remaining capacity should succeed
-        vm.prank(eigenlayerAdmin);
+        vm.prank(admin);
         etherFiNodesManager.queueETHWithdrawal(uint256(val1.pubkeyHash), 25 ether);
         
         // Verify capacity is now exhausted

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -69,26 +69,27 @@ contract PreludeTest is Test, ArrayTestHelper {
 
         vm.selectFork(vm.createFork(vm.envString("MAINNET_RPC_URL")));
 
-        // Upgrade RoleRegistry in place so newly-added role getters defined in
-        // RolesLibrary are reachable on the deployed proxy.
-        vm.prank(roleRegistry.owner());
-        RoleRegistry(address(roleRegistry)).upgradeTo(address(new RoleRegistry(address(0))));
-
         stakingManager = StakingManager(0x25e821b7197B146F7713C3b89B6A4D83516B912d);
         liquidityPool = ILiquidityPool(0x308861A430be4cce5502d0A12724771Fc6DaF216);
         etherFiNodesManager = EtherFiNodesManager(payable(0x8B71140AD2e5d1E7018d2a7f8a288BD3CD38916F));
         auctionManager = AuctionManager(0x00C452aFFee3a17d9Cecc1Bcd2B8d5C7635C4CB9);
 
-        // `_authorizeUpgrade` and `upgradeEtherFiNode` now check
-        // UPGRADE_TIMELOCK_ROLE via `onlyUpgradeTimelock`. Grant it to every
-        // proxy owner pranked for an upgrade call below.
-        vm.startPrank(roleRegistry.owner());
-        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), stakingManager.owner());
-        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), LiquidityPool(payable(address(liquidityPool))).owner());
-        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), etherFiNodesManager.owner());
-        vm.stopPrank();
+        // Deploy a fresh Blacklister so any upgraded impl that wires it as an immutable
+        // has a non-zero target to call into.
+        Blacklister blacklisterImpl = new Blacklister(address(roleRegistry));
+        blacklisterInstance = Blacklister(address(new UUPSProxy(address(blacklisterImpl), abi.encodeWithSelector(Blacklister.initialize.selector))));
 
-        // deploy new staking manager implementation
+        // Deploy rate limiter first with proxy pattern (used by EtherFiNodesManager).
+        EtherFiRateLimiter rateLimiterImpl = new EtherFiRateLimiter(address(roleRegistry));
+        UUPSProxy rateLimiterProxy = new UUPSProxy(address(rateLimiterImpl), "");
+        rateLimiter = EtherFiRateLimiter(address(rateLimiterProxy));
+        rateLimiter.initialize();
+
+        // Upgrade StakingManager / LP / EtherFiNodesManager FIRST, while the
+        // deployed RoleRegistry still exposes the legacy `onlyProtocolUpgrader`
+        // selector that their currently-deployed `_authorizeUpgrade` calls into.
+        // Once we swap RoleRegistry below, that selector is gone, so the order
+        // matters.
         StakingManager stakingManagerImpl = new StakingManager(
             address(liquidityPool),
             address(etherFiNodesManager),
@@ -99,11 +100,6 @@ contract PreludeTest is Test, ArrayTestHelper {
         );
         vm.prank(stakingManager.owner());
         stakingManager.upgradeTo(address(stakingManagerImpl));
-
-        // Deploy a fresh Blacklister so any upgraded impl that wires it as an immutable
-        // has a non-zero target to call into.
-        Blacklister blacklisterImpl = new Blacklister(address(roleRegistry));
-        blacklisterInstance = Blacklister(address(new UUPSProxy(address(blacklisterImpl), abi.encodeWithSelector(Blacklister.initialize.selector))));
 
         // Wire LP immutables to the real mainnet proxy addresses so calls into
         // eETH / withdrawRequestNFT / etc. land on live contracts rather than 0x0.
@@ -126,12 +122,23 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.prank(LiquidityPool(payable(address(liquidityPool))).owner());
         LiquidityPool(payable(address(liquidityPool))).upgradeTo(address(liquidityPoolImpl));
 
-        // Deploy rate limiter first with proxy pattern
-        EtherFiRateLimiter rateLimiterImpl = new EtherFiRateLimiter(address(roleRegistry));
-        UUPSProxy rateLimiterProxy = new UUPSProxy(address(rateLimiterImpl), "");
-        rateLimiter = EtherFiRateLimiter(address(rateLimiterProxy));
-        rateLimiter.initialize();
-        
+        EtherFiNodesManager etherFiNodesManagerImpl = new EtherFiNodesManager(address(stakingManager), address(roleRegistry), address(rateLimiter));
+        vm.prank(etherFiNodesManager.owner());
+        etherFiNodesManager.upgradeTo(address(etherFiNodesManagerImpl));
+
+        // Now swap RoleRegistry in place so newly-added role getters defined in
+        // RolesLibrary are reachable from the freshly-upgraded impls.
+        vm.prank(roleRegistry.owner());
+        RoleRegistry(address(roleRegistry)).upgradeTo(address(new RoleRegistry(address(0))));
+
+        // `upgradeEtherFiNode` checks UPGRADE_TIMELOCK_ROLE via
+        // `onlyUpgradeTimelock`. Grant it to every proxy owner pranked below.
+        vm.startPrank(roleRegistry.owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), stakingManager.owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), LiquidityPool(payable(address(liquidityPool))).owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), etherFiNodesManager.owner());
+        vm.stopPrank();
+
         // upgrade etherFiNode impl
         etherFiNodeImpl = new EtherFiNode(
             address(liquidityPool),
@@ -141,11 +148,6 @@ contract PreludeTest is Test, ArrayTestHelper {
         );
         vm.prank(stakingManager.owner());
         stakingManager.upgradeEtherFiNode(address(etherFiNodeImpl));
-
-        // deploy new efnm implementation
-        EtherFiNodesManager etherFiNodesManagerImpl = new EtherFiNodesManager(address(stakingManager), address(roleRegistry), address(rateLimiter));
-        vm.prank(etherFiNodesManager.owner());
-        etherFiNodesManager.upgradeTo(address(etherFiNodesManagerImpl));
 
         vm.prank(auctionManager.owner());
         auctionManager.disableWhitelist();
@@ -586,7 +588,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         );
 
         // only owner should be able to upgrade
-        vm.expectRevert(IRoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(IRoleRegistry.OnlyUpgradeTimelock.selector);
         stakingManager.upgradeTo(address(stakingManagerImpl));
 
         // should succeed when called by owner
@@ -856,13 +858,13 @@ contract PreludeTest is Test, ArrayTestHelper {
         uint256 nodeId = 1;
 
         // none of the EFNM roles should be allowed to upgrade
-        vm.expectRevert(IRoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(IRoleRegistry.OnlyUpgradeTimelock.selector);
         vm.prank(eigenlayerAdmin);
         etherFiNodesManager.upgradeTo(address(0));
-        vm.expectRevert(IRoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(IRoleRegistry.OnlyUpgradeTimelock.selector);
         vm.prank(user);
         etherFiNodesManager.upgradeTo(address(0));
-        vm.expectRevert(IRoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(IRoleRegistry.OnlyUpgradeTimelock.selector);
         vm.prank(callForwarder);
         etherFiNodesManager.upgradeTo(address(0));
 
@@ -949,7 +951,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         // only protocolUpgrader can upgrade etherFiNode
         EtherFiNode nodeImpl = new EtherFiNode(address(0), address(0), address(0), address(0));
         vm.prank(admin);
-        vm.expectRevert(IRoleRegistry.OnlyProtocolUpgrader.selector);
+        vm.expectRevert(IRoleRegistry.OnlyUpgradeTimelock.selector);
         stakingManager.upgradeEtherFiNode(address(nodeImpl));
 
         vm.prank(roleRegistry.owner());

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -79,6 +79,15 @@ contract PreludeTest is Test, ArrayTestHelper {
         etherFiNodesManager = EtherFiNodesManager(payable(0x8B71140AD2e5d1E7018d2a7f8a288BD3CD38916F));
         auctionManager = AuctionManager(0x00C452aFFee3a17d9Cecc1Bcd2B8d5C7635C4CB9);
 
+        // `_authorizeUpgrade` and `upgradeEtherFiNode` now check
+        // UPGRADE_TIMELOCK_ROLE via `onlyUpgradeTimelock`. Grant it to every
+        // proxy owner pranked for an upgrade call below.
+        vm.startPrank(roleRegistry.owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), stakingManager.owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), LiquidityPool(payable(address(liquidityPool))).owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), etherFiNodesManager.owner());
+        vm.stopPrank();
+
         // deploy new staking manager implementation
         StakingManager stakingManagerImpl = new StakingManager(
             address(liquidityPool),

--- a/test/fork-tests/RoleMigrationStorageIntegrity.t.sol
+++ b/test/fork-tests/RoleMigrationStorageIntegrity.t.sol
@@ -99,7 +99,7 @@ contract RoleMigrationStorageIntegrityTest is Test, Deployed {
         bytes32[] memory preAM = _snapshot(AUCTION_MANAGER);
         bytes32[] memory preER = _snapshot(ETHERFI_RESTAKER);
 
-        address newAM = address(new AuctionManager(ROLE_REGISTRY, address(0), NODE_OPERATOR_MANAGER, STAKING_MANAGER, MEMBERSHIP_MANAGER));
+        address newAM = address(new AuctionManager(ROLE_REGISTRY, address(0), NODE_OPERATOR_MANAGER, STAKING_MANAGER, MEMBERSHIP_MANAGER, TREASURY));
         address newER = address(new EtherFiRestaker(
             LIQUIDITY_POOL,
             LIQUIFIER,

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -417,9 +417,11 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
 
         // Migrate pre-existing locked ETH from LP into the NFT escrow so that
         // pre-existing finalized requests can be claimed against the NFT balance.
+        // `initializeOnUpgradeV2` is now `onlyUpgradeTimelock`, so use the
+        // upgrade-timelock address that already holds UPGRADE_TIMELOCK_ROLE.
         LiquidityPool lp = LiquidityPool(payable(LIQUIDITY_POOL));
         if (!lp.escrowMigrationCompleted()) {
-            vm.prank(lp.owner());
+            vm.prank(UPGRADE_TIMELOCK);
             lp.initializeOnUpgradeV2();
         }
     }

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -136,12 +136,13 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         // Latest-block fork; realistic mainnet state.
         vm.createSelectFork(vm.envString("MAINNET_RPC_URL"));
 
-        // Upgrade RoleRegistry in place so newly-added role getters are
-        // reachable from upgraded contracts that call into roleRegistry from
-        // within their modifiers.
-        address roleRegOwner = IOwnableRead(ROLE_REGISTRY).owner();
-        vm.prank(roleRegOwner);
-        IUUPSProxy(ROLE_REGISTRY).upgradeTo(address(new RoleRegistry(address(0))));
+        // NOTE: RoleRegistry is intentionally NOT upgraded here. The currently
+        // deployed LP/WRN/PQ impls authorize upgrades via the legacy
+        // `roleRegistry.onlyProtocolUpgrader` / `onlyOwner` paths; once we swap
+        // RoleRegistry to the new impl that selector no longer exists, so all
+        // proxy upgrades have to happen against the live RoleRegistry. The
+        // RoleRegistry upgrade itself is performed by `_upgradeRoleRegistry()`
+        // AFTER the other proxies have been upgraded.
 
         // Deploy a fresh Blacklister — newly-upgraded impls (LP, WRN, etc.)
         // now wire it as an immutable. Storage-integrity assertions don't care
@@ -149,6 +150,23 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         // input is well-formed.
         Blacklister bImpl = new Blacklister(ROLE_REGISTRY);
         blacklisterInstance = Blacklister(address(new UUPSProxy(address(bImpl), abi.encodeWithSelector(Blacklister.initialize.selector))));
+    }
+
+    /// @dev Upgrade RoleRegistry to the new impl (after LP/WRN/PQ have already
+    ///      been upgraded) and grant the new UPGRADE_TIMELOCK_ROLE to the
+    ///      mainnet UPGRADE_TIMELOCK address so subsequent calls gated by
+    ///      `onlyUpgradeTimelock` (e.g. `initializeOnUpgradeV2`) can pass.
+    function _upgradeRoleRegistry() internal {
+        address roleRegOwner = IOwnableRead(ROLE_REGISTRY).owner();
+        vm.prank(roleRegOwner);
+        IUUPSProxy(ROLE_REGISTRY).upgradeTo(address(new RoleRegistry(address(0))));
+
+        RoleRegistry rr = RoleRegistry(ROLE_REGISTRY);
+        // Cache the role bytes32 in a local first — calling `rr.UPGRADE_TIMELOCK_ROLE()`
+        // inline as a `grantRole` argument would consume the next `vm.prank` slot.
+        bytes32 upgradeRole = rr.UPGRADE_TIMELOCK_ROLE();
+        vm.prank(roleRegOwner);
+        rr.grantRole(upgradeRole, UPGRADE_TIMELOCK);
     }
 
     function _snap(address target, uint256 n) internal view returns (bytes32[] memory a) {
@@ -213,14 +231,17 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
 
         // ------------------------------------------------------------------
         // 3. Upgrade the proxies in place
-        //    LP:  _authorizeUpgrade -> roleRegistry.onlyProtocolUpgrader
-        //         The UPGRADE_TIMELOCK holds the protocol upgrader role.
-        //    WRN: _authorizeUpgrade -> onlyOwner (read at runtime).
+        //    LP:  legacy _authorizeUpgrade -> roleRegistry.onlyProtocolUpgrader
+        //         which on the deployed RoleRegistry checks `owner() == account`.
+        //         Use the live RoleRegistry owner.
+        //    WRN: legacy _authorizeUpgrade -> onlyOwner (read at runtime).
         // ------------------------------------------------------------------
-        vm.prank(UPGRADE_TIMELOCK);
+        address roleRegOwner = IOwnableRead(ROLE_REGISTRY).owner();
+        address wrnOwner = IOwnableRead(WITHDRAW_REQUEST_NFT).owner();
+
+        vm.prank(roleRegOwner);
         IUUPSProxy(LIQUIDITY_POOL).upgradeTo(newLP);
 
-        address wrnOwner = IOwnableRead(WITHDRAW_REQUEST_NFT).owner();
         vm.prank(wrnOwner);
         IUUPSProxy(WITHDRAW_REQUEST_NFT).upgradeTo(newWRN);
 
@@ -405,20 +426,29 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
             LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours
         ));
 
-        vm.prank(UPGRADE_TIMELOCK);
+        // Upgrade proxies against the LIVE (pre-upgrade) RoleRegistry, since
+        // the deployed LP/PQ impls still call `onlyProtocolUpgrader` and the
+        // deployed WRN impl uses `onlyOwner`.
+        address roleRegOwner = IOwnableRead(ROLE_REGISTRY).owner();
+        address wrnOwner = IOwnableRead(WITHDRAW_REQUEST_NFT).owner();
+
+        vm.prank(roleRegOwner);
         IUUPSProxy(LIQUIDITY_POOL).upgradeTo(newLP);
 
-        address wrnOwner = IOwnableRead(WITHDRAW_REQUEST_NFT).owner();
         vm.prank(wrnOwner);
         IUUPSProxy(WITHDRAW_REQUEST_NFT).upgradeTo(newWRN);
 
-        vm.prank(UPGRADE_TIMELOCK);
+        vm.prank(roleRegOwner);
         IUUPSProxy(PRIORITY_WITHDRAWAL_QUEUE).upgradeTo(newPQ);
+
+        // Now swap RoleRegistry so the freshly-upgraded impls' role getters
+        // (onlyUpgradeTimelock, onlyOperatingMultisig, ...) resolve.
+        _upgradeRoleRegistry();
 
         // Migrate pre-existing locked ETH from LP into the NFT escrow so that
         // pre-existing finalized requests can be claimed against the NFT balance.
-        // `initializeOnUpgradeV2` is now `onlyUpgradeTimelock`, so use the
-        // upgrade-timelock address that already holds UPGRADE_TIMELOCK_ROLE.
+        // `initializeOnUpgradeV2` is `onlyUpgradeTimelock`; UPGRADE_TIMELOCK was
+        // granted UPGRADE_TIMELOCK_ROLE inside `_upgradeRoleRegistry`.
         LiquidityPool lp = LiquidityPool(payable(LIQUIDITY_POOL));
         if (!lp.escrowMigrationCompleted()) {
             vm.prank(UPGRADE_TIMELOCK);
@@ -446,7 +476,8 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
             }),
             0
         ));
-        vm.prank(UPGRADE_TIMELOCK);
+        address roleRegOwner = IOwnableRead(ROLE_REGISTRY).owner();
+        vm.prank(roleRegOwner);
         IUUPSProxy(LIQUIDITY_POOL).upgradeTo(newLP);
 
         // Plant ENTERED directly; the next guarded call must revert with the

--- a/test/fork-tests/pectra-fork-tests/Consolidation-through-EOA.sol
+++ b/test/fork-tests/pectra-fork-tests/Consolidation-through-EOA.sol
@@ -44,26 +44,30 @@ contract ConsolidationThroughEOATest is Test {
         console2.log("=== SETUP ===");
         vm.selectFork(vm.createFork(vm.envString("MAINNET_RPC_URL")));
 
-        // Upgrade RoleRegistry in place so newly-added role getters defined in
+        // Upgrade EtherFiNodesManager and EtherFiRateLimiter FIRST, while the
+        // deployed RoleRegistry still exposes the legacy `onlyProtocolUpgrader`
+        // selector their `_authorizeUpgrade` calls into. Once we swap
+        // RoleRegistry below, that selector is gone.
+        newEtherFiNodesManagerImpl = new EtherFiNodesManager(address(stakingManager), address(roleRegistry), address(rateLimiter));
+        vm.prank(roleRegistry.owner());
+        etherFiNodesManager.upgradeTo(address(newEtherFiNodesManagerImpl));
+
+        address newRateLimiterImpl = address(new EtherFiRateLimiter(address(roleRegistry)));
+        vm.prank(roleRegistry.owner());
+        EtherFiRateLimiter(address(rateLimiter)).upgradeTo(newRateLimiterImpl);
+
+        // Now swap RoleRegistry so newly-added role getters defined in
         // RolesLibrary are reachable on the deployed proxy.
         vm.prank(roleRegistry.owner());
         roleRegistry.upgradeTo(address(new RoleRegistry(address(0))));
 
-        //upgrade the etherfi nodes manager contract
-        newEtherFiNodesManagerImpl = new EtherFiNodesManager(address(stakingManager), address(roleRegistry), address(rateLimiter));
         vm.startPrank(roleRegistry.owner());
-        etherFiNodesManager.upgradeTo(address(newEtherFiNodesManagerImpl));
         roleRegistry.grantRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), realElExiter);
 
         // Setup consolidation rate limiter bucket (required for new rate limiting)
         roleRegistry.grantRole(roleRegistry.OPERATION_MULTISIG_ROLE(), roleRegistry.owner());
         // RateLimiter mutators (createNewLimiter, updateConsumers) are now onlyAdmin → OPERATION_TIMELOCK_ROLE.
         roleRegistry.grantRole(roleRegistry.OPERATION_TIMELOCK_ROLE(), roleRegistry.owner());
-
-        // Upgrade the on-chain rate limiter so it uses the consolidated role model
-        // (the on-chain impl still checks ETHERFI_RATE_LIMITER_ADMIN_ROLE).
-        address newRateLimiterImpl = address(new EtherFiRateLimiter(address(roleRegistry)));
-        EtherFiRateLimiter(address(rateLimiter)).upgradeTo(newRateLimiterImpl);
 
         vm.stopPrank();
 

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -501,7 +501,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         bidIds[0] = 1; 
 
         vm.prank(unauthorizedUser);
-        vm.expectRevert(LiquidityPool.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyOracleOperations.selector);
         liquidityPool.batchCreateBeaconValidators(depositDataArray, bidIds, etherFiNode);
     }
 
@@ -751,7 +751,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
 
         // Try to invalidate without the role
         vm.prank(unauthorizedUser);
-        vm.expectRevert(IStakingManager.IncorrectRole.selector);
+        vm.expectRevert(RoleRegistry.OnlyOracleOperations.selector);
         stakingManager.invalidateRegisteredBeaconValidator(depositData, createdBids[0], etherFiNode);
     }
 

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -88,7 +88,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         vm.prank(liquidityPool.owner());
         liquidityPool.upgradeTo(address(liquidityPoolImpl));
 
-        AuctionManager auctionManagerImpl = new AuctionManager(address(roleRegistry), address(blacklister), address(nodeOperatorManager), address(stakingManager), 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000);
+        AuctionManager auctionManagerImpl = new AuctionManager(address(roleRegistry), address(blacklister), address(nodeOperatorManager), address(stakingManager), 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000, 0x0c83EAe1FE72c390A02E426572854931EefF93BA);
         vm.prank(auctionManager.owner());
         auctionManager.upgradeTo(address(auctionManagerImpl));
 

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -45,17 +45,15 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         vm.selectFork(vm.createFork(vm.envString("MAINNET_RPC_URL")));
         vm.deal(tom, 100 ether);
 
-        // Upgrade RoleRegistry in place so newly-added role getters (e.g.
-        // BLACKLISTED_USER) are reachable from upgraded contracts that call
-        // into roleRegistry from within their modifiers.
-        vm.prank(roleRegistry.owner());
-        roleRegistry.upgradeTo(address(new RoleRegistry(address(0))));
-
         // Deploy a Blacklister so impls that wire it as an immutable have a
         // non-zero target.
         Blacklister bImpl = new Blacklister(address(roleRegistry));
         Blacklister blacklister = Blacklister(address(new UUPSProxy(address(bImpl), abi.encodeWithSelector(Blacklister.initialize.selector))));
 
+        // Upgrade StakingManager / LP FIRST, against the LIVE RoleRegistry — the
+        // deployed impls' `_authorizeUpgrade` still calls `onlyProtocolUpgrader`,
+        // a selector the new RoleRegistry impl no longer exposes. Swap
+        // RoleRegistry only after these have been upgraded.
         StakingManager stakingManagerImpl = new StakingManager(
             address(liquidityPool),
             address(etherFiNodesManager),
@@ -91,6 +89,11 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         AuctionManager auctionManagerImpl = new AuctionManager(address(roleRegistry), address(blacklister), address(nodeOperatorManager), address(stakingManager), 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000, 0x0c83EAe1FE72c390A02E426572854931EefF93BA);
         vm.prank(auctionManager.owner());
         auctionManager.upgradeTo(address(auctionManagerImpl));
+
+        // Now swap RoleRegistry so newly-added role getters (e.g. BLACKLISTED_USER)
+        // are reachable from the freshly-upgraded contracts' modifiers.
+        vm.prank(roleRegistry.owner());
+        roleRegistry.upgradeTo(address(new RoleRegistry(address(0))));
 
         vm.startPrank(roleRegistry.owner());
         roleRegistry.grantRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), admin);

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -67,8 +67,8 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         }
 
         vm.startPrank(owner);
-        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
         liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
         vm.stopPrank();
 
         // Admin-gated setters on WithdrawRequestNFT (e.g. updateShareRemainderSplitToTreasuryInBps)

--- a/test/integration-tests/MinAmountForShare.t.sol
+++ b/test/integration-tests/MinAmountForShare.t.sol
@@ -103,15 +103,11 @@ contract MinAmountForShareForkTest is TestSetup, Deployed {
     // Immutable wiring
     // ---------------------------------------------------------------------
 
-    /// Pre-upgrade: mainnet's currently-deployed LP impl predates this branch, so the
-    /// `minAmountForShare` getter selector does not exist on the deployed bytecode.
-    /// The proxy delegatecall returns no data and reverts. Asserting this guards against
-    /// silent regressions in the pre-upgrade baseline this test suite assumes.
-    function test_fork_minAmount_getter_absent_pre_upgrade() public {
-        (bool ok, ) = address(liquidityPoolInstance).staticcall(
-            abi.encodeWithSignature("minAmountForShare()")
-        );
-        assertFalse(ok, "minAmountForShare getter unexpectedly exists pre-upgrade");
+    /// Post-baseline (after `initializeRealisticFork` upgrades LP in place):
+    /// the `minAmountForShare` getter is present and reads back as zero, since
+    /// TestSetup constructs the LP impl with `minAmountForShare = 0`.
+    function test_fork_minAmount_getter_present_post_setup_upgrade() public view {
+        assertEq(liquidityPoolInstance.minAmountForShare(), 0);
     }
 
     function test_fork_minAmount_immutable_set_after_upgrade() public {

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -79,8 +79,8 @@ contract WithdrawEscrowE2ETest is TestSetup {
         if (!liquidityPoolInstance.escrowMigrationCompleted()) {
             liquidityPoolInstance.initializeOnUpgradeV2();
         }
-        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
         liquidityPoolInstance.setMaxWithdrawAmount(1000 ether);
+        liquidityPoolInstance.setMinWithdrawAmount(0.001 ether);
         _grantRoles();
         vm.stopPrank();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches access control across many core contracts and changes upgrade authorization to `onlyUpgradeTimelock`, which could break operations if roles are misconfigured. Also changes where auction revenue is swept (to `treasury`), impacting ETH flow.
> 
> **Overview**
> **Access control refactor:** Replaces per-contract `IRoleRegistry` storage/modifiers with shared `RolesLibrary` across most upgradeable contracts, and updates call sites/tests/scripts to expect the new `RoleRegistry` revert selectors and checks.
> 
> **Upgrade/admin behavior changes:** UUPS upgrade authorization is consistently gated by `onlyUpgradeTimelock` (including `LiquidityPool.initializeOnUpgradeV2`), and `RoleRegistry` now exposes explicit role constants plus `onlyOracleOperations`/`onlyHousekeepingOperations`/`onlyExecutorOperations`/`onlyEigenpodOperations` helpers.
> 
> **Functional tweaks:** `EtherFiNode` constructor drops the `roleRegistry` parameter, and `AuctionManager` now sweeps `accumulatedRevenue` to a new immutable `treasury` address (removing the previous membership-threshold auto-transfer path) while retagging various operational entrypoints to the updated roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a6342f828b68974b9127432f1ef5f43f1a9020d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->