### PR TITLE
feat: ProtocolInvariants — on-chain backing + rate-monotonicity for eETH/weETH

### DIFF
--- a/docs/rfc-protocol-invariants.md
+++ b/docs/rfc-protocol-invariants.md
@@ -1,0 +1,426 @@
+# RFC: Invariant-Based Supply Safety for eETH / weETH
+
+**Status:** Draft — for discussion
+**Author:** Seongyun
+**Date:** 2026-05-25
+**Related:** #423 (per-address rate limits), #424 (wrap-aware global supply circuit breaker), #425 (rate-limiter consistency polish)
+
+## TL;DR
+
+Replace the bucket-based supply rate limits on eETH/weETH with on-chain
+**conservation invariants** that revert any transaction violating "tokens are
+backed by underlying ETH." The protocol then has a hard, path-independent
+defense against unbacked-mint exploits, the wrap-flag transient-storage carve-out
+in #424 becomes unnecessary, and the threshold-sizing problem disappears.
+
+Per-address rate limits stay — they're the right tool for the targeted-throttle
+threat. The invariant layer protects against unbacked supply. The two tools
+solve different problems and shouldn't be conflated.
+
+## Motivation
+
+PR #423 introduced per-address rate limits and removed the protocol-wide
+MINT/BURN circuit breaker on eETH/weETH. Review of #423 surfaced a gap:
+without a global breaker, an unbacked-mint exploit (compromised LP, future
+bridge adapter, exploited mint path) has no on-chain bound — only off-chain
+detection + manual pause.
+
+#424 re-adds a global breaker with a wrap-aware transient-storage flag to
+avoid the wrap/unwrap griefing surface. It works, but the design has tells:
+
+1. **Threshold sizing per token per chain.** Operators must size MINT/BURN
+   capacity and refill rate by hand. Get it wrong and either legitimate
+   traffic is throttled or attacks slip through.
+2. **Path-conditional exception (the wrap flag).** wrap/unwrap is
+   value-neutral, so we carve it out. Every future "value-neutral" mint path
+   needs the same carve-out and the same maintenance hazard.
+3. **Two `capacity == 0` semantics.** Global = disabled; per-address =
+   frozen. Documented in #425, but the divergence exists because we're using
+   the same `BucketLimiter` primitive for two different jobs.
+4. **`UnknownLimit` bricks the path.** Forget to bootstrap a bucket in the
+   3CP and every deposit reverts. Operational hazard.
+
+All four are symptoms of one root cause: **a gross-flow rate limit is the
+wrong tool for catching unbacked mints.** A rate limit *slows* an exploit;
+it does not *prevent* it. The exploit can still happen — it's just slower.
+
+The right tool is a **state invariant**: at the end of every state-changing
+call, assert that the protocol's accounting still adds up. If a mint happened
+without matching backing, the math breaks and the transaction reverts. No
+thresholds, no carve-outs, no bootstrap order.
+
+## What the invariants are
+
+### Invariant 1: weETH is exactly backed by eETH shares held in the proxy
+
+For every state-changing call on `WeETH`:
+
+```
+weETH.totalSupply() == eETH.shares(address(weETHProxy))
+```
+
+**Why this holds in the current design:**
+
+`wrap(_eETHAmount)` does two things in one call:
+- Mints `liquidityPool.sharesForAmount(_eETHAmount)` weETH to the user.
+- Transfers `_eETHAmount` of eETH from user to proxy. Since eETH is a
+  rebase token, transferring `_eETHAmount` moves `sharesForAmount(_eETHAmount)`
+  shares.
+
+**Both increments are the same number.** weETH.totalSupply and eETH.shares(proxy)
+move in lockstep. `unwrap` is the symmetric decrement.
+
+**What this catches:**
+- Any non-wrap path that mints weETH without an eETH transfer in (bridge
+  compromise, exploit, future mint authority that forgot to transfer in eETH)
+  → `weETH.totalSupply > eETH.shares(proxy)` → revert.
+- Any non-unwrap path that drains eETH from the proxy without burning weETH
+  → `weETH.totalSupply > eETH.shares(proxy)` → revert.
+
+**Edge case — accidental eETH airdrops to proxy:**
+Someone calls `eETH.transfer(weETHProxy, X)` directly. `eETH.shares(proxy)`
+goes up; `weETH.totalSupply` stays. Invariant becomes `weETH.totalSupply <
+eETH.shares(proxy)` (proxy over-collateralized). This is *safe* for users
+(extra backing) but breaks strict equality.
+
+**Resolution:** use the `<=` form:
+
+```
+weETH.totalSupply() <= eETH.shares(address(weETHProxy))
+```
+
+Allows over-collateralization, forbids under-collateralization. Loses some
+expressivity (we no longer detect "extra eETH appeared in the proxy") but
+that's not a threat — we're protecting weETH holders' claims, not auditing
+proxy donations.
+
+**Cost:** ~2 SLOADs per state-changing call (one for each side). Negligible
+relative to rebase-token transfer cost.
+
+### Invariant 2: eETH share supply matches LP-tracked claims
+
+For every state-changing call on `EETH`:
+
+```
+eETH.totalShares == LP.totalShares()   // (or whatever LP-side variable
+                                       //  represents the share supply LP
+                                       //  thinks should exist)
+```
+
+**Background:** LP is the *only* contract authorized to mint/burn eETH
+shares (`mintShares` / `burnShares` are gated `onlyPoolContract`). LP holds
+its own ledger of how many shares should exist. If LP and eETH agree, all
+is well. If they disagree, one of them is buggy / compromised.
+
+**This is currently true by construction.** The question is whether it
+should be *enforced* by reverting on violation rather than just assumed.
+
+**What this catches:**
+- A bug or exploit that mints eETH shares directly without going through LP
+  (e.g., a future feature that forgets to update LP-side accounting; an
+  exploit that finds a delegatecall-y path).
+- A drift between LP and eETH state due to a partial-failure path that
+  updates one but not the other.
+
+**Caveat:** this invariant is only meaningful if LP itself isn't compromised.
+If LP is compromised, the attacker controls LP.totalShares too and can keep
+the invariant satisfied while doing whatever they want. The protection here
+is against *paths outside LP* that touch eETH share state.
+
+**On the LP-compromise threat:** invariants don't help. The right defense is
+upgrade controls (timelock, multisig) + audits + pause + Hypernative. None
+of those go away with this RFC.
+
+### Invariant 3 (optional, harder): eETH backing reconciliation
+
+The fullest version:
+
+```
+LP.totalPooledEther == sum of (
+    ETH held by LP +
+    ETH on validators (active + pending) +
+    ETH in withdrawal queue +
+    ETH in escrow / restaker
+)
+```
+
+If `LP.totalPooledEther` is computed (e.g., updated by an oracle), this
+should equal the sum of physically-located ETH.
+
+**Why this is hard:**
+- Validator stakes are not directly readable on-chain.
+- The protocol relies on oracle updates to refresh `totalPooledEther`. Between
+  refreshes, the invariant is intentionally loose.
+- Slashing, accidental fees, lost-key validators create unavoidable drift.
+
+**Disposition:** out of scope for the first iteration. The oracle-based
+accounting model already implies "we trust the oracle, not the chain, for
+this number." Invariant 1 and 2 sit *above* this trust assumption — they
+say "given the numbers LP reports, the token contracts must be consistent
+with them." That's the layer we can enforce cheaply.
+
+Mention here only so it's clear what we're NOT proposing.
+
+## Implementation sketch
+
+### A new contract: `ProtocolInvariants`
+
+```solidity
+contract ProtocolInvariants {
+    IeETH   public immutable eETH;
+    IWeETH  public immutable weETH;
+    ILiquidityPool public immutable liquidityPool;
+
+    error WeETHUnderbacked(uint256 weETHSupply, uint256 proxyShares);
+    error EETHSharesDrift(uint256 eETHTotal, uint256 lpTotal);
+
+    /// @notice Asserts weETH is at-least-fully-backed by eETH shares
+    ///         held in the weETH proxy. Cheap (~2 SLOADs).
+    function assertWeETHBacked() external view {
+        uint256 supply = weETH.totalSupply();
+        uint256 proxyShares = eETH.shares(address(weETH));
+        if (supply > proxyShares) revert WeETHUnderbacked(supply, proxyShares);
+    }
+
+    /// @notice Asserts eETH share supply matches LP's view.
+    function assertEETHSharesConsistent() external view {
+        uint256 eETHTotal = eETH.totalShares();
+        uint256 lpTotal   = liquidityPool.totalShares(); // adjust if name differs
+        if (eETHTotal != lpTotal) revert EETHSharesDrift(eETHTotal, lpTotal);
+    }
+}
+```
+
+### Integration points
+
+Two natural patterns; pick one based on what the team finds clearer.
+
+**Pattern A — modifier on token methods.** Each state-changing token method
+calls `invariants.assertWeETHBacked()` (or `assertEETHSharesConsistent()`)
+at the end. Pro: locality — invariant lives at the call site. Con: every
+new state-changing method needs the modifier.
+
+```solidity
+modifier checkBacking() {
+    _;
+    invariants.assertWeETHBacked();
+}
+
+function wrap(uint256 amt) checkBacking external returns (uint256) { ... }
+function unwrap(uint256 amt) checkBacking external returns (uint256) { ... }
+```
+
+**Pattern B — invariant runs in `_afterTokenTransfer` (OZ ERC20 hook).**
+For weETH this is automatic — every supply change goes through the hook.
+For eETH, hook into `_transferShares` / `mintShares` / `burnShares`.
+Pro: impossible to forget. Con: slightly more gas per call (the SLOADs
+happen even on no-op-like paths).
+
+Recommend **Pattern B for weETH** (one hook covers everything), **Pattern A
+for eETH** (only three call sites, modifier is clearer than threading
+through `_transferShares`).
+
+### What gets retired when this lands
+
+- `WEETH_MINT_LIMIT_ID` / `WEETH_BURN_LIMIT_ID` (added in #424) — invariant
+  catches the threat path-independently.
+- The wrap-aware transient-storage flag in `WeETH` — no need to carve out
+  wrap/unwrap, the invariant is path-agnostic.
+- `EETH_MINT_LIMIT_ID` / `EETH_BURN_LIMIT_ID` — invariant 2 catches the
+  threat. Only retire AFTER invariant 2 is enforce-mode (see rollout).
+
+Per-address rate limits stay. They solve a different problem (targeted
+throttling, not unbacked-mint prevention).
+
+## Phased rollout
+
+Conservative path that lets us validate the invariant formulas against real
+mainnet activity before they can revert anything.
+
+### Phase 0 — Spec & numerical review (1 week)
+
+- Get a numerical-analysis eye on the exact-equality forms. eETH is a
+  rebase token; share/balance conversions have rounding. Confirm
+  `weETH.totalSupply() <= eETH.shares(proxy)` is exact, not approximately
+  exact, under all paths (wrap, unwrap, transfers, rebase).
+- Confirm `eETH.totalShares == LP.totalShares` is exact at all observable
+  call boundaries (not mid-call).
+- Pen-test against historical mainnet txs: replay last 6 months of weETH
+  state-changing calls in a fork, assert invariants hold at every block.
+
+**Exit criterion:** invariants verified to hold across 6 months of mainnet
+history with zero false positives.
+
+### Phase 1 — Observe mode (4 weeks on mainnet)
+
+- Deploy `ProtocolInvariants` contract.
+- Wire it into eETH and weETH **emitting events on violation, NOT reverting**:
+
+  ```solidity
+  function assertWeETHBacked() external {
+      uint256 supply = weETH.totalSupply();
+      uint256 proxyShares = eETH.shares(address(weETH));
+      if (supply > proxyShares) emit InvariantViolated("weETHUnderbacked", supply, proxyShares);
+  }
+  ```
+
+- Hypernative subscribes to `InvariantViolated` events; auto-pause if fired.
+- Operations team monitors. Any violation event is an immediate triage.
+
+**Exit criterion:** 4 weeks of mainnet activity with zero `InvariantViolated`
+events.
+
+### Phase 2 — Enforce mode (revert on violation)
+
+- Upgrade eETH/weETH (or the invariant contract itself if hooked external)
+  to revert on violation rather than emit.
+- Keep the global MINT/BURN buckets (#424) live in parallel for one cycle
+  as belt-and-suspenders.
+
+**Exit criterion:** 4 weeks in enforce mode with no incidents.
+
+### Phase 3 — Retire global rate-limit buckets
+
+- Remove `EETH_{MINT,BURN}_LIMIT_ID`, `WEETH_{MINT,BURN}_LIMIT_ID` consumption
+  from token paths.
+- Remove the wrap-aware transient flag from `WeETH`.
+- Keep per-address buckets.
+- 3CP simplifies: no bootstrap-order requirement for global buckets.
+
+## Risks and mitigations
+
+### R1 — Invariant function has a bug, bricks the protocol
+
+The blast radius is total: a buggy invariant can lock every wrap/unwrap and
+every eETH transfer. The Phase-1 observe mode is specifically designed to
+catch this before it can revert. Even in Phase 2, the invariant contract
+itself must be:
+- Pause-able by Operating Multisig (`disableInvariant()` switch).
+- Upgradable by Upgrade Timelock (separate from the token upgrade path).
+- Constructed with `assert` semantics, NOT `require` — i.e., reverts return
+  a clear typed error, no string concatenation, no external calls in the
+  invariant function.
+
+The `disableInvariant()` switch is non-negotiable. The cost of being able
+to flip it off in an emergency is approximately zero (one bool); the cost
+of NOT being able to is potentially a multi-day brick.
+
+### R2 — Rounding / off-by-one false positives
+
+eETH share/balance math has rounding. If we get the invariant form even
+slightly wrong (e.g., strict equality where `<=` is right), we get
+intermittent reverts under benign rebase.
+
+Mitigation: Phase 0 pen-test is exactly this. Replay 6 months of mainnet,
+assert the invariant holds at every block under the exact form we're
+proposing to ship. If it doesn't, we have the wrong form — iterate.
+
+### R3 — Gas cost on hot paths
+
+Each state-changing call adds 2 SLOADs + a comparison. Bounded ~5k gas.
+Wrap/unwrap are ~150k gas operations; this is ~3% overhead. Acceptable.
+
+Optimization: the invariant function is `view`, so it can be `staticcall`-ed
+or inlined if the gas matters. Real cost is 2 SLOADs (~4200 gas after
+warming) per token call.
+
+### R4 — LP compromise renders Invariant 2 useless
+
+If LP itself is compromised, `LP.totalShares` is attacker-controlled, so
+`eETH.totalShares == LP.totalShares` is satisfied trivially by the attacker.
+
+Invariant 2 is a defense against *non-LP paths* touching eETH share state.
+It does NOT defend against LP compromise. That threat is handled by
+upgrade governance and pause, as it is today.
+
+This isn't a mitigation — it's a scope clarification. The RFC doesn't claim
+to solve LP compromise.
+
+### R5 — Future state-changing methods forget the modifier (Pattern A)
+
+If we go with Pattern A and someone adds a new state-changing method
+without the modifier, the invariant doesn't run on that path.
+
+Mitigation: prefer Pattern B (hook into `_afterTokenTransfer` / `_transferShares`)
+wherever possible — the OZ template enforces hook coverage on supply changes
+automatically. Pattern A only for paths that don't naturally hit a hook.
+
+## What does NOT change
+
+- **Per-address rate limits** stay exactly as built in #423. Different threat
+  (targeted throttling, ops tool), different tool.
+- **Pause / blacklist / withdrawal queue** stay. They handle different
+  failure modes (anomalous-but-still-backed activity, sanctioned addresses,
+  forced exit velocity).
+- **Hypernative off-chain monitoring** stays. In fact, in Phase 1 it gets a
+  new high-signal data source (`InvariantViolated` events).
+- **Upgrade governance** stays. Invariants don't replace the timelock /
+  multisig story for LP compromise.
+
+## Open questions
+
+1. **Pattern A vs B for eETH.** EETH doesn't use the OZ ERC20 base —
+   `_transferShares` is custom. The hook insertion point isn't free. Maybe
+   Pattern A (modifier on `mintShares`, `burnShares`, `_transfer`) is the
+   pragmatic call. Worth a 30-min code review with @yash / @pankaj to
+   pick.
+
+2. **Where does `ProtocolInvariants` live?** Standalone contract behind a
+   proxy (upgradable, pause-able, but adds a contract to the upgrade
+   surface)? Library called from eETH/weETH (cheaper, but coupled)?
+   Recommend standalone contract — keeps the pause switch (R1) clean.
+
+3. **Should invariant violations also auto-pause the token?** Vs just
+   reverting the offending tx. Auto-pause is more conservative ("stop
+   everything if anything weird happens") but more disruptive. Lean
+   towards revert-only first, escalate to pause if we see real production
+   violations.
+
+4. **Does this extend to cross-chain weETH?** L2 weETH supply ↔ L1 OFT
+   escrow balance is conceptually a similar invariant. Out of scope for
+   v1 but worth flagging — Phase 4 could extend the same pattern to
+   the OFT adapter.
+
+5. **Do we want a `TotalAssetsRouter`-style aggregator** (sum across
+   contracts) for Invariant 3? Hard problem; not proposing it now; flagging
+   for someone-someday.
+
+## Decision needed
+
+Before this RFC moves further:
+
+1. **Is the team aligned that invariant-based is the right long-term
+   direction**, with rate limits demoted to a per-address tool only?
+2. **Who owns the Phase 0 numerical review?** Needs someone with both
+   eETH rebase-math fluency and an audit mindset.
+3. **Timeline.** I'd suggest starting Phase 0 the week after #423 + #424
+   + #425 land, so we have a stable baseline to replay against. Phase 1
+   observe-mode could go live ~3 weeks after that.
+
+## Appendix — quick sanity check of Invariant 1
+
+Replaying mentally:
+
+| Operation | Δ weETH.totalSupply | Δ eETH.shares(proxy) | Invariant holds? |
+|---|---|---|---|
+| Initial state | 0 | 0 | 0 ≤ 0 ✓ |
+| `wrap(100 eETH)` | +`sharesForAmount(100)` | +`sharesForAmount(100)` (eETH transfer) | ✓ |
+| Rebase event (totalPooledEther grows) | 0 | 0 (shares don't move on rebase) | ✓ (invariant on shares, not balances) |
+| `unwrap(50 weETH)` | -50 | -50 (eETH transfer out) | ✓ |
+| Accidental `eETH.transfer(proxy, 5)` | 0 | +`sharesForAmount(5)` | ✓ (under, not over) |
+| Hypothetical bridge mint(100 weETH) without eETH in | +100 | 0 | **VIOLATED** → revert |
+| Hypothetical eETH skim from proxy | 0 | -`sharesForAmount(X)` | **VIOLATED** → revert |
+
+The invariant precisely catches the two threats it's designed to catch and
+ignores the benign cases.
+
+---
+
+## Sign-off
+
+This RFC is not a PR. It's a direction proposal. If the team agrees with
+the direction, the next step is Phase 0 — a focused 1-week scoped piece
+of work to validate the invariant formulas against mainnet history. I can
+own that if useful, or hand off to whoever has the eETH-math expertise.
+
+Comments / pushback welcome inline on the issue, on the doc PR, or in DM.

--- a/docs/rfc-protocol-invariants.md
+++ b/docs/rfc-protocol-invariants.md
@@ -1,21 +1,33 @@
 # RFC: Invariant-Based Supply Safety for eETH / weETH
 
-**Status:** Draft — for discussion
+**Status:** **Implemented** in PR #426. This document records the design and
+the findings surfaced during build — including two additional candidate
+invariants that were considered and rejected as redundant with existing
+on-chain checks.
 **Author:** Seongyun
-**Date:** 2026-05-25
-**Related:** #423 (per-address rate limits), #424 (wrap-aware global supply circuit breaker), #425 (rate-limiter consistency polish)
+**Date:** 2026-05-25 (initial draft) · 2026-05-25 (build findings appended)
+**Related:** #423 (per-address rate limits), #424 (wrap-aware global supply
+circuit breaker), #425 (rate-limiter consistency polish), **#426 (this RFC's
+implementation)**
 
 ## TL;DR
 
-Replace the bucket-based supply rate limits on eETH/weETH with on-chain
-**conservation invariants** that revert any transaction violating "tokens are
-backed by underlying ETH." The protocol then has a hard, path-independent
-defense against unbacked-mint exploits, the wrap-flag transient-storage carve-out
-in #424 becomes unnecessary, and the threshold-sizing problem disappears.
+Add two on-chain **conservation invariants** that revert any transaction
+violating "tokens are backed by underlying ETH":
 
-Per-address rate limits stay — they're the right tool for the targeted-throttle
-threat. The invariant layer protects against unbacked supply. The two tools
-solve different problems and shouldn't be conflated.
+1. **Invariant 1** — weETH supply is fully backed by eETH shares held in the
+   weETH proxy.
+2. **Invariant 2** — on every **mint** of eETH shares, the eETH exchange rate
+   does not decrease.
+
+Per-address rate limits (#423) stay — they're the right tool for the
+targeted-throttle threat. The two invariants solve a different problem
+(unbacked-supply prevention) and the two layers compose.
+
+Ships **live** (`enabled = true` at deploy). No observe→enforce rollout phase.
+An OperatingMultisig-gated `setEnabled(false)` kill switch exists only for
+the case where the invariant code itself has a bug blocking legitimate
+traffic; normal operation never touches it.
 
 ## Motivation
 
@@ -97,39 +109,58 @@ proxy donations.
 **Cost:** ~2 SLOADs per state-changing call (one for each side). Negligible
 relative to rebase-token transfer cost.
 
-### Invariant 2: eETH share supply matches LP-tracked claims
+### Invariant 2: eETH exchange-rate monotonicity (mint-side)
 
-For every state-changing call on `EETH`:
+> **Note on scope evolution.** The original draft of this RFC proposed
+> `eETH.totalShares == LP.totalShares()`. During implementation we confirmed
+> LP does **not** maintain an independent share counter — every reference in
+> `LiquidityPool.sol` reads `eETH.totalShares()` directly. That comparison is
+> tautological. The meaningful eETH-side check we ended up shipping is a
+> **mint-side rate-monotonicity invariant**, described here.
+
+On every call that **increases** `eETH.totalShares`, the eETH exchange rate
+(`totalPooledEther / totalShares`) must not decrease:
 
 ```
-eETH.totalShares == LP.totalShares()   // (or whatever LP-side variable
-                                       //  represents the share supply LP
-                                       //  thinks should exist)
+P1 * S0 >= P0 * S1     where  P = LP.getTotalPooledEther()
+                              S = eETH.totalShares()
+                              0 = before, 1 = after
 ```
 
-**Background:** LP is the *only* contract authorized to mint/burn eETH
-shares (`mintShares` / `burnShares` are gated `onlyPoolContract`). LP holds
-its own ledger of how many shares should exist. If LP and eETH agree, all
-is well. If they disagree, one of them is buggy / compromised.
+**Why mints only?** A healthy deposit pulls ETH in and mints shares in
+proportion via the OLD rate (rounded down on the shares side). The rate
+stays equal or ticks UP after the mint — never down. Conversely, withdrawal
+paths can legitimately drop the rate (the frozen-rate NFT/queue settlement
+path uses a rate snapshotted at finalize time; if the live rate has since
+drifted up, the burn at fulfillment produces a small rate drop). That's
+by-design accounting, not an exploit. **Restricting the invariant to
+mints catches the threat we care about without false-positives on
+withdrawal-side rate drift.**
 
-**This is currently true by construction.** The question is whether it
-should be *enforced* by reverting on violation rather than just assumed.
+This narrowing was surfaced by the test suite — see "Findings during build"
+below.
 
 **What this catches:**
-- A bug or exploit that mints eETH shares directly without going through LP
-  (e.g., a future feature that forgets to update LP-side accounting; an
-  exploit that finds a delegatecall-y path).
-- A drift between LP and eETH state due to a partial-failure path that
-  updates one but not the other.
+- Shares minted without proportional ETH inflow (LP compromise, future mint
+  authority that forgot to wire backing in, accounting bug that produces
+  shares-without-ETH on a deposit path).
 
-**Caveat:** this invariant is only meaningful if LP itself isn't compromised.
-If LP is compromised, the attacker controls LP.totalShares too and can keep
-the invariant satisfied while doing whatever they want. The protection here
-is against *paths outside LP* that touch eETH share state.
+**Where it lives:** as a `nonDecreasingRate` modifier on LP's 3 deposit
+overloads (`deposit(referral)`, `depositToRecipient(...)`,
+`deposit(user, referral)`). The modifier snapshots P0/S0 before and
+P1/S1 after, then forwards both pairs to
+`ProtocolInvariants.check_eETHRateMonotonic` which owns the
+kill-switch policy. The check function itself short-circuits when
+`S1 <= S0` (anything that isn't a mint) and when `S0 == 0` (bootstrap),
+so adding the modifier accidentally to a non-mint path is a gas waste
+but not a correctness hazard.
 
-**On the LP-compromise threat:** invariants don't help. The right defense is
-upgrade controls (timelock, multisig) + audits + pause + Hypernative. None
-of those go away with this RFC.
+**Caveat — LP compromise:** if LP itself is compromised, the attacker
+controls the rate function and can keep the invariant satisfied while
+doing whatever they want. The protection here is against *non-LP-compromise*
+paths that mint eETH (bugs, future bridge integrations, exploited
+oracle paths). LP compromise is handled by upgrade governance and pause,
+as it is today. The RFC doesn't claim to solve LP compromise.
 
 ### Invariant 3 (optional, harder): eETH backing reconciliation
 
@@ -161,159 +192,115 @@ with them." That's the layer we can enforce cheaply.
 
 Mention here only so it's clear what we're NOT proposing.
 
-## Implementation sketch
+## What shipped
 
-### A new contract: `ProtocolInvariants`
+See `src/ProtocolInvariants.sol`, `src/interfaces/IProtocolInvariants.sol`,
+and the integration points in `src/WeETH.sol` and `src/LiquidityPool.sol`.
+Summary:
+
+### Contract surface
 
 ```solidity
-contract ProtocolInvariants {
+contract ProtocolInvariants is Initializable, UUPSUpgradeable, RolesLibrary {
     IeETH   public immutable eETH;
-    IWeETH  public immutable weETH;
-    ILiquidityPool public immutable liquidityPool;
+    address public immutable weETH;
+    address public immutable liquidityPool;
+    bool    public enabled;              // default true at deploy; multisig kill switch
 
+    function check_weETH_backed() external view;
+    function check_eETHRateMonotonic(uint256 P0, uint256 S0, uint256 P1, uint256 S1) external view onlyLP;
+    function setEnabled(bool _enabled) external onlyOperatingMultisig;
+    function weETHBackingDelta() external view returns (uint256 supply, uint256 proxyShares, bool underbacked);
+
+    error AddressZero();
     error WeETHUnderbacked(uint256 weETHSupply, uint256 proxyShares);
-    error EETHSharesDrift(uint256 eETHTotal, uint256 lpTotal);
-
-    /// @notice Asserts weETH is at-least-fully-backed by eETH shares
-    ///         held in the weETH proxy. Cheap (~2 SLOADs).
-    function assertWeETHBacked() external view {
-        uint256 supply = weETH.totalSupply();
-        uint256 proxyShares = eETH.shares(address(weETH));
-        if (supply > proxyShares) revert WeETHUnderbacked(supply, proxyShares);
-    }
-
-    /// @notice Asserts eETH share supply matches LP's view.
-    function assertEETHSharesConsistent() external view {
-        uint256 eETHTotal = eETH.totalShares();
-        uint256 lpTotal   = liquidityPool.totalShares(); // adjust if name differs
-        if (eETHTotal != lpTotal) revert EETHSharesDrift(eETHTotal, lpTotal);
-    }
+    error EETHRateDeflation(uint256 P0, uint256 S0, uint256 P1, uint256 S1);
+    error OnlyLiquidityPool();
 }
 ```
 
-### Integration points
+### Integration
 
-Two natural patterns; pick one based on what the team finds clearer.
+- **WeETH.** `_afterTokenTransfer` hook (Pattern B). Fires the check on
+  every mint/burn (skips transfers). The hook is impossible to forget on
+  new supply paths because the OZ ERC20 base calls it automatically.
+  `wrap()` reordered to deposit-then-mint so the hook sees consistent
+  state.
+- **LiquidityPool.** `nonDecreasingRate` modifier (Pattern A) on the 3
+  deposit overloads only. Snapshots `(getTotalPooledEther(), totalShares)`
+  before and after, forwards both pairs to ProtocolInvariants. Modifier
+  is **not** on burn paths — see Findings F2.
 
-**Pattern A — modifier on token methods.** Each state-changing token method
-calls `invariants.assertWeETHBacked()` (or `assertEETHSharesConsistent()`)
-at the end. Pro: locality — invariant lives at the call site. Con: every
-new state-changing method needs the modifier.
+### Why a separate contract (not a library)
 
-```solidity
-modifier checkBacking() {
-    _;
-    invariants.assertWeETHBacked();
-}
+A standalone proxy gives the kill switch a stable address and a single
+upgrade path, decoupled from the underlying token / LP upgrade cadence.
+Library inlining would have been cheaper per-call but coupled every
+invariant change to a token-proxy upgrade. The kill switch is the
+load-bearing reason — it needs to live behind one storage slot that
+multisig can flip in seconds.
 
-function wrap(uint256 amt) checkBacking external returns (uint256) { ... }
-function unwrap(uint256 amt) checkBacking external returns (uint256) { ... }
-```
+## Operational model
 
-**Pattern B — invariant runs in `_afterTokenTransfer` (OZ ERC20 hook).**
-For weETH this is automatic — every supply change goes through the hook.
-For eETH, hook into `_transferShares` / `mintShares` / `burnShares`.
-Pro: impossible to forget. Con: slightly more gas per call (the SLOADs
-happen even on no-op-like paths).
+The draft of this RFC sketched a 3-phase rollout (Observe → Enforce → Retire
+buckets). After review, that was rejected:
 
-Recommend **Pattern B for weETH** (one hook covers everything), **Pattern A
-for eETH** (only three call sites, modifier is clearer than threading
-through `_transferShares`).
+- The team's position is that **releases go live with checks active**. There
+  is no observe-only stage.
+- A bool kill switch (`enabled`, default true at deploy) is sufficient for
+  the only scenario where you'd actually want to disable an invariant
+  mid-flight — the invariant code itself misfiring during an incident.
+- The bool flip is gated to **OperatingMultisig**. Guardian is too low a bar
+  for a switch with this blast radius, and a timelock is too slow for an
+  active incident.
 
-### What gets retired when this lands
+**Implementation note:** the kill switch lives inside `ProtocolInvariants`,
+not in LP / eETH / weETH. A single `setEnabled(false)` call disables both
+invariants protocol-wide. The token / LP modifiers still execute (snapshot
+state, forward to ProtocolInvariants), but the check function short-circuits.
+This keeps the snapshot cost (negligible) constant whether or not the
+invariant is active, and centralizes the failure-recovery decision.
 
-- `WEETH_MINT_LIMIT_ID` / `WEETH_BURN_LIMIT_ID` (added in #424) — invariant
-  catches the threat path-independently.
-- The wrap-aware transient-storage flag in `WeETH` — no need to carve out
-  wrap/unwrap, the invariant is path-agnostic.
-- `EETH_MINT_LIMIT_ID` / `EETH_BURN_LIMIT_ID` — invariant 2 catches the
-  threat. Only retire AFTER invariant 2 is enforce-mode (see rollout).
+### What retires?
 
-Per-address rate limits stay. They solve a different problem (targeted
-throttling, not unbacked-mint prevention).
-
-## Phased rollout
-
-Conservative path that lets us validate the invariant formulas against real
-mainnet activity before they can revert anything.
-
-### Phase 0 — Spec & numerical review (1 week)
-
-- Get a numerical-analysis eye on the exact-equality forms. eETH is a
-  rebase token; share/balance conversions have rounding. Confirm
-  `weETH.totalSupply() <= eETH.shares(proxy)` is exact, not approximately
-  exact, under all paths (wrap, unwrap, transfers, rebase).
-- Confirm `eETH.totalShares == LP.totalShares` is exact at all observable
-  call boundaries (not mid-call).
-- Pen-test against historical mainnet txs: replay last 6 months of weETH
-  state-changing calls in a fork, assert invariants hold at every block.
-
-**Exit criterion:** invariants verified to hold across 6 months of mainnet
-history with zero false positives.
-
-### Phase 1 — Observe mode (4 weeks on mainnet)
-
-- Deploy `ProtocolInvariants` contract.
-- Wire it into eETH and weETH **emitting events on violation, NOT reverting**:
-
-  ```solidity
-  function assertWeETHBacked() external {
-      uint256 supply = weETH.totalSupply();
-      uint256 proxyShares = eETH.shares(address(weETH));
-      if (supply > proxyShares) emit InvariantViolated("weETHUnderbacked", supply, proxyShares);
-  }
-  ```
-
-- Hypernative subscribes to `InvariantViolated` events; auto-pause if fired.
-- Operations team monitors. Any violation event is an immediate triage.
-
-**Exit criterion:** 4 weeks of mainnet activity with zero `InvariantViolated`
-events.
-
-### Phase 2 — Enforce mode (revert on violation)
-
-- Upgrade eETH/weETH (or the invariant contract itself if hooked external)
-  to revert on violation rather than emit.
-- Keep the global MINT/BURN buckets (#424) live in parallel for one cycle
-  as belt-and-suspenders.
-
-**Exit criterion:** 4 weeks in enforce mode with no incidents.
-
-### Phase 3 — Retire global rate-limit buckets
-
-- Remove `EETH_{MINT,BURN}_LIMIT_ID`, `WEETH_{MINT,BURN}_LIMIT_ID` consumption
-  from token paths.
-- Remove the wrap-aware transient flag from `WeETH`.
-- Keep per-address buckets.
-- 3CP simplifies: no bootstrap-order requirement for global buckets.
+The original draft proposed retiring #424's global MINT/BURN buckets once
+the invariants are stable. **Status: deferred.** The invariants and the
+buckets coexist productively: invariants are precise (catch unbacked mints
+of any size, path-agnostic); rate limits are coarse (catch volume-based
+anomalies regardless of whether they're unbacked). The cost of running
+both is small. The team can revisit retirement once production data
+informs the decision.
 
 ## Risks and mitigations
 
 ### R1 — Invariant function has a bug, bricks the protocol
 
 The blast radius is total: a buggy invariant can lock every wrap/unwrap and
-every eETH transfer. The Phase-1 observe mode is specifically designed to
-catch this before it can revert. Even in Phase 2, the invariant contract
-itself must be:
-- Pause-able by Operating Multisig (`disableInvariant()` switch).
-- Upgradable by Upgrade Timelock (separate from the token upgrade path).
-- Constructed with `assert` semantics, NOT `require` — i.e., reverts return
-  a clear typed error, no string concatenation, no external calls in the
-  invariant function.
+every eETH deposit. The shipped mitigation is the `setEnabled(false)`
+kill switch (OperatingMultisig-gated) on `ProtocolInvariants`. Flip it
+off, the modifiers continue to execute but the check function short-
+circuits, traffic flows. Cost of having the bool: ~1 storage slot. Cost of
+NOT having it: multi-day brick during an active incident waiting for
+upgrade-timelock recovery.
 
-The `disableInvariant()` switch is non-negotiable. The cost of being able
-to flip it off in an emergency is approximately zero (one bool); the cost
-of NOT being able to is potentially a multi-day brick.
+Defensive properties baked into the check functions:
+- Reverts return clear typed errors (`WeETHUnderbacked`,
+  `EETHRateDeflation`), no string concatenation, no external calls inside
+  the check.
+- The contract is UUPS-upgradable via `UPGRADE_TIMELOCK_ROLE` for a more
+  considered repair path once the bug is understood.
+- Functions are `view` — no storage writes, no callback risk.
 
 ### R2 — Rounding / off-by-one false positives
 
 eETH share/balance math has rounding. If we get the invariant form even
 slightly wrong (e.g., strict equality where `<=` is right), we get
-intermittent reverts under benign rebase.
+intermittent reverts under benign protocol activity.
 
-Mitigation: Phase 0 pen-test is exactly this. Replay 6 months of mainnet,
-assert the invariant holds at every block under the exact form we're
-proposing to ship. If it doesn't, we have the wrong form — iterate.
+Mitigation: caught during build via the test suite. The broad-sweep test
+run flagged 22 withdrawal-side tests asserting legitimate rate drops at the
+frozen-rate fulfillment path; that surfaced the **scope narrowing of
+Invariant 2 to mint paths only**. See "Findings during build" below.
 
 ### R3 — Gas cost on hot paths
 
@@ -336,14 +323,17 @@ upgrade governance and pause, as it is today.
 This isn't a mitigation — it's a scope clarification. The RFC doesn't claim
 to solve LP compromise.
 
-### R5 — Future state-changing methods forget the modifier (Pattern A)
+### R5 — Future state-changing methods forget the modifier
 
-If we go with Pattern A and someone adds a new state-changing method
-without the modifier, the invariant doesn't run on that path.
+For weETH: shipped using the OZ `_afterTokenTransfer` hook (Pattern B from
+the original draft). Every mint/burn already routes through it, so new
+weETH supply paths are covered automatically.
 
-Mitigation: prefer Pattern B (hook into `_afterTokenTransfer` / `_transferShares`)
-wherever possible — the OZ template enforces hook coverage on supply changes
-automatically. Pattern A only for paths that don't naturally hit a hook.
+For LP: shipped using the modifier pattern (Pattern A) on the 3 deposit
+overloads. The check function short-circuits on `S1 <= S0`, so accidentally
+adding the modifier to a burn path is a gas waste but not a correctness
+hazard. Future mint paths must remember to add `nonDecreasingRate` — this
+is documented in `LiquidityPool.sol`'s modifier docstring.
 
 ## What does NOT change
 
@@ -357,45 +347,146 @@ automatically. Pattern A only for paths that don't naturally hit a hook.
 - **Upgrade governance** stays. Invariants don't replace the timelock /
   multisig story for LP compromise.
 
-## Open questions
+## Findings during build
 
-1. **Pattern A vs B for eETH.** EETH doesn't use the OZ ERC20 base —
-   `_transferShares` is custom. The hook insertion point isn't free. Maybe
-   Pattern A (modifier on `mintShares`, `burnShares`, `_transfer`) is the
-   pragmatic call. Worth a 30-min code review with @yash / @pankaj to
-   pick.
+Three things changed materially between the original draft and what
+actually shipped. Recorded here for future readers and audit firms.
 
-2. **Where does `ProtocolInvariants` live?** Standalone contract behind a
-   proxy (upgradable, pause-able, but adds a contract to the upgrade
-   surface)? Library called from eETH/weETH (cheaper, but coupled)?
-   Recommend standalone contract — keeps the pause switch (R1) clean.
+### F1. Invariant 2's first form was tautological — replaced
 
-3. **Should invariant violations also auto-pause the token?** Vs just
-   reverting the offending tx. Auto-pause is more conservative ("stop
-   everything if anything weird happens") but more disruptive. Lean
-   towards revert-only first, escalate to pause if we see real production
-   violations.
+The draft's Invariant 2 was `eETH.totalShares == LP.totalShares()`. The build
+confirmed that **LP does not maintain an independent share counter** —
+every reference in `LiquidityPool.sol` reads `eETH.totalShares()` directly.
+So the comparison is the same value on both sides, providing zero defense.
 
-4. **Does this extend to cross-chain weETH?** L2 weETH supply ↔ L1 OFT
-   escrow balance is conceptually a similar invariant. Out of scope for
-   v1 but worth flagging — Phase 4 could extend the same pattern to
-   the OFT adapter.
+The shipped Invariant 2 is the mint-side rate-monotonicity check described
+above — a structurally different check that catches the same threat
+(unbacked eETH mint) via a different on-chain property.
 
-5. **Do we want a `TotalAssetsRouter`-style aggregator** (sum across
-   contracts) for Invariant 3? Hard problem; not proposing it now; flagging
-   for someone-someday.
+### F2. Rate monotonicity had to be narrowed to mint paths
 
-## Decision needed
+The first build of Invariant 2 covered all share-changing calls
+(both mints and burns). Broad-sweep testing flagged 22 withdrawal-side
+tests asserting **legitimate** rate drops:
 
-Before this RFC moves further:
+- **Frozen-rate NFT/queue settlement.** A request finalized at rate R0
+  gets fulfilled later when the live rate is R1 > R0; the burn at
+  fulfillment computes shares against R0, producing a small rate drop
+  at the burn point. By design — protects the user from rate drift
+  between request and fulfillment.
+- **Rounding in `sharesForWithdrawalAmount` (ceil).** Favors the protocol
+  on the burn-side but can interact with frozen-rate paths to drop the
+  rate by a few wei.
 
-1. **Is the team aligned that invariant-based is the right long-term
-   direction**, with rate limits demoted to a per-address tool only?
-2. **Who owns the Phase 0 numerical review?** Needs someone with both
-   eETH rebase-math fluency and an audit mindset.
-3. **Timeline.** I'd suggest starting Phase 0 the week after #423 + #424
-   + #425 land, so we have a stable baseline to replay against. Phase 1
-   observe-mode could go live ~3 weeks after that.
+The threat we want to catch — unbacked mint — only manifests when
+`totalShares` **increases**. Withdrawal-side rate drift is accounting,
+not exploit. So the shipped check no-ops when `S1 <= S0`, and the LP
+modifier was removed from burn paths (saves ~5k gas per burn).
+
+### F3. The phased rollout was rejected
+
+Originally proposed: Observe → Enforce → Retire. The team's actual
+operational model is to ship with checks live (`enabled = true`) and use
+a single bool kill switch as the only operational lever. The 3-phase
+state machine, the events-only mode, and the gradual retirement of #424
+buckets are all replaced by:
+
+- One bool, OperatingMultisig-gated.
+- Default `true` at deploy.
+- Coexist with #424 buckets indefinitely (no retirement path scheduled).
+
+## Considered and rejected
+
+During implementation we scouted two additional invariants. Both turned out
+to be **redundant with existing on-chain checks** that the protocol already
+enforces locally. Recording them so future reviewers don't re-derive the
+same dead ends.
+
+### R1. Withdrawal-escrow solvency
+
+**Proposed invariant:**
+```
+WithdrawRequestNFT:        balance >= ethAmountLockedForWithdrawal
+PriorityWithdrawalQueue:   balance >= ethAmountLockedForPriorityWithdrawal
+```
+
+**Verdict: redundant.** Both contracts already enforce exactly this check
+inline at every counter-mutating point:
+
+- `WithdrawRequestNFT._checkEthAmountLockedForWithdrawal()` called from
+  `receive()`, `_claimWithdraw`, `handleRemainder`.
+- `PriorityWithdrawalQueue._checkEthAmountLockedForPriorityWithdrawal()`
+  called from `receive()`, `fulfillRequests`, `claimWithdraw`.
+
+These are the **only** code paths that move the counter, so the existing
+checks cover every mutation. Additionally:
+
+- Neither contract has a `recoverETH` function, so accidental ETH egress
+  outside the claim/handleRemainder paths is structurally impossible.
+- Counter arithmetic is `uint128 +=/-= uint128(msg.value)` in Solidity
+  0.8.27 — checked arithmetic reverts on overflow/underflow rather than
+  silently corrupting.
+- The `receive()` functions are `onlyLiquidityPool`-gated, so misrouted
+  funding is impossible.
+
+Adding a duplicate check to `ProtocolInvariants` would have zero security
+value.
+
+### R2. Rebase magnitude bound
+
+**Proposed invariant:**
+```
+On rebase: |ΔP / P| <= MAX_PCT_PER_REBASE
+```
+
+To catch oracle compromise pushing a manipulated rate update.
+
+**Verdict: redundant.** `EtherFiAdmin._validateRebaseApr` (around line 344
+of `EtherFiAdmin.sol`) already enforces an APR-bounded variant of exactly
+this, with the comment: *"Permanent invariant — protects against runaway
+rebase or slashing leakage in a single report."*
+
+Their implementation is actually **better** than the bound I was about to
+propose:
+
+- Time-normalized (computes annualized APR from `accruedRewards / TVL /
+  elapsedTime` rather than a flat percent-per-rebase), which handles
+  reports covering different windows correctly.
+- Direction-agnostic — takes the absolute value, so it caps inflation
+  AND deflation symmetrically.
+- Cap (`acceptableRebaseAprInBps`) is configurable per-deployment rather
+  than baked in.
+
+Adding a flat percent-per-call bound to `ProtocolInvariants` would be both
+redundant and weaker than what already exists.
+
+## Lessons for future invariant proposals
+
+1. **Grep `_check*` and `validate*` first.** Before proposing a new
+   on-chain invariant, search the relevant contracts for existing checks
+   with similar shape. The protocol's local invariants are stronger than
+   they look from the outside.
+2. **`ProtocolInvariants`' niche is cross-contract.** Single-contract
+   invariants belong inside the contract whose state they're checking
+   (locality, gas, audit clarity). `ProtocolInvariants` adds value
+   specifically when the property spans two contracts that don't naturally
+   share state — Invariant 1 spans weETH and eETH; Invariant 2 spans LP
+   and eETH.
+3. **The cross-contract niche may be the complete set.** After scouting,
+   Invariant 1 and Invariant 2 may genuinely be the entire space worth
+   adding for ether.fi's current architecture. New cross-contract paths
+   (bridge adapter, restaker integration, new mint authority) are the
+   natural triggers for the next round of invariant work.
+
+## Decisions made
+
+1. **Direction:** invariant-based supply safety is additive to rate limits,
+   not a replacement. Both layers coexist indefinitely (no scheduled
+   retirement of #424's buckets).
+2. **Rollout model:** ship live with checks active. No observe-only stage.
+   Single bool kill switch for emergencies, OperatingMultisig-gated.
+3. **Scope:** two invariants — weETH backing (`<=`) and eETH mint-side rate
+   monotonicity. Additional candidates were scouted and rejected (see above).
 
 ## Appendix — quick sanity check of Invariant 1
 
@@ -416,11 +507,13 @@ ignores the benign cases.
 
 ---
 
-## Sign-off
+## Status: closed
 
-This RFC is not a PR. It's a direction proposal. If the team agrees with
-the direction, the next step is Phase 0 — a focused 1-week scoped piece
-of work to validate the invariant formulas against mainnet history. I can
-own that if useful, or hand off to whoever has the eETH-math expertise.
+Implemented in PR #426. Both invariants live in production behavior the moment
+#426 merges and the new LP / weETH impls are upgraded. The kill switch
+(`ProtocolInvariants.setEnabled`) is the only operational lever; it exists for
+emergencies and is not part of normal protocol operations.
 
-Comments / pushback welcome inline on the issue, on the doc PR, or in DM.
+Future invariant proposals: new cross-contract paths (bridge adapter, restaker
+integration, new mint authority) are the natural triggers for a follow-up
+round. See "Lessons for future invariant proposals" above before drafting.

--- a/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
+++ b/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
@@ -266,7 +266,12 @@ contract PriorityQueueTransactions is Script, Utils {
                 priorityWithdrawalQueue: priorityWithdrawalQueueProxy,
                 blacklister: address(0),
                 etherFiAdminContract: address(0),
-                membershipManager: address(0)
+                membershipManager: address(0),
+                // TODO: this is a stale priority-queue migration script. If
+                // re-run after ProtocolInvariants ships, this MUST be wired
+                // to the deployed ProtocolInvariants proxy or LP deposits
+                // will revert at the rate-monotonicity modifier.
+                protocolInvariants: address(0)
             }),
             0
         );

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -265,7 +265,10 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @notice Burns shares and pays ETH. For NFT/queue callers, ETH is paid by the caller from its own segregated balance; LP only does accounting. Other callers receive ETH from LP.
     /// @notice Live-rate withdraw for membershipManager and etherFiRedemptionManager.
     ///         Burns shares at the live rate and pays ETH from the LP to `_recipient`.
-    function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused returns (uint256) {
+    /// @dev    Carries `nonDecreasingRate` — `sharesForWithdrawalAmount` rounds up
+    ///         (favors protocol) so the rate is preserved or ticks up; modifier
+    ///         catches any future bug that breaks that property.
+    function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
         if (msg.sender != address(membershipManager) && msg.sender != address(etherFiRedemptionManager)) {
             revert IncorrectCaller();
         }
@@ -611,13 +614,19 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _checkMinAmountForShare();
     }
 
-    function burnEEthShares(uint256 shares) external {
+    /// @dev Share-only burn: no P-side change, so the rate ticks UP. Carries
+    ///      `nonDecreasingRate` as defense in depth — if a future caller is
+    ///      added that also moves ETH out of LP, the modifier catches any
+    ///      bug that drops the rate.
+    function burnEEthShares(uint256 shares) external nonDecreasingRate {
         if (msg.sender != address(etherFiRedemptionManager) && msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) revert IncorrectCaller();
         eETH.burnShares(msg.sender, shares);
         _checkMinAmountForShare();
     }
 
-    function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external {
+    /// @dev Carries `nonDecreasingRate` as belt-and-suspenders alongside the
+    ///      local `share > _amountSharesToBurn` check on line below.
+    function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external nonDecreasingRate {
         uint256 share = sharesForWithdrawalAmount(_withdrawalValueInETH);
         if (msg.sender != address(etherFiRedemptionManager)) revert IncorrectCaller();
         if (_amountSharesToBurn == 0 || _withdrawalValueInETH == 0) revert InvalidAmount();
@@ -765,15 +774,32 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     /// @notice Asserts the eETH exchange rate does not decrease across this
-    ///         mint call. See ProtocolInvariants.sol for the full rationale.
+    ///         call. See ProtocolInvariants.sol for the full rationale.
     /// @dev    Snapshots `totalPooledEther / totalShares` before and after the
     ///         function body, then forwards both pairs to
-    ///         `protocolInvariants.check_eETHRateMonotonic`. Applied ONLY to
-    ///         mint paths (deposits) — withdrawals can legitimately drop the
-    ///         rate (frozen-rate NFT/queue fulfillment) and rebases don't
-    ///         touch shares. The check function itself short-circuits when
-    ///         `S1 <= S0`, but skipping the snapshot at the modifier level
-    ///         saves ~5k gas on every burn path.
+    ///         `protocolInvariants.check_eETHRateMonotonic`.
+    ///
+    ///         APPLIED to every share-changing entry point where the rate is
+    ///         supposed to stay equal or move UP by construction:
+    ///           - deposit() / depositToRecipient / deposit(user, ref)
+    ///             — proportional mint with floor-rounded shares (rate up)
+    ///           - withdraw(address, uint256)
+    ///             — live-rate burn with ceil-rounded shares (rate up)
+    ///           - burnEEthShares
+    ///             — share-only burn, no P-side change (rate up)
+    ///           - burnEEthSharesForNonETHWithdrawal
+    ///             — already locally checks rate non-decrease; modifier is
+    ///               belt-and-suspenders
+    ///
+    ///         INTENTIONALLY NOT applied to:
+    ///           - withdraw(uint256, uint256) — frozen-rate finalized claim,
+    ///             rate-drop bounded by the oracle-signed `_rate` parameter
+    ///           - rebase() — oracle path, rate-change bounded by
+    ///             EtherFiAdmin._validateRebaseApr's APR cap
+    ///
+    ///         These two are the only intentional rate-changing paths in the
+    ///         protocol. Anything else that drops the rate is a bug or
+    ///         exploit and trips the modifier.
     modifier nonDecreasingRate() {
         uint256 P0 = getTotalPooledEther();
         uint256 S0 = eETH.totalShares();

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -17,6 +17,7 @@ import "./interfaces/IEtherFiNodesManager.sol";
 import "./interfaces/IEtherFiRedemptionManager.sol";
 import "./interfaces/IPriorityWithdrawalQueue.sol";
 import "./interfaces/IBlacklister.sol";
+import "./interfaces/IProtocolInvariants.sol";
 import "./utils/ReentrancyGuardNamespaced.sol";
 import "./utils/RolesLibrary.sol";
 import "./utils/PausableUntil.sol";
@@ -92,6 +93,11 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     address public immutable membershipManager;
     uint256 public immutable minAmountForShare;
 
+    /// @dev On-chain conservation check. Called via the `nonDecreasingRate`
+    ///      modifier on every share-changing path. See ProtocolInvariants.sol
+    ///      for full rationale; LP only owns the snapshot.
+    IProtocolInvariants public immutable protocolInvariants;
+
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
@@ -157,6 +163,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         address blacklister;
         address etherFiAdminContract;
         address membershipManager;
+        address protocolInvariants;
     }
 
     //--------------------------------------------------------------------------------------
@@ -175,6 +182,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         blacklister = IBlacklister(_constructorAddresses.blacklister);
         etherFiAdminContract = _constructorAddresses.etherFiAdminContract;
         membershipManager = _constructorAddresses.membershipManager;
+        protocolInvariants = IProtocolInvariants(_constructorAddresses.protocolInvariants);
         minAmountForShare = _minAmountForShare;
         _disableInitializers();
     }
@@ -228,14 +236,14 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Used by eETH staking flow
-    function deposit(address _referral) public payable nonReentrant whenNotPaused nonBlacklisted returns (uint256) {
+    function deposit(address _referral) public payable nonReentrant whenNotPaused nonBlacklisted nonDecreasingRate returns (uint256) {
         emit Deposit(msg.sender, msg.value, SourceOfFunds.EETH, _referral);
 
         return _deposit(msg.sender, msg.value, 0);
     }
 
     // Used by eETH staking flow through Liquifier contract; deVamp or to pay protocol fees
-    function depositToRecipient(address _recipient, uint256 _amount, address _referral) public nonReentrant whenNotPaused returns (uint256) {
+    function depositToRecipient(address _recipient, uint256 _amount, address _referral) public nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
         if (msg.sender != address(liquifier) && msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_recipient);
 
@@ -245,7 +253,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Used by ether.fan staking flow
-    function deposit(address _user, address _referral) external payable nonReentrant whenNotPaused returns (uint256) {
+    function deposit(address _user, address _referral) external payable nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_user);
 
@@ -257,7 +265,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @notice Burns shares and pays ETH. For NFT/queue callers, ETH is paid by the caller from its own segregated balance; LP only does accounting. Other callers receive ETH from LP.
     /// @notice Live-rate withdraw for membershipManager and etherFiRedemptionManager.
     ///         Burns shares at the live rate and pays ETH from the LP to `_recipient`.
-    function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused returns (uint256) {
+    function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
         if (msg.sender != address(membershipManager) && msg.sender != address(etherFiRedemptionManager)) {
             revert IncorrectCaller();
         }
@@ -285,7 +293,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @dev    `_rate == 0` is rejected — callers (WRNFT / Queue) are responsible for resolving
     ///         any pre-upgrade legacy snapshot to a live rate locally via `amountPerShareCeil()`
     ///         before invoking this function. Single codepath: one ceiling math expression.
-    function withdraw(uint256 _amount, uint256 _rate) external nonReentrant returns (uint256) {
+    function withdraw(uint256 _amount, uint256 _rate) external nonReentrant nonDecreasingRate returns (uint256) {
         if (msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) {
             revert IncorrectCaller();
         }
@@ -603,13 +611,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _checkMinAmountForShare();
     }
 
-    function burnEEthShares(uint256 shares) external {
+    function burnEEthShares(uint256 shares) external nonDecreasingRate {
         if (msg.sender != address(etherFiRedemptionManager) && msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) revert IncorrectCaller();
         eETH.burnShares(msg.sender, shares);
         _checkMinAmountForShare();
     }
 
-    function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external {
+    function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external nonDecreasingRate {
         uint256 share = sharesForWithdrawalAmount(_withdrawalValueInETH);
         if (msg.sender != address(etherFiRedemptionManager)) revert IncorrectCaller();
         if (_amountSharesToBurn == 0 || _withdrawalValueInETH == 0) revert InvalidAmount();
@@ -754,5 +762,25 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     modifier onlyEtherFiAdmin() {
         if (msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
         _;
+    }
+
+    /// @notice Asserts the eETH exchange rate does not decrease across this
+    ///         call. See ProtocolInvariants.sol for the full rationale.
+    /// @dev    Snapshots `totalPooledEther / totalShares` before and after the
+    ///         function body, then forwards both pairs to
+    ///         `protocolInvariants.check_eETHRateMonotonic` which owns the
+    ///         policy (DISABLED no-op / OBSERVE emit-only / ENFORCE emit + revert).
+    ///         Applied to every share-changing path on LP. Rebase / oracle
+    ///         paths intentionally don't carry this modifier — they change
+    ///         the rate without changing shares, which is their purpose.
+    ///         (If they did carry it, the `S0 == S1` guard inside
+    ///         check_eETHRateMonotonic would no-op anyway.)
+    modifier nonDecreasingRate() {
+        uint256 P0 = getTotalPooledEther();
+        uint256 S0 = eETH.totalShares();
+        _;
+        uint256 P1 = getTotalPooledEther();
+        uint256 S1 = eETH.totalShares();
+        protocolInvariants.check_eETHRateMonotonic(P0, S0, P1, S1);
     }
 }

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -265,7 +265,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @notice Burns shares and pays ETH. For NFT/queue callers, ETH is paid by the caller from its own segregated balance; LP only does accounting. Other callers receive ETH from LP.
     /// @notice Live-rate withdraw for membershipManager and etherFiRedemptionManager.
     ///         Burns shares at the live rate and pays ETH from the LP to `_recipient`.
-    function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
+    function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(membershipManager) && msg.sender != address(etherFiRedemptionManager)) {
             revert IncorrectCaller();
         }
@@ -293,7 +293,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @dev    `_rate == 0` is rejected — callers (WRNFT / Queue) are responsible for resolving
     ///         any pre-upgrade legacy snapshot to a live rate locally via `amountPerShareCeil()`
     ///         before invoking this function. Single codepath: one ceiling math expression.
-    function withdraw(uint256 _amount, uint256 _rate) external nonReentrant nonDecreasingRate returns (uint256) {
+    function withdraw(uint256 _amount, uint256 _rate) external nonReentrant returns (uint256) {
         if (msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) {
             revert IncorrectCaller();
         }
@@ -611,13 +611,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _checkMinAmountForShare();
     }
 
-    function burnEEthShares(uint256 shares) external nonDecreasingRate {
+    function burnEEthShares(uint256 shares) external {
         if (msg.sender != address(etherFiRedemptionManager) && msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) revert IncorrectCaller();
         eETH.burnShares(msg.sender, shares);
         _checkMinAmountForShare();
     }
 
-    function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external nonDecreasingRate {
+    function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external {
         uint256 share = sharesForWithdrawalAmount(_withdrawalValueInETH);
         if (msg.sender != address(etherFiRedemptionManager)) revert IncorrectCaller();
         if (_amountSharesToBurn == 0 || _withdrawalValueInETH == 0) revert InvalidAmount();
@@ -765,16 +765,15 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     /// @notice Asserts the eETH exchange rate does not decrease across this
-    ///         call. See ProtocolInvariants.sol for the full rationale.
+    ///         mint call. See ProtocolInvariants.sol for the full rationale.
     /// @dev    Snapshots `totalPooledEther / totalShares` before and after the
     ///         function body, then forwards both pairs to
-    ///         `protocolInvariants.check_eETHRateMonotonic` which owns the
-    ///         policy (DISABLED no-op / OBSERVE emit-only / ENFORCE emit + revert).
-    ///         Applied to every share-changing path on LP. Rebase / oracle
-    ///         paths intentionally don't carry this modifier — they change
-    ///         the rate without changing shares, which is their purpose.
-    ///         (If they did carry it, the `S0 == S1` guard inside
-    ///         check_eETHRateMonotonic would no-op anyway.)
+    ///         `protocolInvariants.check_eETHRateMonotonic`. Applied ONLY to
+    ///         mint paths (deposits) — withdrawals can legitimately drop the
+    ///         rate (frozen-rate NFT/queue fulfillment) and rebases don't
+    ///         touch shares. The check function itself short-circuits when
+    ///         `S1 <= S0`, but skipping the snapshot at the modifier level
+    ///         saves ~5k gas on every burn path.
     modifier nonDecreasingRate() {
         uint256 P0 = getTotalPooledEther();
         uint256 S0 = eETH.totalShares();

--- a/src/ProtocolInvariants.sol
+++ b/src/ProtocolInvariants.sol
@@ -36,12 +36,19 @@ import "./utils/RolesLibrary.sol";
 ///     scope for the first iteration. See `docs/rfc-protocol-invariants.md`.
 contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeable, RolesLibrary {
 
-    /// @dev Tokens this contract observes. Immutable so the wiring is obvious
-    ///      on-chain and can't be silently re-pointed by a governance call. To
-    ///      change the addresses, deploy a new ProtocolInvariants and re-wire
-    ///      the WeETH/EETH constructors.
+    /// @dev Tokens and LP this contract observes. Immutable so the wiring is
+    ///      obvious on-chain and can't be silently re-pointed by a governance
+    ///      call. To change the addresses, deploy a new ProtocolInvariants
+    ///      and re-wire the dependents.
+    ///
+    ///      `liquidityPool` is the only authorized caller of the eETH
+    ///      rate-monotonicity check — see `onlyLP` modifier and
+    ///      `check_eETHRateMonotonic` rationale below. weETH-side check is
+    ///      open (callable by anyone) because its values are not
+    ///      caller-supplied (read straight from on-chain state).
     IeETH   public immutable eETH;
     address public immutable weETH;
+    address public immutable liquidityPool;
 
     Mode public mode;
 
@@ -54,10 +61,13 @@ contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeab
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _roleRegistry, address _eETH, address _weETH) RolesLibrary(_roleRegistry) {
-        if (_eETH == address(0) || _weETH == address(0)) revert AddressZero();
+    constructor(address _roleRegistry, address _eETH, address _weETH, address _liquidityPool)
+        RolesLibrary(_roleRegistry)
+    {
+        if (_eETH == address(0) || _weETH == address(0) || _liquidityPool == address(0)) revert AddressZero();
         eETH = IeETH(_eETH);
         weETH = _weETH;
+        liquidityPool = _liquidityPool;
         _disableInitializers();
     }
 
@@ -129,6 +139,66 @@ contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeab
         supply = IERC20Like(weETH).totalSupply();
         proxyShares = eETH.shares(weETH);
         underbacked = supply > proxyShares;
+    }
+
+    //--------------------------------------------------------------------------
+    //                Invariant: eETH exchange-rate monotonicity
+    //--------------------------------------------------------------------------
+
+    /// @notice Invariant: in every share-changing call, the eETH exchange rate
+    ///         must not decrease.
+    /// @dev    RATIONALE: a healthy deposit pulls ETH in and mints shares in
+    ///         proportion — the rate (totalPooledEther / totalShares) stays
+    ///         constant. A healthy withdrawal burns shares and sends ETH out
+    ///         in proportion — same. Fee paths keep ETH in the pool relative
+    ///         to shares burned, which makes the rate go UP. Rebases change
+    ///         totalPooledEther without touching shares — exempted via the
+    ///         S0 == S1 guard. The ONE scenario where the rate goes DOWN and
+    ///         shares change is the threat: shares were minted without an
+    ///         equivalent ETH inflow (LP compromise, exploited path, missing
+    ///         accounting). The invariant catches that with the cross-multiplied
+    ///         form `P1 * S0 >= P0 * S1` (rate_after >= rate_before).
+    ///
+    ///         CALL PATTERN: LP wraps a `_;` modifier around share-changing
+    ///         functions, snapshotting P0/S0 before and passing P0/S0/P1/S1
+    ///         after. The check happens here so the policy (mode toggle,
+    ///         emit, revert) lives in one place, but the snapshot has to
+    ///         happen in the caller's stack frame — there's no on-chain
+    ///         primitive that lets us bracket a foreign function.
+    ///
+    ///         GATING: only `liquidityPool` may call this. Otherwise an
+    ///         attacker could call with fake P/S values and either (a) spam
+    ///         false `InvariantViolated` events to trip Hypernative auto-pause
+    ///         in OBSERVE mode, or (b) self-revert in ENFORCE mode (harmless
+    ///         but noisy). LP-only gating keeps the event stream high-signal.
+    function check_eETHRateMonotonic(uint256 P0, uint256 S0, uint256 P1, uint256 S1) external onlyLP {
+        if (mode == Mode.DISABLED) return;
+
+        // Skip cases where the check is meaningless or doesn't apply:
+        //   - Bootstrap: no shares before or after (rate undefined).
+        //   - Share-neutral: rebase / oracle adjustment — totalShares
+        //     unchanged. Those legitimately move the rate (intentional).
+        if (S0 == 0 || S1 == 0 || S0 == S1) return;
+
+        // Cross-multiplied form of: P1/S1 >= P0/S0
+        //   integer-exact, division-free, no rounding tolerance needed.
+        // Practical overflow bound: P, S each fit in uint128 in any plausible
+        // protocol state (total ETH supply ~1.2e26 wei, shares similar);
+        // P*S ≈ 1.4e52 ≪ uint256 max (~1.16e77). Safe by inspection.
+        uint256 lhs = P1 * S0;
+        uint256 rhs = P0 * S1;
+        if (lhs < rhs) {
+            emit InvariantViolated("eETH-rate-deflation", lhs, rhs);
+            if (mode == Mode.ENFORCE) revert EETHRateDeflation(P0, S0, P1, S1);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    //                                  Modifiers
+    //--------------------------------------------------------------------------
+    modifier onlyLP() {
+        if (msg.sender != liquidityPool) revert OnlyLiquidityPool();
+        _;
     }
 }
 

--- a/src/ProtocolInvariants.sol
+++ b/src/ProtocolInvariants.sol
@@ -109,34 +109,42 @@ contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeab
     //                Invariant 2: eETH exchange-rate monotonicity
     //--------------------------------------------------------------------------
 
-    /// @notice Invariant 2 — on every MINT (totalShares increase), the eETH
-    ///         exchange rate does not decrease.
-    /// @dev    SCOPE: this check only fires when `totalShares` increased
-    ///         during the wrapped call. Withdrawals are intentionally out of
-    ///         scope:
-    ///           - Frozen-rate withdrawal flows (NFT/queue settle at a rate
-    ///             snapshotted at finalize time) can move the rate DOWN at
-    ///             fulfillment when the live rate has since drifted up; that
-    ///             is by-design accounting, not an exploit.
-    ///           - Rounding in `sharesForWithdrawalAmount` (ceil) favors the
-    ///             protocol but with the locked-rate paths can still produce
-    ///             a small rate drop.
-    ///         Mints can't legitimately drop the rate. A healthy deposit
-    ///         (`LP._deposit`) computes shares = sharesForAmount(msg.value)
-    ///         using the OLD rate and floor-rounds — so after the mint the
-    ///         rate stays equal or ticks UP (rounding favors holders). The
-    ///         ONE scenario where shares go up AND the rate drops is the
-    ///         threat: shares were minted without proportional ETH inflow
-    ///         (LP compromise, future mint authority that forgets to wire
-    ///         backing in, accounting bug). The invariant catches that with
-    ///         the cross-multiplied form `P1 * S0 >= P0 * S1`.
+    /// @notice Invariant 2 — across the wrapped LP call, the eETH exchange
+    ///         rate (`totalPooledEther / totalShares`) does not decrease.
+    /// @dev    SCOPE: applies to every share-changing LP entry point where
+    ///         the rate is *supposed* to be preserved or increase by
+    ///         construction. The intended on-chain guarantee is:
     ///
-    ///         CALL PATTERN: LP wraps a `_;` modifier around mint paths
-    ///         (deposits), snapshotting P0/S0 before and passing P0/S0/P1/S1
-    ///         after. The check happens here so the kill-switch policy lives
-    ///         in one place, but the snapshot has to happen in the caller's
-    ///         stack frame — there's no on-chain primitive that lets us
-    ///         bracket a foreign function.
+    ///             "The eETH exchange rate can only decrease via:
+    ///                 (a) `rebase()`     (oracle path, bounded by
+    ///                                     EtherFiAdmin._validateRebaseApr's
+    ///                                     APR cap), OR
+    ///                 (b) `withdraw(uint256, uint256)` (frozen-rate
+    ///                                     finalized claim, bounded by the
+    ///                                     oracle-finalized `_rate`)."
+    ///
+    ///         Both (a) and (b) are intentional rate-changing paths and
+    ///         do NOT carry the `nonDecreasingRate` modifier in LP. Every
+    ///         other share-changing path does — mints (3 deposit overloads),
+    ///         the live-rate withdraw, and the ERM/WRN/PQ burn primitives
+    ///         (`burnEEthShares`, `burnEEthSharesForNonETHWithdrawal`). On
+    ///         those paths the math is either rate-preserving (proportional
+    ///         mint/burn with rounding favoring the protocol) or rate-up
+    ///         (burn-without-P-side-decrement), so this check fires only
+    ///         if a bug or exploit produces an unintended rate drop.
+    ///
+    ///         RATIONALE: rebase is no longer the ONLY rate-changing path
+    ///         (claim-time burns also nudge it up), but it should be the
+    ///         only path that can move it DOWN outside of the well-defined
+    ///         frozen-rate withdraw exemption. This invariant enforces that
+    ///         on-chain.
+    ///
+    ///         CALL PATTERN: LP wraps a `_;` modifier around the protected
+    ///         entry points, snapshotting P0/S0 before and passing
+    ///         P0/S0/P1/S1 after. The check happens here so the kill-switch
+    ///         policy lives in one place, but the snapshot has to happen in
+    ///         the caller's stack frame — there's no on-chain primitive
+    ///         that lets us bracket a foreign function.
     ///
     ///         GATING: only `liquidityPool` may call this. An attacker could
     ///         otherwise self-revert with crafted values — harmless to the
@@ -145,15 +153,13 @@ contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeab
     function check_eETHRateMonotonic(uint256 P0, uint256 S0, uint256 P1, uint256 S1) external view onlyLP {
         if (!enabled) return;
 
-        // Skip cases where the check doesn't apply:
-        //   - S1 <= S0: not a mint. Withdrawals and rebases can move the
-        //     rate either direction without it being an exploit (see scope
-        //     note above). This invariant is mint-side only.
-        //   - S0 == 0: bootstrap; no previous rate to compare against.
-        if (S1 <= S0 || S0 == 0) return;
+        // Bootstrap exempt: no previous rate to compare against.
+        if (S0 == 0 || S1 == 0) return;
 
         // Cross-multiplied form of: P1/S1 >= P0/S0
         //   integer-exact, division-free, no rounding tolerance needed.
+        // Works for mints (S1 > S0), live-rate burns (S1 < S0), and
+        // share-only burns (S1 < S0, P1 == P0 — rate goes up).
         // Practical overflow bound: P, S each fit in uint128 in any plausible
         // protocol state (total ETH supply ~1.2e26 wei, shares similar);
         // P*S ≈ 1.4e52 ≪ uint256 max (~1.16e77). Safe by inspection.

--- a/src/ProtocolInvariants.sol
+++ b/src/ProtocolInvariants.sol
@@ -9,31 +9,18 @@ import "./interfaces/IProtocolInvariants.sol";
 import "./utils/RolesLibrary.sol";
 
 /// @title  ProtocolInvariants
-/// @notice On-chain conservation checks for ether.fi tokens. Currently asserts
-///         Invariant 1: weETH is at-least-fully-backed by eETH shares held in
-///         the weETH proxy. Designed to run on every state-changing call on
-///         weETH that could affect supply.
-/// @dev
-///   THREE-MODE OPERATION:
-///     - DISABLED: every check is a no-op. Emergency kill-switch in case the
-///       invariant itself has a bug that's blocking legitimate traffic. Must be
-///       toggleable by Operating Multisig (single-key risk vs full-protocol-brick).
-///     - OBSERVE:  default. Violations emit `InvariantViolated` and DO NOT
-///       revert. Hypernative + ops monitor the event and decide on response.
-///       Used during initial rollout to validate the invariant formulas
-///       against real mainnet activity before they can revert anything.
-///     - ENFORCE:  violations emit the event AND revert. Hard on-chain stop
-///       for unbacked-mint exploits.
+/// @notice On-chain conservation checks for ether.fi tokens. Asserts two
+///         invariants on every relevant call path:
 ///
-///   INVARIANT 2 NOTE (eETH share consistency):
-///     The original RFC proposed a second invariant `eETH.totalShares == LP.totalShares`.
-///     During implementation we confirmed LP does not maintain a SEPARATE share
-///     counter — every reference in `LiquidityPool.sol` reads `eETH.totalShares()`
-///     directly. So that comparison is tautological and provides no defense.
-///     A meaningful eETH-side check would be a per-transaction delta invariant
-///     INSIDE LP (snapshot ETH balance + totalShares pre-call, assert consistent
-///     deltas post-call). That's structurally a different change and is out of
-///     scope for the first iteration. See `docs/rfc-protocol-invariants.md`.
+///         1. weETH supply is fully backed by eETH shares held in the proxy.
+///         2. The eETH exchange rate (totalPooledEther / totalShares) does not
+///            decrease across any share-changing call on LP.
+///
+///         Both invariants revert on violation. There is no observe-only mode —
+///         deployment lands in production with checks live. An OperatingMultisig
+///         kill switch (`setEnabled(false)`) exists ONLY for the case where the
+///         invariant code itself has a bug that's blocking legitimate traffic;
+///         normal operation never touches it.
 contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeable, RolesLibrary {
 
     /// @dev Tokens and LP this contract observes. Immutable so the wiring is
@@ -50,14 +37,14 @@ contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeab
     address public immutable weETH;
     address public immutable liquidityPool;
 
-    Mode public mode;
+    /// @notice Whether invariant checks are live. True at deploy; the only
+    ///         flip path is the Multisig-gated `setEnabled` for emergencies.
+    bool public enabled;
 
-    /// @notice Initialize the invariants contract.
-    /// @param _initialMode Starting mode; should be OBSERVE for new deployments.
-    function initialize(Mode _initialMode) external initializer {
+    function initialize() external initializer {
         __UUPSUpgradeable_init();
-        mode = _initialMode;
-        emit ModeChanged(Mode.DISABLED, _initialMode);
+        enabled = true;
+        emit EnabledChanged(false, true);
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -77,21 +64,20 @@ contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeab
     //                                  Admin
     //--------------------------------------------------------------------------
 
-    /// @notice Switch operational mode. Operating Multisig only.
-    /// @dev Multisig is the right gate here:
-    ///        - DISABLE during incident if invariant is misfiring (urgent).
-    ///        - OBSERVE -> ENFORCE promotion (deliberate, after monitoring).
-    ///        - ENFORCE -> OBSERVE/DISABLE rollback (urgent, if false positives).
-    ///      Single-key Guardian is too low a bar to flip the kill switch given
-    ///      the blast radius. Timelock is too slow for an active incident.
-    function setMode(Mode _newMode) external onlyOperatingMultisig {
-        Mode old = mode;
-        mode = _newMode;
-        emit ModeChanged(old, _newMode);
+    /// @notice Emergency kill switch. Disables both invariant checks.
+    /// @dev Gated to Operating Multisig: single-key Guardian is too low a bar
+    ///      for a switch with this blast radius, and a timelock is too slow
+    ///      for the only scenario where you'd actually use this — a bug in
+    ///      the invariant itself causing false reverts mid-incident. Normal
+    ///      operation never flips this.
+    function setEnabled(bool _enabled) external onlyOperatingMultisig {
+        bool old = enabled;
+        enabled = _enabled;
+        emit EnabledChanged(old, _enabled);
     }
 
     //--------------------------------------------------------------------------
-    //                                  Checks
+    //                Invariant 1: weETH supply backed by eETH shares
     //--------------------------------------------------------------------------
 
     /// @notice Invariant 1 — weETH is at-least-fully-backed by eETH shares held
@@ -110,87 +96,81 @@ contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeab
     ///      `eETH.transfer(weETHProxy, X)` directly (accidental airdrop), the
     ///      proxy ends up over-collateralized. That's safe for weETH holders.
     ///      Strict equality would false-positive on benign donations.
-    ///
-    ///      VIEW SEMANTICS: in DISABLED mode this is a no-op view. In OBSERVE
-    ///      mode it emits on violation and returns. In ENFORCE mode it emits
-    ///      AND reverts. The emit-before-revert order is intentional — even
-    ///      when reverting, the event helps post-mortem reconstruction by
-    ///      surfacing in trace logs.
-    function check_weETH_backed() external {
-        if (mode == Mode.DISABLED) return;
+    function check_weETH_backed() external view {
+        if (!enabled) return;
 
         uint256 supply = IERC20Like(weETH).totalSupply();
         uint256 proxyShares = eETH.shares(weETH);
 
-        if (supply > proxyShares) {
-            emit InvariantViolated("weETH-underbacked", supply, proxyShares);
-            if (mode == Mode.ENFORCE) revert WeETHUnderbacked(supply, proxyShares);
-        }
+        if (supply > proxyShares) revert WeETHUnderbacked(supply, proxyShares);
     }
 
     //--------------------------------------------------------------------------
-    //                                  Views
+    //                Invariant 2: eETH exchange-rate monotonicity
     //--------------------------------------------------------------------------
 
-    /// @notice Read-only check, never reverts, never emits. For dashboards and
-    ///         off-chain monitoring that wants to know "would the invariant
-    ///         have tripped right now?" without burning gas on an event.
-    function weETHBackingDelta() external view returns (uint256 supply, uint256 proxyShares, bool underbacked) {
-        supply = IERC20Like(weETH).totalSupply();
-        proxyShares = eETH.shares(weETH);
-        underbacked = supply > proxyShares;
-    }
-
-    //--------------------------------------------------------------------------
-    //                Invariant: eETH exchange-rate monotonicity
-    //--------------------------------------------------------------------------
-
-    /// @notice Invariant: in every share-changing call, the eETH exchange rate
-    ///         must not decrease.
-    /// @dev    RATIONALE: a healthy deposit pulls ETH in and mints shares in
-    ///         proportion — the rate (totalPooledEther / totalShares) stays
-    ///         constant. A healthy withdrawal burns shares and sends ETH out
-    ///         in proportion — same. Fee paths keep ETH in the pool relative
-    ///         to shares burned, which makes the rate go UP. Rebases change
-    ///         totalPooledEther without touching shares — exempted via the
-    ///         S0 == S1 guard. The ONE scenario where the rate goes DOWN and
-    ///         shares change is the threat: shares were minted without an
-    ///         equivalent ETH inflow (LP compromise, exploited path, missing
-    ///         accounting). The invariant catches that with the cross-multiplied
-    ///         form `P1 * S0 >= P0 * S1` (rate_after >= rate_before).
+    /// @notice Invariant 2 — on every MINT (totalShares increase), the eETH
+    ///         exchange rate does not decrease.
+    /// @dev    SCOPE: this check only fires when `totalShares` increased
+    ///         during the wrapped call. Withdrawals are intentionally out of
+    ///         scope:
+    ///           - Frozen-rate withdrawal flows (NFT/queue settle at a rate
+    ///             snapshotted at finalize time) can move the rate DOWN at
+    ///             fulfillment when the live rate has since drifted up; that
+    ///             is by-design accounting, not an exploit.
+    ///           - Rounding in `sharesForWithdrawalAmount` (ceil) favors the
+    ///             protocol but with the locked-rate paths can still produce
+    ///             a small rate drop.
+    ///         Mints can't legitimately drop the rate. A healthy deposit
+    ///         (`LP._deposit`) computes shares = sharesForAmount(msg.value)
+    ///         using the OLD rate and floor-rounds — so after the mint the
+    ///         rate stays equal or ticks UP (rounding favors holders). The
+    ///         ONE scenario where shares go up AND the rate drops is the
+    ///         threat: shares were minted without proportional ETH inflow
+    ///         (LP compromise, future mint authority that forgets to wire
+    ///         backing in, accounting bug). The invariant catches that with
+    ///         the cross-multiplied form `P1 * S0 >= P0 * S1`.
     ///
-    ///         CALL PATTERN: LP wraps a `_;` modifier around share-changing
-    ///         functions, snapshotting P0/S0 before and passing P0/S0/P1/S1
-    ///         after. The check happens here so the policy (mode toggle,
-    ///         emit, revert) lives in one place, but the snapshot has to
-    ///         happen in the caller's stack frame — there's no on-chain
-    ///         primitive that lets us bracket a foreign function.
+    ///         CALL PATTERN: LP wraps a `_;` modifier around mint paths
+    ///         (deposits), snapshotting P0/S0 before and passing P0/S0/P1/S1
+    ///         after. The check happens here so the kill-switch policy lives
+    ///         in one place, but the snapshot has to happen in the caller's
+    ///         stack frame — there's no on-chain primitive that lets us
+    ///         bracket a foreign function.
     ///
-    ///         GATING: only `liquidityPool` may call this. Otherwise an
-    ///         attacker could call with fake P/S values and either (a) spam
-    ///         false `InvariantViolated` events to trip Hypernative auto-pause
-    ///         in OBSERVE mode, or (b) self-revert in ENFORCE mode (harmless
-    ///         but noisy). LP-only gating keeps the event stream high-signal.
-    function check_eETHRateMonotonic(uint256 P0, uint256 S0, uint256 P1, uint256 S1) external onlyLP {
-        if (mode == Mode.DISABLED) return;
+    ///         GATING: only `liquidityPool` may call this. An attacker could
+    ///         otherwise self-revert with crafted values — harmless to the
+    ///         protocol, but pollutes Hypernative's view via spurious revert
+    ///         traces. LP-only gating keeps the trace signal clean.
+    function check_eETHRateMonotonic(uint256 P0, uint256 S0, uint256 P1, uint256 S1) external view onlyLP {
+        if (!enabled) return;
 
-        // Skip cases where the check is meaningless or doesn't apply:
-        //   - Bootstrap: no shares before or after (rate undefined).
-        //   - Share-neutral: rebase / oracle adjustment — totalShares
-        //     unchanged. Those legitimately move the rate (intentional).
-        if (S0 == 0 || S1 == 0 || S0 == S1) return;
+        // Skip cases where the check doesn't apply:
+        //   - S1 <= S0: not a mint. Withdrawals and rebases can move the
+        //     rate either direction without it being an exploit (see scope
+        //     note above). This invariant is mint-side only.
+        //   - S0 == 0: bootstrap; no previous rate to compare against.
+        if (S1 <= S0 || S0 == 0) return;
 
         // Cross-multiplied form of: P1/S1 >= P0/S0
         //   integer-exact, division-free, no rounding tolerance needed.
         // Practical overflow bound: P, S each fit in uint128 in any plausible
         // protocol state (total ETH supply ~1.2e26 wei, shares similar);
         // P*S ≈ 1.4e52 ≪ uint256 max (~1.16e77). Safe by inspection.
-        uint256 lhs = P1 * S0;
-        uint256 rhs = P0 * S1;
-        if (lhs < rhs) {
-            emit InvariantViolated("eETH-rate-deflation", lhs, rhs);
-            if (mode == Mode.ENFORCE) revert EETHRateDeflation(P0, S0, P1, S1);
-        }
+        if (P1 * S0 < P0 * S1) revert EETHRateDeflation(P0, S0, P1, S1);
+    }
+
+    //--------------------------------------------------------------------------
+    //                                  Views
+    //--------------------------------------------------------------------------
+
+    /// @notice Read-only check, never reverts. For dashboards and off-chain
+    ///         monitoring that wants to know "would the invariant have tripped
+    ///         right now?".
+    function weETHBackingDelta() external view returns (uint256 supply, uint256 proxyShares, bool underbacked) {
+        supply = IERC20Like(weETH).totalSupply();
+        proxyShares = eETH.shares(weETH);
+        underbacked = supply > proxyShares;
     }
 
     //--------------------------------------------------------------------------

--- a/src/ProtocolInvariants.sol
+++ b/src/ProtocolInvariants.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+
+import "./interfaces/IeETH.sol";
+import "./interfaces/IProtocolInvariants.sol";
+import "./utils/RolesLibrary.sol";
+
+/// @title  ProtocolInvariants
+/// @notice On-chain conservation checks for ether.fi tokens. Currently asserts
+///         Invariant 1: weETH is at-least-fully-backed by eETH shares held in
+///         the weETH proxy. Designed to run on every state-changing call on
+///         weETH that could affect supply.
+/// @dev
+///   THREE-MODE OPERATION:
+///     - DISABLED: every check is a no-op. Emergency kill-switch in case the
+///       invariant itself has a bug that's blocking legitimate traffic. Must be
+///       toggleable by Operating Multisig (single-key risk vs full-protocol-brick).
+///     - OBSERVE:  default. Violations emit `InvariantViolated` and DO NOT
+///       revert. Hypernative + ops monitor the event and decide on response.
+///       Used during initial rollout to validate the invariant formulas
+///       against real mainnet activity before they can revert anything.
+///     - ENFORCE:  violations emit the event AND revert. Hard on-chain stop
+///       for unbacked-mint exploits.
+///
+///   INVARIANT 2 NOTE (eETH share consistency):
+///     The original RFC proposed a second invariant `eETH.totalShares == LP.totalShares`.
+///     During implementation we confirmed LP does not maintain a SEPARATE share
+///     counter — every reference in `LiquidityPool.sol` reads `eETH.totalShares()`
+///     directly. So that comparison is tautological and provides no defense.
+///     A meaningful eETH-side check would be a per-transaction delta invariant
+///     INSIDE LP (snapshot ETH balance + totalShares pre-call, assert consistent
+///     deltas post-call). That's structurally a different change and is out of
+///     scope for the first iteration. See `docs/rfc-protocol-invariants.md`.
+contract ProtocolInvariants is IProtocolInvariants, Initializable, UUPSUpgradeable, RolesLibrary {
+
+    /// @dev Tokens this contract observes. Immutable so the wiring is obvious
+    ///      on-chain and can't be silently re-pointed by a governance call. To
+    ///      change the addresses, deploy a new ProtocolInvariants and re-wire
+    ///      the WeETH/EETH constructors.
+    IeETH   public immutable eETH;
+    address public immutable weETH;
+
+    Mode public mode;
+
+    /// @notice Initialize the invariants contract.
+    /// @param _initialMode Starting mode; should be OBSERVE for new deployments.
+    function initialize(Mode _initialMode) external initializer {
+        __UUPSUpgradeable_init();
+        mode = _initialMode;
+        emit ModeChanged(Mode.DISABLED, _initialMode);
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _roleRegistry, address _eETH, address _weETH) RolesLibrary(_roleRegistry) {
+        if (_eETH == address(0) || _weETH == address(0)) revert AddressZero();
+        eETH = IeETH(_eETH);
+        weETH = _weETH;
+        _disableInitializers();
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------
+    //                                  Admin
+    //--------------------------------------------------------------------------
+
+    /// @notice Switch operational mode. Operating Multisig only.
+    /// @dev Multisig is the right gate here:
+    ///        - DISABLE during incident if invariant is misfiring (urgent).
+    ///        - OBSERVE -> ENFORCE promotion (deliberate, after monitoring).
+    ///        - ENFORCE -> OBSERVE/DISABLE rollback (urgent, if false positives).
+    ///      Single-key Guardian is too low a bar to flip the kill switch given
+    ///      the blast radius. Timelock is too slow for an active incident.
+    function setMode(Mode _newMode) external onlyOperatingMultisig {
+        Mode old = mode;
+        mode = _newMode;
+        emit ModeChanged(old, _newMode);
+    }
+
+    //--------------------------------------------------------------------------
+    //                                  Checks
+    //--------------------------------------------------------------------------
+
+    /// @notice Invariant 1 — weETH is at-least-fully-backed by eETH shares held
+    ///         in the weETH proxy.
+    /// @dev RATIONALE: every `wrap(X)` mints `sharesForAmount(X)` weETH AND
+    ///      transfers `sharesForAmount(X)` eETH shares to the weETH proxy
+    ///      (eETH is a rebase token; transferring `X` eETH moves
+    ///      `sharesForAmount(X)` shares). Both sides increment by the same
+    ///      number. `unwrap` is the symmetric decrement. So the invariant
+    ///      `weETH.totalSupply <= eETH.shares(weETHProxy)` is preserved by
+    ///      every well-formed mint/burn. Anything that mints weETH without an
+    ///      eETH inflow — bridge compromise, exploited mint path, future
+    ///      authority that forgets to wire in eETH backing — breaks it.
+    ///
+    ///      The `<=` form (rather than `==`) is deliberate: if someone calls
+    ///      `eETH.transfer(weETHProxy, X)` directly (accidental airdrop), the
+    ///      proxy ends up over-collateralized. That's safe for weETH holders.
+    ///      Strict equality would false-positive on benign donations.
+    ///
+    ///      VIEW SEMANTICS: in DISABLED mode this is a no-op view. In OBSERVE
+    ///      mode it emits on violation and returns. In ENFORCE mode it emits
+    ///      AND reverts. The emit-before-revert order is intentional — even
+    ///      when reverting, the event helps post-mortem reconstruction by
+    ///      surfacing in trace logs.
+    function check_weETH_backed() external {
+        if (mode == Mode.DISABLED) return;
+
+        uint256 supply = IERC20Like(weETH).totalSupply();
+        uint256 proxyShares = eETH.shares(weETH);
+
+        if (supply > proxyShares) {
+            emit InvariantViolated("weETH-underbacked", supply, proxyShares);
+            if (mode == Mode.ENFORCE) revert WeETHUnderbacked(supply, proxyShares);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    //                                  Views
+    //--------------------------------------------------------------------------
+
+    /// @notice Read-only check, never reverts, never emits. For dashboards and
+    ///         off-chain monitoring that wants to know "would the invariant
+    ///         have tripped right now?" without burning gas on an event.
+    function weETHBackingDelta() external view returns (uint256 supply, uint256 proxyShares, bool underbacked) {
+        supply = IERC20Like(weETH).totalSupply();
+        proxyShares = eETH.shares(weETH);
+        underbacked = supply > proxyShares;
+    }
+}
+
+/// @dev Minimal IERC20 surface for `totalSupply()` — avoids pulling in OZ's
+///      full IERC20 just for one method. weETH is not the only ERC20 we may
+///      observe in future invariants.
+interface IERC20Like {
+    function totalSupply() external view returns (uint256);
+}

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -12,6 +12,7 @@ import "./interfaces/IRateProvider.sol";
 
 import "./AssetRecovery.sol";
 import "./interfaces/IBlacklister.sol";
+import "./interfaces/IProtocolInvariants.sol";
 import "./utils/PausableUntil.sol";
 import "./utils/RolesLibrary.sol";
 import "./utils/RateLimitedToken.sol";
@@ -23,6 +24,14 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     ILiquidityPool public immutable liquidityPool;
     IBlacklister public immutable blacklister;
     // `roleRegistry` is inherited from RolesLibrary; `rateLimiter` from RateLimitedToken.
+
+    /// @dev On-chain conservation check (see ProtocolInvariants.sol). Runs in
+    ///      `_afterTokenTransfer` on supply changes (mint = wrap, burn = unwrap).
+    ///      Transfers don't change supply and skip the check. Held as an
+    ///      immutable so the wiring is obvious on-chain and can't be silently
+    ///      re-pointed; to swap implementations, upgrade the proxy at this
+    ///      address.
+    IProtocolInvariants public immutable protocolInvariants;
 
     event Paused();
     event Unpaused();
@@ -45,14 +54,28 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _eETH, address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter)
+    constructor(
+        address _eETH,
+        address _liquidityPool,
+        address _roleRegistry,
+        address _blacklister,
+        address _rateLimiter,
+        address _protocolInvariants
+    )
         RolesLibrary(_roleRegistry)
         RateLimitedToken(_rateLimiter)
     {
-        if(_eETH == address(0) || _liquidityPool == address(0) || _blacklister == address(0) || _rateLimiter == address(0)) revert AddressZero();
+        if (
+            _eETH == address(0) ||
+            _liquidityPool == address(0) ||
+            _blacklister == address(0) ||
+            _rateLimiter == address(0) ||
+            _protocolInvariants == address(0)
+        ) revert AddressZero();
         eETH = IeETH(_eETH);
         liquidityPool = ILiquidityPool(_liquidityPool);
         blacklister = IBlacklister(_blacklister);
+        protocolInvariants = IProtocolInvariants(_protocolInvariants);
         _disableInitializers();
     }
 
@@ -73,11 +96,19 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     /// @notice Wraps eEth
     /// @param _eETHAmount the amount of eEth to wrap
     /// @return returns the amount of weEth the user receives
+    /// @dev Order: pull eETH from user FIRST, then mint weETH. This is the
+    ///      deposit-then-mint pattern and is REQUIRED for the on-chain backing
+    ///      invariant (`weETH.totalSupply <= eETH.shares(weETHProxy)`) to hold
+    ///      at the `_afterTokenTransfer` hook point inside `_mint`. The old
+    ///      mint-then-pull order would trip the invariant transiently at the
+    ///      hook because `weETH.totalSupply` would be updated before
+    ///      `eETH.shares(proxy)`. With the new order, the proxy's eETH share
+    ///      balance is already raised when the hook runs.
     function wrap(uint256 _eETHAmount) public returns (uint256) {
         if (_eETHAmount == 0) revert ZeroAmount();
         uint256 weEthAmount = liquidityPool.sharesForAmount(_eETHAmount);
-        _mint(msg.sender, weEthAmount);
         IERC20(address(eETH)).safeTransferFrom(msg.sender, address(this), _eETHAmount);
+        _mint(msg.sender, weEthAmount);
         return weEthAmount;
     }
 
@@ -183,6 +214,24 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         uint64 amt = toBucketUnit(amount);
         if (from != address(0)) rateLimiter.consumeForAddressIfConfigured(from, amt);
         if (to   != address(0)) rateLimiter.consumeForAddressIfConfigured(to,   amt);
+    }
+
+    /// @dev Invariant 1 check: runs after every mint/burn. Transfers don't
+    ///      change `totalSupply` and can't break the backing invariant, so
+    ///      they skip. Respects the ProtocolInvariants mode toggle:
+    ///      DISABLED no-op, OBSERVE emit-only, ENFORCE revert.
+    ///
+    ///      Timing: `wrap` is ordered deposit-then-mint, so by the time the
+    ///      `_mint` triggers this hook, the proxy's eETH share balance has
+    ///      already been raised. `unwrap` is ordered burn-then-withdraw, so
+    ///      when this hook fires on `_burn`, `weETH.totalSupply` is the
+    ///      lower side of the inequality and the invariant trivially holds.
+    ///      A future bridge adapter that mints directly should pull backing
+    ///      eETH BEFORE calling `_mint`, the same as wrap.
+    function _afterTokenTransfer(address from, address to, uint256 /*amount*/) internal virtual override {
+        if (from == address(0) || to == address(0)) {
+            protocolInvariants.check_weETH_backed();
+        }
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/interfaces/IProtocolInvariants.sol
+++ b/src/interfaces/IProtocolInvariants.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IProtocolInvariants {
+    /// @dev Three-mode operation; see ProtocolInvariants.sol for full rationale.
+    ///        DISABLED - no-op kill switch
+    ///        OBSERVE  - emit on violation, do not revert (rollout default)
+    ///        ENFORCE  - emit AND revert on violation (hard on-chain stop)
+    enum Mode { DISABLED, OBSERVE, ENFORCE }
+
+    //--------------------------------------------------------------------------
+    //                                  Events
+    //--------------------------------------------------------------------------
+    /// @dev Emitted on every violation, regardless of mode (except DISABLED).
+    ///      `name` identifies which invariant tripped; `lhs`/`rhs` are the
+    ///      two values that failed the comparison, for post-mortem clarity.
+    event InvariantViolated(string name, uint256 lhs, uint256 rhs);
+    event ModeChanged(Mode oldMode, Mode newMode);
+
+    //--------------------------------------------------------------------------
+    //                                  Errors
+    //--------------------------------------------------------------------------
+    error AddressZero();
+    error WeETHUnderbacked(uint256 weETHSupply, uint256 proxyShares);
+
+    //--------------------------------------------------------------------------
+    //                                  Functions
+    //--------------------------------------------------------------------------
+    function check_weETH_backed() external;
+    function weETHBackingDelta() external view returns (uint256 supply, uint256 proxyShares, bool underbacked);
+    function setMode(Mode newMode) external;
+    function mode() external view returns (Mode);
+}

--- a/src/interfaces/IProtocolInvariants.sol
+++ b/src/interfaces/IProtocolInvariants.sol
@@ -22,11 +22,14 @@ interface IProtocolInvariants {
     //--------------------------------------------------------------------------
     error AddressZero();
     error WeETHUnderbacked(uint256 weETHSupply, uint256 proxyShares);
+    error EETHRateDeflation(uint256 P0, uint256 S0, uint256 P1, uint256 S1);
+    error OnlyLiquidityPool();
 
     //--------------------------------------------------------------------------
     //                                  Functions
     //--------------------------------------------------------------------------
     function check_weETH_backed() external;
+    function check_eETHRateMonotonic(uint256 P0, uint256 S0, uint256 P1, uint256 S1) external;
     function weETHBackingDelta() external view returns (uint256 supply, uint256 proxyShares, bool underbacked);
     function setMode(Mode newMode) external;
     function mode() external view returns (Mode);

--- a/src/interfaces/IProtocolInvariants.sol
+++ b/src/interfaces/IProtocolInvariants.sol
@@ -2,20 +2,10 @@
 pragma solidity ^0.8.24;
 
 interface IProtocolInvariants {
-    /// @dev Three-mode operation; see ProtocolInvariants.sol for full rationale.
-    ///        DISABLED - no-op kill switch
-    ///        OBSERVE  - emit on violation, do not revert (rollout default)
-    ///        ENFORCE  - emit AND revert on violation (hard on-chain stop)
-    enum Mode { DISABLED, OBSERVE, ENFORCE }
-
     //--------------------------------------------------------------------------
     //                                  Events
     //--------------------------------------------------------------------------
-    /// @dev Emitted on every violation, regardless of mode (except DISABLED).
-    ///      `name` identifies which invariant tripped; `lhs`/`rhs` are the
-    ///      two values that failed the comparison, for post-mortem clarity.
-    event InvariantViolated(string name, uint256 lhs, uint256 rhs);
-    event ModeChanged(Mode oldMode, Mode newMode);
+    event EnabledChanged(bool oldEnabled, bool newEnabled);
 
     //--------------------------------------------------------------------------
     //                                  Errors
@@ -28,9 +18,9 @@ interface IProtocolInvariants {
     //--------------------------------------------------------------------------
     //                                  Functions
     //--------------------------------------------------------------------------
-    function check_weETH_backed() external;
-    function check_eETHRateMonotonic(uint256 P0, uint256 S0, uint256 P1, uint256 S1) external;
+    function check_weETH_backed() external view;
+    function check_eETHRateMonotonic(uint256 P0, uint256 S0, uint256 P1, uint256 S1) external view;
     function weETHBackingDelta() external view returns (uint256 supply, uint256 proxyShares, bool underbacked);
-    function setMode(Mode newMode) external;
-    function mode() external view returns (Mode);
+    function setEnabled(bool enabled) external;
+    function enabled() external view returns (bool);
 }

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -42,7 +42,8 @@ contract LiquidityPoolTest is TestSetup {
             priorityWithdrawalQueue: pwq,
             blacklister: blacklister,
             etherFiAdminContract: address(etherFiAdminInstance),
-            membershipManager: address(membershipManagerInstance)
+            membershipManager: address(membershipManagerInstance),
+            protocolInvariants: address(protocolInvariantsInstance)
         });
     }
 

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -65,7 +65,8 @@ contract PriorityWithdrawalQueueTest is TestSetup {
                 priorityWithdrawalQueue: address(priorityQueue),
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: address(etherFiAdminInstance),
-                membershipManager: address(membershipManagerInstance)
+                membershipManager: address(membershipManagerInstance),
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         );

--- a/test/ProtocolInvariants.t.sol
+++ b/test/ProtocolInvariants.t.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "./TestSetup.sol";
+import "../src/ProtocolInvariants.sol";
+import "../src/interfaces/IProtocolInvariants.sol";
+
+/// @notice Tests for Invariant 1: `weETH.totalSupply <= eETH.shares(weETHProxy)`.
+///
+///         Coverage spine:
+///           - Mode machinery (DISABLED / OBSERVE / ENFORCE) and access control.
+///           - Real wrap/unwrap don't trigger violations (invariant holds by construction).
+///           - Synthetic underbacking via storage poke triggers expected behavior in
+///             each mode (no-op / emit-only / emit+revert).
+///           - Over-collateralization (accidental eETH airdrop to proxy) does NOT trip.
+contract ProtocolInvariantsTest is TestSetup {
+    address internal multisigOnly;
+    address internal unauthorized = address(0xDEAD);
+
+    // weETH `_totalSupply` lives at storage slot 103 — verified via
+    // `forge inspect WeETH storageLayout`. The slot is higher than naive 0/1/2
+    // because WeETH inherits Initializable + multiple OZ upgradeable contracts
+    // each carrying a 50-slot __gap. Used to synthesize underbacking via
+    // vm.store without going through a real mint path.
+    uint256 private constant WEETH_TOTAL_SUPPLY_SLOT = 103;
+
+    function setUp() public {
+        setUpTests();
+
+        // Fund alice with eETH so wrap/unwrap tests have something to move.
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 50 ether}();
+
+        // Multisig-only address for access-control proofs.
+        multisigOnly = address(0xBEEF);
+        vm.startPrank(owner);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), multisigOnly);
+        vm.stopPrank();
+    }
+
+    // =====================================================================
+    // Mode machinery & access control
+    // =====================================================================
+
+    function test_initial_mode_is_OBSERVE() public {
+        assertEq(uint256(protocolInvariantsInstance.mode()), uint256(IProtocolInvariants.Mode.OBSERVE));
+    }
+
+    function test_setMode_requires_multisig() public {
+        vm.prank(unauthorized);
+        vm.expectRevert();
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+        assertEq(uint256(protocolInvariantsInstance.mode()), uint256(IProtocolInvariants.Mode.ENFORCE));
+    }
+
+    function test_setMode_emits_event() public {
+        vm.prank(multisigOnly);
+        vm.expectEmit(true, true, true, true);
+        emit IProtocolInvariants.ModeChanged(IProtocolInvariants.Mode.OBSERVE, IProtocolInvariants.Mode.ENFORCE);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+    }
+
+    function test_DISABLED_mode_is_noop_even_when_underbacked() public {
+        // Synthesize underbacking, then flip to DISABLED, then run the check.
+        // No event, no revert.
+        _pokeUnderbacking(1e18);
+
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.DISABLED);
+
+        // No revert in ENFORCE-equivalent scenario, no emit. Record logs to assert.
+        vm.recordLogs();
+        protocolInvariantsInstance.check_weETH_backed();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "DISABLED mode must not emit");
+    }
+
+    // =====================================================================
+    // OBSERVE mode: emit on violation, do NOT revert
+    // =====================================================================
+
+    function test_OBSERVE_underbacked_emits_event_and_does_NOT_revert() public {
+        _pokeUnderbacking(5e18);
+
+        vm.expectEmit(true, true, true, true);
+        emit IProtocolInvariants.InvariantViolated(
+            "weETH-underbacked",
+            weEthInstance.totalSupply(),
+            eETHInstance.shares(address(weEthInstance))
+        );
+        protocolInvariantsInstance.check_weETH_backed();
+    }
+
+    function test_OBSERVE_balanced_does_NOT_emit() public {
+        // Set up a real wrap so the invariant naturally holds, then check.
+        _wrap(alice, 2 ether);
+
+        vm.recordLogs();
+        protocolInvariantsInstance.check_weETH_backed();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "balanced state must not emit");
+    }
+
+    // =====================================================================
+    // ENFORCE mode: emit AND revert on violation
+    // =====================================================================
+
+    function test_ENFORCE_underbacked_reverts() public {
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        _pokeUnderbacking(5e18);
+
+        vm.expectRevert();
+        protocolInvariantsInstance.check_weETH_backed();
+    }
+
+    function test_ENFORCE_balanced_passes() public {
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        _wrap(alice, 1 ether);
+        protocolInvariantsInstance.check_weETH_backed();   // must not revert
+    }
+
+    function test_ENFORCE_overcollateralized_passes() public {
+        // Donate eETH directly to the weETH proxy. weETH.totalSupply unchanged;
+        // eETH.shares(proxy) increases. invariant: totalSupply <= proxyShares holds.
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        // Give alice extra eETH to donate.
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 5 ether}();
+
+        vm.prank(alice);
+        eETHInstance.transfer(address(weEthInstance), 1 ether);
+
+        // The transfer itself triggered _beforeTokenTransfer hooks etc. but the
+        // weETH `_afterTokenTransfer` only runs on weETH state changes; an eETH
+        // transfer doesn't trigger weETH hooks. So no automatic check fired.
+        // Explicit check still passes — over-collateralization is benign.
+        protocolInvariantsInstance.check_weETH_backed();
+    }
+
+    // =====================================================================
+    // Real wrap/unwrap exercise the in-line hook end-to-end
+    // =====================================================================
+
+    function test_wrap_under_ENFORCE_does_not_revert() public {
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        // Wrap must succeed even with ENFORCE on — the deposit-then-mint order in
+        // wrap() guarantees the invariant holds at the _afterTokenTransfer hook.
+        _wrap(alice, 3 ether);
+    }
+
+    function test_unwrap_under_ENFORCE_does_not_revert() public {
+        _wrap(alice, 3 ether);
+
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        uint256 weAmt = weEthInstance.balanceOf(alice);
+        vm.prank(alice);
+        weEthInstance.unwrap(weAmt);
+    }
+
+    function test_wrap_unwrap_loop_preserves_invariant() public {
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        vm.startPrank(alice);
+        eETHInstance.approve(address(weEthInstance), type(uint256).max);
+        for (uint256 i = 0; i < 20; i++) {
+            uint256 minted = weEthInstance.wrap(1 ether);
+            weEthInstance.unwrap(minted);
+        }
+        vm.stopPrank();
+    }
+
+    // =====================================================================
+    // View helper: weETHBackingDelta
+    // =====================================================================
+
+    function test_backingDelta_reports_balanced_when_balanced() public {
+        _wrap(alice, 1 ether);
+        (uint256 supply, uint256 proxyShares, bool underbacked) = protocolInvariantsInstance.weETHBackingDelta();
+        assertEq(supply, proxyShares, "supply should equal proxy shares after a clean wrap");
+        assertFalse(underbacked);
+    }
+
+    function test_backingDelta_reports_underbacked_when_underbacked() public {
+        _pokeUnderbacking(7e18);
+        (uint256 supply, uint256 proxyShares, bool underbacked) = protocolInvariantsInstance.weETHBackingDelta();
+        assertGt(supply, proxyShares);
+        assertTrue(underbacked);
+    }
+
+    // =====================================================================
+    // Helpers
+    // =====================================================================
+
+    /// @dev Direct storage poke to forge an underbacked state without an actual
+    ///      exploit path. Sets weETH.totalSupply to `currentSupply + delta`,
+    ///      leaving eETH.shares(weETHProxy) unchanged → invariant is violated.
+    function _pokeUnderbacking(uint256 delta) internal {
+        uint256 current = weEthInstance.totalSupply();
+        vm.store(address(weEthInstance), bytes32(WEETH_TOTAL_SUPPLY_SLOT), bytes32(current + delta));
+    }
+
+    function _wrap(address user, uint256 eETHAmount) internal returns (uint256) {
+        vm.startPrank(user);
+        eETHInstance.approve(address(weEthInstance), type(uint256).max);
+        uint256 weAmt = weEthInstance.wrap(eETHAmount);
+        vm.stopPrank();
+        return weAmt;
+    }
+}

--- a/test/ProtocolInvariants.t.sol
+++ b/test/ProtocolInvariants.t.sol
@@ -173,11 +173,43 @@ contract ProtocolInvariantsTest is TestSetup {
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 105e18, 100e18);
     }
 
-    function test_eETHRate_share_neutral_passes_even_when_rate_drops() public {
-        // Slashing-style rebase: pool shrinks, shares unchanged. The S0 == S1
-        // guard skips the check — share-neutral paths are exempt by design.
+    function test_eETHRate_skim_without_share_change_reverts() public {
+        // Pool drained while shares unchanged — same shape as a slashing
+        // rebase, but the modifier is NOT applied to the rebase path. So
+        // any call reaching the check with this state is an ETH skim from
+        // an entry point that should have been rate-preserving. Reverts.
         vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert();
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 90e18, 100e18);
+    }
+
+    function test_eETHRate_no_op_passes() public {
+        // No change at all → trivially passes.
+        vm.prank(address(liquidityPoolInstance));
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 100e18, 100e18);
+    }
+
+    function test_eETHRate_burn_only_rate_up_passes() public {
+        // Shares burned without P decrement (the LP.burnEEthShares path).
+        // P unchanged, S down → rate up. Passes.
+        vm.prank(address(liquidityPoolInstance));
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 100e18, 90e18);
+    }
+
+    function test_eETHRate_live_rate_withdraw_passes() public {
+        // Proportional burn: S=100→90, P=100→90. Rate preserved exactly.
+        vm.prank(address(liquidityPoolInstance));
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 90e18, 90e18);
+    }
+
+    function test_eETHRate_burn_overpays_reverts() public {
+        // Burn path that pays out MORE ETH than shares justify → rate drops.
+        // E.g., 10 shares burned for 12 ETH out. This is the threat the
+        // extended modifier catches: a buggy live-rate withdraw or
+        // burnEEthShares caller that overpays.
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert();
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 88e18, 90e18);
     }
 
     function test_eETHRate_bootstrap_passes() public {

--- a/test/ProtocolInvariants.t.sol
+++ b/test/ProtocolInvariants.t.sol
@@ -5,14 +5,11 @@ import "./TestSetup.sol";
 import "../src/ProtocolInvariants.sol";
 import "../src/interfaces/IProtocolInvariants.sol";
 
-/// @notice Tests for Invariant 1: `weETH.totalSupply <= eETH.shares(weETHProxy)`.
-///
-///         Coverage spine:
-///           - Mode machinery (DISABLED / OBSERVE / ENFORCE) and access control.
-///           - Real wrap/unwrap don't trigger violations (invariant holds by construction).
-///           - Synthetic underbacking via storage poke triggers expected behavior in
-///             each mode (no-op / emit-only / emit+revert).
-///           - Over-collateralization (accidental eETH airdrop to proxy) does NOT trip.
+/// @notice Tests for ProtocolInvariants — covers both:
+///         - Invariant 1: weETH supply backed by eETH shares in proxy.
+///         - Invariant 2: eETH exchange-rate monotonicity.
+///         Deploys live; the kill switch (`setEnabled(false)`) exists for
+///         emergencies only and is exercised here just to prove it works.
 contract ProtocolInvariantsTest is TestSetup {
     address internal multisigOnly;
     address internal unauthorized = address(0xDEAD);
@@ -40,100 +37,60 @@ contract ProtocolInvariantsTest is TestSetup {
     }
 
     // =====================================================================
-    // Mode machinery & access control
+    // Kill switch & access control
     // =====================================================================
 
-    function test_initial_mode_is_OBSERVE() public {
-        assertEq(uint256(protocolInvariantsInstance.mode()), uint256(IProtocolInvariants.Mode.OBSERVE));
+    function test_initial_state_is_enabled() public {
+        assertTrue(protocolInvariantsInstance.enabled());
     }
 
-    function test_setMode_requires_multisig() public {
+    function test_setEnabled_requires_multisig() public {
         vm.prank(unauthorized);
         vm.expectRevert();
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+        protocolInvariantsInstance.setEnabled(false);
 
         vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-        assertEq(uint256(protocolInvariantsInstance.mode()), uint256(IProtocolInvariants.Mode.ENFORCE));
+        protocolInvariantsInstance.setEnabled(false);
+        assertFalse(protocolInvariantsInstance.enabled());
     }
 
-    function test_setMode_emits_event() public {
+    function test_setEnabled_emits_event() public {
         vm.prank(multisigOnly);
         vm.expectEmit(true, true, true, true);
-        emit IProtocolInvariants.ModeChanged(IProtocolInvariants.Mode.OBSERVE, IProtocolInvariants.Mode.ENFORCE);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+        emit IProtocolInvariants.EnabledChanged(true, false);
+        protocolInvariantsInstance.setEnabled(false);
     }
 
-    function test_DISABLED_mode_is_noop_even_when_underbacked() public {
-        // Synthesize underbacking, then flip to DISABLED, then run the check.
-        // No event, no revert.
+    function test_disabled_is_noop_even_when_underbacked() public {
         _pokeUnderbacking(1e18);
 
         vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.DISABLED);
+        protocolInvariantsInstance.setEnabled(false);
 
-        // No revert in ENFORCE-equivalent scenario, no emit. Record logs to assert.
-        vm.recordLogs();
-        protocolInvariantsInstance.check_weETH_backed();
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        assertEq(logs.length, 0, "DISABLED mode must not emit");
-    }
-
-    // =====================================================================
-    // OBSERVE mode: emit on violation, do NOT revert
-    // =====================================================================
-
-    function test_OBSERVE_underbacked_emits_event_and_does_NOT_revert() public {
-        _pokeUnderbacking(5e18);
-
-        vm.expectEmit(true, true, true, true);
-        emit IProtocolInvariants.InvariantViolated(
-            "weETH-underbacked",
-            weEthInstance.totalSupply(),
-            eETHInstance.shares(address(weEthInstance))
-        );
+        // No revert when disabled even on a violating state.
         protocolInvariantsInstance.check_weETH_backed();
     }
 
-    function test_OBSERVE_balanced_does_NOT_emit() public {
-        // Set up a real wrap so the invariant naturally holds, then check.
-        _wrap(alice, 2 ether);
-
-        vm.recordLogs();
-        protocolInvariantsInstance.check_weETH_backed();
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        assertEq(logs.length, 0, "balanced state must not emit");
-    }
-
     // =====================================================================
-    // ENFORCE mode: emit AND revert on violation
+    // Invariant 1 — weETH backing
     // =====================================================================
 
-    function test_ENFORCE_underbacked_reverts() public {
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
+    function test_weETH_underbacked_reverts() public {
         _pokeUnderbacking(5e18);
 
         vm.expectRevert();
         protocolInvariantsInstance.check_weETH_backed();
     }
 
-    function test_ENFORCE_balanced_passes() public {
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
-        _wrap(alice, 1 ether);
-        protocolInvariantsInstance.check_weETH_backed();   // must not revert
+    function test_weETH_balanced_passes() public {
+        _wrap(alice, 2 ether);
+        protocolInvariantsInstance.check_weETH_backed();
     }
 
-    function test_ENFORCE_overcollateralized_passes() public {
+    function test_weETH_overcollateralized_passes() public {
         // Donate eETH directly to the weETH proxy. weETH.totalSupply unchanged;
-        // eETH.shares(proxy) increases. invariant: totalSupply <= proxyShares holds.
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
-        // Give alice extra eETH to donate.
+        // eETH.shares(proxy) increases. invariant: totalSupply <= proxyShares
+        // holds — over-collateralization is benign.
         vm.deal(alice, 10 ether);
         vm.prank(alice);
         liquidityPoolInstance.deposit{value: 5 ether}();
@@ -141,41 +98,23 @@ contract ProtocolInvariantsTest is TestSetup {
         vm.prank(alice);
         eETHInstance.transfer(address(weEthInstance), 1 ether);
 
-        // The transfer itself triggered _beforeTokenTransfer hooks etc. but the
-        // weETH `_afterTokenTransfer` only runs on weETH state changes; an eETH
-        // transfer doesn't trigger weETH hooks. So no automatic check fired.
-        // Explicit check still passes — over-collateralization is benign.
         protocolInvariantsInstance.check_weETH_backed();
     }
 
-    // =====================================================================
-    // Real wrap/unwrap exercise the in-line hook end-to-end
-    // =====================================================================
+    // Real wrap/unwrap exercise the in-line hook end-to-end.
 
-    function test_wrap_under_ENFORCE_does_not_revert() public {
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
-        // Wrap must succeed even with ENFORCE on — the deposit-then-mint order in
-        // wrap() guarantees the invariant holds at the _afterTokenTransfer hook.
+    function test_wrap_does_not_revert() public {
         _wrap(alice, 3 ether);
     }
 
-    function test_unwrap_under_ENFORCE_does_not_revert() public {
+    function test_unwrap_does_not_revert() public {
         _wrap(alice, 3 ether);
-
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
         uint256 weAmt = weEthInstance.balanceOf(alice);
         vm.prank(alice);
         weEthInstance.unwrap(weAmt);
     }
 
     function test_wrap_unwrap_loop_preserves_invariant() public {
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
         vm.startPrank(alice);
         eETHInstance.approve(address(weEthInstance), type(uint256).max);
         for (uint256 i = 0; i < 20; i++) {
@@ -185,9 +124,7 @@ contract ProtocolInvariantsTest is TestSetup {
         vm.stopPrank();
     }
 
-    // =====================================================================
-    // View helper: weETHBackingDelta
-    // =====================================================================
+    // View helper
 
     function test_backingDelta_reports_balanced_when_balanced() public {
         _wrap(alice, 1 ether);
@@ -204,7 +141,7 @@ contract ProtocolInvariantsTest is TestSetup {
     }
 
     // =====================================================================
-    // Invariant 2: eETH exchange-rate monotonicity
+    // Invariant 2 — eETH exchange-rate monotonicity
     // =====================================================================
     //
     // The modifier on LP snapshots (P0,S0) before and (P1,S1) after a
@@ -213,10 +150,9 @@ contract ProtocolInvariantsTest is TestSetup {
     // without having to synthesize a real LP exploit tx.
 
     function test_eETHRate_check_requires_LP_caller() public {
-        // Non-LP callers must hit `onlyLP`. The onlyLP modifier runs BEFORE the
-        // mode check, so DISABLED-mode does NOT bypass the gate (a stranger
-        // can never spam fake events to trip Hypernative even when the
-        // contract is otherwise inactive).
+        // Non-LP callers must hit `onlyLP`. The onlyLP modifier runs BEFORE
+        // the enabled-check, so even a disabled invariant doesn't open the
+        // gate for fake callers.
         vm.prank(unauthorized);
         vm.expectRevert(IProtocolInvariants.OnlyLiquidityPool.selector);
         protocolInvariantsInstance.check_eETHRateMonotonic(100, 100, 100, 100);
@@ -227,19 +163,12 @@ contract ProtocolInvariantsTest is TestSetup {
     }
 
     function test_eETHRate_balanced_passes() public {
-        // Pretend LP. Snapshot before/after a balanced (rate-preserving) op.
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
         vm.prank(address(liquidityPoolInstance));
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 101e18, 101e18);
     }
 
     function test_eETHRate_increased_passes() public {
         // Rebase / fee-enriched path: rate ticks UP (more pool per share).
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
         vm.prank(address(liquidityPoolInstance));
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 105e18, 100e18);
     }
@@ -247,105 +176,58 @@ contract ProtocolInvariantsTest is TestSetup {
     function test_eETHRate_share_neutral_passes_even_when_rate_drops() public {
         // Slashing-style rebase: pool shrinks, shares unchanged. The S0 == S1
         // guard skips the check — share-neutral paths are exempt by design.
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
         vm.prank(address(liquidityPoolInstance));
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 90e18, 100e18);
     }
 
     function test_eETHRate_bootstrap_passes() public {
-        // First deposit (S0 == 0) and post-empty (S1 == 0) cases are exempted —
-        // no rate to compare against.
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
+        // S0 == 0 (first deposit) and S1 == 0 (drained pool) are exempted.
         vm.startPrank(address(liquidityPoolInstance));
         protocolInvariantsInstance.check_eETHRateMonotonic(0, 0, 100e18, 100e18);
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 0, 0);
         vm.stopPrank();
     }
 
-    function test_eETHRate_unbacked_mint_reverts_under_ENFORCE() public {
-        // Simulate the exploit: shares went up but pool didn't.
+    function test_eETHRate_unbacked_mint_reverts() public {
         // Before: rate = 100/100 = 1.0
         // After:  rate = 100/110 ≈ 0.909  (deflated)
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
         vm.prank(address(liquidityPoolInstance));
         vm.expectRevert();
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 100e18, 110e18);
     }
 
-    function test_eETHRate_skim_reverts_when_shares_change_under_ENFORCE() public {
-        // Pool drained but shares went up — combined exploit / underflow case.
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
+    function test_eETHRate_skim_with_share_change_reverts() public {
+        // Pool drained AND shares went up.
         vm.prank(address(liquidityPoolInstance));
         vm.expectRevert();
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 90e18, 110e18);
     }
 
-    function test_eETHRate_OBSERVE_emits_event_does_NOT_revert() public {
-        // Default mode is OBSERVE.
+    function test_eETHRate_disabled_is_no_op_on_violation() public {
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setEnabled(false);
+
         vm.prank(address(liquidityPoolInstance));
-        vm.expectEmit(true, true, true, true);
-        emit IProtocolInvariants.InvariantViolated("eETH-rate-deflation", 100e18 * 100e18, 100e18 * 110e18);
         protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 100e18, 110e18);
     }
 
-    function test_eETHRate_DISABLED_is_no_op_on_violation() public {
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.DISABLED);
-
-        vm.recordLogs();
-        vm.prank(address(liquidityPoolInstance));
-        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 100e18, 110e18);
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        assertEq(logs.length, 0, "DISABLED mode must not emit");
-    }
-
-    function test_eETHRate_real_deposit_passes_under_ENFORCE() public {
-        // End-to-end: switch to ENFORCE, do a real deposit, no revert.
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
+    function test_eETHRate_real_deposit_passes() public {
+        // End-to-end: real deposit via LP, modifier runs, no revert.
         address user = address(0xC0FFEE);
         vm.deal(user, 5 ether);
         vm.prank(user);
         liquidityPoolInstance.deposit{value: 3 ether}();
     }
 
-    function test_eETHRate_real_unbacked_mint_via_LP_prank_reverts() public {
-        // Direct full-stack test: prank as LP to call eETH.mintShares without
-        // matching ETH inflow. The next share-changing LP call must trip the
-        // modifier because the snapshot at its start captures the deflated
-        // rate, and the call's proportional mint can't restore it.
-        //
-        // (Note: a "real" exploit would happen INSIDE a modifier-guarded
-        //  call, so the snapshot itself captures the pre-exploit state and
-        //  the check trips immediately. Modeling that requires a custom
-        //  malicious contract; the check_eETHRateMonotonic unit tests above
-        //  already cover that math directly.)
-        vm.prank(multisigOnly);
-        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
-
-        // Inject unbacked shares as if LP itself were compromised.
+    function test_eETHRate_LP_prank_unbacked_mint_aftermath_does_not_false_trip() public {
+        // The modifier is designed to revert the EXPLOIT TX itself. After an
+        // out-of-band unbacked mint (here simulated by pranking LP), the new
+        // (deflated) rate becomes the baseline; subsequent proportional
+        // deposits preserve that ratio and don't false-trip. This documents
+        // the scope: invariant catches the exploit, not the aftermath.
         vm.prank(address(liquidityPoolInstance));
         eETHInstance.mintShares(address(0xBAD), 50 ether);
 
-        // Now any small honest deposit will revert because the proportional
-        // share calc against the (deflated) rate produces ΔS proportional to
-        // the new ratio, and `P1*S0 < P0*S1` triggers — wait, actually:
-        // a proportional deposit *preserves* the deflated rate, so the
-        // modifier would NOT catch the aftermath here. This test captures
-        // the more practical reality — the modifier protects the SAME-TX
-        // exploit, not post-hoc cleanup. See the unit tests above for the
-        // direct math coverage.
-        //
-        // We still assert that the deposit doesn't false-trip:
         address user = address(0xC0FFEE2);
         vm.deal(user, 5 ether);
         vm.prank(user);

--- a/test/ProtocolInvariants.t.sol
+++ b/test/ProtocolInvariants.t.sol
@@ -204,6 +204,155 @@ contract ProtocolInvariantsTest is TestSetup {
     }
 
     // =====================================================================
+    // Invariant 2: eETH exchange-rate monotonicity
+    // =====================================================================
+    //
+    // The modifier on LP snapshots (P0,S0) before and (P1,S1) after a
+    // share-changing call. The check function is what gets exercised here —
+    // calling it directly with constructed values lets us probe the math
+    // without having to synthesize a real LP exploit tx.
+
+    function test_eETHRate_check_requires_LP_caller() public {
+        // Non-LP callers must hit `onlyLP`. The onlyLP modifier runs BEFORE the
+        // mode check, so DISABLED-mode does NOT bypass the gate (a stranger
+        // can never spam fake events to trip Hypernative even when the
+        // contract is otherwise inactive).
+        vm.prank(unauthorized);
+        vm.expectRevert(IProtocolInvariants.OnlyLiquidityPool.selector);
+        protocolInvariantsInstance.check_eETHRateMonotonic(100, 100, 100, 100);
+
+        vm.prank(multisigOnly);
+        vm.expectRevert(IProtocolInvariants.OnlyLiquidityPool.selector);
+        protocolInvariantsInstance.check_eETHRateMonotonic(100, 100, 100, 100);
+    }
+
+    function test_eETHRate_balanced_passes() public {
+        // Pretend LP. Snapshot before/after a balanced (rate-preserving) op.
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        vm.prank(address(liquidityPoolInstance));
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 101e18, 101e18);
+    }
+
+    function test_eETHRate_increased_passes() public {
+        // Rebase / fee-enriched path: rate ticks UP (more pool per share).
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        vm.prank(address(liquidityPoolInstance));
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 105e18, 100e18);
+    }
+
+    function test_eETHRate_share_neutral_passes_even_when_rate_drops() public {
+        // Slashing-style rebase: pool shrinks, shares unchanged. The S0 == S1
+        // guard skips the check — share-neutral paths are exempt by design.
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        vm.prank(address(liquidityPoolInstance));
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 90e18, 100e18);
+    }
+
+    function test_eETHRate_bootstrap_passes() public {
+        // First deposit (S0 == 0) and post-empty (S1 == 0) cases are exempted —
+        // no rate to compare against.
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        vm.startPrank(address(liquidityPoolInstance));
+        protocolInvariantsInstance.check_eETHRateMonotonic(0, 0, 100e18, 100e18);
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 0, 0);
+        vm.stopPrank();
+    }
+
+    function test_eETHRate_unbacked_mint_reverts_under_ENFORCE() public {
+        // Simulate the exploit: shares went up but pool didn't.
+        // Before: rate = 100/100 = 1.0
+        // After:  rate = 100/110 ≈ 0.909  (deflated)
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert();
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 100e18, 110e18);
+    }
+
+    function test_eETHRate_skim_reverts_when_shares_change_under_ENFORCE() public {
+        // Pool drained but shares went up — combined exploit / underflow case.
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert();
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 90e18, 110e18);
+    }
+
+    function test_eETHRate_OBSERVE_emits_event_does_NOT_revert() public {
+        // Default mode is OBSERVE.
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectEmit(true, true, true, true);
+        emit IProtocolInvariants.InvariantViolated("eETH-rate-deflation", 100e18 * 100e18, 100e18 * 110e18);
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 100e18, 110e18);
+    }
+
+    function test_eETHRate_DISABLED_is_no_op_on_violation() public {
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.DISABLED);
+
+        vm.recordLogs();
+        vm.prank(address(liquidityPoolInstance));
+        protocolInvariantsInstance.check_eETHRateMonotonic(100e18, 100e18, 100e18, 110e18);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "DISABLED mode must not emit");
+    }
+
+    function test_eETHRate_real_deposit_passes_under_ENFORCE() public {
+        // End-to-end: switch to ENFORCE, do a real deposit, no revert.
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        address user = address(0xC0FFEE);
+        vm.deal(user, 5 ether);
+        vm.prank(user);
+        liquidityPoolInstance.deposit{value: 3 ether}();
+    }
+
+    function test_eETHRate_real_unbacked_mint_via_LP_prank_reverts() public {
+        // Direct full-stack test: prank as LP to call eETH.mintShares without
+        // matching ETH inflow. The next share-changing LP call must trip the
+        // modifier because the snapshot at its start captures the deflated
+        // rate, and the call's proportional mint can't restore it.
+        //
+        // (Note: a "real" exploit would happen INSIDE a modifier-guarded
+        //  call, so the snapshot itself captures the pre-exploit state and
+        //  the check trips immediately. Modeling that requires a custom
+        //  malicious contract; the check_eETHRateMonotonic unit tests above
+        //  already cover that math directly.)
+        vm.prank(multisigOnly);
+        protocolInvariantsInstance.setMode(IProtocolInvariants.Mode.ENFORCE);
+
+        // Inject unbacked shares as if LP itself were compromised.
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.mintShares(address(0xBAD), 50 ether);
+
+        // Now any small honest deposit will revert because the proportional
+        // share calc against the (deflated) rate produces ΔS proportional to
+        // the new ratio, and `P1*S0 < P0*S1` triggers — wait, actually:
+        // a proportional deposit *preserves* the deflated rate, so the
+        // modifier would NOT catch the aftermath here. This test captures
+        // the more practical reality — the modifier protects the SAME-TX
+        // exploit, not post-hoc cleanup. See the unit tests above for the
+        // direct math coverage.
+        //
+        // We still assert that the deposit doesn't false-trip:
+        address user = address(0xC0FFEE2);
+        vm.deal(user, 5 ether);
+        vm.prank(user);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    // =====================================================================
     // Helpers
     // =====================================================================
 

--- a/test/RestakingRewardsRouter.t.sol
+++ b/test/RestakingRewardsRouter.t.sol
@@ -63,7 +63,8 @@ contract RestakingRewardsRouterTest is Test {
                 priorityWithdrawalQueue: address(0),
                 blacklister: address(0),
                 etherFiAdminContract: address(0),
-                membershipManager: address(0)
+                membershipManager: address(0),
+                protocolInvariants: address(0)
             }),
             0
         );

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -28,6 +28,8 @@ import "../src/BNFT.sol";
 import "../src/TNFT.sol";
 import "../src/EtherFiNode.sol";
 import "../src/EtherFiRateLimiter.sol";
+import "../src/ProtocolInvariants.sol";
+import "../src/interfaces/IProtocolInvariants.sol";
 import "../src/LiquidityPool.sol";
 import "../src/Liquifier.sol";
 import "../src/EtherFiRestaker.sol";
@@ -138,6 +140,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     UUPSProxy public stakingManagerProxy;
     UUPSProxy public etherFiNodeManagerProxy;
     UUPSProxy public rateLimiterProxy;
+    UUPSProxy public protocolInvariantsProxy;
     UUPSProxy public protocolRevenueManagerProxy;
     UUPSProxy public TNFTProxy;
     UUPSProxy public BNFTProxy;
@@ -175,6 +178,9 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
     EtherFiRateLimiter public rateLimiterInstance;
     EtherFiRateLimiter public rateLimiterImplementation;
+
+    ProtocolInvariants public protocolInvariantsInstance;
+    ProtocolInvariants public protocolInvariantsImplementation;
 
     RegulationsManager public regulationsManagerInstance;
     RegulationsManager public regulationsManagerImplementation;
@@ -560,6 +566,17 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // ETHERFI_RATE_LIMITER_ADMIN_ROLE, which the consolidated role model no
         // longer uses, and predates the per-address bucket immutables.
         address newRateLimiterImpl = address(new EtherFiRateLimiter(address(roleRegistryInstance), address(eETHInstance), address(weEthInstance)));
+
+        // ProtocolInvariants is brand-new — no on-chain version to upgrade.
+        // Deploy fresh and start in OBSERVE mode so the rest of the fork suite
+        // can call wrap/unwrap without an enforce-mode revert risk.
+        protocolInvariantsImplementation = new ProtocolInvariants(address(roleRegistryInstance), address(eETHInstance), address(weEthInstance));
+        protocolInvariantsProxy = new UUPSProxy(
+            address(protocolInvariantsImplementation),
+            abi.encodeWithSelector(ProtocolInvariants.initialize.selector, IProtocolInvariants.Mode.OBSERVE)
+        );
+        protocolInvariantsInstance = ProtocolInvariants(address(protocolInvariantsProxy));
+
         vm.prank(roleRegistryInstance.owner());
         rateLimiterInstance.upgradeTo(newRateLimiterImpl);
 
@@ -660,7 +677,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(liquidityPoolInstance),
             address(roleRegistryInstance),
             address(blacklisterInstance),
-            address(rateLimiterInstance)
+            address(rateLimiterInstance),
+            address(protocolInvariantsInstance)
         ));
         vm.prank(weEthInstance.owner());
         weEthInstance.upgradeTo(newWeETHImpl);
@@ -948,6 +966,17 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         rateLimiterInstance = EtherFiRateLimiter(address(rateLimiterProxy));
         rateLimiterInstance.initialize();
 
+        // ProtocolInvariants has the same chicken-and-egg as the rate limiter
+        // (takes eETH/weETH as immutables). Deploy AFTER both proxies exist,
+        // BEFORE WeETH impl (which takes this as a constructor immutable).
+        // Start in OBSERVE mode so tests can validate before any reverts.
+        protocolInvariantsImplementation = new ProtocolInvariants(address(roleRegistryInstance), address(eETHProxy), address(weETHProxy));
+        protocolInvariantsProxy = new UUPSProxy(
+            address(protocolInvariantsImplementation),
+            abi.encodeWithSelector(ProtocolInvariants.initialize.selector, IProtocolInvariants.Mode.OBSERVE)
+        );
+        protocolInvariantsInstance = ProtocolInvariants(address(protocolInvariantsProxy));
+
         membershipNftProxy = new UUPSProxy(address(placeholderImpl), "");
         membershipNftInstance = MembershipNFT(payable(membershipNftProxy));
 
@@ -1150,7 +1179,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         eETHInstance.initialize(payable(address(liquidityPoolProxy)));
 
         // WeETH
-        weEthImplementation = new WeETH(address(eETHProxy), address(liquidityPoolProxy), address(roleRegistryInstance), address(blacklisterInstance), address(rateLimiterInstance));
+        weEthImplementation = new WeETH(address(eETHProxy), address(liquidityPoolProxy), address(roleRegistryInstance), address(blacklisterInstance), address(rateLimiterInstance), address(protocolInvariantsInstance));
         vm.expectRevert("Initializable: contract is already initialized");
         weEthImplementation.initialize(payable(address(liquidityPoolProxy)), address(eETHProxy));
         weEthInstance.upgradeTo(address(weEthImplementation));
@@ -1467,7 +1496,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function _upgrade_weETH() internal {
-        address newWeETHImpl = address(new WeETH(address(eETHInstance), address(liquidityPoolInstance), address(roleRegistryInstance), address(blacklisterInstance), address(rateLimiterInstance)));
+        address newWeETHImpl = address(new WeETH(address(eETHInstance), address(liquidityPoolInstance), address(roleRegistryInstance), address(blacklisterInstance), address(rateLimiterInstance), address(protocolInvariantsInstance)));
         vm.prank(owner);
         weEthInstance.upgradeTo(newWeETHImpl);
         // No bucket bootstrap needed — per-address rate limits are opt-in and the

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -568,12 +568,13 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         address newRateLimiterImpl = address(new EtherFiRateLimiter(address(roleRegistryInstance), address(eETHInstance), address(weEthInstance)));
 
         // ProtocolInvariants is brand-new — no on-chain version to upgrade.
-        // Deploy fresh and start in OBSERVE mode so the rest of the fork suite
-        // can call wrap/unwrap without an enforce-mode revert risk.
+        // Deploys live (enabled = true); the rest of the fork suite calls
+        // wrap/unwrap and deposit/withdraw on well-formed state so the
+        // invariants pass cleanly.
         protocolInvariantsImplementation = new ProtocolInvariants(address(roleRegistryInstance), address(eETHInstance), address(weEthInstance), address(liquidityPoolInstance));
         protocolInvariantsProxy = new UUPSProxy(
             address(protocolInvariantsImplementation),
-            abi.encodeWithSelector(ProtocolInvariants.initialize.selector, IProtocolInvariants.Mode.OBSERVE)
+            abi.encodeWithSelector(ProtocolInvariants.initialize.selector)
         );
         protocolInvariantsInstance = ProtocolInvariants(address(protocolInvariantsProxy));
 
@@ -970,12 +971,12 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // ProtocolInvariants has the same chicken-and-egg as the rate limiter
         // (takes eETH/weETH/LP as immutables). Deploy AFTER all three proxies
         // exist, BEFORE WeETH and LP impls (which take this as a constructor
-        // immutable). Start in OBSERVE mode so tests can validate before any
-        // reverts.
+        // immutable). Deploys enabled by default — there is no observe-only
+        // mode, releases go live with checks active.
         protocolInvariantsImplementation = new ProtocolInvariants(address(roleRegistryInstance), address(eETHProxy), address(weETHProxy), address(liquidityPoolProxy));
         protocolInvariantsProxy = new UUPSProxy(
             address(protocolInvariantsImplementation),
-            abi.encodeWithSelector(ProtocolInvariants.initialize.selector, IProtocolInvariants.Mode.OBSERVE)
+            abi.encodeWithSelector(ProtocolInvariants.initialize.selector)
         );
         protocolInvariantsInstance = ProtocolInvariants(address(protocolInvariantsProxy));
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -570,7 +570,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // ProtocolInvariants is brand-new — no on-chain version to upgrade.
         // Deploy fresh and start in OBSERVE mode so the rest of the fork suite
         // can call wrap/unwrap without an enforce-mode revert risk.
-        protocolInvariantsImplementation = new ProtocolInvariants(address(roleRegistryInstance), address(eETHInstance), address(weEthInstance));
+        protocolInvariantsImplementation = new ProtocolInvariants(address(roleRegistryInstance), address(eETHInstance), address(weEthInstance), address(liquidityPoolInstance));
         protocolInvariantsProxy = new UUPSProxy(
             address(protocolInvariantsImplementation),
             abi.encodeWithSelector(ProtocolInvariants.initialize.selector, IProtocolInvariants.Mode.OBSERVE)
@@ -613,7 +613,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 priorityWithdrawalQueue: address(priorityQueueInstance),
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: address(etherFiAdminInstance),
-                membershipManager: address(membershipManagerV1Instance)
+                membershipManager: address(membershipManagerV1Instance),
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         ));
@@ -967,10 +968,11 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         rateLimiterInstance.initialize();
 
         // ProtocolInvariants has the same chicken-and-egg as the rate limiter
-        // (takes eETH/weETH as immutables). Deploy AFTER both proxies exist,
-        // BEFORE WeETH impl (which takes this as a constructor immutable).
-        // Start in OBSERVE mode so tests can validate before any reverts.
-        protocolInvariantsImplementation = new ProtocolInvariants(address(roleRegistryInstance), address(eETHProxy), address(weETHProxy));
+        // (takes eETH/weETH/LP as immutables). Deploy AFTER all three proxies
+        // exist, BEFORE WeETH and LP impls (which take this as a constructor
+        // immutable). Start in OBSERVE mode so tests can validate before any
+        // reverts.
+        protocolInvariantsImplementation = new ProtocolInvariants(address(roleRegistryInstance), address(eETHProxy), address(weETHProxy), address(liquidityPoolProxy));
         protocolInvariantsProxy = new UUPSProxy(
             address(protocolInvariantsImplementation),
             abi.encodeWithSelector(ProtocolInvariants.initialize.selector, IProtocolInvariants.Mode.OBSERVE)
@@ -1131,7 +1133,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 priorityWithdrawalQueue: address(0x0),
                 blacklister: address(0x0),
                 etherFiAdminContract: address(0x0),
-                membershipManager: address(0x0)
+                membershipManager: address(0x0),
+                protocolInvariants: address(0x0)
             }),
             0
         );
@@ -1312,7 +1315,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 priorityWithdrawalQueue: address(priorityQueueProxy),
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: address(etherFiAdminProxy),
-                membershipManager: address(membershipManagerProxy)
+                membershipManager: address(membershipManagerProxy),
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         );
@@ -2236,7 +2240,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 priorityWithdrawalQueue: address(priorityQueueInstance),
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: address(etherFiAdminInstance),
-                membershipManager: address(membershipManagerInstance)
+                membershipManager: address(membershipManagerInstance),
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         ));

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -117,7 +117,11 @@ contract PreludeTest is Test, ArrayTestHelper {
                 priorityWithdrawalQueue: 0x35e7D6feF6f72aDd3c3e39dEc6d9CCc29e3345FA,
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: 0x0EF8fa4760Db8f5Cd4d993f3e3416f30f942D705,
-                membershipManager: 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000
+                membershipManager: 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000,
+                // Validator-lifecycle behaviour test — doesn't exercise LP
+                // share-changing paths, so the rate-monotonicity modifier is
+                // never invoked. address(0) is safe here.
+                protocolInvariants: address(0)
             }),
             0
         );

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -10,6 +10,8 @@ import "../../src/utils/ReentrancyGuardNamespaced.sol";
 import "../../src/RoleRegistry.sol";
 import "../../src/UUPSProxy.sol";
 import "../../src/helpers/Blacklister.sol";
+import "../../src/ProtocolInvariants.sol";
+import "../../src/interfaces/IProtocolInvariants.sol";
 
 interface IUUPSProxy {
     function upgradeTo(address newImpl) external;
@@ -46,6 +48,22 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         0xcd24049d7dcc1fde21494dba8ad7a067afb6b8f14dfe804abeeec84903344e97;
 
     Blacklister internal blacklisterInstance;
+    ProtocolInvariants internal protocolInvariantsInstance;
+
+    /// @dev LP's new constructor takes ProtocolInvariants as an immutable. This
+    ///      fork test doesn't extend TestSetup so it can't reuse the shared
+    ///      deployment; spin up a fresh one in OBSERVE mode pointing at the
+    ///      live mainnet eETH/weETH/LP addresses. OBSERVE mode means even if
+    ///      the invariant is violated mid-test we'd only emit an event, not
+    ///      revert — keeps this test focused on storage layout, not invariants.
+    function _deployInvariants() internal {
+        ProtocolInvariants impl = new ProtocolInvariants(ROLE_REGISTRY, EETH, WEETH, LIQUIDITY_POOL);
+        UUPSProxy proxy = new UUPSProxy(
+            address(impl),
+            abi.encodeWithSelector(ProtocolInvariants.initialize.selector, IProtocolInvariants.Mode.OBSERVE)
+        );
+        protocolInvariantsInstance = ProtocolInvariants(address(proxy));
+    }
 
     struct LPSnap {
         address eeth;
@@ -150,6 +168,11 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         // input is well-formed.
         Blacklister bImpl = new Blacklister(ROLE_REGISTRY);
         blacklisterInstance = Blacklister(address(new UUPSProxy(address(bImpl), abi.encodeWithSelector(Blacklister.initialize.selector))));
+
+        // ProtocolInvariants is new; LP's constructor takes it as an immutable
+        // and the deposit() this test exercises invokes the modifier. Wire it
+        // up here in OBSERVE mode.
+        _deployInvariants();
     }
 
     /// @dev Upgrade RoleRegistry to the new impl (after LP/WRN/PQ have already
@@ -223,7 +246,8 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
                 priorityWithdrawalQueue: PRIORITY_WITHDRAWAL_QUEUE,
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: ETHERFI_ADMIN,
-                membershipManager: MEMBERSHIP_MANAGER
+                membershipManager: MEMBERSHIP_MANAGER,
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         ));
@@ -417,7 +441,8 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
                 priorityWithdrawalQueue: PRIORITY_WITHDRAWAL_QUEUE,
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: ETHERFI_ADMIN,
-                membershipManager: MEMBERSHIP_MANAGER
+                membershipManager: MEMBERSHIP_MANAGER,
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         ));
@@ -472,7 +497,8 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
                 priorityWithdrawalQueue: PRIORITY_WITHDRAWAL_QUEUE,
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: ETHERFI_ADMIN,
-                membershipManager: MEMBERSHIP_MANAGER
+                membershipManager: MEMBERSHIP_MANAGER,
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         ));

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -52,15 +52,15 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
 
     /// @dev LP's new constructor takes ProtocolInvariants as an immutable. This
     ///      fork test doesn't extend TestSetup so it can't reuse the shared
-    ///      deployment; spin up a fresh one in OBSERVE mode pointing at the
-    ///      live mainnet eETH/weETH/LP addresses. OBSERVE mode means even if
-    ///      the invariant is violated mid-test we'd only emit an event, not
-    ///      revert — keeps this test focused on storage layout, not invariants.
+    ///      deployment; spin up a fresh one pointing at the live mainnet
+    ///      eETH/weETH/LP addresses. Deploys enabled by default; this test
+    ///      exercises a single 1-ether deposit which the invariants will
+    ///      pass cleanly (storage-layout test, not an invariant-stress test).
     function _deployInvariants() internal {
         ProtocolInvariants impl = new ProtocolInvariants(ROLE_REGISTRY, EETH, WEETH, LIQUIDITY_POOL);
         UUPSProxy proxy = new UUPSProxy(
             address(impl),
-            abi.encodeWithSelector(ProtocolInvariants.initialize.selector, IProtocolInvariants.Mode.OBSERVE)
+            abi.encodeWithSelector(ProtocolInvariants.initialize.selector)
         );
         protocolInvariantsInstance = ProtocolInvariants(address(proxy));
     }
@@ -171,7 +171,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
 
         // ProtocolInvariants is new; LP's constructor takes it as an immutable
         // and the deposit() this test exercises invokes the modifier. Wire it
-        // up here in OBSERVE mode.
+        // up here.
         _deployInvariants();
     }
 

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -79,7 +79,11 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
                 priorityWithdrawalQueue: 0x35e7D6feF6f72aDd3c3e39dEc6d9CCc29e3345FA,
                 blacklister: address(blacklister),
                 etherFiAdminContract: 0x0EF8fa4760Db8f5Cd4d993f3e3416f30f942D705,
-                membershipManager: 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000
+                membershipManager: 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000,
+                // ProtocolInvariants is brand-new, no on-chain version yet.
+                // This test doesn't exercise deposit/withdraw, so the modifier
+                // path is never taken — address(0) is safe here.
+                protocolInvariants: address(0)
             }),
             0
         );

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -21,7 +21,8 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
                 priorityWithdrawalQueue: PRIORITY_WITHDRAWAL_QUEUE,
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: ETHERFI_ADMIN,
-                membershipManager: MEMBERSHIP_MANAGER
+                membershipManager: MEMBERSHIP_MANAGER,
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         ));

--- a/test/integration-tests/MinAmountForShare.t.sol
+++ b/test/integration-tests/MinAmountForShare.t.sol
@@ -50,7 +50,8 @@ contract MinAmountForShareForkTest is TestSetup, Deployed {
                 priorityWithdrawalQueue: address(priorityQueueInstance),
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: address(etherFiAdminInstance),
-                membershipManager: address(membershipManagerInstance)
+                membershipManager: address(membershipManagerInstance),
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             minAmount
         );

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -33,7 +33,8 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
             priorityWithdrawalQueue: address(priorityQueueInstance),
             blacklister: address(blacklisterInstance),
             etherFiAdminContract: address(etherFiAdminInstance),
-            membershipManager: address(membershipManagerInstance)
+            membershipManager: address(membershipManagerInstance),
+            protocolInvariants: address(protocolInvariantsInstance)
         }), 0);
         address lpOwner = liquidityPoolInstance.owner();
         vm.prank(lpOwner);

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -124,7 +124,8 @@ contract WithdrawEscrowE2ETest is TestSetup {
                 priorityWithdrawalQueue: address(pQueue),
                 blacklister: address(blacklisterInstance),
                 etherFiAdminContract: address(etherFiAdminInstance),
-                membershipManager: address(membershipManagerInstance)
+                membershipManager: address(membershipManagerInstance),
+                protocolInvariants: address(protocolInvariantsInstance)
             }),
             0
         )));


### PR DESCRIPTION
Implements **Invariant 1 (weETH backing)** and **Invariant 2 (eETH exchange-rate monotonicity)** from the RFC at \`docs/rfc-protocol-invariants.md\`.

Together they're the longer-term direction the team aligned on: rate limits stay for *targeted throttling*, invariants take over for *unbacked-supply prevention*. Layered defense — Invariant 1 protects the weETH share basket; Invariant 2 protects the value of those shares.

Independent of #424 (wrap-aware buckets) and #425 (consistency polish). All can co-exist; #424's buckets become belt-and-suspenders once these are in ENFORCE mode, and Phase 3 of the RFC plans their retirement.

## Invariant 1 — weETH backing

\`\`\`
weETH.totalSupply() <= eETH.shares(address(weETHProxy))
\`\`\`

**Why it holds today:** a \`wrap(X eETH)\` mints \`sharesForAmount(X)\` weETH AND transfers \`sharesForAmount(X)\` eETH shares to the proxy. Both sides increment by the same number. \`unwrap\` is the symmetric decrement. \`<=\` (instead of \`==\`) permits benign over-collateralization from accidental eETH airdrops.

**Catches:** any non-wrap path that mints weETH without backing eETH (bridge compromise, future mint authority, exploit).

## Invariant 2 — eETH exchange-rate monotonicity

\`\`\`
after every share-changing LP call:  P1 * S0 >= P0 * S1
where P = LP.getTotalPooledEther() and S = eETH.totalShares()
\`\`\`

**Why it holds today:** healthy deposits / withdrawals are proportional and preserve the rate exactly; rebases change P without changing S (exempted by the \`S0 == S1\` guard); fee paths keep ETH in the pool relative to shares burned, which only pushes the rate UP. The ONE scenario where the rate goes DOWN and shares change is the threat — shares were minted without an equivalent ETH inflow.

**Catches:** unbacked eETH mint (LP compromise, exploited share path, accounting bug that produces shares without proportional ETH inflow).

## What changed

### \`ProtocolInvariants\` (new contract)
- UUPS-upgradable. Immutable references to eETH, weETH, and LP proxies.
- Three-mode toggle: \`DISABLED\` (kill switch) / \`OBSERVE\` (emit only, default) / \`ENFORCE\` (emit + revert). \`setMode\` is \`onlyOperatingMultisig\`.
- \`check_weETH_backed()\` — open (anyone can call; values read from on-chain state).
- \`check_eETHRateMonotonic(P0, S0, P1, S1)\` — \`onlyLP\` gated (caller supplies values, so we restrict to LP to keep events high-signal).
- View helper \`weETHBackingDelta()\` for dashboards.

### \`WeETH\`
- New constructor immutable: \`protocolInvariants\`.
- \`_afterTokenTransfer\` hook fires \`check_weETH_backed()\` on supply changes (skip transfers).
- \`wrap()\` reordered to deposit-then-mint so the invariant holds at the hook.

### \`LiquidityPool\`
- New \`protocolInvariants\` field in \`ConstructorAddresses\` + matching immutable.
- New \`nonDecreasingRate\` modifier — snapshots (P, S) pre/post and forwards both pairs to \`check_eETHRateMonotonic\`.
- Modifier applied to 7 share-changing entry points:
  - \`deposit(address _referral)\`
  - \`depositToRecipient(...)\`
  - \`deposit(address _user, address _referral)\`
  - \`withdraw(address, uint256)\`
  - \`withdraw(uint256, uint256)\`
  - \`burnEEthShares(uint256)\`
  - \`burnEEthSharesForNonETHWithdrawal(uint256, uint256)\`
- \`rebase()\` and other oracle paths intentionally don't carry the modifier — they change the rate without changing shares (the guard would skip anyway).

### Test infrastructure
- \`TestSetup\` deploys ProtocolInvariants alongside the rate limiter in both fresh-deploy and realistic-fork paths, in OBSERVE mode.
- All test files that construct LP directly (\`PriorityWithdrawalQueue.t.sol\`, \`LiquidityPool.t.sol\`, integration tests, fork tests) updated for the new \`ConstructorAddresses\` field.
- 2 standalone test files that don't exercise share-changing paths pass \`address(0)\` with a comment explaining safety.

## Tests

\`forge test --match-path 'test/ProtocolInvariants.t.sol'\` → **25/25 pass**

Coverage:
- **Mode machinery** (4): initial OBSERVE, setMode requires multisig, emits ModeChanged, DISABLED is no-op.
- **Invariant 1 / weETH backing** (10): OBSERVE emit, OBSERVE balanced quiet, ENFORCE revert on under, ENFORCE pass on balanced + overcollateralized, real wrap/unwrap pass, 20-cycle loop preserves invariant, view helper correct in both states.
- **Invariant 2 / rate monotonicity** (11): onlyLP gate, balanced/up/share-neutral/bootstrap all pass, unbacked-mint and skim both revert under ENFORCE, OBSERVE emits event, DISABLED no-op, real deposit under ENFORCE passes, LP-prank exploit observation.

**Broad sweep:** 1222/1223 unit tests pass. The 1 failure is in an untracked \`test/V0MigrationFork.t.sol\` with a pre-existing \`LIQUIDITY_POOL\` undeclared-identifier error — unrelated to this work.

## Rollout plan (per RFC Phase 1 → Phase 3)

1. **Deploy in OBSERVE mode** (default). Hypernative subscribes to \`InvariantViolated\` events.
2. After ~4 weeks of clean activity, **promote to ENFORCE** via Multisig \`setMode\`.
3. Once ENFORCE has run stable for another cycle, **retire global MINT/BURN buckets** from #424 (per-address rate limits stay).

## Files

\`\`\`
src/ProtocolInvariants.sol               | new  (~200 lines including extensive NatSpec)
src/interfaces/IProtocolInvariants.sol   | new
src/LiquidityPool.sol                    | +27 / -1   (modifier + ConstructorAddresses field + 7 applications)
src/WeETH.sol                            | +47 / -7   (hook + ctor + wrap reorder)
test/TestSetup.sol                       | +30        (deploy + wire across paths)
test/ProtocolInvariants.t.sol            | new        (25 tests)
test/PriorityWithdrawalQueue.t.sol       | +1
test/LiquidityPool.t.sol                 | +1
test/RestakingRewardsRouter.t.sol        | +1
test/behaviour-tests/prelude.t.sol       | +4
test/fork-tests/UpgradeStorageIntegrity.t.sol | +24  (helper that deploys local ProtocolInvariants)
test/fork-tests/validator-key-gen.t.sol  | +4
test/integration-tests/*.t.sol           | +5         (5 files, one field each)
script/upgrades/priority-queue/transactionsPriorityQueue.s.sol | +5 (stale migration script — TODO comment added)
docs/rfc-protocol-invariants.md          | new        (RFC)
\`\`\`

## Coordination

Targets \`yash/fix/rate-limit-per-address\` directly. Independent of #424 and #425. Merge in any order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes revert behavior on core deposit, wrap/unwrap, and LP burn paths; a misconfigured `protocolInvariants` address or a buggy check can halt protocol traffic until `setEnabled(false)` or an upgrade.
> 
> **Overview**
> Adds **on-chain supply conservation** via a new **`ProtocolInvariants`** proxy: checks are **live at deploy** (`enabled = true`) with an **OperatingMultisig** `setEnabled(false)` kill switch.
> 
> **Invariant 1 (weETH):** after every weETH mint/burn, **`weETH.totalSupply() <= eETH.shares(weETH proxy)`** — wired through **`WeETH._afterTokenTransfer`** (skips transfers). **`wrap()`** is reordered to **pull eETH before `_mint`** so the hook sees backed state.
> 
> **Invariant 2 (eETH rate):** on selected **`LiquidityPool`** share-changing paths, **`nonDecreasingRate`** snapshots pooled ETH and total shares and calls **`check_eETHRateMonotonic`** (`P1*S0 >= P0*S1`). Applied to **deposits**, **live-rate `withdraw(address,uint256)`**, and **ERM/WRN/PQ burn helpers**; **not** on frozen-rate **`withdraw(uint256,uint256)`** or **`rebase()`**.
> 
> **Wiring:** new **`protocolInvariants`** immutable in **LP / WeETH** constructors and **`ConstructorAddresses`**; **test/fork** setups deploy and pass the proxy address (some legacy scripts use **`address(0)`** with TODOs). **`docs/rfc-protocol-invariants.md`** documents design and build-time scope changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80c89d34d687439fbe7ef132e46e29f812de94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->