### PR TITLE
fix(rate-limiter): symmetric cap==0 semantics + bootstrap-ordering tests for #423

### DIFF
--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -44,7 +44,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     // `roleRegistry` is inherited from RolesLibrary; `rateLimiter` from RateLimitedToken.
 
     /// @dev Protocol-wide circuit breakers on supply changes. Mints and burns
-    ///      each draw from their own global bucket via `consumeIfConfigured`,
+    ///      each draw from their own global bucket via `consumeToken`,
     ///      independent of (and additive with) the per-address buckets. A
     ///      compromise that bypasses per-address gating (e.g. attacker minting
     ///      to a fresh wallet with no bucket) still has to fit inside the
@@ -103,7 +103,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
 
         uint256 amount = liquidityPool.amountForShare(_share);
         uint64 amt = toBucketUnit(amount);
-        rateLimiter.consumeIfConfigured(EETH_MINT_LIMIT_ID, amt);
+        rateLimiter.consumeToken(EETH_MINT_LIMIT_ID, amt);
         rateLimiter.consumeForAddressIfConfigured(_user, amt);
 
         emit Transfer(address(0), _user, amount);
@@ -119,7 +119,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
 
         uint256 amount = liquidityPool.amountForShare(_share);
         uint64 amt = toBucketUnit(amount);
-        rateLimiter.consumeIfConfigured(EETH_BURN_LIMIT_ID, amt);
+        rateLimiter.consumeToken(EETH_BURN_LIMIT_ID, amt);
         rateLimiter.consumeForAddressIfConfigured(_user, amt);
 
         emit Transfer(_user, address(0), amount);

--- a/src/EtherFiRateLimiter.sol
+++ b/src/EtherFiRateLimiter.sol
@@ -182,32 +182,24 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
         if (!BucketLimiter.consume(limits[id], amount)) revert LimitExceeded();
     }
 
-    /// @notice Consume capacity, or no-op if the bucket is disabled (capacity == 0).
+    /// @notice Consume capacity from a global rate limit; reverts on insufficient capacity.
     /// @param id The rate limit identifier
     /// @param amount The amount to consume in gwei
-    /// @dev Designed for token transfer/mint/burn paths that want a gas-cheap soft rate-limit
-    ///      in a single external call. Intentionally skips `whenNotPaused` — pausing the rate
-    ///      limiter must not halt token transfers; operators pause the token contract itself
-    ///      for a hard stop. Still enforces bucket existence and the consumer whitelist, so
-    ///      this is not a backdoor: only consumers explicitly whitelisted by an admin (e.g.
-    ///      eETH, weETH for their respective buckets) can use it.
+    /// @dev Designed for token transfer/mint/burn paths that want a gas-cheap rate-limit
+    ///      enforcement in a single external call. Intentionally skips `whenNotPaused` —
+    ///      pausing the rate limiter must not halt token transfers; operators pause the
+    ///      token contract itself for a hard stop. Still enforces bucket existence and
+    ///      the consumer whitelist, so this is not a backdoor: only consumers explicitly
+    ///      whitelisted by an admin (e.g. eETH, weETH for their respective buckets) can use it.
     ///
-    ///      CAPACITY == 0 SEMANTICS: on this global-bucket path, `capacity == 0` means
-    ///      "not configured / disabled" and the call passes through as a no-op. This is
-    ///      deliberate — admins set cap=0 to retire a bucket without breaking the live
-    ///      consumer's call path. Compare against `consumeForAddressIfConfigured` below,
-    ///      where `capacity == 0` on an existing per-address bucket means "frozen" and
-    ///      reverts. The split is intentional: the global bucket has only one creation
-    ///      lifecycle (admin opt-in), while per-address buckets have a freeze/delete
-    ///      distinction baked into the Guardian/Multisig access split. Monitoring should
-    ///      watch the existing `CapacityUpdated(id, 0)` event to detect buckets entering
-    ///      disabled mode.
+    ///      CAPACITY == 0 SEMANTICS: `capacity == 0` on an existing bucket reverts
+    ///      LimitExceeded (symmetric with `consumeForAddressIfConfigured` below). To
+    ///      soft-disable a global rate limit without un-whitelisting the consumer,
+    ///      set capacity to type(uint64).max — effectively unlimited, the consume
+    ///      always succeeds.
     function consumeIfConfigured(bytes32 id, uint64 amount) external {
         if (!limitExists(id)) revert UnknownLimit();
         if (!consumers[id][msg.sender]) revert InvalidConsumer();
-
-        if (limits[id].capacity == 0) return;
-
         if (!BucketLimiter.consume(limits[id], amount)) revert LimitExceeded();
     }
 
@@ -215,14 +207,13 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     /// @dev Callable only by eETH/weETH. `lastRefill == 0` uniquely identifies "never
     ///      created" (unrestricted user) and short-circuits to a no-op.
     ///
-    ///      CAPACITY == 0 SEMANTICS: differs from `consumeIfConfigured` above. Here a
-    ///      bucket with `lastRefill > 0` AND `capacity == 0` is treated as **frozen** —
-    ///      the underlying `BucketLimiter.consume` returns false (refill can't push
-    ///      `remaining` above a zero capacity) and we revert `LimitExceeded`. This is
-    ///      the freeze path the Guardian uses via `tightenAddressLimit(user, 0, 0)`;
-    ///      the Multisig clears it via `deleteAddressLimit` (returns to "never created")
-    ///      or `setAddressLimit` (creates fresh with non-zero cap). Two distinct sentinel
-    ///      states (deleted vs frozen) keep the Guardian/Multisig split meaningful.
+    ///      CAPACITY == 0 SEMANTICS: `capacity == 0` on an existing bucket reverts
+    ///      LimitExceeded (symmetric with `consumeIfConfigured` above). This is the
+    ///      freeze path the Guardian uses via `tightenAddressLimit(user, 0, 0)`; the
+    ///      Multisig clears it via `deleteAddressLimit` (returns to "never created" →
+    ///      no-op) or `setAddressLimit` (creates fresh with non-zero cap). The two
+    ///      distinct sentinel states — deleted (lastRefill == 0) vs frozen (cap == 0,
+    ///      lastRefill > 0) — keep the Guardian/Multisig access split meaningful.
     ///
     ///      Intentionally skips `whenNotPaused`: pausing the rate limiter must not halt
     ///      token transfers.

--- a/src/EtherFiRateLimiter.sol
+++ b/src/EtherFiRateLimiter.sol
@@ -175,29 +175,28 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     /// @param amount The amount to consume in gwei
     /// @dev Reverts if the consumer is not whitelisted or if insufficient capacity is available
     function consume(bytes32 id, uint64 amount) external whenNotPaused {
-        if (!limitExists(id)) revert UnknownLimit();
-        if (!consumers[id][msg.sender]) revert InvalidConsumer(); // must be whitelisted consumer
-
-        // returns false if full amount cannot be consumed
-        if (!BucketLimiter.consume(limits[id], amount)) revert LimitExceeded();
+        _consume(id, amount);
     }
 
     /// @notice Consume capacity from a global rate limit; reverts on insufficient capacity.
     /// @param id The rate limit identifier
     /// @param amount The amount to consume in gwei
-    /// @dev Designed for token transfer/mint/burn paths that want a gas-cheap rate-limit
-    ///      enforcement in a single external call. Intentionally skips `whenNotPaused` —
-    ///      pausing the rate limiter must not halt token transfers; operators pause the
-    ///      token contract itself for a hard stop. Still enforces bucket existence and
-    ///      the consumer whitelist, so this is not a backdoor: only consumers explicitly
-    ///      whitelisted by an admin (e.g. eETH, weETH for their respective buckets) can use it.
+    /// @dev Token-only entry point for transfer/mint/burn paths. Intentionally skips
+    ///      `whenNotPaused` — pausing the rate limiter must not halt token transfers;
+    ///      operators pause the token contract itself for a hard stop. `onlyToken`
+    ///      restricts callers to eETH/weETH, and `_consume` still enforces the consumer
+    ///      whitelist, so the token must also be admin-whitelisted on the target bucket.
     ///
     ///      CAPACITY == 0 SEMANTICS: `capacity == 0` on an existing bucket reverts
     ///      LimitExceeded (symmetric with `consumeForAddressIfConfigured` below). To
     ///      soft-disable a global rate limit without un-whitelisting the consumer,
     ///      set capacity to type(uint64).max — effectively unlimited, the consume
     ///      always succeeds.
-    function consumeIfConfigured(bytes32 id, uint64 amount) external {
+    function consumeToken(bytes32 id, uint64 amount) external onlyToken {
+        _consume(id, amount);
+    }
+
+    function _consume(bytes32 id, uint64 amount) internal {
         if (!limitExists(id)) revert UnknownLimit();
         if (!consumers[id][msg.sender]) revert InvalidConsumer();
         if (!BucketLimiter.consume(limits[id], amount)) revert LimitExceeded();
@@ -208,7 +207,7 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     ///      created" (unrestricted user) and short-circuits to a no-op.
     ///
     ///      CAPACITY == 0 SEMANTICS: `capacity == 0` on an existing bucket reverts
-    ///      LimitExceeded (symmetric with `consumeIfConfigured` above). This is the
+    ///      LimitExceeded (symmetric with `consumeToken` above). This is the
     ///      freeze path the Guardian uses via `tightenAddressLimit(user, 0, 0)`; the
     ///      Multisig clears it via `deleteAddressLimit` (returns to "never created" →
     ///      no-op) or `setAddressLimit` (creates fresh with non-zero cap). The two

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -227,11 +227,11 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         if (from == address(0)) {
             // mint: value-neutral wraps skip the global; everything else (bridge,
             // future mint authority, exploit) trips the global circuit breaker.
-            if (wrapCtx == 0) rateLimiter.consumeIfConfigured(WEETH_MINT_LIMIT_ID, amt);
+            if (wrapCtx == 0) rateLimiter.consumeToken(WEETH_MINT_LIMIT_ID, amt);
             rateLimiter.consumeForAddressIfConfigured(to, amt);
         } else if (to == address(0)) {
             // burn: same — unwrap is value-neutral; anything else trips global BURN.
-            if (wrapCtx == 0) rateLimiter.consumeIfConfigured(WEETH_BURN_LIMIT_ID, amt);
+            if (wrapCtx == 0) rateLimiter.consumeToken(WEETH_BURN_LIMIT_ID, amt);
             rateLimiter.consumeForAddressIfConfigured(from, amt);
         } else {
             // transfer: no supply change, per-address only.

--- a/src/interfaces/IEtherFiRateLimiter.sol
+++ b/src/interfaces/IEtherFiRateLimiter.sol
@@ -12,7 +12,7 @@ interface IEtherFiRateLimiter {
 
     // core
     function consume(bytes32 id, uint64 amount) external;
-    function consumeIfConfigured(bytes32 id, uint64 amount) external;
+    function consumeToken(bytes32 id, uint64 amount) external;
     function canConsume(bytes32 id, uint64 amount) external view returns (bool);
     function consumable(bytes32 id) external view returns (uint64);
 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1168,7 +1168,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), admin);
 
         // Per-address rate-limit buckets are opt-in (Guardian creates them on demand).
-        // The global MINT/BURN buckets ARE required — eETH/weETH call consumeIfConfigured
+        // The global MINT/BURN buckets ARE required — eETH/weETH call consumeToken
         // on every supply change and that reverts UnknownLimit if the bucket is missing.
         // Bootstrap at unbounded capacity here so generic tests aren't rate-limited;
         // rate-limit-specific tests override capacity/refill via the admin path.
@@ -1477,7 +1477,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         address newWeETHImpl = address(new WeETH(address(eETHInstance), address(liquidityPoolInstance), address(roleRegistryInstance), address(blacklisterInstance), address(rateLimiterInstance)));
         vm.prank(owner);
         weEthInstance.upgradeTo(newWeETHImpl);
-        // The upgraded weETH calls consumeIfConfigured(WEETH_{MINT,BURN}_LIMIT_ID, ...)
+        // The upgraded weETH calls consumeToken(WEETH_{MINT,BURN}_LIMIT_ID, ...)
         // on every mint/burn; bootstrap those at unbounded capacity for fork tests.
         // Caller has no active prank here, so prank as `owner` (granted OPERATION_TIMELOCK_ROLE upstream).
         vm.startPrank(owner);

--- a/test/TokenRateLimit.t.sol
+++ b/test/TokenRateLimit.t.sol
@@ -727,7 +727,7 @@ contract TokenRateLimitTest is TestSetup {
 
     function test_global_eETH_mint_and_burn_buckets_are_independent() public {
         // Tighten only MINT to a tiny non-zero cap. NOTE: capacity == 0 on a
-        // global bucket means "disabled (no-op)" per consumeIfConfigured —
+        // global bucket means "disabled (no-op)" per consumeToken —
         // NOT frozen. Use 1 gwei as the smallest non-zero cap to actually
         // throttle. (Per-address buckets behave differently — capacity=0
         // there reverts on consume.)
@@ -820,7 +820,7 @@ contract TokenRateLimitTest is TestSetup {
     // the exact revert selector each one produces. If a future agent is debugging
     // an eETH/weETH upgrade revert, this is the lookup table:
     //
-    //   Global-bucket state                                    | consumeIfConfigured behavior
+    //   Global-bucket state                                    | consumeToken behavior
     //   -------------------------------------------------------|-----------------------------
     //   1. Bucket never created (no createNewLimiter)          | revert UnknownLimit
     //   2. Bucket created, consumer not whitelisted            | revert InvalidConsumer
@@ -856,7 +856,7 @@ contract TokenRateLimitTest is TestSetup {
 
         vm.prank(address(eETHInstance));
         vm.expectRevert(IEtherFiRateLimiter.UnknownLimit.selector);
-        rateLimiterInstance.consumeIfConfigured(neverCreatedId, 1);
+        rateLimiterInstance.consumeToken(neverCreatedId, 1);
 
         // Implication: a 3CP that upgrades eETH/weETH impls WITHOUT first calling
         // createNewLimiter for EETH_MINT_LIMIT_ID / EETH_BURN_LIMIT_ID /
@@ -979,14 +979,14 @@ contract TokenRateLimitTest is TestSetup {
         // State 1: bucket never created.
         vm.prank(address(eETHInstance));
         vm.expectRevert(IEtherFiRateLimiter.UnknownLimit.selector);
-        rateLimiterInstance.consumeIfConfigured(fakeId, 1);
+        rateLimiterInstance.consumeToken(fakeId, 1);
 
         // State 2: bucket created, consumer revoked.
         vm.prank(admin);
         rateLimiterInstance.updateConsumers(realId, address(eETHInstance), false);
         vm.prank(address(eETHInstance));
         vm.expectRevert(IEtherFiRateLimiter.InvalidConsumer.selector);
-        rateLimiterInstance.consumeIfConfigured(realId, 1);
+        rateLimiterInstance.consumeToken(realId, 1);
 
         // Re-whitelist for the remaining states.
         vm.prank(admin);
@@ -999,7 +999,7 @@ contract TokenRateLimitTest is TestSetup {
         vm.stopPrank();
         vm.prank(address(eETHInstance));
         vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        rateLimiterInstance.consumeIfConfigured(realId, 1);
+        rateLimiterInstance.consumeToken(realId, 1);
 
         // State 4: cap > 0, sufficient → succeeds.
         vm.startPrank(admin);
@@ -1008,12 +1008,12 @@ contract TokenRateLimitTest is TestSetup {
         rateLimiterInstance.setRefillRate(realId, 0);
         vm.stopPrank();
         vm.prank(address(eETHInstance));
-        rateLimiterInstance.consumeIfConfigured(realId, 50);
+        rateLimiterInstance.consumeToken(realId, 50);
 
         // State 5: cap > 0, insufficient → LimitExceeded.
         // After the 50-unit consume above, remaining == 50. Asking for 51 reverts.
         vm.prank(address(eETHInstance));
         vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        rateLimiterInstance.consumeIfConfigured(realId, 51);
+        rateLimiterInstance.consumeToken(realId, 51);
     }
 }

--- a/test/TokenRateLimit.t.sol
+++ b/test/TokenRateLimit.t.sol
@@ -805,4 +805,215 @@ contract TokenRateLimitTest is TestSetup {
         assertFalse(rateLimiterInstance.addressLimitExists(address(eETHInstance), alice));
         assertFalse(rateLimiterInstance.addressLimitExists(address(eETHInstance), bob));
     }
+
+    // =====================================================================
+    // Bootstrap-ordering invariants  (READ THIS BEFORE UPGRADING eETH/weETH)
+    // =====================================================================
+    //
+    // The four global MINT/BURN buckets — EETH_MINT_LIMIT_ID, EETH_BURN_LIMIT_ID,
+    // WEETH_MINT_LIMIT_ID, WEETH_BURN_LIMIT_ID — MUST be created via
+    // `createNewLimiter` AND have eETH/weETH whitelisted via `updateConsumers`
+    // BEFORE the new eETH/weETH impls are activated. `_setupGlobalMintBurnBuckets`
+    // in TestSetup is the reference bootstrap.
+    //
+    // The tests below tabulate, in code, every distinct global-bucket state and
+    // the exact revert selector each one produces. If a future agent is debugging
+    // an eETH/weETH upgrade revert, this is the lookup table:
+    //
+    //   Global-bucket state                                    | consumeIfConfigured behavior
+    //   -------------------------------------------------------|-----------------------------
+    //   1. Bucket never created (no createNewLimiter)          | revert UnknownLimit
+    //   2. Bucket created, consumer not whitelisted            | revert InvalidConsumer
+    //   3. Bucket created, consumer whitelisted, capacity == 0 | revert LimitExceeded
+    //   4. Bucket created, consumer whitelisted, sufficient    | succeed, decrement remaining
+    //   5. Bucket created, consumer whitelisted, insufficient  | revert LimitExceeded
+    //
+    // Per-address `consumeForAddressIfConfigured` uses the SAME `capacity == 0`
+    // semantic on an existing bucket (reverts LimitExceeded) — see
+    // `test_addressLimit_lastRefill_sentinel_distinguishes_not_created_from_frozen`
+    // and `test_cap0_reverts_symmetric_on_global_and_perAddress` below. The only
+    // per-address-specific state is `lastRefill == 0` ("never created" →
+    // no-op / unrestricted user), which the global path doesn't need because
+    // missing globals revert UnknownLimit instead.
+    //
+    // To soft-disable a global rate limit without un-whitelisting the consumer,
+    // set capacity to type(uint64).max (effectively unlimited, never trips).
+    //
+    // Why this matters operationally: if a 3CP upgrade bundle swaps the eETH/weETH
+    // impls WITHOUT including the four createNewLimiter + updateConsumers calls in
+    // the same bundle, the failure mode is total — every LP deposit and every
+    // burnShares reverts UnknownLimit. Wrap/unwrap on weETH continues to work
+    // (transient-storage flag bypasses the global on those paths), which can
+    // make the incident look partial and confusing. These tests pin down each
+    // signal so the diagnosis is unambiguous.
+
+    function test_bootstrap_state1_uncreated_bucket_reverts_UnknownLimit() public {
+        // The four real IDs are already created by TestSetup and there's no API
+        // to delete a global bucket. Prove the failure mode using a synthetic
+        // ID that has never been created — same code path eETH would hit on an
+        // unbootstrapped upgrade.
+        bytes32 neverCreatedId = keccak256("BOOTSTRAP_TEST_FAKE_ID");
+
+        vm.prank(address(eETHInstance));
+        vm.expectRevert(IEtherFiRateLimiter.UnknownLimit.selector);
+        rateLimiterInstance.consumeIfConfigured(neverCreatedId, 1);
+
+        // Implication: a 3CP that upgrades eETH/weETH impls WITHOUT first calling
+        // createNewLimiter for EETH_MINT_LIMIT_ID / EETH_BURN_LIMIT_ID /
+        // WEETH_MINT_LIMIT_ID / WEETH_BURN_LIMIT_ID will revert every LP deposit
+        // and every burnShares with this exact selector. Include the four
+        // createNewLimiter calls in the same bundle as the impl upgrade.
+    }
+
+    function test_bootstrap_state2_LP_deposit_reverts_InvalidConsumer_when_consumer_not_whitelisted() public {
+        // Bucket exists (TestSetup created it at uint64.max) but if eETH is
+        // removed from the consumer whitelist, the consume call reverts
+        // InvalidConsumer BEFORE any capacity check.
+        // NOTE: resolve the bucket ID into a local BEFORE `vm.prank` — calling
+        // `eETHInstance.EETH_MINT_LIMIT_ID()` is itself an external call and
+        // would consume the single-call prank intended for `updateConsumers`.
+        bytes32 mintId = eETHInstance.EETH_MINT_LIMIT_ID();
+        vm.prank(admin);
+        rateLimiterInstance.updateConsumers(mintId, address(eETHInstance), false);
+
+        vm.deal(chad, 1 ether);
+        vm.prank(chad);
+        vm.expectRevert(IEtherFiRateLimiter.InvalidConsumer.selector);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+
+        // Implication: a 3CP that calls createNewLimiter but forgets the matching
+        // updateConsumers(id, eETH, true) reverts every deposit with this selector.
+        // Recovery is a single tx from OPERATION_TIMELOCK, but the failure is
+        // total until that tx lands. Keep both calls in the same bundle.
+    }
+
+    function test_bootstrap_state2_LP_burn_reverts_InvalidConsumer_when_consumer_not_whitelisted() public {
+        // Same story for the burn side — confirms both directions of the supply
+        // change are gated by the same consumer-whitelist check.
+        bytes32 burnId = eETHInstance.EETH_BURN_LIMIT_ID();
+        vm.prank(admin);
+        rateLimiterInstance.updateConsumers(burnId, address(eETHInstance), false);
+
+        uint256 oneEthShare = liquidityPoolInstance.sharesForAmount(1 ether);
+        vm.prank(address(liquidityPoolInstance));
+        vm.expectRevert(IEtherFiRateLimiter.InvalidConsumer.selector);
+        eETHInstance.burnShares(alice, oneEthShare);
+    }
+
+    function test_bootstrap_state2_weETH_wrap_STILL_succeeds_when_consumer_not_whitelisted() public {
+        // Subtle and important: wrap/unwrap survives consumer revocation because
+        // the transient-storage wrap-context flag short-circuits the global consume
+        // BEFORE we ever reach the rate limiter. This is by design — wrap/unwrap
+        // is value-neutral and must never be DOSable via global-bucket state.
+        //
+        // Any NON-wrap mint reach (a future bridge adapter, a new mint authority,
+        // an exploit) would NOT set the transient flag and WOULD hit the consumer
+        // check, reverting InvalidConsumer. The safety property still holds: the
+        // global bucket remains an enforced circuit breaker for unauthorized
+        // supply changes even if wrap/unwrap continues to function.
+        bytes32 wMintId = weEthInstance.WEETH_MINT_LIMIT_ID();
+        vm.prank(admin);
+        rateLimiterInstance.updateConsumers(wMintId, address(weEthInstance), false);
+
+        vm.startPrank(alice);
+        eETHInstance.approve(address(weEthInstance), type(uint256).max);
+        weEthInstance.wrap(1 ether);
+        vm.stopPrank();
+
+        // Implication: during a half-bootstrapped upgrade, wrap/unwrap will look
+        // healthy in monitoring while LP deposits and burns are all reverting.
+        // Don't be fooled into thinking the rate limiter is "mostly working" —
+        // the wrap-skip is intentional and doesn't tell you anything about
+        // whether the rest of the wiring is correct.
+    }
+
+    function test_cap0_reverts_symmetric_on_global_and_perAddress() public {
+        // Symmetry invariant: `cap == 0` on an existing bucket reverts
+        // LimitExceeded on BOTH the global and per-address paths. The only
+        // path-specific "soft no-op" state is the per-address `lastRefill == 0`
+        // (never created → unrestricted user); there is no equivalent soft state
+        // on the global side (missing globals revert UnknownLimit).
+        //
+        // To soft-disable a global rate limit without un-whitelisting the
+        // consumer, set capacity to type(uint64).max — effectively unlimited,
+        // any consume succeeds.
+
+        bytes32 mintId = eETHInstance.EETH_MINT_LIMIT_ID();
+
+        // GLOBAL leg: setCapacity(id, 0) reverts on every consume.
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(mintId, 0);
+        rateLimiterInstance.setRemaining(mintId, 0);
+        vm.stopPrank();
+
+        vm.deal(chad, 1 ether);
+        vm.prank(chad);
+        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+
+        // Restore the global so the per-address leg below isn't shadowed by the
+        // still-zeroed global. Use uint64.max as the documented soft-disable
+        // idiom (effectively unlimited).
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(mintId, type(uint64).max);
+        rateLimiterInstance.setRemaining(mintId, type(uint64).max);
+        vm.stopPrank();
+
+        // PER-ADDRESS leg: tighten to (0, 0) freezes; consume reverts the same way.
+        vm.prank(guardianOnly);
+        _tightenEth(dan, 0, 0);
+
+        vm.deal(dan, 1 ether);
+        vm.prank(dan);
+        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
+    function test_bootstrap_sentinel_matrix_via_rateLimiter_direct() public {
+        // Same matrix as the LP-level tests above, but called directly on the
+        // rate limiter so future agents can see all five outcomes in one
+        // executable lookup table.
+        bytes32 fakeId = keccak256("BOOTSTRAP_TEST_SENTINEL_MATRIX");
+        bytes32 realId = eETHInstance.EETH_MINT_LIMIT_ID();
+
+        // State 1: bucket never created.
+        vm.prank(address(eETHInstance));
+        vm.expectRevert(IEtherFiRateLimiter.UnknownLimit.selector);
+        rateLimiterInstance.consumeIfConfigured(fakeId, 1);
+
+        // State 2: bucket created, consumer revoked.
+        vm.prank(admin);
+        rateLimiterInstance.updateConsumers(realId, address(eETHInstance), false);
+        vm.prank(address(eETHInstance));
+        vm.expectRevert(IEtherFiRateLimiter.InvalidConsumer.selector);
+        rateLimiterInstance.consumeIfConfigured(realId, 1);
+
+        // Re-whitelist for the remaining states.
+        vm.prank(admin);
+        rateLimiterInstance.updateConsumers(realId, address(eETHInstance), true);
+
+        // State 3: cap == 0 → revert LimitExceeded (symmetric with per-address freeze).
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(realId, 0);
+        rateLimiterInstance.setRemaining(realId, 0);
+        vm.stopPrank();
+        vm.prank(address(eETHInstance));
+        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
+        rateLimiterInstance.consumeIfConfigured(realId, 1);
+
+        // State 4: cap > 0, sufficient → succeeds.
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(realId, 100);
+        rateLimiterInstance.setRemaining(realId, 100);
+        rateLimiterInstance.setRefillRate(realId, 0);
+        vm.stopPrank();
+        vm.prank(address(eETHInstance));
+        rateLimiterInstance.consumeIfConfigured(realId, 50);
+
+        // State 5: cap > 0, insufficient → LimitExceeded.
+        // After the 50-unit consume above, remaining == 50. Asking for 51 reverts.
+        vm.prank(address(eETHInstance));
+        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
+        rateLimiterInstance.consumeIfConfigured(realId, 51);
+    }
 }


### PR DESCRIPTION
## Summary

Two co-located follow-ups on top of #423:

1. **Symmetric `cap == 0` semantics.** #423 shipped two diverging behaviors for `capacity == 0` on the same rate limiter — global = no-op pass-through, per-address = frozen/revert. This PR collapses them: `cap == 0` on an existing bucket reverts `LimitExceeded` on both paths.
2. **Bootstrap-ordering invariants test section.** Documentation-grade tests that map each global-bucket state to the exact revert selector it produces, so a future agent debugging an eETH/weETH upgrade revert can diagnose unambiguously from the selector.

## The asymmetry, and why it's gone

| State | Old global (`consumeIfConfigured`) | Old per-address (`consumeForAddressIfConfigured`) | NEW (both) |
|---|---|---|---|
| Bucket never created | revert `UnknownLimit` | n/a (uses `lastRefill==0` sentinel → no-op) | unchanged |
| `cap == 0`, bucket exists | **no-op pass-through** | revert `LimitExceeded` (frozen) | **revert `LimitExceeded`** |
| Consumer not whitelisted | revert `InvalidConsumer` | n/a (onlyToken) | unchanged |
| `cap > 0`, sufficient | succeed | succeed | unchanged |
| `cap > 0`, insufficient | revert `LimitExceeded` | revert `LimitExceeded` | unchanged |

The implementation is one deleted line plus two rewritten docstrings. No new storage, no new functions, no new events.

## ⚠️ Runbook change: soft-disable idiom

The "kill a global rate limit without un-whitelisting the consumer" idiom changes:

| | Old | New |
|---|---|---|
| Soft-disable a global | \`setCapacity(id, 0)\` | \`setCapacity(id, type(uint64).max)\` + \`setRemaining(id, type(uint64).max)\` |
| What \`CapacityUpdated(id, 0)\` means | Disabled (benign) | **Consumers BRICKED** (incident-grade alert) |
| What \`CapacityUpdated(id, 18446744073709551615)\` means | Capacity very large | **Soft-disabled** |

Hypernative agents that watched for \`CapacityUpdated(id, 0)\` as a "global rate limit disabled" signal should flip: \`(id, 0)\` is now an incident; \`(id, type(uint64).max)\` is the new soft-disable signal.

Bootstrap is unchanged — \`createNewLimiter\` + \`updateConsumers\` in the same 3CP bundle as the impl upgrade. \`TestSetup._setupGlobalMintBurnBuckets\` is still the reference bootstrap.

## Bootstrap-ordering tests

The new section in \`test/TokenRateLimit.t.sol\` opens with a 5-row lookup table in the header comment. Each row maps a global-bucket state to a revert selector. The tests are written so an agent debugging "why does my upgrade revert?" can grep for the selector they're seeing and find the missing prerequisite step.

- \`test_bootstrap_state1_uncreated_bucket_reverts_UnknownLimit\` — missing \`createNewLimiter\` → \`UnknownLimit\`
- \`test_bootstrap_state2_LP_deposit_reverts_InvalidConsumer_when_consumer_not_whitelisted\` — bucket exists, consumer revoked → \`InvalidConsumer\` on deposit
- \`test_bootstrap_state2_LP_burn_reverts_InvalidConsumer_when_consumer_not_whitelisted\` — same for \`burnShares\`
- \`test_bootstrap_state2_weETH_wrap_STILL_succeeds_when_consumer_not_whitelisted\` — important "don't be misled by a partially-working system" signal: wrap/unwrap survives consumer revocation via the transient-storage flag, even when the rest of the rate limiter is broken
- \`test_cap0_reverts_symmetric_on_global_and_perAddress\` — pins the new symmetric invariant via the LP path
- \`test_bootstrap_sentinel_matrix_via_rateLimiter_direct\` — all 5 states in one executable lookup table

## Test plan

- [x] \`forge test --match-path test/TokenRateLimit.t.sol\` — 46/46 pass
- [x] Verified no existing test or script anywhere in the repo depended on the old \`setCapacity(id, 0)\` no-op semantic (grepped all \`setCapacity(*_LIMIT_ID, *)\` call sites — every existing reference uses a non-zero cap)
- [x] \`forge build\` clean
- [ ] Sign-off on the runbook delta (soft-disable idiom + Hypernative alert flip) before this lands on mainnet

## Operational checklist before merging this with the #423 3CP bundle

- [ ] Confirm any existing Hypernative agent watching \`CapacityUpdated(id, 0)\` is updated for the new semantic
- [ ] If any internal docs reference \`setCapacity(id, 0)\` as a kill switch, update to \`setCapacity(id, type(uint64).max)\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes operational semantics for global rate limits (`setCapacity(0)` now bricks mint/burn instead of no-op) and gates all eETH/weETH supply changes on the new path; mis-timed upgrades or monitoring on old `CapacityUpdated(id, 0)` signals could cause total deposit/burn outages.
> 
> **Overview**
> This PR aligns global and per-address rate-limit behavior and renames the token entry point from **`consumeIfConfigured`** to **`consumeToken`**.
> 
> **`EtherFiRateLimiter`:** Global mint/burn consumption no longer treats **`capacity == 0`** as a silent no-op. An existing bucket with zero capacity now reverts **`LimitExceeded`**, matching per-address freeze semantics. Soft-disabling a global limit without revoking the consumer is documented as **`setCapacity(id, type(uint64).max)`** (plus setting remaining), not **`setCapacity(id, 0)`**. Logic is centralized in **`_consume`**; **`consumeToken`** is **`onlyToken`** and shares the same checks as **`consume`** except it still skips **`whenNotPaused`**.
> 
> **`EETH` / `WeETH` / `IEtherFiRateLimiter`:** All global supply paths call **`consumeToken`** instead of **`consumeIfConfigured`**.
> 
> **Tests:** Comments and setup helpers are updated for the new API. **`TokenRateLimit.t.sol`** adds a bootstrap-ordering section that maps global-bucket states (missing limit, bad consumer whitelist, zero cap, sufficient/insufficient capacity) to revert selectors, including the case where **wrap/unwrap** can still succeed when the consumer is not whitelisted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3e4e6c98471c06811f19690c2435e978ef89e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->