### PR TITLE
yash/fix/hard-oracle-quorum

### DIFF
--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -253,25 +253,27 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         return BEACON_GENESIS_TIME;
     }
 
-    function addCommitteeMember(address _address) public onlyAdmin {
+    function addCommitteeMember(address _address, uint32 _quorumSize) public onlyAdmin {
         if (committeeMemberStates[_address].registered) revert AlreadyRegistered();
         numCommitteeMembers++;
         numActiveCommitteeMembers++;
         committeeMemberStates[_address] = CommitteeMemberState(true, true, 0, 0);
+        quorumSize = _quorumSize;
         _checkQuorum();
         emit CommitteeMemberAdded(_address);
     }
 
-    function removeCommitteeMember(address _address) public onlyAdmin {
+    function removeCommitteeMember(address _address, uint32 _quorumSize) public onlyAdmin {
         if (!committeeMemberStates[_address].registered) revert NotRegistered();
         numCommitteeMembers--;
         if (committeeMemberStates[_address].enabled) numActiveCommitteeMembers--;
         delete committeeMemberStates[_address];
+        quorumSize = _quorumSize;
         _checkQuorum();
         emit CommitteeMemberRemoved(_address);
     }
 
-    function manageCommitteeMember(address _address, bool _enabled) public onlyOperatingMultisig {
+    function manageCommitteeMember(address _address, bool _enabled, uint32 _quorumSize) public onlyOperatingMultisig {
         if (!committeeMemberStates[_address].registered) revert NotRegistered();
         if (committeeMemberStates[_address].enabled == _enabled) revert AlreadyInTargetState();
         committeeMemberStates[_address].enabled = _enabled;
@@ -280,12 +282,12 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         } else {
             numActiveCommitteeMembers--;
         }
+        quorumSize = _quorumSize;
         _checkQuorum();
         emit CommitteeMemberUpdated(_address, _enabled);
     }
 
     function setQuorumSize(uint32 _quorumSize) public onlyAdmin {
-        if (_quorumSize < minQuorumSize) revert InvalidQuorum();
         quorumSize = _quorumSize;
         _checkQuorum();
         emit QuorumUpdated(_quorumSize);
@@ -329,7 +331,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     }
 
     function _checkQuorum() internal view {
-        if (numActiveCommitteeMembers < quorumSize || numActiveCommitteeMembers > 2 * quorumSize) revert InvalidQuorum();
+        if (quorumSize < minQuorumSize || numActiveCommitteeMembers < quorumSize || numActiveCommitteeMembers >= 2 * quorumSize) revert InvalidQuorum();
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}

--- a/src/interfaces/IEtherFiOracle.sol
+++ b/src/interfaces/IEtherFiOracle.sol
@@ -45,9 +45,9 @@ interface IEtherFiOracle {
     function generateReportHash(OracleReport calldata _report) external pure returns (bytes32);
     function computeSlotAtTimestamp(uint256 timestamp) external view returns (uint32);
 
-    function addCommitteeMember(address _address) external;
-    function removeCommitteeMember(address _address) external;
-    function manageCommitteeMember(address _address, bool _enabled) external;
+    function addCommitteeMember(address _address, uint32 _quorumSize) external;
+    function removeCommitteeMember(address _address, uint32 _quorumSize) external;
+    function manageCommitteeMember(address _address, bool _enabled, uint32 _quorumSize) external;
     function setQuorumSize(uint32 _quorumSize) external;
     function setOracleReportPeriod(uint32 _reportPeriodSlot) external;
     function setConsensusVersion(uint32 _consensusVersion) external;

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -48,7 +48,7 @@ contract EtherFiOracleTest is TestSetup {
 
         // chad is added to the committee
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
         (bool registered, bool enabled, uint32 lastReportRefSlot, uint32 numReports) = etherFiOracleInstance.committeeMemberStates(chad);
         assertEq(registered, true);
         assertEq(enabled, true);
@@ -63,7 +63,7 @@ contract EtherFiOracleTest is TestSetup {
 
         // Owner disables chad's report submission
         vm.prank(owner);
-        etherFiOracleInstance.manageCommitteeMember(chad, false);
+        etherFiOracleInstance.manageCommitteeMember(chad, false, 2);
         (registered, enabled, lastReportRefSlot, numReports) = etherFiOracleInstance.committeeMemberStates(chad);
         assertEq(registered, true);
         assertEq(enabled, false);
@@ -252,7 +252,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_report_submission_before_processing_last_published_one_fails() public {
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         // period 2
         _moveClock(1024 + 2 * slotsPerEpoch);
@@ -275,7 +275,7 @@ contract EtherFiOracleTest is TestSetup {
     function test_change_report_start_slot1() public { 
         vm.prank(owner);
         bytes[] memory emptyBytes = new bytes[](0);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
         _moveClock(1024 + 2 * 32);
@@ -414,7 +414,7 @@ contract EtherFiOracleTest is TestSetup {
 
         // TODO enable this test for mainnet
         // vm.expectRevert("Quorum size must be greater than 1");
-        // etherFiOracleInstance.setQuorumSize(1);
+        // etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         etherFiOracleInstance.setQuorumSize(2);
 
@@ -490,7 +490,7 @@ contract EtherFiOracleTest is TestSetup {
         // numActive=3 (alice, bob, chad), quorum stays at the default 2 because
         // setQuorumSize(5) would now revert with InvalidQuorum (numActive < quorum).
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -529,7 +529,7 @@ contract EtherFiOracleTest is TestSetup {
     function test_postReportWaitTimeInSlots() public {
         bytes[] memory emptyBytes = new bytes[](0);
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         // period 2
         _moveClock(1024 + 2 * slotsPerEpoch);
@@ -562,7 +562,7 @@ contract EtherFiOracleTest is TestSetup {
     function test_report_earlier_than_last_admin_execution_fails() public {
         vm.prank(owner);
         bytes[] memory emptyBytes = new bytes[](0);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
         _moveClock(1024 + 2 * 32);
@@ -606,8 +606,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_consensus_scenario_example1() public {
         vm.startPrank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
-        etherFiOracleInstance.setQuorumSize(2);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
         vm.stopPrank();
 
         _moveClock(1024 + 2 * slotsPerEpoch);
@@ -652,8 +651,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_execute_task_treasury_payout() public {
         vm.startPrank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
-        etherFiOracleInstance.setQuorumSize(2);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
         liquidityPoolInstance.setFeeRecipient(address(owner));
         vm.stopPrank();
 
@@ -672,38 +670,38 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_removeCommitteeMember() public {
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
-        
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
+
         assertEq(etherFiOracleInstance.numCommitteeMembers(), 3); // alice, bob, chad
         assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 3);
 
         vm.prank(owner);
-        etherFiOracleInstance.removeCommitteeMember(chad);
+        etherFiOracleInstance.removeCommitteeMember(chad, 2);
 
         assertEq(etherFiOracleInstance.numCommitteeMembers(), 2);
         assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 2);
-        
+
         (bool registered, bool enabled,,) = etherFiOracleInstance.committeeMemberStates(chad);
         assertEq(registered, false);
         assertEq(enabled, false);
 
         vm.prank(owner);
         vm.expectRevert(EtherFiOracle.NotRegistered.selector);
-        etherFiOracleInstance.removeCommitteeMember(chad);
+        etherFiOracleInstance.removeCommitteeMember(chad, 2);
     }
 
     function test_removeCommitteeMember_disabled() public {
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
-        
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
+
         vm.prank(owner);
-        etherFiOracleInstance.manageCommitteeMember(chad, false);
-        
+        etherFiOracleInstance.manageCommitteeMember(chad, false, 2);
+
         assertEq(etherFiOracleInstance.numCommitteeMembers(), 3);
         assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 2);
 
         vm.prank(owner);
-        etherFiOracleInstance.removeCommitteeMember(chad);
+        etherFiOracleInstance.removeCommitteeMember(chad, 2);
 
         assertEq(etherFiOracleInstance.numCommitteeMembers(), 2);
         assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 2);
@@ -711,7 +709,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_getConsensusTimestamp() public {
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -731,7 +729,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_getConsensusSlot() public {
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
         uint32 currentSlot = etherFiOracleInstance.computeSlotAtTimestamp(block.timestamp);
@@ -812,7 +810,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_slotForNextReport_edgeCases() public {
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         // Submit a report first to have a published report
         _moveClock(1024 + 2 * slotsPerEpoch);
@@ -831,7 +829,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_blockStampForNextReport() public {
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         // Submit a report first
         _moveClock(1024 + 2 * slotsPerEpoch);
@@ -852,36 +850,37 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_manageCommitteeMember_alreadyInTargetState() public {
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
 
         // Try to enable when already enabled
         vm.prank(owner);
         vm.expectRevert(EtherFiOracle.AlreadyInTargetState.selector);
-        etherFiOracleInstance.manageCommitteeMember(chad, true);
+        etherFiOracleInstance.manageCommitteeMember(chad, true, 2);
 
         // Disable first
         vm.prank(owner);
-        etherFiOracleInstance.manageCommitteeMember(chad, false);
+        etherFiOracleInstance.manageCommitteeMember(chad, false, 2);
 
         // Try to disable when already disabled
         vm.prank(owner);
         vm.expectRevert(EtherFiOracle.AlreadyInTargetState.selector);
-        etherFiOracleInstance.manageCommitteeMember(chad, false);
+        etherFiOracleInstance.manageCommitteeMember(chad, false, 2);
     }
 
     function test_addCommitteeMember_alreadyRegistered() public {
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
 
         vm.prank(owner);
         vm.expectRevert(EtherFiOracle.AlreadyRegistered.selector);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
     }
 
     // ========== _checkQuorum invariant tests ==========
     // _checkQuorum reverts with InvalidQuorum when:
+    //   - quorumSize < minQuorumSize, or
     //   - numActiveCommitteeMembers < quorumSize (too few members for the quorum), or
-    //   - numActiveCommitteeMembers / quorumSize > 2 (quorum too small relative to membership).
+    //   - numActiveCommitteeMembers >= 2 * quorumSize (quorum not a strict majority).
     // The check runs after every add/remove/manage/setQuorum mutation, so each
     // mutation needs to leave the (members, quorum) pair inside the valid band.
 
@@ -901,9 +900,9 @@ contract EtherFiOracleTest is TestSetup {
     function test_setQuorumSize_revertsWhenRatioTooLow() public {
         // First grow membership to 3 so the ratio path is reachable
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
 
-        // 3 / 1 = 3 > 2 -> revert (quorum is too small for the active set)
+        // 3 / 1 = 3 >= 2 -> revert (quorum is too small for the active set)
         vm.prank(owner);
         vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
         etherFiOracleInstance.setQuorumSize(1);
@@ -916,35 +915,32 @@ contract EtherFiOracleTest is TestSetup {
         assertEq(etherFiOracleInstance.quorumSize(), 2);
     }
 
-    function test_addCommitteeMember_revertsWhenRatioWouldExceedTwo() public {
-        // Drop quorum to 1 first (legal at numActive=2 since 2/1=2, not > 2)
-        vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
-
-        // Adding chad makes numActive=3, and 3/1 = 3 > 2 -> revert
+    function test_addCommitteeMember_revertsWhenRatioReachesTwo() public {
+        // numActive becomes 3 after the add. Passing _quorumSize=1 means
+        // numActive >= 2 * quorum (3 >= 2) -> revert.
         vm.prank(owner);
         vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 1);
     }
 
     function test_removeCommitteeMember_revertsWhenBelowQuorum() public {
         // numActive=2, quorum=2; removing alice drops numActive to 1 < quorum -> revert
         vm.prank(owner);
         vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
-        etherFiOracleInstance.removeCommitteeMember(alice);
+        etherFiOracleInstance.removeCommitteeMember(alice, 2);
     }
 
     function test_removeCommitteeMember_okWhenMemberWasDisabled() public {
         // Disabling alice already accounted for the numActive drop, so removing her
         // (which only touches numCommitteeMembers, not numActive) keeps quorum valid.
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
         // numActive=3 after add; disable alice -> numActive=2, quorum=2 (still valid)
         vm.prank(owner);
-        etherFiOracleInstance.manageCommitteeMember(alice, false);
+        etherFiOracleInstance.manageCommitteeMember(alice, false, 2);
 
         vm.prank(owner);
-        etherFiOracleInstance.removeCommitteeMember(alice);
+        etherFiOracleInstance.removeCommitteeMember(alice, 2);
 
         assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 2);
         assertEq(etherFiOracleInstance.numCommitteeMembers(), 2);
@@ -954,20 +950,20 @@ contract EtherFiOracleTest is TestSetup {
         // numActive=2, quorum=2; disabling bob drops numActive to 1 -> revert
         vm.prank(owner);
         vm.expectRevert(EtherFiOracle.InvalidQuorum.selector);
-        etherFiOracleInstance.manageCommitteeMember(bob, false);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 2);
     }
 
     function test_manageCommitteeMember_reenableKeepsQuorumValid() public {
         // First need a disable that is legal (so add chad to give us headroom)
         vm.prank(owner);
-        etherFiOracleInstance.addCommitteeMember(chad);
+        etherFiOracleInstance.addCommitteeMember(chad, 2);
         vm.prank(owner);
-        etherFiOracleInstance.manageCommitteeMember(chad, false);
+        etherFiOracleInstance.manageCommitteeMember(chad, false, 2);
         assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 2);
 
         // Re-enable chad: numActive goes back to 3, quorum=2, still valid
         vm.prank(owner);
-        etherFiOracleInstance.manageCommitteeMember(chad, true);
+        etherFiOracleInstance.manageCommitteeMember(chad, true, 2);
         assertEq(etherFiOracleInstance.numActiveCommitteeMembers(), 3);
     }
 
@@ -1087,7 +1083,7 @@ contract EtherFiOracleTest is TestSetup {
         // RoleRegistry is already initialized and alice already has the role in setUpTests
 
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1152,7 +1148,7 @@ contract EtherFiOracleTest is TestSetup {
         // RoleRegistry is already initialized and alice already has the role in setUpTests
 
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1179,7 +1175,7 @@ contract EtherFiOracleTest is TestSetup {
         // bob doesn't have the role, so we'll use alice for both
 
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1221,7 +1217,7 @@ contract EtherFiOracleTest is TestSetup {
         // RoleRegistry is already initialized and alice already has both roles in setUpTests
 
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1288,7 +1284,7 @@ contract EtherFiOracleTest is TestSetup {
 
         // Execute a task to set lastHandledReportRefSlot
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1312,7 +1308,7 @@ contract EtherFiOracleTest is TestSetup {
 
         // Execute a task to set lastHandledReportRefBlock
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1338,7 +1334,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_canExecuteTasks_edgeCases() public {
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1364,7 +1360,7 @@ contract EtherFiOracleTest is TestSetup {
     function test_executeTasks_wrongRefSlotFrom() public {
         // RoleRegistry is already initialized and alice already has the role in setUpTests
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1392,7 +1388,7 @@ contract EtherFiOracleTest is TestSetup {
     function test_executeTasks_wrongRefBlockFrom() public {
         // RoleRegistry is already initialized and alice already has the role in setUpTests
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -1419,7 +1415,7 @@ contract EtherFiOracleTest is TestSetup {
 
     function test_executeTasks_permissionless() public {
         vm.prank(owner);
-        etherFiOracleInstance.setQuorumSize(1);
+        etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
         _moveClock(1024 + 2 * slotsPerEpoch);
 

--- a/test/EtherFiTimelock.t.sol
+++ b/test/EtherFiTimelock.t.sol
@@ -309,29 +309,39 @@ contract TimelockTest is TestSetup {
         address avs_etherfi_oracle2 = address(0x2c7cB7d5dC4aF9caEE654553a144C76F10D4b320);
         address target = address(etherFiOracleInstance);
         
-        // Check and remove if they exist
+        // Check and remove if they exist. Pick a quorum that satisfies the
+        // _checkQuorum invariant for the resulting numActive after each mutation:
+        // strict majority -> quorum = numActive / 2 + 1 (with numActive >= 1).
         (bool registered1, , , ) = etherFiOracleInstance.committeeMemberStates(etherfi_oracle1);
         if (registered1) {
-            bytes memory data = abi.encodeWithSelector(EtherFiOracle.removeCommitteeMember.selector, etherfi_oracle1);
+            uint32 newActive = etherFiOracleInstance.numActiveCommitteeMembers() - 1;
+            uint32 newQuorum = newActive == 0 ? 1 : newActive / 2 + 1;
+            bytes memory data = abi.encodeWithSelector(EtherFiOracle.removeCommitteeMember.selector, etherfi_oracle1, newQuorum);
             _execute_timelock(target, data, true, true, true, true);
         }
-        
+
         (bool registered2, , , ) = etherFiOracleInstance.committeeMemberStates(etherfi_oracle2);
         if (registered2) {
-            bytes memory data = abi.encodeWithSelector(EtherFiOracle.removeCommitteeMember.selector, etherfi_oracle2);
+            uint32 newActive = etherFiOracleInstance.numActiveCommitteeMembers() - 1;
+            uint32 newQuorum = newActive == 0 ? 1 : newActive / 2 + 1;
+            bytes memory data = abi.encodeWithSelector(EtherFiOracle.removeCommitteeMember.selector, etherfi_oracle2, newQuorum);
             _execute_timelock(target, data, true, true, true, true);
         }
-        
+
         // Add new members if they don't exist
         (bool registered3, , , ) = etherFiOracleInstance.committeeMemberStates(avs_etherfi_oracle1);
         if (!registered3) {
-            bytes memory data = abi.encodeWithSelector(EtherFiOracle.addCommitteeMember.selector, avs_etherfi_oracle1);
+            uint32 newActive = etherFiOracleInstance.numActiveCommitteeMembers() + 1;
+            uint32 newQuorum = newActive / 2 + 1;
+            bytes memory data = abi.encodeWithSelector(EtherFiOracle.addCommitteeMember.selector, avs_etherfi_oracle1, newQuorum);
             _execute_timelock(target, data, true, true, true, true);
         }
-        
+
         (bool registered4, , , ) = etherFiOracleInstance.committeeMemberStates(avs_etherfi_oracle2);
         if (!registered4) {
-            bytes memory data = abi.encodeWithSelector(EtherFiOracle.addCommitteeMember.selector, avs_etherfi_oracle2);
+            uint32 newActive = etherFiOracleInstance.numActiveCommitteeMembers() + 1;
+            uint32 newQuorum = newActive / 2 + 1;
+            bytes memory data = abi.encodeWithSelector(EtherFiOracle.addCommitteeMember.selector, avs_etherfi_oracle2, newQuorum);
             _execute_timelock(target, data, true, true, true, true);
         }
     }

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1360,13 +1360,13 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             genesisSlotTimestamp = 0;
         }
         // Initialize quorum at 1 so we can add committee members one-by-one
-        // without tripping the new _checkQuorum invariant
-        // (numActive < quorum reverts). Once both members are registered,
-        // raise quorum to its real value of 2.
+        // without tripping the _checkQuorum invariant. Each add bumps quorum
+        // alongside numActive so the (members, quorum) pair stays in the
+        // valid band (quorum >= minQuorum, numActive >= quorum,
+        // numActive < 2 * quorum).
         etherFiOracleInstance.initialize(1, 1024, 0, 32, 12, genesisSlotTimestamp);
-        etherFiOracleInstance.addCommitteeMember(alice);
-        etherFiOracleInstance.addCommitteeMember(bob);
-        etherFiOracleInstance.setQuorumSize(2);
+        etherFiOracleInstance.addCommitteeMember(alice, 1);
+        etherFiOracleInstance.addCommitteeMember(bob, 2);
 
         vm.stopPrank();
 

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -106,11 +106,17 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         // (registered=true, enabled=true, lastReportRefSlot=0, numReports=0), clearing any stale
         // submission from mainnet without adding new committee members.
         address oracleOwner = etherFiOracleInstance.owner();
+        // Each add/remove now requires a _quorumSize that satisfies the strict-majority
+        // invariant for the resulting numActive. Compute a fresh value at each step
+        // so this works regardless of mainnet's current quorum.
         vm.startPrank(oracleOwner);
-        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_1);
-        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_1);
-        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_2);
-        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_2);
+        uint32 active = etherFiOracleInstance.numActiveCommitteeMembers();
+        uint32 quorumAfterRemove = active > 1 ? (active - 1) / 2 + 1 : 1;
+        uint32 quorumAfterAdd = active / 2 + 1;
+        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_1, quorumAfterRemove);
+        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_1, quorumAfterAdd);
+        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_2, quorumAfterRemove);
+        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_2, quorumAfterAdd);
         vm.stopPrank();
     }
 

--- a/test/integration-tests/Withdraw.t.sol
+++ b/test/integration-tests/Withdraw.t.sol
@@ -92,10 +92,16 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         vm.prank(rrOwner);
         roleRegistryInstance.grantRole(opTimelockRole, oracleOwner);
         vm.startPrank(oracleOwner);
-        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_1);
-        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_1);
-        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_2);
-        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_2);
+        // Each add/remove now requires a _quorumSize that satisfies the strict-majority
+        // invariant for the resulting numActive. Compute fresh values so this works
+        // regardless of mainnet's current quorum.
+        uint32 active = etherFiOracleInstance.numActiveCommitteeMembers();
+        uint32 quorumAfterRemove = active > 1 ? (active - 1) / 2 + 1 : 1;
+        uint32 quorumAfterAdd = active / 2 + 1;
+        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_1, quorumAfterRemove);
+        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_1, quorumAfterAdd);
+        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_2, quorumAfterRemove);
+        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_2, quorumAfterAdd);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes how oracle consensus quorum and active membership are updated on-chain, including a breaking ABI for admin/timelock operations that govern report finalization.
> 
> **Overview**
> **Oracle committee APIs** now require an explicit `quorumSize` on `addCommitteeMember`, `removeCommitteeMember`, and `manageCommitteeMember`. Each call updates `quorumSize` before `_checkQuorum()`, so membership and quorum must be adjusted together instead of relying on a separate `setQuorumSize` step.
> 
> **Quorum validation** in `_checkQuorum` is tightened: it now rejects `quorumSize < minQuorumSize`, and the upper bound uses **`numActiveCommitteeMembers >= 2 * quorumSize`** (strict majority) instead of `> 2 * quorumSize`. `setQuorumSize` no longer duplicates the min-quorum check; that lives only in `_checkQuorum`.
> 
> **Call sites** (unit tests, `TestSetup`, mainnet-fork timelock tests, integration flows) pass computed quorums—often `numActive / 2 + 1`—and many paths that previously called `setQuorumSize(1)` now disable a member via `manageCommitteeMember(..., false, 1)` to reach quorum 1 legally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d71cbdd1bfff9d1b60298af691d1bd1a1008339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->