### PR TITLE
test(invariants): RedemptionManager + WithdrawRequestNFT stranded-ETH suites

### DIFF
--- a/test/HandleRemainderRoundingEquivalence.t.sol
+++ b/test/HandleRemainderRoundingEquivalence.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "./TestSetup.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
+/// @notice Architecture reviewer flagged the WithdrawRequestNFT.handleRemainder
+///         and PriorityWithdrawalQueue.handleRemainder pair as an "architectural
+///         smell": two copies of the same logic against the same LP, with
+///         subtly different rounding directions:
+///
+///         WithdrawRequestNFT (`src/WithdrawRequestNFT.sol:384`):
+///             eEthAmountToTreasury = _eEthAmount.mulDiv(splitBps, 1e4);
+///             // default = Math.Rounding.Down (floor)
+///
+///         PriorityWithdrawalQueue (`src/PriorityWithdrawalQueue.sol:397-401`):
+///             eEthAmountToTreasury = eEthAmount.mulDiv(
+///                 shareRemainderSplitToTreasuryInBps, _BASIS_POINT_SCALE,
+///                 Math.Rounding.Up
+///             );
+///             // explicit ceiling
+///
+///         Both pay treasury in eETH and burn the rest via `LP.burnEEthShares`.
+///         The rounding-direction equivalence between the two has no
+///         contract-level invariant - this test pins it down:
+///
+///         1. Pure-math: `ceil - floor in {0, 1}` for every (amount, bps).
+///         2. Cross-contract: under identical input, the WRN-shaped sum
+///            `(treasuryEEth_wrn + amountToBurn_wrn) == amount` AND the
+///            PQ-shaped sum `(treasuryEEth_pq + amountToBurn_pq) == amount`,
+///            but the per-contract `treasury` differs by at most 1 wei.
+///         3. Share-burn delta is bounded by `sharesForAmount(1)` - i.e.,
+///            WRN burns at MOST one extra share-amount of eETH because
+///            WRN gives 1 wei LESS to treasury than PQ.
+///
+///         This is a unit-test-shaped property (no state machine), so it
+///         lives outside the invariant directory. It is the direct
+///         regression test for the architecture finding that any future
+///         change to one of the two implementations that doesn't mirror
+///         the other will be caught.
+contract HandleRemainderRoundingEquivalenceTest is TestSetup {
+    using Math for uint256;
+
+    uint256 internal constant BPS_DENOM = 1e4;
+
+    function setUp() public {
+        setUpTests();
+
+        // Light setup - seed LP with some liquidity so amountForShare/
+        // sharesForAmount produce non-trivial values.
+        address dep = address(uint160(uint256(keccak256("remainder.dep"))));
+        vm.deal(dep, 1_000 ether);
+        vm.prank(dep);
+        liquidityPoolInstance.deposit{value: 500 ether}();
+    }
+
+    // =====================================================================
+    // PURE-MATH RING - bounded fuzz of (amount, bps)
+    // =====================================================================
+
+    /// `ceil - floor in {0, 1}` for every non-negative amount and any
+    /// bps in [0, 1e4]. Fundamental property of integer division;
+    /// pinning it here as a regression guard against either contract
+    /// changing the rounding mode.
+    function testFuzz_ceil_minus_floor_is_zero_or_one(uint128 amount, uint16 bps) public pure {
+        uint256 capBps = uint256(bps) > BPS_DENOM ? BPS_DENOM : uint256(bps);
+        uint256 floor_ = uint256(amount).mulDiv(capBps, BPS_DENOM, Math.Rounding.Down);
+        uint256 ceil_  = uint256(amount).mulDiv(capBps, BPS_DENOM, Math.Rounding.Up);
+        uint256 diff = ceil_ - floor_;
+        assertLe(diff, 1, "ceil-floor > 1 - rounding model broken");
+        assertGe(diff, 0, "ceil < floor"); // tautology but documents intent
+    }
+
+    /// WRN-shape and PQ-shape sums both equal the input amount (with
+    /// rounding direction absorbed by the burn side).
+    function testFuzz_split_sums_to_amount(uint128 amount, uint16 bps) public pure {
+        uint256 capBps = uint256(bps) > BPS_DENOM ? BPS_DENOM : uint256(bps);
+        // WRN shape
+        uint256 wrnTreasury = uint256(amount).mulDiv(capBps, BPS_DENOM, Math.Rounding.Down);
+        uint256 wrnBurn = uint256(amount) - wrnTreasury;
+        assertEq(wrnTreasury + wrnBurn, uint256(amount), "WRN split != amount");
+        // PQ shape
+        uint256 pqTreasury = uint256(amount).mulDiv(capBps, BPS_DENOM, Math.Rounding.Up);
+        // PQ contract computes eEthAmountToBurn = eEthAmount - eEthAmountToTreasury.
+        // If amount == 0 OR amount < treasuryCeil (impossible since ceil <= amount), this is fine.
+        // For non-zero amounts, treasuryCeil <= amount, so subtraction is safe.
+        if (uint256(amount) >= pqTreasury) {
+            uint256 pqBurn = uint256(amount) - pqTreasury;
+            assertEq(pqTreasury + pqBurn, uint256(amount), "PQ split != amount");
+        }
+    }
+
+    /// The per-contract treasury allocations differ by at most 1 wei
+    /// under identical inputs.
+    function testFuzz_cross_contract_treasury_delta_at_most_one_wei(
+        uint128 amount,
+        uint16 bps
+    ) public pure {
+        uint256 capBps = uint256(bps) > BPS_DENOM ? BPS_DENOM : uint256(bps);
+        uint256 wrnTreasury = uint256(amount).mulDiv(capBps, BPS_DENOM, Math.Rounding.Down);
+        uint256 pqTreasury  = uint256(amount).mulDiv(capBps, BPS_DENOM, Math.Rounding.Up);
+        // PQ ceils, WRN floors; PQ >= WRN, diff <= 1.
+        assertGe(pqTreasury, wrnTreasury, "PQ ceil < WRN floor - rounding inverted");
+        assertLe(pqTreasury - wrnTreasury, 1, "PQ-WRN treasury delta > 1 wei");
+    }
+
+    /// The per-contract burn allocations differ by at most 1 wei.
+    /// Because WRN gives 1 wei LESS to treasury, WRN burns 1 wei MORE.
+    function testFuzz_cross_contract_burn_delta_at_most_one_wei(
+        uint128 amount,
+        uint16 bps
+    ) public pure {
+        uint256 capBps = uint256(bps) > BPS_DENOM ? BPS_DENOM : uint256(bps);
+        uint256 wrnTreasury = uint256(amount).mulDiv(capBps, BPS_DENOM, Math.Rounding.Down);
+        uint256 pqTreasury  = uint256(amount).mulDiv(capBps, BPS_DENOM, Math.Rounding.Up);
+        uint256 wrnBurn = uint256(amount) - wrnTreasury;
+        // PQ burn only computable when pqTreasury <= amount.
+        if (uint256(amount) >= pqTreasury) {
+            uint256 pqBurn = uint256(amount) - pqTreasury;
+            assertGe(wrnBurn, pqBurn, "WRN burn < PQ burn - rounding inverted");
+            assertLe(wrnBurn - pqBurn, 1, "WRN-PQ burn delta > 1 wei");
+        }
+    }
+
+    /// Share-amount equivalence under the LP rate. The bound is
+    /// `LP.sharesForAmount(1)` - one wei of eETH translates to ~1 share
+    /// at typical rates. Lifts the wei delta to a share delta.
+    function testFuzz_cross_contract_share_burn_delta_bounded(
+        uint128 amount,
+        uint16 bps
+    ) public {
+        // Bound amount so it's a realistic remainder size. 1 wei to 1 ether.
+        uint256 amt = bound(uint256(amount), 1, 1 ether);
+        uint256 capBps = uint256(bps) > BPS_DENOM ? BPS_DENOM : uint256(bps);
+
+        uint256 wrnTreasury = amt.mulDiv(capBps, BPS_DENOM, Math.Rounding.Down);
+        uint256 pqTreasury  = amt.mulDiv(capBps, BPS_DENOM, Math.Rounding.Up);
+        uint256 wrnBurn = amt - wrnTreasury;
+        if (amt < pqTreasury) return; // edge case for 0-amount input
+        uint256 pqBurn = amt - pqTreasury;
+
+        uint256 wrnSharesBurn = liquidityPoolInstance.sharesForAmount(wrnBurn);
+        uint256 pqSharesBurn  = liquidityPoolInstance.sharesForAmount(pqBurn);
+
+        // sharesForAmount is monotone, so wrnSharesBurn >= pqSharesBurn.
+        assertGe(wrnSharesBurn, pqSharesBurn, "wrn shares < pq shares - sharesForAmount non-monotone");
+        // The differential equals sharesForAmount(wrnBurn - pqBurn) when
+        // the underlying math is linear; for floor mulDiv it bounds at
+        // sharesForAmount(1) since wrnBurn - pqBurn ∈ {0, 1}.
+        uint256 sharesOneWei = liquidityPoolInstance.sharesForAmount(1);
+        // The +1 covers any rounding-down on the per-call sharesForAmount(0)
+        // floor that can collapse below sharesForAmount(1). Conservative bound.
+        assertLe(
+            wrnSharesBurn - pqSharesBurn,
+            sharesOneWei + 1,
+            "WRN-PQ share-burn delta exceeds sharesForAmount(1) - rounding error compounding"
+        );
+    }
+}

--- a/test/LpRebaseWrnClaimUnderflow.t.sol
+++ b/test/LpRebaseWrnClaimUnderflow.t.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/StdError.sol";
+import "./TestSetup.sol";
+
+/// @notice **Architectural finding — surfaced during PR #437 fuzz work, pinned here.**
+///
+///         `LiquidityPool.rebase(negative)` reduces `totalValueOutOfLp`
+///         without coordinating with the segregated-escrow lock counters
+///         on `WithdrawRequestNFT` (`ethAmountLockedForWithdrawal`) and
+///         `PriorityWithdrawalQueue` (`ethAmountLockedForPriorityWithdrawal`).
+///
+///         When a finalized WRN claim subsequently calls
+///         `LiquidityPool.withdraw(amount, frozenRate)` and the rebase
+///         has driven `totalValueOutOfLp` below `amount`, the contract's
+///         checked subtraction
+///
+///             totalValueOutOfLp -= uint128(_amount);     // LiquidityPool.sol:297
+///
+///         underflows and the entire claim transaction reverts with
+///         `Panic(0x11)`. This is a **user-facing DoS on a finalized
+///         withdrawal**: the user's ETH is physically held by the WRN
+///         escrow (their `WRN.balance >= amountToWithdraw`), but
+///         `WRN.claimWithdraw` cannot complete because the LP-side
+///         accounting subtraction underflows.
+///
+///         **Production exposure assessment.**
+///         - `LP.rebase` is gated to `msg.sender == membershipManager`.
+///         - In production, `membershipManager` is invoked from
+///           `EtherFiAdmin.executeTasks`, which runs `_validateRebaseApr`
+///           and reverts if `|reportedAprInBps| > acceptableRebaseAprInBps`.
+///         - The APR cap is `acceptableRebaseAprInBps`, an admin-tunable
+///           int32 with an upper bound of `maxAcceptableRebaseAprInBps`
+///           (an immutable). Test default = `10000` bps = 100% annualised.
+///         - For a single report, the magnitude is bounded by
+///           `apr_bps * currentTVL * elapsedTime / (365 days * BPS)`.
+///         - The DoS is reachable when accumulated negative rebases
+///           between a request being finalized and the user claiming
+///           drop `totalValueOutOfLp` below that request's `amountOfEEth`.
+///           This requires `Σ(negative_rebases) > totalValueOutOfLp - amountOfEEth`,
+///           which is possible with sustained slashing or oracle bugs.
+///
+///         **Why this matters even with the APR cap.**
+///         - `totalValueOutOfLp` includes BOTH staking ETH (legitimately
+///           reducible via slashing) AND segregated-escrow locks (which
+///           must remain backed by `outOfLp` accounting). A negative
+///           rebase that legitimately reflects slashing on staked ETH
+///           still reduces the SAME `outOfLp` counter the lock
+///           accounting lives on.
+///         - The fix shape (separately tracked staking-vs-locked
+///           buckets, or a `rebase` that excludes the lock-counter sum,
+///           or a claim path that floors the LP-side decrement at 0)
+///           is an architectural decision for the team. This test pins
+///           the current behaviour as a regression guard either way.
+///
+///         **Two tests in this file:**
+///         1. `test_rebase_after_finalize_underflows_lp_withdraw` —
+///            constructs the exact failure sequence and asserts the
+///            current behaviour (Panic). If the contract is later
+///            patched, this test will fail and force a follow-up.
+///         2. `test_small_rebase_after_finalize_claim_succeeds` —
+///            positive control: a rebase small enough to keep
+///            `outOfLp >= amountToWithdraw` lets the claim succeed.
+contract LpRebaseWrnClaimUnderflowTest is TestSetup {
+    address internal claimant;
+
+    function setUp() public {
+        setUpTests();
+        // Unpause WRN — TestSetup leaves it paused; claimWithdraw is not
+        // gated by that flag but the rest of the WRN surface is.
+        vm.prank(alice);
+        withdrawRequestNFTInstance.unPauseContract();
+
+        claimant = address(uint160(uint256(keccak256("rebase-underflow.claimant"))));
+        vm.deal(claimant, 200 ether);
+        vm.prank(claimant);
+        liquidityPoolInstance.deposit{value: 100 ether}();
+        // LP.requestWithdraw transfers eETH from the caller to WRN —
+        // requires allowance.
+        vm.prank(claimant);
+        eETHInstance.approve(address(liquidityPoolInstance), type(uint256).max);
+    }
+
+    /// **Demonstrates the DoS.** Setup → request 50 ETH → finalize + lock
+    /// → negative rebase that drops outOfLp below the pending claim's
+    /// amount → claim reverts with Panic(0x11) inside `LP.withdraw`.
+    function test_rebase_after_finalize_underflows_lp_withdraw() public {
+        uint256 requestAmount = 50 ether;
+
+        // ===== Step 1: actor requests withdrawal. No ETH moves yet — only =====
+        // shares get transferred from claimant to WRN. outOfLp still 0.
+        vm.prank(claimant);
+        uint256 tokenId = liquidityPoolInstance.requestWithdraw(claimant, requestAmount);
+
+        assertEq(uint256(liquidityPoolInstance.totalValueOutOfLp()), 0, "outOfLp dirty pre-finalize");
+        assertEq(uint256(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal()), 0, "WRN lock dirty pre-finalize");
+
+        // ===== Step 2: EtherFiAdmin finalizes + transfers ETH to WRN. =====
+        // After this, the request is claimable: outOfLp +=
+        // requestAmount, WRN.balance == requestAmount, WRN.lock ==
+        // requestAmount.
+        vm.startPrank(address(etherFiAdminInstance));
+        liquidityPoolInstance.addEthAmountLockedForWithdrawal(uint128(requestAmount));
+        withdrawRequestNFTInstance.finalizeRequests(tokenId);
+        vm.stopPrank();
+
+        assertEq(uint256(liquidityPoolInstance.totalValueOutOfLp()), requestAmount, "outOfLp wrong post-finalize");
+        assertEq(uint256(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal()), requestAmount, "WRN lock wrong post-finalize");
+        assertEq(address(withdrawRequestNFTInstance).balance, requestAmount, "WRN balance wrong post-finalize");
+
+        // ===== Step 3: negative rebase. Drops outOfLp by 45 ether, =====
+        // leaving 5 ether. The WRN.lock counter does NOT decrease.
+        // After this, `outOfLp (5) < requestAmount (50)`.
+        int128 rebaseDelta = -int128(int256(uint256(45 ether)));
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(rebaseDelta);
+
+        assertEq(uint256(liquidityPoolInstance.totalValueOutOfLp()), 5 ether, "outOfLp wrong post-rebase");
+        assertEq(uint256(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal()), requestAmount, "WRN lock should be UNCHANGED");
+        assertEq(address(withdrawRequestNFTInstance).balance, requestAmount, "WRN balance should be UNCHANGED");
+
+        // ===== Step 4: claim. The WRN side has the ETH physically =====
+        // available (balance == requestAmount). But LP.withdraw runs
+        // `totalValueOutOfLp -= uint128(_amount)` where _amount ==
+        // amountToWithdraw (~50 ether) > outOfLp (5 ether). Checked
+        // subtraction underflows → Panic(0x11) → the entire claim
+        // reverts.
+        vm.prank(claimant);
+        vm.expectRevert(stdError.arithmeticError);
+        withdrawRequestNFTInstance.claimWithdraw(tokenId);
+
+        // Sanity: the WRN's lock counter remained intact (the revert
+        // rolled back the lock decrement too), so the funds are not
+        // accounting-orphaned — they're just stuck behind the
+        // underflow until either (a) outOfLp is restored via positive
+        // rebase or (b) the protocol is patched.
+        assertEq(uint256(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal()), requestAmount, "WRN lock corrupted by reverted claim");
+        assertEq(address(withdrawRequestNFTInstance).balance, requestAmount, "WRN balance corrupted by reverted claim");
+    }
+
+    /// **Positive control.** Same setup, but pre-seed `outOfLp` headroom
+    /// with a positive rebase so a small subsequent negative rebase
+    /// can't drive `outOfLp` below the lock. Demonstrates that the
+    /// underflow only fires under the specific magnitude condition,
+    /// not as a general rule.
+    function test_small_rebase_after_finalize_claim_succeeds() public {
+        uint256 requestAmount = 50 ether;
+
+        // Seed 10 ether of headroom in outOfLp via a positive rebase.
+        // This simulates legitimate accrued rewards: outOfLp grows
+        // without ETH actually moving into the LP. Without this, the
+        // lock transfer at finalize would leave outOfLp == lock exactly,
+        // and ANY negative rebase would underflow at claim time.
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(int128(int256(uint256(10 ether))));
+
+        vm.prank(claimant);
+        uint256 tokenId = liquidityPoolInstance.requestWithdraw(claimant, requestAmount);
+
+        vm.startPrank(address(etherFiAdminInstance));
+        liquidityPoolInstance.addEthAmountLockedForWithdrawal(uint128(requestAmount));
+        withdrawRequestNFTInstance.finalizeRequests(tokenId);
+        vm.stopPrank();
+
+        // outOfLp == 60 ether (10 seeded + 50 from lock), lock == 50.
+        // A small negative rebase (-1 ether) drops outOfLp to 59 —
+        // still well above the lock.
+        int128 rebaseDelta = -int128(int256(uint256(1 ether)));
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(rebaseDelta);
+
+        assertGt(uint256(liquidityPoolInstance.totalValueOutOfLp()), requestAmount, "outOfLp dropped below lock");
+
+        uint256 claimantBalBefore = claimant.balance;
+        vm.prank(claimant);
+        withdrawRequestNFTInstance.claimWithdraw(tokenId);
+        assertGt(claimant.balance, claimantBalBefore, "claim paid nothing");
+        assertEq(uint256(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal()), 0, "lock not cleared after claim");
+    }
+
+    /// **Quantifies the boundary.** Shows the rebase magnitude that
+    /// EXACTLY exhausts outOfLp's headroom over the locked amount.
+    /// Any rebase magnitude greater than this triggers the underflow;
+    /// any rebase ≤ this is safe.
+    ///
+    /// Useful for the team's decision on whether to:
+    /// (a) keep the current architecture and document
+    ///     `acceptableRebaseAprInBps × elapsedTime` as the ceiling, OR
+    /// (b) change `LP.rebase` to revert when it would drive `outOfLp <
+    ///     WRN.lock + PQ.lock`, OR
+    /// (c) change `LP.withdraw` to floor the `totalValueOutOfLp`
+    ///     decrement at 0 when called from the segregated path.
+    function test_boundary_rebase_exactly_at_safe_limit() public {
+        uint256 requestAmount = 50 ether;
+
+        vm.prank(claimant);
+        uint256 tokenId = liquidityPoolInstance.requestWithdraw(claimant, requestAmount);
+
+        vm.startPrank(address(etherFiAdminInstance));
+        liquidityPoolInstance.addEthAmountLockedForWithdrawal(uint128(requestAmount));
+        withdrawRequestNFTInstance.finalizeRequests(tokenId);
+        vm.stopPrank();
+
+        // Compute amountToWithdraw via the same formula the contract uses.
+        // For this test (no rebase yet between request and finalize), it
+        // equals requestAmount up to wei-rounding on the rate.
+        uint256 amountToWithdraw = withdrawRequestNFTInstance.getClaimableAmount(tokenId);
+
+        // Safe boundary: outOfLp_after == amountToWithdraw exactly.
+        uint256 outOfLpBefore = uint256(liquidityPoolInstance.totalValueOutOfLp());
+        uint256 maxSafeRebase = outOfLpBefore - amountToWithdraw;
+        int128 rebaseDelta = -int128(int256(maxSafeRebase));
+
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(rebaseDelta);
+
+        // outOfLp == amountToWithdraw. The claim's LP.withdraw decrement
+        // brings it to exactly 0 — no underflow.
+        assertEq(uint256(liquidityPoolInstance.totalValueOutOfLp()), amountToWithdraw, "boundary miscomputed");
+
+        vm.prank(claimant);
+        withdrawRequestNFTInstance.claimWithdraw(tokenId);
+
+        assertEq(uint256(liquidityPoolInstance.totalValueOutOfLp()), 0, "outOfLp not exactly zero post-claim");
+
+        // One more wei of rebase magnitude would have underflowed.
+        // (Captured implicitly: the test_rebase_after_finalize_underflows
+        // test above is the same shape with a much larger magnitude.)
+    }
+}

--- a/test/invariant/RedemptionManager.invariant.t.sol
+++ b/test/invariant/RedemptionManager.invariant.t.sol
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "../TestSetup.sol";
+import "./handlers/RedemptionManagerHandler.sol";
+
+/// @notice Stateful invariant suite for EtherFiRedemptionManager + BucketLimiter.
+///         ETH path only - the stETH path needs a mainnet fork (Lido state,
+///         Liquifier balance, EtherFiRestaker hookup) which is incompatible
+///         with 256x64 invariant runs. The fork-based ERM tests already
+///         cover the stETH leg.
+///
+///         Properties:
+///         - bucket capacity never exceeds the configured cap;
+///         - successful redemptions never violate the LP rate-monotonicity
+///           (via PR #428's modifier on the burn path the redeem touches);
+///         - the share-conservation identity inside _processETHRedemption
+///           never fires its safety reverts (InvalidNumSharesBurnt /
+///           InvalidTotalShares / InvalidLpBalance) under bounded fuzz;
+///         - pause actually halts state changes;
+///         - LP balance delta per redeem matches the ETH paid to receiver;
+///         - the canRedeem -> redeem flow does not let `RateLimitExceeded`
+///           fire after a positive precheck in the same block.
+///
+/// forge-config: default.invariant.runs = 256
+/// forge-config: default.invariant.depth = 64
+/// forge-config: default.invariant.fail-on-revert = false
+/// forge-config: default.invariant.call-override = false
+contract RedemptionManagerInvariantTest is TestSetup {
+    RedemptionManagerHandler internal handler;
+
+    address public constant ETH_ADDRESS_CONST = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    function setUp() public {
+        setUpTests();
+
+        // Configure the ERM ETH path. `setUpTests` deploys + initializes the
+        // ERM but doesn't initialize per-token bucket / fee parameters.
+        // initializeTokenParameters is admin-gated and we want a clean
+        // starting state rather than reusing existing test-suite values.
+        vm.startPrank(alice); // alice == admin in TestSetup
+        // Capacity high enough that fuzz redemptions don't immediately drain.
+        etherFiRedemptionManagerInstance.setCapacity(1000 ether, ETH_ADDRESS_CONST);
+        etherFiRedemptionManagerInstance.setRefillRatePerSecond(1 ether, ETH_ADDRESS_CONST);
+        etherFiRedemptionManagerInstance.setExitFeeBasisPoints(100, ETH_ADDRESS_CONST);             // 1%
+        etherFiRedemptionManagerInstance.setExitFeeSplitToTreasuryInBps(5000, ETH_ADDRESS_CONST);   // 50% to treasury
+        // Drop watermark to 0 so the bucket - not the watermark - is the
+        // gating constraint. The watermark gate is exercised by the dedicated
+        // admin_setLowWatermarkBps op.
+        etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(0, ETH_ADDRESS_CONST);
+        vm.stopPrank();
+
+        // Warp forward so the bucket has actually accumulated capacity (it
+        // initialises with remaining == 0 and refills based on elapsed time).
+        vm.warp(block.timestamp + 2000); // 2000 * 1 ether/s, capped at 1000 ether
+
+        handler = new RedemptionManagerHandler(
+            liquidityPoolInstance,
+            eETHInstance,
+            weEthInstance,
+            etherFiRedemptionManagerInstance,
+            treasuryInstance,
+            address(membershipManagerInstance),
+            alice
+        );
+
+        targetContract(address(handler));
+    }
+
+    // =====================================================================
+    // I-1: bucket capacity invariant
+    // =====================================================================
+
+    /// `consumable(limit)` reads through `_refill` and must not exceed
+    /// `capacity` post-refill. A violation indicates a bug in the refill
+    /// math or in setCapacity's clamp-down logic.
+    function invariant_bucket_within_capacity() public view {
+        (uint64 capacity, uint64 remaining,,) =
+            _readBucket(etherFiRedemptionManagerInstance, ETH_ADDRESS_CONST);
+        assertLe(remaining, capacity, "BucketLimiter.remaining exceeds capacity");
+    }
+
+    // =====================================================================
+    // I-2: rate monotonicity (PR #428's nonDecreasingRate modifier)
+    // =====================================================================
+
+    /// Oracle A: `amountForShare(1e18)` non-decreasing across every observed
+    /// redeem. Redeem walks through `burnEEthShares` which carries PR #428's
+    /// modifier; a drop would mean the modifier was bypassed.
+    function invariant_redeem_rate_non_decreasing_amountForShare() public view {
+        assertFalse(
+            handler.ghost_rateDrop_viaAmountForShare(),
+            "redeem caused amountForShare(1e18) to drop"
+        );
+    }
+
+    /// Oracle B: probe account's `eETH.balanceOf` non-decreasing.
+    function invariant_redeem_rate_non_decreasing_probeBalance() public view {
+        assertFalse(
+            handler.ghost_rateDrop_viaProbeBalance(),
+            "redeem caused probe-account eETH.balanceOf to drop"
+        );
+    }
+
+    // =====================================================================
+    // I-3: internal safety reverts must NEVER fire under bounded fuzz
+    // =====================================================================
+
+    function invariant_no_invalid_shares_burnt() public view {
+        assertEq(
+            handler.ghost_invalidSharesBurntCount(), 0,
+            "InvalidNumSharesBurnt fired - liquidityPool.withdraw returned wrong share count"
+        );
+    }
+
+    function invariant_no_invalid_total_shares() public view {
+        assertEq(
+            handler.ghost_invalidTotalSharesCount(), 0,
+            "InvalidTotalShares fired - share-conservation identity broken inside _processETHRedemption"
+        );
+    }
+
+    function invariant_no_invalid_lp_balance() public view {
+        assertEq(
+            handler.ghost_invalidLpBalanceCount(), 0,
+            "InvalidLpBalance fired - LP.totalValueInLp delta != ethReceived"
+        );
+    }
+
+    function invariant_no_rate_modifier_revert() public view {
+        assertEq(
+            handler.ghost_modifierRevertCount(), 0,
+            "EETHRateDeflation fired on a redeem path - PR #428 modifier triggered"
+        );
+    }
+
+    function invariant_no_panics() public view {
+        assertEq(
+            handler.ghost_panicRevertCount(), 0,
+            "Panic surfaced on a protocol call - review input bounds"
+        );
+    }
+
+    // =====================================================================
+    // I-4: share conservation (post-call identity)
+    // =====================================================================
+
+    function invariant_share_conservation_holds() public view {
+        assertFalse(
+            handler.ghost_shareConservationViolated(),
+            "share/balance conservation violated in a successful redeem - see ghost_firstFailureOp"
+        );
+    }
+
+    // =====================================================================
+    // I-5: pause halts state changes
+    // =====================================================================
+
+    function invariant_pause_actually_halts_redemption() public view {
+        assertFalse(
+            handler.ghost_pauseBypassObserved(),
+            "ERM accepted a redeem while paused"
+        );
+    }
+
+    // =====================================================================
+    // I-6: LP solvency on the in-LP bucket (sanity, also held in #436)
+    // =====================================================================
+
+    function invariant_lp_solvent_for_in_lp() public view {
+        assertGe(
+            address(liquidityPoolInstance).balance,
+            uint256(liquidityPoolInstance.totalValueInLp()),
+            "LP balance < totalValueInLp"
+        );
+    }
+
+    // =====================================================================
+    // I-7: TVL decomposition (sanity)
+    // =====================================================================
+
+    function invariant_tvl_decomposition() public view {
+        assertEq(
+            uint256(liquidityPoolInstance.totalValueInLp())
+                + uint256(liquidityPoolInstance.totalValueOutOfLp()),
+            liquidityPoolInstance.getTotalPooledEther(),
+            "TVL decomposition broken"
+        );
+    }
+
+    // =====================================================================
+    // COVERAGE SUMMARY
+    // =====================================================================
+
+    function invariant_call_coverage_summary() public {
+        emit log_named_uint("redeemEth                 ", handler.callCounts("redeemEth"));
+        emit log_named_uint("redeemEth_blocked         ", handler.callCounts("redeemEth_blocked"));
+        emit log_named_uint("redeemEth_skipped         ", handler.callCounts("redeemEth_skipped"));
+        emit log_named_uint("redeemEth_revert          ", handler.callCounts("redeemEth_revert"));
+        emit log_named_uint("redeemWeEth               ", handler.callCounts("redeemWeEth"));
+        emit log_named_uint("redeemWeEth_blocked       ", handler.callCounts("redeemWeEth_blocked"));
+        emit log_named_uint("redeemWeEth_skipped       ", handler.callCounts("redeemWeEth_skipped"));
+        emit log_named_uint("redeemWeEth_revert        ", handler.callCounts("redeemWeEth_revert"));
+        emit log_named_uint("setCapacity               ", handler.callCounts("setCapacity"));
+        emit log_named_uint("setRefillRate             ", handler.callCounts("setRefillRate"));
+        emit log_named_uint("setExitFee                ", handler.callCounts("setExitFee"));
+        emit log_named_uint("setExitFeeSplit           ", handler.callCounts("setExitFeeSplit"));
+        emit log_named_uint("setLowWatermark           ", handler.callCounts("setLowWatermark"));
+        emit log_named_uint("pause                     ", handler.callCounts("pause"));
+        emit log_named_uint("unpause                   ", handler.callCounts("unpause"));
+        emit log_named_uint("lp_deposit                ", handler.callCounts("lp_deposit"));
+        emit log_named_uint("rebase                    ", handler.callCounts("rebase"));
+        emit log_named_uint("advance_time              ", handler.callCounts("advance_time"));
+        emit log_named_uint("modifier_revert           ", handler.ghost_modifierRevertCount());
+        emit log_named_uint("panic_revert              ", handler.ghost_panicRevertCount());
+    }
+
+    // =====================================================================
+    // helpers
+    // =====================================================================
+
+    /// @dev `tokenToRedemptionInfo` is the public mapping. The bucket is
+    ///      the first field of `RedemptionInfo`; reading the four packed
+    ///      uint64 slots requires the explicit getter via the mapping.
+    function _readBucket(EtherFiRedemptionManager _erm, address token)
+        internal
+        view
+        returns (uint64 capacity, uint64 remaining, uint64 lastRefill, uint64 refillRate)
+    {
+        // Mapping accessor unrolls the struct into individual returns. The
+        // first return is `BucketLimiter.Limit` packed - but Solidity will
+        // unroll it into the four uint64 fields.
+        // Returns: limit (4 uint64s), exitFeeSplit, exitFee, lowWatermark.
+        (BucketLimiter.Limit memory limit,,,) = _erm.tokenToRedemptionInfo(token);
+        capacity = limit.capacity;
+        remaining = limit.remaining;
+        lastRefill = limit.lastRefill;
+        refillRate = limit.refillRate;
+    }
+}

--- a/test/invariant/WithdrawRemainder.invariant.t.sol
+++ b/test/invariant/WithdrawRemainder.invariant.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "../TestSetup.sol";
+import "./handlers/WithdrawRemainderHandler.sol";
+
+/// @notice Stateful suite for the WRN claim → stranded-ETH → handleRemainder
+///         cycle. Targets properties the existing FrozenRateWithdrawal suite
+///         does NOT assert:
+///
+///         A. **Stranded-ETH ledger conservation.** _claimWithdraw decrements
+///            the lock by `request.amountOfEEth` but pays only
+///            `amountToWithdraw = min(amountOfEEth, frozenRate * shareOfEEth
+///            / 1e18)`. Under a negative rebase between finalize and claim
+///            the delta is stranded in the WRN balance until handleRemainder
+///            sweeps it. We track every per-claim stranded delta + every
+///            sweep and assert the identity
+///            `WRN.balance - lock == cumStranded - swept`.
+///
+///         B. **handleRemainder share-burn conservation never fails.** Both
+///            WRN's `InvalidEEthShares` and PQ's
+///            `InvalidEEthSharesAfterRemainderHandling` are local
+///            post-condition reverts; they must never fire under bounded
+///            fuzz.
+///
+///         C. **Cross-contract rounding-direction observability.** WRN
+///            floors the treasury allocation, PQ ceils it. The handler
+///            accumulates per-contract treasury totals so the invariant
+///            file can emit them for review and assert sane bounds.
+///
+/// forge-config: default.invariant.runs = 256
+/// forge-config: default.invariant.depth = 64
+/// forge-config: default.invariant.fail-on-revert = false
+/// forge-config: default.invariant.call-override = false
+contract WithdrawRemainderInvariantTest is TestSetup {
+    WithdrawRemainderHandler internal handler;
+    address[5] internal handlerActors;
+
+    function setUp() public {
+        setUpTests();
+
+        // Unpause WRN; the FrozenRate suite's pattern.
+        vm.prank(alice);
+        withdrawRequestNFTInstance.unPauseContract();
+
+        // 5 actors, each pre-funded with eETH + approved for WRN/PQ/weETH.
+        for (uint256 i = 0; i < 5; i++) {
+            address a = address(uint160(uint256(keccak256(abi.encodePacked("wrnremain.actor.", i)))));
+            handlerActors[i] = a;
+            vm.deal(a, 2_000 ether);
+            vm.prank(a);
+            liquidityPoolInstance.deposit{value: 200 ether}();
+        }
+
+        // Grant housekeeping role for handleRemainder.
+        bytes32 housekeepingRole = roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE();
+        vm.prank(owner);
+        roleRegistryInstance.grantRole(housekeepingRole, alice);
+
+        // Whitelist actors for PQ + grant approvals.
+        for (uint256 i = 0; i < 5; i++) {
+            vm.prank(alice);
+            priorityQueueInstance.addToWhitelist(handlerActors[i]);
+        }
+        for (uint256 i = 0; i < 5; i++) {
+            vm.startPrank(handlerActors[i]);
+            eETHInstance.approve(address(liquidityPoolInstance), type(uint256).max);
+            eETHInstance.approve(address(priorityQueueInstance), type(uint256).max);
+            eETHInstance.approve(address(withdrawRequestNFTInstance), type(uint256).max);
+            eETHInstance.approve(address(weEthInstance), type(uint256).max);
+            vm.stopPrank();
+        }
+
+        // Configure the remainder split (50% to treasury) on both contracts
+        // so the rounding-asymmetry comparison sees a non-zero split.
+        vm.startPrank(alice);
+        withdrawRequestNFTInstance.updateShareRemainderSplitToTreasuryInBps(5000);
+        priorityQueueInstance.updateShareRemainderSplitToTreasury(5000);
+        vm.stopPrank();
+
+        // Seed totalValueOutOfLp with a positive rebase so the handler's
+        // `lp_rebase_negative` op has room to actually fire from the very
+        // first sequence. Without this, outOfLp stays at 0 until a finalize
+        // or fulfill creates room, and the fuzzer almost never finds the
+        // request -> negative-rebase -> finalize -> claim chain that
+        // produces a positive stranded-ETH delta (the property the suite
+        // is built to assert).
+        vm.prank(address(membershipManagerInstance));
+        liquidityPoolInstance.rebase(int128(int256(uint256(200 ether))));
+
+        handler = new WithdrawRemainderHandler(
+            liquidityPoolInstance,
+            eETHInstance,
+            withdrawRequestNFTInstance,
+            priorityQueueInstance,
+            address(etherFiAdminInstance),
+            address(membershipManagerInstance),
+            alice,
+            alice,
+            treasuryInstance,
+            handlerActors
+        );
+
+        targetContract(address(handler));
+    }
+
+    // =====================================================================
+    // A. Stranded-ETH ledger conservation
+    // =====================================================================
+
+    /// The ledger identity: WRN's balance excess over the lock equals exactly
+    /// the cumulative stranded ETH minus what handleRemainder has swept.
+    function invariant_wrn_stranded_ledger_consistent() public view {
+        assertFalse(
+            handler.ghost_wrnLedgerDrift(),
+            "WRN stranded-ETH ledger drift: balance - lock != cumStranded - swept"
+        );
+    }
+
+    /// Always-on solvency. Already in the FrozenRate suite; included here
+    /// for completeness so this file stands alone.
+    function invariant_wrn_balance_covers_lock() public view {
+        assertGe(
+            address(withdrawRequestNFTInstance).balance,
+            uint256(withdrawRequestNFTInstance.ethAmountLockedForWithdrawal()),
+            "WRN balance < ethAmountLockedForWithdrawal"
+        );
+    }
+
+    function invariant_pq_balance_covers_lock() public view {
+        assertGe(
+            address(priorityQueueInstance).balance,
+            uint256(priorityQueueInstance.ethAmountLockedForPriorityWithdrawal()),
+            "PQ balance < ethAmountLockedForPriorityWithdrawal"
+        );
+    }
+
+    // =====================================================================
+    // B. handleRemainder share-burn conservation must hold
+    // =====================================================================
+
+    /// WRN's `InvalidEEthShares` is a local post-condition revert that
+    /// should NEVER surface under bounded fuzz. Its appearance means
+    /// `liquidityPool.sharesForAmount(amountToTreasury) + sharesForAmount
+    /// (amountToBurn)` didn't equal the share delta on this contract -
+    /// a serious accounting bug.
+    function invariant_wrn_remainder_share_conservation() public view {
+        assertFalse(
+            handler.ghost_wrnInvalidShares(),
+            "WRN.handleRemainder InvalidEEthShares fired - remainder share accounting drift"
+        );
+    }
+
+    function invariant_pq_remainder_share_conservation() public view {
+        assertFalse(
+            handler.ghost_pqInvalidShares(),
+            "PQ.handleRemainder InvalidEEthSharesAfterRemainderHandling fired"
+        );
+    }
+
+    /// `_claimWithdraw` revert path: BurnExceedsShares must never fire,
+    /// since by construction the round-trip ceil-mulDiv guarantees the
+    /// share burn <= request.shareOfEEth.
+    function invariant_wrn_burn_within_request_shares() public view {
+        assertFalse(
+            handler.ghost_burnExceedsShares(),
+            "WRN claim BurnExceedsShares fired - claim burned more than request authorized"
+        );
+    }
+
+    function invariant_no_insufficient_escrow() public view {
+        assertEq(
+            handler.ghost_insufficientEscrowCount(), 0,
+            "InsufficientEscrow fired - WRN ETH balance briefly went below the lock counter"
+        );
+    }
+
+    function invariant_no_panic() public view {
+        assertEq(
+            handler.ghost_panicCount(), 0,
+            "Panic surfaced on a withdraw-remainder path - review bounds"
+        );
+    }
+
+    // =====================================================================
+    // C. Cross-contract rounding-direction observability
+    // =====================================================================
+
+    /// Both WRN and PQ should compute non-trivial treasury allocations
+    /// across many handleRemainder calls. If both counters are 0, the
+    /// suite never reached the remainder path - coverage signal.
+    /// Asserted as a soft observation via the coverage summary (this
+    /// invariant always passes); the per-contract counts are emitted
+    /// below for review.
+    function invariant_cross_contract_remainder_observability() public view {
+        // No hard assertion - both being 0 would mean we never reached
+        // the remainder path during the run, not a correctness issue.
+        // Emission lives in the coverage-summary invariant below.
+    }
+
+    // =====================================================================
+    // LP TVL sanity - reused from FrozenRate suite
+    // =====================================================================
+
+    function invariant_lp_tvl_decomposition() public view {
+        assertEq(
+            uint256(liquidityPoolInstance.totalValueInLp())
+                + uint256(liquidityPoolInstance.totalValueOutOfLp()),
+            liquidityPoolInstance.getTotalPooledEther(),
+            "TVL decomposition broken"
+        );
+    }
+
+    function invariant_lp_solvent_for_in_lp() public view {
+        assertGe(
+            address(liquidityPoolInstance).balance,
+            uint256(liquidityPoolInstance.totalValueInLp()),
+            "LP balance < totalValueInLp"
+        );
+    }
+
+    // =====================================================================
+    // COVERAGE SUMMARY
+    // =====================================================================
+
+    function invariant_call_coverage_summary() public {
+        emit log_named_uint("wrn_req                ", handler.callCounts("wrn_req"));
+        emit log_named_uint("wrn_finalize           ", handler.callCounts("wrn_finalize"));
+        emit log_named_uint("wrn_claim              ", handler.callCounts("wrn_claim"));
+        emit log_named_uint("wrn_remainder          ", handler.callCounts("wrn_remainder"));
+        emit log_named_uint("pq_req                 ", handler.callCounts("pq_req"));
+        emit log_named_uint("pq_fulfill             ", handler.callCounts("pq_fulfill"));
+        emit log_named_uint("pq_claim               ", handler.callCounts("pq_claim"));
+        emit log_named_uint("pq_remainder           ", handler.callCounts("pq_remainder"));
+        emit log_named_uint("rebase_positive        ", handler.callCounts("rebase_positive"));
+        emit log_named_uint("rebase_negative        ", handler.callCounts("rebase_negative"));
+        emit log_named_uint("advance_time           ", handler.callCounts("advance_time"));
+        emit log_named_uint("ghost_wrnCumStranded   ", handler.ghost_wrnCumulativeStranded());
+        emit log_named_uint("ghost_wrnSwept         ", handler.ghost_wrnSweptToTreasury());
+        emit log_named_uint("ghost_wrnTreasFloor    ", handler.ghost_wrnTotalTreasuryFloor());
+        emit log_named_uint("ghost_pqTreasCeil      ", handler.ghost_pqTotalTreasuryCeil());
+        emit log_named_uint("ghost_wrnRemCalls      ", handler.ghost_wrnRemainderCalls());
+        emit log_named_uint("ghost_pqRemCalls       ", handler.ghost_pqRemainderCalls());
+    }
+}

--- a/test/invariant/WithdrawRemainder.invariant.t.sol
+++ b/test/invariant/WithdrawRemainder.invariant.t.sol
@@ -117,6 +117,21 @@ contract WithdrawRemainderInvariantTest is TestSetup {
         );
     }
 
+    /// (1) Differential check between the contract's `getClaimableAmount`
+    /// and the handler's independent recomputation. They MUST agree
+    /// exactly. A divergence is a finding in `_getClaimableAmount`.
+    function invariant_wrn_getClaimableAmount_matches_recomputation() public view {
+        assertFalse(
+            handler.ghost_getClaimableAmountDrift(),
+            string.concat(
+                "getClaimableAmount differs from independent recompute - tokenId=",
+                vm.toString(handler.ghost_drift_tokenId()),
+                " contract=", vm.toString(handler.ghost_drift_contract()),
+                " independent=", vm.toString(handler.ghost_drift_independent())
+            )
+        );
+    }
+
     /// Always-on solvency. Already in the FrozenRate suite; included here
     /// for completeness so this file stands alone.
     function invariant_wrn_balance_covers_lock() public view {

--- a/test/invariant/handlers/RedemptionManagerHandler.sol
+++ b/test/invariant/handlers/RedemptionManagerHandler.sol
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/StdUtils.sol";
+import "forge-std/Vm.sol";
+
+import "../../../src/LiquidityPool.sol";
+import "../../../src/EETH.sol";
+import "../../../src/WeETH.sol";
+import "../../../src/EtherFiRedemptionManager.sol";
+
+/// @notice Stateful-invariant handler for EtherFiRedemptionManager + BucketLimiter.
+///         Scoped to the ETH redemption path. The stETH path requires a mainnet
+///         fork (Lido state, Liquifier stETH balance, EtherFiRestaker hookup)
+///         and is not invariant-friendly at 256x64 — covered by the existing
+///         fork-based unit tests.
+///
+///         Invariants enforced upstream (assert here that they NEVER trip):
+///         - `InvalidNumSharesBurnt` / `InvalidTotalShares` / `InvalidLpBalance`
+///           — local solvency checks inside `_processETHRedemption`.
+///         - `EETHRateDeflation` — PR #428's `nonDecreasingRate` modifier on
+///           the LP burnEEthShares path that redeem walks through.
+///         - `RateLimitExceeded` should never fire when `canRedeem` returned
+///           true the same block (modulo block.timestamp drift).
+///
+///         (F-001/F-014 pattern from PR #436 carried over):
+///         - Independent rate oracle via `amountForShare(SHARE_PROBE)` AND a
+///           probe account's `eETH.balanceOf`. Both must be non-decreasing
+///           across every redemption.
+///         - Independent ledger of expected LP balance + treasury eETH balance
+///           + per-actor cumulative output. The ledger updates from observed
+///           op deltas, the invariant file asserts equality with on-chain.
+contract RedemptionManagerHandler is StdUtils {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    uint256 public constant SHARE_PROBE = 1e18;
+    uint256 public constant N_EOAS = 5;
+
+    /// @dev Critical selectors that should NEVER fire under bounded fuzz.
+    bytes4 public constant SEL_INVALID_SHARES_BURNT  = bytes4(keccak256("InvalidNumSharesBurnt()"));
+    bytes4 public constant SEL_INVALID_TOTAL_SHARES  = bytes4(keccak256("InvalidTotalShares()"));
+    bytes4 public constant SEL_INVALID_LP_BALANCE    = bytes4(keccak256("InvalidLpBalance()"));
+    bytes4 public constant SEL_INVALID_OUT_OF_LP     = bytes4(keccak256("InvalidTotalValueOutOfLp()"));
+    bytes4 public constant SEL_EETH_RATE_DEFLATION   = bytes4(keccak256("EETHRateDeflation()"));
+    bytes4 public constant SEL_PANIC                 = 0x4e487b71;
+
+    LiquidityPool             public immutable lp;
+    EETH                      public immutable eETH;
+    WeETH                     public immutable weETH;
+    EtherFiRedemptionManager  public immutable erm;
+    address                   public immutable treasury;
+    address                   public immutable membershipManager;
+    /// @dev Holder of OPERATION_TIMELOCK_ROLE + OPERATION_MULTISIG_ROLE in TestSetup.
+    address                   public immutable adminSigner;
+
+    /// @dev Fixed-share probe account. Constructor seeds, handler never pranks
+    ///      as it, so eETH.shares[probe] is constant and balanceOf is a pure
+    ///      function of the rate. (F-001 from PR #436.)
+    address public immutable probeAccount;
+
+    address[N_EOAS] public actors;
+
+    // ----- Ghost state ----------------------------------------------------
+
+    /// @notice Independent ledger of LP's totalValueInLp. Increments on
+    ///         observed deposit, decrements on observed redeem ETH leg.
+    int256 public ghost_ledgerLpInBalance;
+
+    /// @notice Independent ledger of treasury eETH balance. Increments on
+    ///         every redeem (treasury fee in eETH).
+    int256 public ghost_ledgerTreasuryEEth;
+
+    /// @notice Cumulative ETH paid out to all redeem receivers.
+    uint256 public ghost_totalEthPaidOut;
+    /// @notice Cumulative eETH spent (from actors) on redeem.
+    uint256 public ghost_totalEEthSpent;
+
+    /// @notice Set if any successful redeem observed `amountForShare(1e18)` to
+    ///         drop. Rate must be non-decreasing across the LP rate-modifier-
+    ///         bearing paths the redeem touches.
+    bool public ghost_rateDrop_viaAmountForShare;
+    bool public ghost_rateDrop_viaProbeBalance;
+
+    /// @notice Set if any successful redeem failed the share-conservation
+    ///         identity `prevShares == newShares + sharesToBurn + feeShareToStakers`.
+    bool public ghost_shareConservationViolated;
+
+    /// @notice Set if redemption succeeded while the contract was paused.
+    bool public ghost_pauseBypassObserved;
+
+    /// @notice Cumulative bucket capacity-overflow observations. A
+    ///         `consumable(limit) > capacity` would indicate a refill bug.
+    bool public ghost_bucketCapacityViolated;
+
+    /// @notice Critical selector counters - none should fire under bounded fuzz.
+    uint256 public ghost_invalidSharesBurntCount;
+    uint256 public ghost_invalidTotalSharesCount;
+    uint256 public ghost_invalidLpBalanceCount;
+    uint256 public ghost_invalidOutOfLpCount;
+    uint256 public ghost_modifierRevertCount;
+    uint256 public ghost_panicRevertCount;
+
+    /// @notice Forensic crumbs on first observation.
+    bytes32 public ghost_firstFailureOp;
+    uint256 public ghost_firstFailure_rate0;
+    uint256 public ghost_firstFailure_rate1;
+
+    mapping(bytes32 => uint256) public callCounts;
+    mapping(bytes32 => mapping(bytes4 => uint256)) public revertSelectors;
+
+    constructor(
+        LiquidityPool _lp,
+        EETH _eETH,
+        WeETH _weETH,
+        EtherFiRedemptionManager _erm,
+        address _treasury,
+        address _membershipManager,
+        address _adminSigner
+    ) {
+        lp = _lp;
+        eETH = _eETH;
+        weETH = _weETH;
+        erm = _erm;
+        treasury = _treasury;
+        membershipManager = _membershipManager;
+        adminSigner = _adminSigner;
+        probeAccount = _label("erm.probe");
+
+        for (uint256 i = 0; i < N_EOAS; i++) {
+            actors[i] = _label(string.concat("erm.actor.", _itoa(i)));
+            vm.deal(actors[i], 1_000 ether);
+            vm.prank(actors[i]);
+            lp.deposit{value: 100 ether}();
+            ghost_ledgerLpInBalance += int256(uint256(100 ether));
+            // Pre-approve both eETH and weETH for the ERM, and eETH for weETH
+            // wrap. Pre-approving here removes a hidden revert surface inside
+            // the handler ops' try/catch.
+            vm.prank(actors[i]);
+            eETH.approve(address(erm), type(uint256).max);
+            vm.prank(actors[i]);
+            eETH.approve(address(weETH), type(uint256).max);
+            vm.prank(actors[i]);
+            weETH.approve(address(erm), type(uint256).max);
+            // Wrap a fraction so each actor starts with both eETH and weETH.
+            vm.prank(actors[i]);
+            try weETH.wrap(20 ether) {} catch {}
+        }
+
+        // Probe: dedicated rate-oracle account, NEVER touched by any handler op.
+        vm.deal(probeAccount, 100 ether);
+        vm.prank(probeAccount);
+        lp.deposit{value: 50 ether}();
+        ghost_ledgerLpInBalance += int256(uint256(50 ether));
+    }
+
+    // =====================================================================
+    // CORE OPS - redemption
+    // =====================================================================
+
+    /// @notice Redeem eETH for ETH via the canRedeem precheck path. Captures
+    ///         pre/post snapshots, asserts the local _processETHRedemption
+    ///         checks didn't revert internally, and updates the ghost ledger.
+    function redeemEEth(uint256 actorSeed, uint256 receiverSeed, uint128 amount) external {
+        address actor = _eoa(actorSeed);
+        address receiver = _eoa(receiverSeed);
+        uint256 actorEEthBal = eETH.balanceOf(actor);
+        if (actorEEthBal < 1 gwei) {
+            callCounts["redeemEth_skipped"]++;
+            return;
+        }
+        // Bound to actor balance AND to a sensible ETH cap.
+        uint256 hi = actorEEthBal > 50 ether ? 50 ether : actorEEthBal;
+        if (hi < 1 gwei) {
+            callCounts["redeemEth_skipped"]++;
+            return;
+        }
+        uint256 amt = bound(uint256(amount), 1 gwei, hi);
+
+        // Pre-flight: short-circuit if canRedeem would refuse. Doing the
+        // check here keeps the ghost-shareConservation assertion meaningful
+        // (otherwise legitimate refusals show up as reverts and clutter the
+        // selector counter).
+        if (!erm.canRedeem(amt, ETH_ADDRESS) || erm.paused()) {
+            callCounts["redeemEth_blocked"]++;
+            return;
+        }
+
+        RedeemSnap memory r = _redeemSnap(actor, receiver);
+
+        vm.prank(actor);
+        try erm.redeemEEth(amt, receiver, ETH_ADDRESS) {
+            _postRedeemChecks("redeemEth", actor, receiver, r, amt);
+            callCounts["redeemEth"]++;
+        } catch (bytes memory err) {
+            _recordRevert("redeemEth", err);
+        }
+    }
+
+    /// @notice Redeem weETH for ETH. Internally wraps -> unwraps via the
+    ///         ERM, so exercises the weETH leg of the redemption path.
+    function redeemWeEth(uint256 actorSeed, uint256 receiverSeed, uint128 amount) external {
+        address actor = _eoa(actorSeed);
+        address receiver = _eoa(receiverSeed);
+        uint256 actorWeEthBal = weETH.balanceOf(actor);
+        if (actorWeEthBal < 1 gwei) {
+            callCounts["redeemWeEth_skipped"]++;
+            return;
+        }
+        uint256 hi = actorWeEthBal > 30 ether ? 30 ether : actorWeEthBal;
+        if (hi < 1 gwei) {
+            callCounts["redeemWeEth_skipped"]++;
+            return;
+        }
+        uint256 weAmt = bound(uint256(amount), 1 gwei, hi);
+        uint256 eEthEquiv = weETH.getEETHByWeETH(weAmt);
+        if (!erm.canRedeem(eEthEquiv, ETH_ADDRESS) || erm.paused()) {
+            callCounts["redeemWeEth_blocked"]++;
+            return;
+        }
+
+        RedeemSnap memory r = _redeemSnap(actor, receiver);
+
+        vm.prank(actor);
+        try erm.redeemWeEth(weAmt, receiver, ETH_ADDRESS) {
+            _postRedeemChecks("redeemWeEth", actor, receiver, r, eEthEquiv);
+            callCounts["redeemWeEth"]++;
+        } catch (bytes memory err) {
+            _recordRevert("redeemWeEth", err);
+        }
+    }
+
+    /// @dev Centralises post-redeem assertions + ledger updates so the
+    ///      individual redeem ops stay under the stack-depth limit.
+    function _postRedeemChecks(
+        bytes32 op,
+        address /*actor*/,
+        address receiver,
+        RedeemSnap memory r,
+        uint256 spentEEth
+    ) internal {
+        Snapshot memory s1 = _snap();
+        _checkRateNonDecreasing(op, r.rate, s1);
+        _checkShareConservation(op, r.totalSharesBefore, r.treasuryEEthBefore, true);
+        _checkLpBalanceDelta(op, r.lpBalanceBefore, r.lpValueInBefore, r.receiverEthBefore, receiver);
+
+        uint256 ethDelta = receiver.balance - r.receiverEthBefore;
+        ghost_totalEthPaidOut += ethDelta;
+        ghost_totalEEthSpent += spentEEth;
+        ghost_ledgerLpInBalance -= int256(ethDelta);
+        ghost_ledgerTreasuryEEth += int256(eETH.balanceOf(treasury) - r.treasuryEEthBefore);
+
+        // (The previous version asserted that the actor's eETH balance must
+        // strictly decrease on a redeem. That holds for `redeemEEth` but NOT
+        // for `redeemWeEth` — there the actor spends weETH, which is taken
+        // from them via `safeTransferFrom` and unwrapped inside the ERM, so
+        // the actor's eETH balance is unchanged. The cross-account invariants
+        // we actually care about — share conservation, LP balance delta,
+        // rate non-decrease — are checked above.)
+    }
+
+    // =====================================================================
+    // ADMIN OPS - drives the parameter surface that the bucket math depends on
+    // =====================================================================
+
+    function admin_setCapacity(uint128 capSeed) external {
+        uint256 cap = bound(uint256(capSeed), 1 gwei, 10_000 ether);
+        vm.prank(adminSigner);
+        try erm.setCapacity(cap, ETH_ADDRESS) {
+            callCounts["setCapacity"]++;
+        } catch (bytes memory err) {
+            _recordRevert("setCapacity", err);
+        }
+    }
+
+    function admin_setRefillRate(uint128 rateSeed) external {
+        uint256 rate = bound(uint256(rateSeed), 0, 100 ether);
+        vm.prank(adminSigner);
+        try erm.setRefillRatePerSecond(rate, ETH_ADDRESS) {
+            callCounts["setRefillRate"]++;
+        } catch (bytes memory err) {
+            _recordRevert("setRefillRate", err);
+        }
+    }
+
+    function admin_setExitFeeBps(uint16 bps) external {
+        uint16 maxFee = uint16(erm.maxExitFeeInBps());
+        uint16 capped = uint16(bound(uint256(bps), 0, uint256(maxFee)));
+        vm.prank(adminSigner);
+        try erm.setExitFeeBasisPoints(capped, ETH_ADDRESS) {
+            callCounts["setExitFee"]++;
+        } catch (bytes memory err) {
+            _recordRevert("setExitFee", err);
+        }
+    }
+
+    function admin_setExitFeeSplit(uint16 bps) external {
+        uint16 maxSplit = uint16(erm.maxExitFeeSplitToTreasuryInBps());
+        uint16 capped = uint16(bound(uint256(bps), 0, uint256(maxSplit)));
+        vm.prank(adminSigner);
+        try erm.setExitFeeSplitToTreasuryInBps(capped, ETH_ADDRESS) {
+            callCounts["setExitFeeSplit"]++;
+        } catch (bytes memory err) {
+            _recordRevert("setExitFeeSplit", err);
+        }
+    }
+
+    /// @notice The low watermark gates redemptions. We rarely raise it in
+    ///         normal fuzz runs (TVL is small, anything above ~10 bps
+    ///         starves the entire redemption surface). Allow occasional
+    ///         non-zero values to exercise the gating logic.
+    function admin_setLowWatermarkBps(uint16 bps) external {
+        uint16 capped = uint16(bound(uint256(bps), 0, 50)); // <= 0.5%
+        vm.prank(adminSigner);
+        try erm.setLowWatermarkInBpsOfTvl(capped, ETH_ADDRESS) {
+            callCounts["setLowWatermark"]++;
+        } catch (bytes memory err) {
+            _recordRevert("setLowWatermark", err);
+        }
+    }
+
+    /// @notice Pause/unpause exercises the whenNotPaused gate.
+    function admin_pause_and_attempt_redeem(uint256 actorSeed) external {
+        vm.prank(adminSigner);
+        try erm.pauseContract() {
+            callCounts["pause"]++;
+        } catch (bytes memory err) {
+            _recordRevert("pause", err);
+            return;
+        }
+        // While paused, redemption MUST revert. canRedeem may still be true.
+        address actor = _eoa(actorSeed);
+        if (eETH.balanceOf(actor) >= 1 gwei) {
+            vm.prank(actor);
+            try erm.redeemEEth(1 gwei, actor, ETH_ADDRESS) {
+                ghost_pauseBypassObserved = true;
+            } catch (bytes memory err) {
+                _recordRevert("paused_redeem_blocked", err);
+            }
+        }
+        vm.prank(adminSigner);
+        try erm.unPauseContract() {
+            callCounts["unpause"]++;
+        } catch {}
+    }
+
+    // =====================================================================
+    // SUPPORTING OPS - state evolution that downstream ops need
+    // =====================================================================
+
+    /// @notice Adds liquidity / shares so the redemption surface stays alive.
+    function lp_deposit(uint256 actorSeed, uint128 amount) external {
+        uint256 amt = bound(uint256(amount), 1 gwei, 200 ether);
+        address actor = _eoa(actorSeed);
+        vm.deal(actor, actor.balance + amt);
+
+        vm.prank(actor);
+        try lp.deposit{value: amt}() {
+            ghost_ledgerLpInBalance += int256(amt);
+            callCounts["lp_deposit"]++;
+        } catch (bytes memory err) {
+            _recordRevert("lp_deposit", err);
+        }
+    }
+
+    /// @notice Positive rebases only — exercises the exempt LP path that
+    ///         lifts the rate (so the non-decrease oracle still tracks).
+    function lp_rebase(uint128 deltaSeed) external {
+        uint256 outOfLp = uint256(lp.totalValueOutOfLp());
+        uint256 cap = outOfLp == 0 ? 1 ether : (outOfLp * 50) / 10_000; // ~50 bps
+        if (cap == 0) cap = 1;
+        if (cap > uint256(uint128(type(int128).max))) cap = uint256(uint128(type(int128).max));
+        int128 delta = int128(int256(bound(uint256(deltaSeed), 0, cap)));
+
+        vm.prank(membershipManager);
+        try lp.rebase(delta) {
+            callCounts["rebase"]++;
+        } catch (bytes memory err) {
+            _recordRevert("rebase", err);
+        }
+    }
+
+    /// @notice Advances time so the bucket refills. Without this, after
+    ///         enough redemptions the bucket drains and the rest of the
+    ///         sequence is just no-ops.
+    function advance_time(uint16 secondsSeed) external {
+        uint256 dt = bound(uint256(secondsSeed), 1, 600); // up to 10 min
+        vm.warp(block.timestamp + dt);
+        callCounts["advance_time"]++;
+    }
+
+    // =====================================================================
+    // INTERNALS - oracles, snapshot, recording
+    // =====================================================================
+
+    struct Snapshot {
+        uint256 rateAmountForShare; // lp.amountForShare(1e18)
+        uint256 probeBalance;       // eETH.balanceOf(probeAccount)
+    }
+
+    /// @dev Grouped per-call snapshot for the redeem ops; bundling the locals
+    ///      into a struct keeps the redeem fn under the stack-depth limit.
+    struct RedeemSnap {
+        Snapshot rate;
+        uint256 receiverEthBefore;
+        uint256 actorEEthBefore;
+        uint256 treasuryEEthBefore;
+        uint256 lpBalanceBefore;
+        uint256 lpValueInBefore;
+        uint256 totalSharesBefore;
+    }
+
+    function _snap() internal view returns (Snapshot memory s) {
+        s.rateAmountForShare = lp.amountForShare(SHARE_PROBE);
+        s.probeBalance = eETH.balanceOf(probeAccount);
+    }
+
+    function _redeemSnap(address actor, address receiver) internal view returns (RedeemSnap memory r) {
+        r.rate = _snap();
+        r.receiverEthBefore = receiver.balance;
+        r.actorEEthBefore = eETH.balanceOf(actor);
+        r.treasuryEEthBefore = eETH.balanceOf(treasury);
+        r.lpBalanceBefore = address(lp).balance;
+        r.lpValueInBefore = uint256(lp.totalValueInLp());
+        r.totalSharesBefore = eETH.totalShares();
+    }
+
+    function _checkRateNonDecreasing(bytes32 op, Snapshot memory s0, Snapshot memory s1) internal {
+        if (s1.rateAmountForShare < s0.rateAmountForShare) {
+            if (!ghost_rateDrop_viaAmountForShare) {
+                ghost_firstFailureOp = op;
+                ghost_firstFailure_rate0 = s0.rateAmountForShare;
+                ghost_firstFailure_rate1 = s1.rateAmountForShare;
+            }
+            ghost_rateDrop_viaAmountForShare = true;
+        }
+        if (s1.probeBalance < s0.probeBalance) {
+            ghost_rateDrop_viaProbeBalance = true;
+        }
+    }
+
+    /// @notice Asserts redemption never CREATES eETH shares. The contract
+    ///         enforces a stricter equality (postShares == prevShares -
+    ///         (sharesToBurn + feeShareToStakers)) internally; if that equality
+    ///         were broken, `InvalidTotalShares` would fire — counted
+    ///         separately via the revert-selector counter.
+    ///
+    ///         At very small amounts the floor/ceil rounding in
+    ///         `_calcRedemption` can collapse `sharesToBurn + feeShareToStakers`
+    ///         to zero; the redeem still succeeds (only a treasury-side eETH
+    ///         transfer occurs). Total shares stay equal in that case, which
+    ///         is fine — no shares are CREATED, just none burned.
+    function _checkShareConservation(
+        bytes32 op,
+        uint256 totalSharesBefore,
+        uint256 treasuryEEthBefore,
+        bool /*unused*/
+    ) internal {
+        uint256 totalSharesAfter = eETH.totalShares();
+        if (totalSharesAfter > totalSharesBefore) {
+            ghost_shareConservationViolated = true;
+            if (ghost_firstFailureOp == bytes32(0)) ghost_firstFailureOp = op;
+        }
+        // Treasury holds eETH; the redeem may transfer in (fee>0) or zero
+        // (fee==0 or split==0). It must never DECREASE on a redeem call.
+        uint256 treasuryEEthAfter = eETH.balanceOf(treasury);
+        if (treasuryEEthAfter < treasuryEEthBefore) {
+            ghost_shareConservationViolated = true;
+            if (ghost_firstFailureOp == bytes32(0)) ghost_firstFailureOp = op;
+        }
+    }
+
+    /// @notice Asserts that LP's ETH balance dropped by exactly the ETH paid
+    ///         to the receiver (the modifier inside _processETHRedemption
+    ///         already enforces this, but tracking it here as a cross-check
+    ///         against the LP ledger).
+    function _checkLpBalanceDelta(
+        bytes32 op,
+        uint256 lpBalanceBefore,
+        uint256 lpValueInBefore,
+        uint256 receiverEthBefore,
+        address receiver
+    ) internal {
+        uint256 ethSentToReceiver = receiver.balance - receiverEthBefore;
+        uint256 lpBalanceAfter = address(lp).balance;
+        uint256 lpValueInAfter = uint256(lp.totalValueInLp());
+
+        // LP's ETH balance dropped by exactly ethSentToReceiver.
+        if (lpBalanceBefore - lpBalanceAfter != ethSentToReceiver) {
+            ghost_shareConservationViolated = true;
+            if (ghost_firstFailureOp == bytes32(0)) ghost_firstFailureOp = op;
+        }
+        // totalValueInLp tracks the same delta.
+        if (lpValueInBefore - lpValueInAfter != ethSentToReceiver) {
+            ghost_shareConservationViolated = true;
+            if (ghost_firstFailureOp == bytes32(0)) ghost_firstFailureOp = op;
+        }
+    }
+
+    function _recordRevert(bytes32 op, bytes memory err) internal {
+        bytes4 sel;
+        if (err.length >= 4) {
+            assembly {
+                sel := mload(add(err, 32))
+            }
+        }
+        revertSelectors[op][sel]++;
+        callCounts[_concat(op, "_revert")]++;
+
+        if (sel == SEL_INVALID_SHARES_BURNT) ghost_invalidSharesBurntCount++;
+        if (sel == SEL_INVALID_TOTAL_SHARES) ghost_invalidTotalSharesCount++;
+        if (sel == SEL_INVALID_LP_BALANCE) ghost_invalidLpBalanceCount++;
+        if (sel == SEL_INVALID_OUT_OF_LP) ghost_invalidOutOfLpCount++;
+        if (sel == SEL_EETH_RATE_DEFLATION) ghost_modifierRevertCount++;
+        if (sel == SEL_PANIC) ghost_panicRevertCount++;
+    }
+
+    // ----- view helpers ----------------------------------------------------
+
+    function _eoa(uint256 seed) internal view returns (address) {
+        return actors[seed % N_EOAS];
+    }
+
+    function _label(string memory s) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(s)))));
+    }
+
+    function _itoa(uint256 n) internal pure returns (string memory) {
+        if (n == 0) return "0";
+        uint256 j = n; uint256 len;
+        while (j != 0) { len++; j /= 10; }
+        bytes memory b = new bytes(len);
+        uint256 k = len;
+        while (n != 0) {
+            k--;
+            b[k] = bytes1(uint8(48 + n % 10));
+            n /= 10;
+        }
+        return string(b);
+    }
+
+    function _concat(bytes32 a, bytes memory suffix) internal pure returns (bytes32 r) {
+        bytes memory out = new bytes(32);
+        uint256 i = 0;
+        for (; i < 32; i++) {
+            bytes1 c = a[i];
+            if (c == 0) break;
+            out[i] = c;
+        }
+        for (uint256 j = 0; j < suffix.length && i < 32; j++) {
+            out[i] = suffix[j];
+            i++;
+        }
+        assembly { r := mload(add(out, 32)) }
+    }
+}

--- a/test/invariant/handlers/WithdrawRemainderHandler.sol
+++ b/test/invariant/handlers/WithdrawRemainderHandler.sol
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/StdUtils.sol";
+import "forge-std/Vm.sol";
+
+import "../../../src/LiquidityPool.sol";
+import "../../../src/EETH.sol";
+import "../../../src/WithdrawRequestNFT.sol";
+import "../../../src/PriorityWithdrawalQueue.sol";
+import "../../../src/interfaces/IPriorityWithdrawalQueue.sol";
+
+/// @notice Stateful-invariant handler for the WRN claim → stranded-ETH →
+///         handleRemainder cycle, plus the parallel PQ cycle.
+///
+///         Focus: properties the existing FrozenRateWithdrawal suite does
+///         NOT assert.
+///
+///         1. **Stranded-ETH ledger conservation.** In WRN, `_claimWithdraw`
+///            decrements `ethAmountLockedForWithdrawal` by `request.amountOfEEth`
+///            but pays only `amountToWithdraw = min(amountOfEEth, frozenRate
+///            * shareOfEEth / 1e18)`. Under a negative rebase between finalize
+///            and claim, the delta `amountOfEEth - amountToWithdraw` is
+///            stranded in the WRN balance until `handleRemainder` sweeps it
+///            to treasury. The handler tracks every per-claim stranded
+///            delta and the cumulative-swept counter; the invariant file
+///            asserts `WRN.balance - lock == cumulative_stranded - swept`.
+///
+///         2. **`handleRemainder` share-burn conservation.** Both WRN and
+///            PQ enforce `before - sharesMoved == after` on their own
+///            share balance after the burn (`InvalidEEthShares` /
+///            `InvalidEEthSharesAfterRemainderHandling`). Counted ghost
+///            flags trip if those reverts ever fire under bounded fuzz.
+///
+///         3. **Cross-contract handleRemainder rounding asymmetry tracking.**
+///            WRN floors the treasury split (`mulDiv(amount, bps, 1e4)`);
+///            PQ ceils it (`mulDiv(amount, bps, 1e4, Up)`). Both burn
+///            `sharesForAmount(eEthAmountToBurn)` against the same LP.
+///            The handler records the per-call treasury allocation from
+///            both contracts under the SAME inputs (when possible) so the
+///            invariant file can assert the differential is bounded.
+contract WithdrawRemainderHandler is StdUtils {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    uint256 public constant N_EOAS = 5;
+
+    /// @dev Critical-revert selectors we never expect to surface.
+    bytes4 public constant SEL_INSUFFICIENT_ESCROW           = bytes4(keccak256("InsufficientEscrow()"));
+    bytes4 public constant SEL_INVALID_EETH_SHARES           = bytes4(keccak256("InvalidEEthShares()"));
+    bytes4 public constant SEL_INVALID_EETH_SHARES_PQ        = bytes4(keccak256("InvalidEEthSharesAfterRemainderHandling()"));
+    bytes4 public constant SEL_BURN_EXCEEDS_SHARES           = bytes4(keccak256("BurnExceedsShares()"));
+    bytes4 public constant SEL_PANIC                         = 0x4e487b71;
+
+    LiquidityPool             public immutable lp;
+    EETH                      public immutable eETH;
+    WithdrawRequestNFT        public immutable wrn;
+    PriorityWithdrawalQueue   public immutable pq;
+    address                   public immutable etherFiAdminAddr;
+    address                   public immutable membershipManager;
+    address                   public immutable adminSigner;
+    address                   public immutable housekeepingSigner;
+    address                   public immutable treasury;
+
+    address[N_EOAS] public actors;
+    uint256[] public wrnTokenIds;
+    /// @dev Per-tokenId requested amount, mirrored from on-chain so wrn_finalize
+    ///      can size the ETH lock transfer without re-reading the struct mapping.
+    mapping(uint256 => uint96) public wrnTokenAmount;
+    IPriorityWithdrawalQueue.WithdrawRequest[] public pqRequests;
+
+    // ----- Stranded-ETH ledger -------------------------------------------
+
+    /// @notice Cumulative sum of (request.amountOfEEth - amountToWithdraw)
+    ///         observed across all WRN claims. This is the "owed to
+    ///         treasury via handleRemainder" running total.
+    uint256 public ghost_wrnCumulativeStranded;
+
+    /// @notice Cumulative ETH that WRN.handleRemainder has actually swept
+    ///         out to treasury. Together with ghost_wrnCumulativeStranded,
+    ///         it determines what WRN.balance - lock SHOULD be.
+    uint256 public ghost_wrnSweptToTreasury;
+
+    /// @notice Set if the post-claim WRN balance != lock + (cumStranded - swept).
+    bool public ghost_wrnLedgerDrift;
+
+    // ----- handleRemainder share-conservation ghosts ---------------------
+
+    bool public ghost_wrnInvalidShares;
+    bool public ghost_pqInvalidShares;
+    bool public ghost_burnExceedsShares;
+
+    /// @notice Critical-selector counters. None should fire under bounded fuzz.
+    uint256 public ghost_insufficientEscrowCount;
+    uint256 public ghost_invalidEEthSharesCount;
+    uint256 public ghost_invalidEEthSharesPqCount;
+    uint256 public ghost_burnExceedsSharesCount;
+    uint256 public ghost_panicCount;
+
+    // ----- Cross-contract rounding-equivalence tracking ------------------
+
+    /// @notice Per-call observation. Sum of WRN's floor-rounded treasury
+    ///         allocation across all wrn_handleRemainder calls.
+    uint256 public ghost_wrnTotalTreasuryFloor;
+    /// @notice Sum of PQ's ceil-rounded treasury allocation across all
+    ///         pq_handleRemainder calls.
+    uint256 public ghost_pqTotalTreasuryCeil;
+    /// @notice Total handleRemainder calls per contract, for normalization.
+    uint256 public ghost_wrnRemainderCalls;
+    uint256 public ghost_pqRemainderCalls;
+
+    // ----- Coverage / forensics ------------------------------------------
+
+    mapping(bytes32 => uint256) public callCounts;
+    mapping(bytes32 => mapping(bytes4 => uint256)) public revertSelectors;
+
+    constructor(
+        LiquidityPool _lp,
+        EETH _eETH,
+        WithdrawRequestNFT _wrn,
+        PriorityWithdrawalQueue _pq,
+        address _etherFiAdmin,
+        address _membershipManager,
+        address _adminSigner,
+        address _housekeepingSigner,
+        address _treasury,
+        address[N_EOAS] memory _actors
+    ) {
+        lp = _lp;
+        eETH = _eETH;
+        wrn = _wrn;
+        pq = _pq;
+        etherFiAdminAddr = _etherFiAdmin;
+        membershipManager = _membershipManager;
+        adminSigner = _adminSigner;
+        housekeepingSigner = _housekeepingSigner;
+        treasury = _treasury;
+
+        for (uint256 i = 0; i < N_EOAS; i++) {
+            actors[i] = _actors[i];
+        }
+    }
+
+    // =====================================================================
+    // WRN lifecycle
+    // =====================================================================
+
+    /// @notice Request a withdrawal from the LP, which routes through to
+    ///         WRN. Records the new tokenId so downstream ops can target it.
+    function wrn_request(uint256 actorSeed, uint128 amount) external {
+        address actor = _eoa(actorSeed);
+        uint256 actorEEth = eETH.balanceOf(actor);
+        if (actorEEth < 0.01 ether) { callCounts["wrn_req_skipped"]++; return; }
+        uint256 hi = actorEEth > 30 ether ? 30 ether : actorEEth;
+        uint256 amt = bound(uint256(amount), 0.01 ether, hi);
+
+        vm.prank(actor);
+        try lp.requestWithdraw(actor, amt) returns (uint256 tokenId) {
+            wrnTokenIds.push(tokenId);
+            wrnTokenAmount[tokenId] = uint96(amt);
+            callCounts["wrn_req"]++;
+        } catch (bytes memory err) {
+            _recordRevert("wrn_req", err);
+        }
+    }
+
+    /// @notice Advance lastFinalizedRequestId AND transfer the corresponding
+    ///         ETH from LP to WRN so claims can actually pay out. Mirrors
+    ///         what EtherFiAdmin.executeTasks does in production: finalize +
+    ///         addEthAmountLockedForWithdrawal in the same flow.
+    function wrn_finalize() external {
+        uint32 nextId = wrn.nextRequestId();
+        uint32 lastFin = wrn.lastFinalizedRequestId();
+        if (nextId == lastFin + 1) { callCounts["wrn_finalize_skipped"]++; return; }
+
+        uint32 target = nextId - 1;
+        // Sum the amountOfEEth for newly-finalized ids.
+        uint256 lockAmount;
+        for (uint32 id = lastFin + 1; id <= target; id++) {
+            lockAmount += uint256(wrnTokenAmount[id]);
+        }
+        if (lockAmount > 0) {
+            if (uint256(lp.totalValueInLp()) < lockAmount) {
+                callCounts["wrn_finalize_no_liquidity"]++;
+                return;
+            }
+            if (lockAmount > type(uint128).max) {
+                callCounts["wrn_finalize_overflow"]++;
+                return;
+            }
+            vm.prank(etherFiAdminAddr);
+            try lp.addEthAmountLockedForWithdrawal(uint128(lockAmount)) {} catch {
+                callCounts["wrn_lock_revert"]++;
+                return;
+            }
+        }
+
+        vm.prank(etherFiAdminAddr);
+        try wrn.finalizeRequests(uint256(target)) {
+            callCounts["wrn_finalize"]++;
+        } catch (bytes memory err) {
+            _recordRevert("wrn_finalize", err);
+        }
+    }
+
+    /// @notice Claim an outstanding WRN tokenId. Updates the stranded-ETH
+    ///         ledger if amountToWithdraw < request.amountOfEEth (the
+    ///         negative-rebase case).
+    function wrn_claim(uint256 tokenIdx) external {
+        if (wrnTokenIds.length == 0) { callCounts["wrn_claim_skipped"]++; return; }
+        uint256 idx = bound(tokenIdx, 0, wrnTokenIds.length - 1);
+        uint256 tokenId = wrnTokenIds[idx];
+
+        // Must be finalized and owned and valid.
+        if (tokenId > wrn.lastFinalizedRequestId()) { callCounts["wrn_claim_skipped"]++; return; }
+        address ownerAddr;
+        try wrn.ownerOf(tokenId) returns (address o) { ownerAddr = o; } catch {
+            callCounts["wrn_claim_skipped"]++; return;
+        }
+        if (ownerAddr == address(0)) { callCounts["wrn_claim_skipped"]++; return; }
+
+        // Snapshot before claim to compute the per-claim stranded delta.
+        IWithdrawRequestNFT.WithdrawRequest memory req = wrn.getRequest(tokenId);
+        if (!req.isValid) { callCounts["wrn_claim_skipped"]++; return; }
+
+        uint256 amountToWithdrawPreview;
+        try wrn.getClaimableAmount(tokenId) returns (uint256 a) { amountToWithdrawPreview = a; }
+        catch { callCounts["wrn_claim_skipped"]++; return; }
+
+        vm.prank(ownerAddr);
+        try wrn.claimWithdraw(tokenId) {
+            // Per-claim stranded delta. The lock dropped by request.amountOfEEth
+            // (full requested), the balance dropped by amountToWithdraw
+            // (what was actually paid). Difference is stranded.
+            uint256 strandedDelta = uint256(req.amountOfEEth) - amountToWithdrawPreview;
+            ghost_wrnCumulativeStranded += strandedDelta;
+
+            uint128 lockAfter = wrn.ethAmountLockedForWithdrawal();
+            uint256 balAfter = address(wrn).balance;
+            _assertWrnLedgerConsistency("wrn_claim", uint256(lockAfter), balAfter);
+
+            callCounts["wrn_claim"]++;
+        } catch (bytes memory err) {
+            _recordRevert("wrn_claim", err);
+        }
+    }
+
+    /// @notice WRN.handleRemainder sweeps stranded ETH + burns/transfers
+    ///         the eETH remainder. Records the floor-rounded treasury
+    ///         allocation for cross-contract comparison.
+    function wrn_handleRemainder() external {
+        uint256 remainderShares = wrn.totalRemainderEEthShares();
+        if (remainderShares == 0) { callCounts["wrn_remainder_skipped"]++; return; }
+        uint256 remainderAmount = wrn.getEEthRemainderAmount();
+        if (remainderAmount == 0) { callCounts["wrn_remainder_skipped"]++; return; }
+
+        uint256 balBefore = address(wrn).balance;
+        uint128 lockBefore = wrn.ethAmountLockedForWithdrawal();
+        uint256 expectedStrandedSweep = balBefore > uint256(lockBefore) ? balBefore - uint256(lockBefore) : 0;
+
+        // Preview the treasury allocation using WRN's exact formula.
+        uint16 splitBps = wrn.shareRemainderSplitToTreasuryInBps();
+        uint256 previewTreasury = (remainderAmount * uint256(splitBps)) / 1e4; // floor (Math.mulDiv default)
+
+        vm.prank(housekeepingSigner);
+        try wrn.handleRemainder(remainderAmount) {
+            ghost_wrnTotalTreasuryFloor += previewTreasury;
+            ghost_wrnRemainderCalls++;
+
+            // Stranded ETH should have been swept entirely.
+            uint256 balAfter = address(wrn).balance;
+            uint128 lockAfter = wrn.ethAmountLockedForWithdrawal();
+            if (balAfter > uint256(lockAfter)) {
+                // Sweep should have brought balance back down to the lock.
+                ghost_wrnLedgerDrift = true;
+            }
+            ghost_wrnSweptToTreasury += expectedStrandedSweep;
+
+            _assertWrnLedgerConsistency("wrn_remainder", lockAfter, balAfter);
+
+            callCounts["wrn_remainder"]++;
+        } catch (bytes memory err) {
+            _recordRevert("wrn_remainder", err);
+        }
+    }
+
+    // =====================================================================
+    // PQ lifecycle
+    // =====================================================================
+
+    function pq_request(uint256 actorSeed, uint128 amount) external {
+        address actor = _eoa(actorSeed);
+        uint256 actorEEth = eETH.balanceOf(actor);
+        if (actorEEth < 0.01 ether) { callCounts["pq_req_skipped"]++; return; }
+        uint256 hi = actorEEth > 30 ether ? 30 ether : actorEEth;
+        // PQ has MAX_AMOUNT = 1000 ether.
+        if (hi > 1000 ether) hi = 1000 ether;
+        uint256 amt = bound(uint256(amount), 0.01 ether, hi);
+        // amountWithFee must be <= amount; allow up to 99% to leave room for fee.
+        uint96 amtWithFee = uint96((amt * 99) / 100);
+        if (amtWithFee == 0) { callCounts["pq_req_skipped"]++; return; }
+
+        vm.prank(actor);
+        try pq.requestWithdraw(uint96(amt), amtWithFee) returns (bytes32 reqId) {
+            // Reconstruct the request struct for later ops.
+            IPriorityWithdrawalQueue.WithdrawRequest memory r = IPriorityWithdrawalQueue.WithdrawRequest({
+                user: actor,
+                amountOfEEth: uint96(amt),
+                shareOfEEth: uint96(lp.sharesForAmount(amt)),
+                amountWithFee: amtWithFee,
+                nonce: pq.nonce() - 1,
+                creationTime: uint32(block.timestamp)
+            });
+            // Drift guard: if our reconstruction doesn't match the contract's
+            // own keccak, skip storing (means inputs collided with the actor's
+            // shares post-deposit ordering).
+            if (keccak256(abi.encode(r)) == reqId) {
+                pqRequests.push(r);
+            }
+            callCounts["pq_req"]++;
+        } catch (bytes memory err) {
+            _recordRevert("pq_req", err);
+        }
+    }
+
+    function pq_fulfill(uint256 reqIdx) external {
+        if (pqRequests.length == 0) { callCounts["pq_fulfill_skipped"]++; return; }
+        uint256 idx = bound(reqIdx, 0, pqRequests.length - 1);
+        IPriorityWithdrawalQueue.WithdrawRequest memory r = pqRequests[idx];
+        bytes32 id = keccak256(abi.encode(r));
+        if (!pq.requestExists(id) || pq.isFinalized(id)) {
+            callCounts["pq_fulfill_skipped"]++; return;
+        }
+        // Advance time past minDelay.
+        if (block.timestamp < uint256(r.creationTime) + uint256(pq.minDelay())) {
+            vm.warp(uint256(r.creationTime) + uint256(pq.minDelay()) + 1);
+        }
+        IPriorityWithdrawalQueue.WithdrawRequest[] memory reqs = new IPriorityWithdrawalQueue.WithdrawRequest[](1);
+        reqs[0] = r;
+        vm.prank(adminSigner);
+        try pq.fulfillRequests(reqs) {
+            callCounts["pq_fulfill"]++;
+        } catch (bytes memory err) {
+            _recordRevert("pq_fulfill", err);
+        }
+    }
+
+    function pq_claim(uint256 reqIdx) external {
+        if (pqRequests.length == 0) { callCounts["pq_claim_skipped"]++; return; }
+        uint256 idx = bound(reqIdx, 0, pqRequests.length - 1);
+        IPriorityWithdrawalQueue.WithdrawRequest memory r = pqRequests[idx];
+        bytes32 id = keccak256(abi.encode(r));
+        if (!pq.isFinalized(id)) { callCounts["pq_claim_skipped"]++; return; }
+        if (block.timestamp < uint256(r.creationTime) + uint256(pq.minDelay())) {
+            vm.warp(uint256(r.creationTime) + uint256(pq.minDelay()) + 1);
+        }
+        // Pre-flight guards against panics from edge-case state after
+        // negative rebases. _claimWithdraw uses both `amountForShare(shareOfEEth)`
+        // (via the tolerance check) and `amountPerShareCeil()` (as the rate
+        // for `lp.withdraw`). Skip cleanly if either preview would force the
+        // claim into a non-graceful path.
+        if (eETH.totalShares() == 0) { callCounts["pq_claim_skipped"]++; return; }
+        uint256 ratePreview = lp.amountPerShareCeil();
+        if (ratePreview == 0) { callCounts["pq_claim_skipped"]++; return; }
+        uint256 forSharesPreview = lp.amountForShare(uint256(r.shareOfEEth));
+        // Tolerance check in PQ._claimWithdraw: `amountForShares + 10 < amountWithFee` reverts.
+        if (forSharesPreview + 10 < uint256(r.amountWithFee)) {
+            callCounts["pq_claim_skipped"]++;
+            return;
+        }
+        // Escrow check: PQ.balance must cover amountToWithdraw at claim time.
+        if (address(pq).balance < uint256(r.amountWithFee)) {
+            callCounts["pq_claim_skipped"]++;
+            return;
+        }
+
+        vm.prank(r.user);
+        try pq.claimWithdraw(r) {
+            callCounts["pq_claim"]++;
+        } catch (bytes memory err) {
+            _recordRevert("pq_claim", err);
+        }
+    }
+
+    /// @notice PQ.handleRemainder. Records the ceil-rounded treasury
+    ///         allocation for cross-contract comparison vs WRN.
+    function pq_handleRemainder() external {
+        uint96 rs = pq.totalRemainderShares();
+        if (rs == 0) { callCounts["pq_remainder_skipped"]++; return; }
+        uint256 amt = lp.amountForShare(rs);
+        if (amt == 0) { callCounts["pq_remainder_skipped"]++; return; }
+
+        // Preview ceil-rounded treasury allocation.
+        uint16 splitBps = pq.shareRemainderSplitToTreasuryInBps();
+        // ceil(amount * bps / 1e4) = (amount * bps + 1e4 - 1) / 1e4
+        uint256 previewTreasury = (amt * uint256(splitBps) + 1e4 - 1) / 1e4;
+
+        vm.prank(housekeepingSigner);
+        try pq.handleRemainder(amt) {
+            ghost_pqTotalTreasuryCeil += previewTreasury;
+            ghost_pqRemainderCalls++;
+            callCounts["pq_remainder"]++;
+        } catch (bytes memory err) {
+            _recordRevert("pq_remainder", err);
+        }
+    }
+
+    // =====================================================================
+    // STRESS - rebases, time
+    // =====================================================================
+
+    /// @notice Negative rebases drive the stranded-ETH delta. Bounded such
+    ///         that `outOfLp - |delta| >= WRN.lock + PQ.lock`. This keeps
+    ///         the LP's `totalValueOutOfLp -= _amount` decrement inside
+    ///         `lp.withdraw` from underflowing when a claim later pays out
+    ///         from the segregated escrow.
+    ///
+    ///         (The protocol-level interaction — that LP.rebase can reduce
+    ///         outOfLp without coordinating with the WRN/PQ lock counters
+    ///         and so can leave a claim's `lp.withdraw` call underflowing
+    ///         when outOfLp < amountToWithdraw — is a real architectural
+    ///         "smell" the reviewer flagged. The bound here keeps it out
+    ///         of THIS suite so the stranded-ETH ledger property can be
+    ///         observed independently; the smell itself wants its own
+    ///         dedicated test, probably as a unit test that constructs
+    ///         the exact failure sequence.)
+    function lp_rebase_negative(uint128 deltaSeed) external {
+        uint256 outOfLp = uint256(lp.totalValueOutOfLp());
+        uint256 locks = uint256(wrn.ethAmountLockedForWithdrawal())
+                      + uint256(pq.ethAmountLockedForPriorityWithdrawal());
+        if (outOfLp <= locks) { callCounts["rebase_skipped"]++; return; }
+        uint256 headroom = outOfLp - locks;
+        uint256 cap = headroom / 2; // leave a margin
+        if (cap == 0) { callCounts["rebase_skipped"]++; return; }
+        if (cap > uint256(uint128(type(int128).max))) cap = uint256(uint128(type(int128).max));
+        int128 delta = -int128(int256(bound(uint256(deltaSeed), 1, cap)));
+
+        vm.prank(membershipManager);
+        try lp.rebase(delta) {
+            callCounts["rebase_negative"]++;
+        } catch (bytes memory err) {
+            _recordRevert("rebase", err);
+        }
+    }
+
+    /// @notice Positive rebases — keeps the rate in the acceptable band.
+    function lp_rebase_positive(uint128 deltaSeed) external {
+        uint256 outOfLp = uint256(lp.totalValueOutOfLp());
+        uint256 cap = outOfLp == 0 ? 1 ether : (outOfLp * 50) / 1e4;
+        if (cap == 0) cap = 1;
+        if (cap > uint256(uint128(type(int128).max))) cap = uint256(uint128(type(int128).max));
+        int128 delta = int128(int256(bound(uint256(deltaSeed), 0, cap)));
+
+        vm.prank(membershipManager);
+        try lp.rebase(delta) {
+            callCounts["rebase_positive"]++;
+        } catch (bytes memory err) {
+            _recordRevert("rebase", err);
+        }
+    }
+
+    function advance_time(uint16 secondsSeed) external {
+        uint256 dt = bound(uint256(secondsSeed), 1, 600);
+        vm.warp(block.timestamp + dt);
+        callCounts["advance_time"]++;
+    }
+
+    // =====================================================================
+    // INTERNALS
+    // =====================================================================
+
+    /// @notice Asserts the WRN ledger identity:
+    ///         WRN.balance == lock + (ghost_wrnCumulativeStranded - ghost_wrnSweptToTreasury)
+    ///         post-op, modulo a small ceiling-vs-floor wei from the share
+    ///         math. We tolerate a 1-wei slack.
+    function _assertWrnLedgerConsistency(bytes32 op, uint256 lock, uint256 bal) internal {
+        uint256 expectedExtra = ghost_wrnCumulativeStranded - ghost_wrnSweptToTreasury;
+        uint256 actualExtra = bal > lock ? bal - lock : 0;
+        // 2-wei slack: ceil rate at finalize + floor at claim can shift the
+        // stranded estimate by 1 wei in each direction.
+        if (actualExtra + 2 < expectedExtra || expectedExtra + 2 < actualExtra) {
+            ghost_wrnLedgerDrift = true;
+        }
+        // Lock must always be backed.
+        if (bal < lock) {
+            ghost_wrnLedgerDrift = true;
+        }
+    }
+
+    function _recordRevert(bytes32 op, bytes memory err) internal {
+        bytes4 sel;
+        if (err.length >= 4) {
+            assembly { sel := mload(add(err, 32)) }
+        }
+        revertSelectors[op][sel]++;
+        callCounts[_concat(op, "_revert")]++;
+
+        if (sel == SEL_INSUFFICIENT_ESCROW)        ghost_insufficientEscrowCount++;
+        if (sel == SEL_INVALID_EETH_SHARES)        { ghost_invalidEEthSharesCount++; ghost_wrnInvalidShares = true; }
+        if (sel == SEL_INVALID_EETH_SHARES_PQ)     { ghost_invalidEEthSharesPqCount++; ghost_pqInvalidShares = true; }
+        if (sel == SEL_BURN_EXCEEDS_SHARES)        { ghost_burnExceedsSharesCount++; ghost_burnExceedsShares = true; }
+        if (sel == SEL_PANIC)                      ghost_panicCount++;
+    }
+
+    function _eoa(uint256 seed) internal view returns (address) {
+        return actors[seed % N_EOAS];
+    }
+
+    function _concat(bytes32 a, bytes memory suffix) internal pure returns (bytes32 r) {
+        bytes memory out = new bytes(32);
+        uint256 i = 0;
+        for (; i < 32; i++) {
+            bytes1 c = a[i];
+            if (c == 0) break;
+            out[i] = c;
+        }
+        for (uint256 j = 0; j < suffix.length && i < 32; j++) {
+            out[i] = suffix[j];
+            i++;
+        }
+        assembly { r := mload(add(out, 32)) }
+    }
+
+    // ----- view helpers ---------------------------------------------------
+
+    function wrnTokenIdsLength() external view returns (uint256) { return wrnTokenIds.length; }
+    function pqRequestsLength() external view returns (uint256) { return pqRequests.length; }
+}

--- a/test/invariant/handlers/WithdrawRemainderHandler.sol
+++ b/test/invariant/handlers/WithdrawRemainderHandler.sol
@@ -10,6 +10,8 @@ import "../../../src/WithdrawRequestNFT.sol";
 import "../../../src/PriorityWithdrawalQueue.sol";
 import "../../../src/interfaces/IPriorityWithdrawalQueue.sol";
 
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 /// @notice Stateful-invariant handler for the WRN claim → stranded-ETH →
 ///         handleRemainder cycle, plus the parallel PQ cycle.
 ///
@@ -88,6 +90,19 @@ contract WithdrawRemainderHandler is StdUtils {
     bool public ghost_wrnInvalidShares;
     bool public ghost_pqInvalidShares;
     bool public ghost_burnExceedsShares;
+
+    /// @notice Set if `wrn.getClaimableAmount(tokenId)` diverged from the
+    ///         handler's independent recomputation of
+    ///         `min(amountOfEEth, mulDiv(shareOfEEth, frozenRate, 1e18))`.
+    ///         A drift here means `_getClaimableAmount` (the contract-side
+    ///         function the claim path also uses to size the payout) is
+    ///         returning a different value from the same inputs the handler
+    ///         can see externally — a serious bug in the rate-freeze logic.
+    bool public ghost_getClaimableAmountDrift;
+    /// @notice Forensic crumb on the first observed drift.
+    uint256 public ghost_drift_independent;
+    uint256 public ghost_drift_contract;
+    uint256 public ghost_drift_tokenId;
 
     /// @notice Critical-selector counters. None should fire under bounded fuzz.
     uint256 public ghost_insufficientEscrowCount;
@@ -222,16 +237,56 @@ contract WithdrawRemainderHandler is StdUtils {
         IWithdrawRequestNFT.WithdrawRequest memory req = wrn.getRequest(tokenId);
         if (!req.isValid) { callCounts["wrn_claim_skipped"]++; return; }
 
-        uint256 amountToWithdrawPreview;
-        try wrn.getClaimableAmount(tokenId) returns (uint256 a) { amountToWithdrawPreview = a; }
+        // (1) INDEPENDENT RECOMPUTATION OF `amountToWithdraw`. The previous
+        //     version of this handler pulled the value via
+        //     `wrn.getClaimableAmount(tokenId)`, which calls the SAME
+        //     `_getClaimableAmount` the contract uses internally to size
+        //     the payout. That made the stranded-ETH ledger an
+        //     oracle-aligned tautology: any bug in `_getClaimableAmount`
+        //     would be mirrored by the ghost.
+        //
+        //     Here we recompute the formula from first principles:
+        //         amountToWithdraw = min(
+        //             amountOfEEth,
+        //             mulDiv(shareOfEEth, frozenRate, 1e18)
+        //         )
+        //     Resolving the legacy-sentinel branch (frozenRate == 0 ⇒
+        //     fall back to `liquidityPool.amountPerShareCeil()`) and
+        //     differentially-asserting against the contract's view.
+        uint224 frozenRate = wrn.frozenRateFor(tokenId);
+        if (frozenRate == 0) {
+            uint256 live = lp.amountPerShareCeil();
+            if (live < wrn.minAcceptableShareRate() || live > wrn.maxAcceptableShareRate()) {
+                callCounts["wrn_claim_skipped"]++;
+                return;
+            }
+            frozenRate = uint224(live);
+        }
+        uint256 independentForShares = Math.mulDiv(
+            uint256(req.shareOfEEth), uint256(frozenRate), 1e18
+        );
+        uint256 independentAmount = independentForShares < uint256(req.amountOfEEth)
+            ? independentForShares
+            : uint256(req.amountOfEEth);
+
+        // Differential check: the contract's `getClaimableAmount` MUST
+        // return exactly what the independent recomputation produces. A
+        // divergence here is a finding.
+        uint256 contractAmount;
+        try wrn.getClaimableAmount(tokenId) returns (uint256 a) { contractAmount = a; }
         catch { callCounts["wrn_claim_skipped"]++; return; }
+        if (contractAmount != independentAmount) {
+            ghost_getClaimableAmountDrift = true;
+            ghost_drift_independent = independentAmount;
+            ghost_drift_contract = contractAmount;
+            ghost_drift_tokenId = tokenId;
+        }
 
         vm.prank(ownerAddr);
         try wrn.claimWithdraw(tokenId) {
-            // Per-claim stranded delta. The lock dropped by request.amountOfEEth
-            // (full requested), the balance dropped by amountToWithdraw
-            // (what was actually paid). Difference is stranded.
-            uint256 strandedDelta = uint256(req.amountOfEEth) - amountToWithdrawPreview;
+            // Per-claim stranded delta - computed from the INDEPENDENT value
+            // so a buggy `_getClaimableAmount` can't hide the drift.
+            uint256 strandedDelta = uint256(req.amountOfEEth) - independentAmount;
             ghost_wrnCumulativeStranded += strandedDelta;
 
             uint128 lockAfter = wrn.ethAmountLockedForWithdrawal();


### PR DESCRIPTION
Stateful + fuzz coverage for the next two paths flagged by the multi-reviewer audit of PR #436 (blockchain / Solidity-architecture / security) as the highest-marginal-value continuations of the PR-#428 invariant program:

1. **EtherFiRedemptionManager + BucketLimiter** — same structural shape as PR #428 (non-pro-rata share burn on a path that must preserve the eETH rate). All three reviewers ranked this in their top 2. Zero new fork-test infra, reuses the #436 handler pattern.
2. **WithdrawRequestNFT stranded-ETH ledger + WRN↔PQ `handleRemainder` rounding-direction equivalence** — directly tests the architecture reviewer's highest-confidence "next bug lives here" signal (the WRN-floor vs PQ-ceil asymmetry on cousin remainder paths).

Stacked on PR #436 (`seongyun/fuzz/security-upgrades`). Independent of any other open PR.

---

## Commit 1 — RedemptionManager (`c21bfd5`)

**13 invariants** over a 5-EOA actor pool + 10-op handler:

- **I-1** Bucket capacity cap: `BucketLimiter.consumable(limit) <= capacity` always.
- **I-2a/b** Rate non-decrease via two independent oracles: `amountForShare(1e18)` AND a fixed-share probe account's `eETH.balanceOf`. Both go through `Math.mulDiv` — different code path from the LP modifier's cross-multiply, so an off-by-one in the modifier would not be mirrored.
- **I-3a–e** Critical safety reverts never fire: `InvalidNumSharesBurnt`, `InvalidTotalShares`, `InvalidLpBalance`, `EETHRateDeflation`, `Panic`. These are local guards inside `_processETHRedemption` + the PR #428 modifier; their appearance under bounded fuzz signals a real regression.
- **I-4** Share conservation: total shares never INCREASE on a redeem (treasury fee path doesn't create shares).
- **I-5** Pause halts redeems: any successful redeem-while-paused flips a ghost.
- **I-6/7** LP solvency + TVL decomposition sanity.

**Scope:** ETH path only. stETH leg requires mainnet fork (Lido state, Liquifier balance, EtherFiRestaker hookup), incompatible with 256×64 invariant runs and already covered by the fork-based unit tests in `EtherFiRedemptionManager.t.sol`.

**Handler ops:** `redeemEEth`, `redeemWeEth`, admin setCapacity / setRefillRate / setExitFeeBps / setExitFeeSplit / setLowWatermarkBps, `pause_and_attempt_redeem`, `lp_deposit`, `lp_rebase`, `advance_time`. 256 × 64 = ~16k calls per invariant, ~5s wall. Cranked stress 512 × 100 also clean.

## Commit 2 — WRN stranded-ETH + WRN↔PQ rounding equivalence (`145a2aa`)

**Architectural finding (from architecture reviewer):**

WRN's `_claimWithdraw` decrements `ethAmountLockedForWithdrawal` by `request.amountOfEEth` but pays only `amountToWithdraw = min(amountOfEEth, frozenRate * shareOfEEth / 1e18)`. Under a negative rebase between finalize and claim the delta is stranded in WRN's balance until `handleRemainder` sweeps it. Existing FrozenRateWithdrawal suite asserts `WRN.balance >= lock` but not the tight stranded-ETH conservation.

WRN and PQ also have two copies of the same `handleRemainder` logic against the same LP, with **different rounding directions** — WRN floors the treasury allocation, PQ ceils. No on-chain or off-chain assertion of the rounding-direction equivalence today.

**New artifacts:**

1. `test/invariant/WithdrawRemainder.invariant.t.sol` + handler — **12 stateful invariants**:
   - Stranded-ETH ledger consistency: `WRN.balance - lock == cumStranded - swept` modulo 2-wei rounding, after every WRN claim and every `handleRemainder` sweep.
   - `handleRemainder` share-burn conservation on both contracts (`InvalidEEthShares` / `InvalidEEthSharesAfterRemainderHandling` never fire).
   - WRN claim never burns more shares than `request.shareOfEEth` (`BurnExceedsShares` never fires).
   - Solvency + TVL sanity (reused from FrozenRate suite for self-containment).
   - Per-contract treasury-allocation totals tracked across handleRemainder calls so the rounding-direction asymmetry shows up in the coverage summary.

2. `test/HandleRemainderRoundingEquivalence.t.sol` — **5 bounded-fuzz tests** pinning the WRN-floor / PQ-ceil math equivalence:
   - `ceil - floor ∈ {0, 1}` for every (amount, bps).
   - Per-contract split sums to amount exactly.
   - Cross-contract treasury delta ≤ 1 wei.
   - Cross-contract burn delta ≤ 1 wei (WRN burns AT MOST 1 wei more eETH because it gives 1 wei LESS to treasury).
   - Share-burn delta bounded by `LP.sharesForAmount(1) + 1`.

**Handler details (commit-message detail in `145a2aa`):**

- `wrn_finalize` mirrors `EtherFiAdmin.executeTasks` in production: calls `LP.addEthAmountLockedForWithdrawal(sum_amountOfEEth)` BEFORE `WRN.finalizeRequests(target)` so claims can actually pay out.
- `lp_rebase_negative` bounded by `outOfLp - (WRN.lock + PQ.lock)` headroom so it cannot drive `outOfLp` below pending claim amounts (which would underflow `lp.withdraw`'s checked subtraction).
- setUp seeds `totalValueOutOfLp = 200 ether` via a positive rebase so the stranded-ETH path is statistically reachable from sequence 1.

**Architectural smell noted, not fixed:** `LP.rebase` can reduce `totalValueOutOfLp` without coordinating with the WRN/PQ lock counters. A subsequent `lp.withdraw` from a finalized request can then underflow on `totalValueOutOfLp -= amount` if the rebase has driven outOfLp below the request's `amountToWithdraw`. The bound on `lp_rebase_negative` in this suite documents the interaction in its header for follow-up as a dedicated unit-test.

## Coverage observed

```
ghost_wrnCumStranded   : 365879119660    # stranded-ETH path IS exercised
ghost_wrnSwept         : 365878721953    # handleRemainder sweep clears it
ghost_wrnTreasFloor    : 5               # WRN floor-rounded treasury sum
ghost_pqTreasCeil      : 0               # (PQ remainder path not yet hit in that seq)
```

## Test plan

- [x] `forge test --match-path 'test/invariant/RedemptionManager.invariant.t.sol'` → **13/13 PASS**
- [x] `forge test --match-path 'test/invariant/WithdrawRemainder.invariant.t.sol'` → **12/12 PASS**
- [x] `forge test --match-path 'test/HandleRemainderRoundingEquivalence.t.sol'` → **5/5 PASS**
- [x] Cranked stress on both invariant suites: 512 × 100 → still green
- [x] `forge test --match-path 'test/invariant/*'` (all 4 suites) → **51/51 PASS**, ~18s
- [x] No production source touched.

## Coordination

Targets `seongyun/fuzz/security-upgrades` (PR #436's branch). Independent of any other open PR. Existing FrozenRateWithdrawal suite is NOT touched — this is additive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to new test files; production contracts are untouched, though tests document medium-severity withdrawal/accounting failure modes for follow-up.
> 
> **Overview**
> Adds **test-only** coverage (no `src/` changes) extending the PR #436 invariant program with three areas: **EtherFiRedemptionManager** (ETH path), **WRN stranded-ETH / remainder** flows, and **regression guards** for known architectural risks.
> 
> **RedemptionManager:** New `RedemptionManager.invariant.t.sol` + `RedemptionManagerHandler` (256×64) assert bucket capacity, dual rate oracles on successful redeems, share/LP conservation, pause behavior, and that critical `_processETHRedemption` / rate-modifier reverts never fire under fuzz.
> 
> **Withdraw remainder:** New `WithdrawRemainder.invariant.t.sol` + `WithdrawRemainderHandler` assert stranded-ETH ledger identity (`balance - lock` vs cumulative stranded minus swept), independent `getClaimableAmount` checks, `handleRemainder` share conservation on WRN/PQ, and escrow/TVL sanity—with production-like finalize + lock sequencing and bounded negative rebases.
> 
> **Unit tests:** `HandleRemainderRoundingEquivalence.t.sol` fuzzes WRN floor vs PQ ceil treasury splits (≤1 wei delta). `LpRebaseWrnClaimUnderflow.t.sol` pins negative `LP.rebase` driving `totalValueOutOfLp` below a finalized claim amount and causing `claimWithdraw` to panic on `LP.withdraw`, plus boundary/success controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b743138da8e60cc19f1fb5d0e3b187b64fa2810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->