### PR TITLE
feat: stored exchange rate (exploratory, on top of #428)

### DIFF
--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -76,6 +76,19 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     uint256 public minWithdrawAmount;
     bool public escrowMigrationCompleted;
 
+    /// @notice Stored eETH exchange rate, expressed as ETH per SHARE_UNIT
+    ///         (1e18) shares. Source of truth for all amount<->share
+    ///         conversions on the protocol's read paths.
+    /// @dev    Updated ONLY by `rebase()` (oracle-driven). Deposits and
+    ///         proportional withdrawals preserve the rate by construction
+    ///         (share math uses this stored value, so the derived rate
+    ///         can't drift on those paths).
+    ///
+    ///         Initialized in `initializeExchangeRate()` from the current
+    ///         derived value at upgrade time so the first read after
+    ///         upgrade is identical to the pre-upgrade derived rate.
+    uint256 public exchangeRate;
+
     //--------------------------------------------------------------------------------------
     //-------------------------------------  IMMUTABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
@@ -144,7 +157,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     error AlreadyRegistered();
     error NotRegistered();
     error ContractPaused();
-    error EETHRateDeflation(uint256 P0, uint256 S0, uint256 P1, uint256 S1);
 
     struct ConstructorAddresses {
         address stakingManager;
@@ -190,10 +202,32 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
     function initialize(address _eEthAddress, address _stakingManagerAddress, address _nodesManagerAddress, address _membershipManagerAddress, address _tNftAddress, address _etherFiAdminContract, address _withdrawRequestNFT) external initializer {
         if (_eEthAddress == address(0) || _stakingManagerAddress == address(0) || _nodesManagerAddress == address(0) || _membershipManagerAddress == address(0) || _tNftAddress == address(0)) revert DataNotSet();
-        
+
         __Ownable_init();
         __UUPSUpgradeable_init();
         paused = true;
+
+        // Bootstrap the stored exchange rate to 1.0 (SHARE_UNIT). First
+        // deposit at this rate creates 1:1 shares; subsequent rebases
+        // update the rate from accruedRewards.
+        exchangeRate = SHARE_UNIT;
+    }
+
+    /// @notice One-shot post-upgrade initializer for the stored exchange rate.
+    ///         Snaps the current derived rate (`totalPooledEther / totalShares`)
+    ///         into the `exchangeRate` storage slot. Must be called as part of
+    ///         the upgrade to the stored-rate impl; subsequent rebases update
+    ///         the slot from then on.
+    /// @dev    Idempotent in the sense that re-calling on an already-initialized
+    ///         pool re-snaps the rate to the current derived value. Gated to
+    ///         upgrade timelock since this is a state migration.
+    function initializeExchangeRate() external onlyUpgradeTimelock {
+        uint256 totalShares = eETH.totalShares();
+        if (totalShares == 0) {
+            exchangeRate = SHARE_UNIT;   // bootstrap rate before any shares exist
+        } else {
+            exchangeRate = Math.mulDiv(getTotalPooledEther(), SHARE_UNIT, totalShares, Math.Rounding.Down);
+        }
     }
 
     /// @notice One-shot post-upgrade migration that sweeps existing locked ETH from LP to WithdrawRequestNFT and PriorityWithdrawalQueue.
@@ -229,14 +263,14 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Used by eETH staking flow
-    function deposit(address _referral) public payable nonReentrant whenNotPaused nonBlacklisted nonDecreasingRate returns (uint256) {
+    function deposit(address _referral) public payable nonReentrant whenNotPaused nonBlacklisted returns (uint256) {
         emit Deposit(msg.sender, msg.value, SourceOfFunds.EETH, _referral);
 
         return _deposit(msg.sender, msg.value, 0);
     }
 
     // Used by eETH staking flow through Liquifier contract; deVamp or to pay protocol fees
-    function depositToRecipient(address _recipient, uint256 _amount, address _referral) public nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
+    function depositToRecipient(address _recipient, uint256 _amount, address _referral) public nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(liquifier) && msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_recipient);
 
@@ -246,7 +280,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     // Used by ether.fan staking flow
-    function deposit(address _user, address _referral) external payable nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
+    function deposit(address _user, address _referral) external payable nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_user);
 
@@ -258,7 +292,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     /// @notice Burns shares and pays ETH. For NFT/queue callers, ETH is paid by the caller from its own segregated balance; LP only does accounting. Other callers receive ETH from LP.
     /// @notice Live-rate withdraw for membershipManager and etherFiRedemptionManager.
     ///         Burns shares at the live rate and pays ETH from the LP to `_recipient`.
-    function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
+    function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(membershipManager) && msg.sender != address(etherFiRedemptionManager)) {
             revert IncorrectCaller();
         }
@@ -500,9 +534,18 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         totalValueOutOfLp = uint128(int128(totalValueOutOfLp) + _accruedRewards);
 
+        // Stored-rate model: the oracle's accruedRewards update both the
+        // accounting (totalValueOutOfLp) and the published rate. Rate is
+        // recomputed from the post-rebase pool / shares — this is the ONLY
+        // path that moves the stored rate.
+        uint256 totalShares = eETH.totalShares();
+        if (totalShares > 0) {
+            exchangeRate = Math.mulDiv(getTotalPooledEther(), SHARE_UNIT, totalShares, Math.Rounding.Down);
+        }
+
         _checkMinAmountForShare();
 
-        emit Rebase(getTotalPooledEther(), eETH.totalShares());
+        emit Rebase(getTotalPooledEther(), totalShares);
     }
 
     /// @notice pay protocol fees including 5% to treaury, 5% to node operator and ethfund bnft holders
@@ -604,13 +647,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _checkMinAmountForShare();
     }
 
-    function burnEEthShares(uint256 shares) external nonDecreasingRate {
+    function burnEEthShares(uint256 shares) external {
         if (msg.sender != address(etherFiRedemptionManager) && msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) revert IncorrectCaller();
         eETH.burnShares(msg.sender, shares);
         _checkMinAmountForShare();
     }
 
-    function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external nonDecreasingRate {
+    function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external {
         uint256 share = sharesForWithdrawalAmount(_withdrawalValueInETH);
         if (msg.sender != address(etherFiRedemptionManager)) revert IncorrectCaller();
         if (_amountSharesToBurn == 0 || _withdrawalValueInETH == 0) revert InvalidAmount();
@@ -645,11 +688,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     function _sharesForDepositAmount(uint256 _depositAmount) internal view returns (uint256) {
-        uint256 totalPooledEther = getTotalPooledEther() - _depositAmount;
-        if (totalPooledEther == 0) {
-            return _depositAmount;
-        }
-        return Math.mulDiv(_depositAmount, eETH.totalShares(), totalPooledEther, Math.Rounding.Down);
+        // Stored-rate model: shares from amount uses the cached rate set by
+        // the last rebase. Deposits don't change the rate (proportional
+        // mint), so no rate update needed afterward. Bootstrap case
+        // (rate == 0) mints 1:1 to seed the pool — first deposit
+        // establishes the rate via initialize.
+        if (exchangeRate == 0) return _depositAmount;
+        return Math.mulDiv(_depositAmount, SHARE_UNIT, exchangeRate, Math.Rounding.Down);
     }
 
     function _sendFund(address _recipient, uint256 _amount) internal {
@@ -672,55 +717,45 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     //--------------------------------------------------------------------------------------
 
     function getTotalEtherClaimOf(address _user) external view returns (uint256) {
-        uint256 staked;
-        uint256 totalShares = eETH.totalShares();
-        if (totalShares > 0) {
-            staked = Math.mulDiv(getTotalPooledEther(), eETH.shares(_user), totalShares, Math.Rounding.Down);
-        }
-        return staked;
+        // Stored-rate model: user's claim = their shares * stored rate.
+        return Math.mulDiv(eETH.shares(_user), exchangeRate, SHARE_UNIT, Math.Rounding.Down);
     }
 
+    /// @notice Sum of in-LP balance and out-of-LP accounting. Used as the
+    ///         internal accounting anchor (solvency checks, oracle reconciliation
+    ///         at rebase). Note: this is the "ETH the protocol thinks it has"
+    ///         based on running accounting, which may drift from
+    ///         `totalShares * exchangeRate / SHARE_UNIT` between rebases (e.g.
+    ///         after frozen-rate withdrawals). The user-facing rate is the
+    ///         stored `exchangeRate`; this function is for internal/oracle
+    ///         use.
     function getTotalPooledEther() public view returns (uint256) {
         return totalValueOutOfLp + totalValueInLp;
     }
 
     function sharesForAmount(uint256 _amount) public view returns (uint256) {
-        uint256 totalPooledEther = getTotalPooledEther();
-        if (totalPooledEther == 0) {
-            return 0;
-        }
-        return Math.mulDiv(_amount, eETH.totalShares(), totalPooledEther, Math.Rounding.Down);
+        if (exchangeRate == 0) return 0;
+        return Math.mulDiv(_amount, SHARE_UNIT, exchangeRate, Math.Rounding.Down);
     }
 
     /// @dev withdrawal rounding errors favor the protocol by rounding up
     function sharesForWithdrawalAmount(uint256 _amount) public view returns (uint256) {
-        uint256 totalPooledEther = getTotalPooledEther();
-        if (totalPooledEther == 0) {
-            return 0;
-        }
-
-        // ceiling division so rounding errors favor the protocol
-        return Math.mulDiv(_amount, eETH.totalShares(), totalPooledEther, Math.Rounding.Up);
+        if (exchangeRate == 0) return 0;
+        return Math.mulDiv(_amount, SHARE_UNIT, exchangeRate, Math.Rounding.Up);
     }
 
     function amountForShare(uint256 _share) public view returns (uint256) {
-        uint256 totalShares = eETH.totalShares();
-        if (totalShares == 0) {
-            return 0;
-        }
-        return Math.mulDiv(_share, getTotalPooledEther(), totalShares, Math.Rounding.Down);
+        return Math.mulDiv(_share, exchangeRate, SHARE_UNIT, Math.Rounding.Down);
     }
 
-    /// @notice ETH value of `1e18` shares, rounded UP. Single source of truth for the rate
-    ///         snapshotted by segregated callers (WithdrawRequestNFT / PriorityWithdrawalQueue)
-    ///         at finalize/fulfill. Ceiling rounding keeps the frozen rate >= `amountForShare`'s
-    ///         floor value so the round-trips at claim time satisfy:
-    ///         `shareOfEEth * rate / 1e18 >= amountForShare(shareOfEEth)` (solvency check) and
-    ///         `ceil(amount * 1e18 / rate) <= shareOfEEth` (burn-bounded-by-request).
+    /// @notice ETH value of `1e18` shares, rounded UP. With the stored-rate
+    ///         model this is exactly the stored `exchangeRate` (which is
+    ///         already denominated as ETH per SHARE_UNIT shares). The
+    ///         frozen-rate withdraw path snapshots this value at finalize
+    ///         time; subsequent rebases that change the stored rate don't
+    ///         retroactively affect the snapshot.
     function amountPerShareCeil() public view returns (uint256) {
-        uint256 totalShares = eETH.totalShares();
-        if (totalShares == 0) return 0;
-        return Math.mulDiv(SHARE_UNIT, getTotalPooledEther(), totalShares, Math.Rounding.Up);
+        return exchangeRate;
     }
 
     function _checkTotalValueInLp() internal view {
@@ -757,43 +792,11 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _;
     }
 
-    /// @notice Invariant — the eETH exchange rate
-    ///         (`totalPooledEther / totalShares`) does not decrease across
-    ///         this call. Snapshots (P0, S0) before the function body, then
-    ///         (P1, S1) after, and asserts `P1 * S0 >= P0 * S1` (the
-    ///         cross-multiplied form of `P1/S1 >= P0/S0`, integer-exact).
-    ///
-    ///         APPLIED to every share-changing entry point where the rate
-    ///         is supposed to stay equal or move UP by construction:
-    ///           - deposit() / depositToRecipient / deposit(user, ref)
-    ///             — proportional mint, floor-rounded shares (rate up)
-    ///           - withdraw(address, uint256)
-    ///             — live-rate burn, ceil-rounded shares (rate up)
-    ///           - burnEEthShares
-    ///             — share-only burn, no P-side change (rate up)
-    ///           - burnEEthSharesForNonETHWithdrawal
-    ///             — already locally checks rate non-decrease; modifier is
-    ///               belt-and-suspenders
-    ///
-    ///         INTENTIONALLY NOT applied to:
-    ///           - withdraw(uint256, uint256) — frozen-rate finalized claim,
-    ///             rate-drop bounded by the oracle-signed `_rate` parameter
-    ///             (WRN/PQ-only)
-    ///           - rebase() — oracle path, rate-change bounded by
-    ///             EtherFiAdmin._validateRebaseApr's APR cap
-    ///
-    ///         These two are the only intentional rate-changing paths.
-    ///         Anything else that drops the rate trips the modifier.
-    ///
-    ///         Overflow note: P, S each fit in uint128 in any plausible
-    ///         protocol state; P*S ≈ 1.4e52 ≪ uint256 max. Safe by inspection.
-    modifier nonDecreasingRate() {
-        uint256 P0 = getTotalPooledEther();
-        uint256 S0 = eETH.totalShares();
-        _;
-        uint256 P1 = getTotalPooledEther();
-        uint256 S1 = eETH.totalShares();
-        // Bootstrap exempt (no rate before/after to compare).
-        if (S0 != 0 && S1 != 0 && P1 * S0 < P0 * S1) revert EETHRateDeflation(P0, S0, P1, S1);
-    }
+    // Note: the previous `nonDecreasingRate` modifier from #428 is removed in
+    // this design. With the stored-rate model the eETH exchange rate is a
+    // first-class state variable updated only by `rebase()`. "The rate can
+    // only change via rebase" is enforced by access control on `rebase()`'s
+    // caller (membershipManager / etherFiAdmin path), not by a math check on
+    // derived state. Deposits/withdrawals operate at the stored rate and
+    // cannot move it; the math invariant becomes structurally true.
 }

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -759,6 +759,12 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             liquidityPoolInstance.initializeOnUpgradeV2();
         }
 
+        // Stored-rate model: the new LP impl introduces an `exchangeRate`
+        // state variable that's set on every rebase. Snap it from the
+        // current derived rate before the rest of the suite runs.
+        vm.prank(_roleRegOwner);
+        liquidityPoolInstance.initializeExchangeRate();
+
         // The upgraded WeETH/EETH still have global MINT/BURN circuit-breaker
         // buckets (plus the new opt-in per-address buckets for transfers).
         // Bootstrap MINT/BURN at unbounded capacity on the fork so generic


### PR DESCRIPTION
Exploratory PR stacked on #428. Makes the eETH/weETH exchange rate a first-class state variable, with `rebase()` as the only path that updates it.

## Changes

**LP refactor (+96 / -87 lines):**

- New storage variable `uint256 public exchangeRate` (1 slot, appended after `escrowMigrationCompleted`, upgrade-safe).
- `initialize()` bootstraps rate to `SHARE_UNIT` (1.0) for fresh deployments.
- New one-shot `initializeExchangeRate()` (onlyUpgradeTimelock) snaps the rate from current derived value at upgrade time.
- `rebase()` updates `exchangeRate = totalPooledEther × SHARE_UNIT / totalShares` post-rebase (rounded down — stored ≤ derived so the protocol never over-promises).
- `amountForShare`, `sharesForAmount`, `sharesForWithdrawalAmount`, `amountPerShareCeil`, `_sharesForDepositAmount`, `getTotalEtherClaimOf` all read the stored rate.
- `getTotalPooledEther()` retained as the internal-accounting anchor (`totalValueInLp + totalValueOutOfLp`). Used by `_checkTotalValueInLp` and by `rebase` for the next-rate computation. Diverges from `totalShares × exchangeRate` between rebases by design.
- The `nonDecreasingRate` modifier from #428 is removed. With stored rate, "rate only changes via rebase" is enforced by access control on the setter.

**TestSetup (+6 lines):**

Adds an `initializeExchangeRate()` call to the realistic-fork upgrade path.

## Test results

1213/1222 unit tests pass. The 9 failures are behavioral changes requiring test updates, not bugs:

| Test | Old behavior | New behavior |
|---|---|---|
| `test_SharesForAmountZeroPool` (×2 in LP.t.sol) | Returns 0 when pool empty | Returns `amount × SHARE_UNIT / SHARE_UNIT` from bootstrap rate |
| `test_minAmountForShare_burnEEthShares_increases_ratio` | Burn immediately increases derived rate | Stored rate unchanged; hidden gain recognized at next rebase |
| `test_minAmountForShare_burnEEthShares_reverts_at_zero_total_shares` | Reverts via `_checkMinAmountForShare` | Stored rate stable, no check fires |
| `test_UnwrappingWithRewards` (WeETH.t.sol) | Exact wei amount | Off-by-one (two floors instead of one) |
| `test_WrapWithPermitGriefingAttack` (WeETH.t.sol) | Same | Same |
| `test_MintShares` (EETH.t.sol) | Bucket consumption via `amountForShare` | 1-wei rounding diff |
| `test_eETH_burn_consumes_user_bucket` (TokenRateLimit.t.sol) | Bucket amount at exact rate | 1-wei diff at cap boundary |
| `test_global_eETH_burn_bucket_throttles_protocol_wide_burns` | Same | Same |

11/11 invariant tests from #428 still pass. Invariant 1 (weETH backing) is unchanged. Invariant 2's modifier is removed; the property holds structurally.

## Not included

- Test fixes for the 9 failures above.
- Fork-test validation against mainnet state.
- Downstream integration audit (Liquifier, OFT, Pendle, Aave/Morpho).
- Frozen-rate withdraw path solvency analysis (see Open questions).
- WRN/PQ `finalizationRates` checkpoint scheme simplification. With stored rate canonical, the checkpoint store can probably retire in favor of `rateAtRequest` per request. Additional 500-1000 lines if pursued.

## Open questions

### Frozen-rate withdraw solvency

`LP.withdraw(uint256 _amount, uint256 _rate)` (WRN/PQ-only) accepts an oracle-finalized rate that may differ from the current stored rate. When `_rate > storedRate` (negative rebase between request and finalize), the burn pays out more ETH than the stored rate justifies. After the call, derived rate drops below stored rate.

In the derived-rate model: rate just changes; the math reconciles.

In the stored-rate model: stored rate is HIGHER than derived rate until next rebase. The protocol has promised more `shares × storedRate` of ETH than its pool backs. If everyone tried to withdraw at storedRate before next rebase, the protocol would be insolvent by the over-pay amount.

Mitigation options:

1. Recompute stored rate after frozen-rate burn. Defeats "only rebase updates rate."
2. Add solvency check on every burn: `totalShares × exchangeRate ≤ getTotalPooledEther + buffer`.
3. Accept the drift; rely on oracle to rebase frequently. Window of insolvency is bounded by rebase cadence.
4. Redesign frozen-rate semantics — pay at current stored rate at claim time, accept post-finalize rebase risk for requested users.

This decision is required before the PR can ship.

### Downstream rounding sensitivity

The 1-wei dust differences in the failing tests are not unique to those tests. Any contract that does `amountForShare`-style math may see slightly different results. Worth auditing:

- Liquifier discount math (stETH→eETH conversion)
- OFT adapter's lock/release accounting
- Pendle PT/YT split math (if it round-trips through `getRate`)
- Aave's wETH rate provider

None are likely broken, but all should be audited.

## Scope estimate

- Core refactor (this PR): ~200 lines.
- Test fixes for the 9 failing tests: ~150-300 lines.
- Fork test validation and adjustments: ~100-300 lines.
- Downstream integration audit and adjustments: TBD.
- WRN/PQ simplification (optional): ~500-1000 lines.

Without WRN/PQ: realistic full scope is 500-800 lines.

## Coordination

Stacks on #428. If #428 lands, this rebases trivially. If this ships in place of #428, target `yash/fix/rate-limit-per-address` directly and remove the `nonDecreasingRate` modifier in the same commit.