### PR TITLE
fix(rate-limiter): consistency + clarity polish on #423

### DIFF
--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -236,10 +236,22 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     }
 
     // [INTERNAL FUNCTIONS]
-    function _transfer(address _sender, address _recipient, uint256 _amount) internal {
+    /// @dev Order mirrors `WeETH._beforeTokenTransfer`: pause + blacklist checks
+    ///      run BEFORE the rate-limit consume so a paused/blacklisted call doesn't
+    ///      bother the external rate limiter, and so blacklist / pause states
+    ///      cannot be silently observed via rate-limit state changes (atomic revert
+    ///      makes this safe either way, but consistent ordering removes the
+    ///      duplicate-check footprint that previously lived in `_transferShares`).
+    function _transfer(address _sender, address _recipient, uint256 _amount) internal whenNotPaused {
+        blacklister.nonBlacklisted(_sender);
+        blacklister.nonBlacklisted(_recipient);
+        blacklister.nonBlacklisted(msg.sender);
+        if (_sender == address(0) || _recipient == address(0)) revert AddressZero();
+
         uint64 amt = toBucketUnit(_amount);
         rateLimiter.consumeForAddressIfConfigured(_sender,    amt);
         rateLimiter.consumeForAddressIfConfigured(_recipient, amt);
+
         uint256 _sharesToTransfer = liquidityPool.sharesForAmount(_amount);
         _transferShares(_sender, _recipient, _sharesToTransfer);
         emit Transfer(_sender, _recipient, _amount);
@@ -252,11 +264,9 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit Approval(_owner, _spender, _amount);
     }
 
-    function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal whenNotPaused{
-        blacklister.nonBlacklisted(_sender);
-        blacklister.nonBlacklisted(_recipient);
-        blacklister.nonBlacklisted(msg.sender);
-        if (_sender == address(0) || _recipient == address(0)) revert AddressZero();
+    /// @dev Pure share-accounting; pause / blacklist / address-zero gates live
+    ///      in the caller (`_transfer`). Internal-only; not callable elsewhere.
+    function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal {
         if (_sharesAmount > shares[_sender]) revert TransferAmountExceedsBalance();
 
         shares[_sender] -= _sharesAmount;

--- a/src/EtherFiRateLimiter.sol
+++ b/src/EtherFiRateLimiter.sol
@@ -31,6 +31,7 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     //-------------------------------------------------------------------------
     //-------------------------  Deployment  ----------------------------------
     //-------------------------------------------------------------------------
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _roleRegistry, address _eETH, address _weETH) RolesLibrary(_roleRegistry) {
         eETH = _eETH;
         weETH = _weETH;
@@ -120,8 +121,15 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     ///      be created with any starting parameters because there's no looser prior state
     ///      to compare against (no bucket == unrestricted). `capacity = 0` on an existing
     ///      bucket is the tightest move and acts as a hard freeze (consume reverts).
-    ///      `BucketLimiter.setCapacity` / `setRefillRate` preserve `remaining`, capped to
-    ///      the new capacity — so tightening can't accidentally refill a half-drained bucket.
+    ///
+    ///      Remaining-balance behavior: `BucketLimiter.setCapacity` / `setRefillRate`
+    ///      apply any pending refill FIRST (against the previous cap/rate), then enforce
+    ///      the new lower bounds. So a long-drained bucket can effectively be refreshed
+    ///      to (refilled-previous-state) then capped down to `newCapacity`. Net effect:
+    ///      `remaining` is bounded above by both the refilled-previous-state and the new
+    ///      capacity. The user can never end up with MORE consumable than they could
+    ///      have spent in one consume against the previous cap, so tightening still only
+    ///      restricts the user's max burst — it cannot loosen them.
     function tightenAddressLimit(address user, uint64 capacity, uint64 refillRate) external onlyToken {
         BucketLimiter.Limit storage lim = addressLimits[msg.sender][user];
         if (lim.lastRefill == 0) {
@@ -182,8 +190,18 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     ///      limiter must not halt token transfers; operators pause the token contract itself
     ///      for a hard stop. Still enforces bucket existence and the consumer whitelist, so
     ///      this is not a backdoor: only consumers explicitly whitelisted by an admin (e.g.
-    ///      eETH, weETH for their respective buckets) can use it. Monitoring should watch the
-    ///      existing CapacityUpdated(id, 0) event to detect buckets entering disabled mode.
+    ///      eETH, weETH for their respective buckets) can use it.
+    ///
+    ///      CAPACITY == 0 SEMANTICS: on this global-bucket path, `capacity == 0` means
+    ///      "not configured / disabled" and the call passes through as a no-op. This is
+    ///      deliberate — admins set cap=0 to retire a bucket without breaking the live
+    ///      consumer's call path. Compare against `consumeForAddressIfConfigured` below,
+    ///      where `capacity == 0` on an existing per-address bucket means "frozen" and
+    ///      reverts. The split is intentional: the global bucket has only one creation
+    ///      lifecycle (admin opt-in), while per-address buckets have a freeze/delete
+    ///      distinction baked into the Guardian/Multisig access split. Monitoring should
+    ///      watch the existing `CapacityUpdated(id, 0)` event to detect buckets entering
+    ///      disabled mode.
     function consumeIfConfigured(bytes32 id, uint64 amount) external {
         if (!limitExists(id)) revert UnknownLimit();
         if (!consumers[id][msg.sender]) revert InvalidConsumer();
@@ -195,10 +213,19 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
 
     /// @notice Consume from a per-address bucket; no-op if the user has no bucket configured.
     /// @dev Callable only by eETH/weETH. `lastRefill == 0` uniquely identifies "never
-    ///      created" (unrestricted user). When a bucket exists, a `BucketLimiter.consume`
-    ///      failure reverts — this includes the frozen case (`capacity == 0`) since refill
-    ///      can't push `remaining` above zero capacity. Intentionally skips `whenNotPaused`:
-    ///      pausing the rate limiter must not halt token transfers.
+    ///      created" (unrestricted user) and short-circuits to a no-op.
+    ///
+    ///      CAPACITY == 0 SEMANTICS: differs from `consumeIfConfigured` above. Here a
+    ///      bucket with `lastRefill > 0` AND `capacity == 0` is treated as **frozen** —
+    ///      the underlying `BucketLimiter.consume` returns false (refill can't push
+    ///      `remaining` above a zero capacity) and we revert `LimitExceeded`. This is
+    ///      the freeze path the Guardian uses via `tightenAddressLimit(user, 0, 0)`;
+    ///      the Multisig clears it via `deleteAddressLimit` (returns to "never created")
+    ///      or `setAddressLimit` (creates fresh with non-zero cap). Two distinct sentinel
+    ///      states (deleted vs frozen) keep the Guardian/Multisig split meaningful.
+    ///
+    ///      Intentionally skips `whenNotPaused`: pausing the rate limiter must not halt
+    ///      token transfers.
     function consumeForAddressIfConfigured(address user, uint64 amount) external onlyToken {
         BucketLimiter.Limit storage lim = addressLimits[msg.sender][user];
         if (lim.lastRefill == 0) return;


### PR DESCRIPTION
Small follow-up to #423 with four targeted fixes. Pure docs + one safe reorder; no logic change beyond `EETH._transfer`'s check ordering. Independent of #424 (which adds the wrap-aware global supply buckets).

## Changes

### 1. Add `@custom:oz-upgrades-unsafe-allow constructor` to `EtherFiRateLimiter`

The contract is UUPS-upgradeable and now takes immutable `eETH`/`weETH` addresses via its constructor. Without the annotation the OZ upgrades plugin rejects it. `WeETH` already has this annotation; rate limiter should match.

### 2. Rewrite the `tightenAddressLimit` remaining-balance docstring

Old text:
> `BucketLimiter.setCapacity` / `setRefillRate` preserve `remaining`, capped to the new capacity — so tightening can't accidentally refill a half-drained bucket.

That's misleading under non-zero `refillRate`. `BucketLimiter.setCapacity` calls `refill()` first (against the OLD cap), THEN sets the new cap and caps `remaining` down. So a drained bucket with elapsed refill can have `remaining` jump up to `min(refilled-previous-state, newCapacity)`.

New text precisely describes the order and explicitly notes the invariant that matters: the user can never end up with MORE consumable than they could have spent in one consume against the previous cap, so tightening still only restricts max burst. The previous wording implied `remaining` was preserved literally, which it isn't. **Pure docs; no logic change.**

### 3. Document the deliberate `capacity == 0` semantic split

`consumeIfConfigured` (global) and `consumeForAddressIfConfigured` (per-address) intentionally treat `capacity == 0` differently:

| API | `capacity == 0` means |
|---|---|
| `consumeIfConfigured` | **disabled / not configured** — call passes as no-op |
| `consumeForAddressIfConfigured` (with `lastRefill > 0`) | **frozen** — `BucketLimiter.consume` returns false → revert |

This split is intentional: global buckets have a single admin lifecycle (admin opts a path in once and may later retire it via `cap=0`), while per-address buckets have a freeze/delete distinction baked into the Guardian (freeze: `tightenAddressLimit(user, 0, 0)`) vs Multisig (delete: `deleteAddressLimit`) access split. Two distinct sentinel states (deleted vs frozen) are what keeps that role split meaningful.

The old docstrings didn't surface this divergence and during review of #423 it tripped expectations (`setCapacity(globalId, 0)` "doesn't freeze, why?"). The fix is to spell it out clearly in both function comments. **Pure docs.**

### 4. `EETH._transfer`: reorder pause/blacklist BEFORE rate-limit consume

`WeETH._beforeTokenTransfer` runs pause → blacklist → consume. `EETH._transfer` ran consume → pause/blacklist (the latter living inside `_transferShares`). Atomic revert kept it safe, but:
- Wastes gas on revert when paused/blacklisted (touched external rate limiter for no reason).
- Inconsistent with the WeETH path — confusing for readers.

Fix:
- Pull `whenNotPaused` + blacklist + address-zero check up into `_transfer`.
- Consolidate them out of `_transferShares` (which is internal-only and only called from `_transfer`).
- `_transferShares` becomes pure share-accounting.

Behavior is identical from the outside; gas slightly cheaper on revert; check ordering now matches WeETH.

## Tests

- `forge test --match-path 'test/TokenRateLimit.t.sol'` → **29/29 pass**
- `forge test --match-path 'test/EETH.t.sol'` → **47/47 pass**
- `forge test --match-path 'test/WeETH.t.sol'` → **46/46 pass**
- `forge test --match-path 'test/LiquidityPool.t.sol'` → **138/138 pass**

## Relationship to #424

This PR and #424 are independent and can be merged in either order. #424 adds the wrap-aware global supply circuit breaker on top of #423; this PR is pure consistency/clarity polish. Both target Yash's branch directly.

## Files changed

```
src/EtherFiRateLimiter.sol  | +27 / -10 (3 docstrings + 1 annotation; no logic)
src/EETH.sol                | +14 / -4  (reorder _transfer; simplify _transferShares)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly NatSpec and check ordering on transfers; external behavior is unchanged aside from slightly cheaper reverts when paused or blacklisted.
> 
> **Overview**
> Follow-up polish on the rate-limiter work: **documentation and one safe check reorder**, with no intentional change to rate-limit math beyond clearer comments.
> 
> **`EtherFiRateLimiter`** adds the OpenZeppelin upgrades **`@custom:oz-upgrades-unsafe-allow constructor`** annotation (aligned with other UUPS contracts like `WeETH`). Docstrings are expanded for **`tightenAddressLimit`** (refill runs before cap/rate tightening; tightening still cannot increase max burst vs the prior cap) and for the deliberate **`capacity == 0`** split: global **`consumeIfConfigured`** treats zero as disabled (no-op), while per-address **`consumeForAddressIfConfigured`** treats an existing zero-cap bucket as **frozen** (revert).
> 
> **`EETH._transfer`** now runs **pause, blacklist, and zero-address checks before** per-address rate-limit consumption—matching **`WeETH._beforeTokenTransfer`**—and **`_transferShares`** is left as share accounting only. Observable transfer outcomes stay the same; reverts on pause/blacklist avoid touching the rate limiter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10cc4aec61e7b60fbe3cefe9c8b6735d9fbcb97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->