### PR TITLE
yash/refactor/deprecated_vars

### DIFF
--- a/src/AuctionManager.sol
+++ b/src/AuctionManager.sol
@@ -8,7 +8,6 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import "./interfaces/IAuctionManager.sol";
 import "./interfaces/INodeOperatorManager.sol";
-import "./interfaces/IProtocolRevenueManager.sol";
 import "./interfaces/IBlacklister.sol";
 import "./utils/PausableUntil.sol";
 import "./utils/RolesLibrary.sol";
@@ -33,24 +32,19 @@ contract AuctionManager is
     uint256 public numberOfBids;
     uint256 public numberOfActiveBids;
 
-    INodeOperatorManager private DEPRECATED_nodeOperatorManager;
-    IProtocolRevenueManager private DEPRECATED_protocolRevenueManager;
+    // deprecated storage slots
+    uint256[2] private __gap_0;
+    uint160 private __gap_1;
 
-    address private DEPRECATED_stakingManagerContractAddress;
     bool public whitelistEnabled;
-
     mapping(uint256 => Bid) public bids;
 
-    address private DEPRECATED_admin;
+    // deprecated storage slots
+    uint256[4] private __gap_2;
 
-    // new state variables for phase 2
-    address private DEPRECATED_membershipManagerContractAddress;
-    uint128 public accumulatedRevenue;
-    uint128 public accumulatedRevenueThreshold;
-
-    mapping(address => bool) private DEPRECATED_admins;
-
-    // Immutables are not part of proxy storage; stored in implementation bytecode only.
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
     IBlacklister public immutable blacklister;
     INodeOperatorManager public immutable nodeOperatorManager;
     address public immutable stakingManagerContractAddress;
@@ -67,6 +61,10 @@ contract AuctionManager is
     event WhitelistDisabled(bool whitelistStatus);
     event WhitelistEnabled(bool whitelistStatus);
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
     error AddressZero();
     error InvalidBidSize();
     error NotWhitelisted();
@@ -81,6 +79,10 @@ contract AuctionManager is
     error InvalidMaxBid();
     error InvalidWhitelistAmount();
     error IncorrectCaller();
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  CONSTRUCTOR  ----------------------------------
+    //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _roleRegistry, address _blacklister, address _nodeOperatorManagerContract, address _stakingManagerContractAddress, address _membershipManagerContractAddress, address _treasury) RolesLibrary(_roleRegistry) {
@@ -214,13 +216,6 @@ contract AuctionManager is
         bid.isActive = true;
         numberOfActiveBids++;
         emit BidReEnteredAuction(_bidId);
-    }
-
-    function transferAccumulatedRevenue() external onlyHousekeepingOperations {
-        uint256 transferAmount = accumulatedRevenue;
-        accumulatedRevenue = 0;
-        (bool sent, ) = treasury.call{value: transferAmount}("");
-        if (!sent) revert EtherTransferFailed();
     }
 
     /// @notice Disables the whitelisting phase of the bidding

--- a/src/EETH.sol
+++ b/src/EETH.sol
@@ -19,7 +19,13 @@ import "./utils/PausableUntil.sol";
 
 contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, IERC20PermitUpgradeable, IeETH, AssetRecovery, RolesLibrary, RateLimitedToken {
     using CountersUpgradeable for CountersUpgradeable.Counter;
-    ILiquidityPool private DEPRECATED_liquidityPool;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
+
+    // deprecated storage slot
+    uint160 private __gap_0;
 
     uint256 public totalShares;
     mapping (address => uint256) public shares;
@@ -27,7 +33,9 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     mapping (address => CountersUpgradeable.Counter) private _nonces;
     bool public paused;
 
-    bytes32 private constant _PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
 
     // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
     // invalidate the cached domain separator if the chain id changes.
@@ -43,6 +51,9 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     IBlacklister public immutable blacklister;
     // `roleRegistry` is inherited from RolesLibrary; `rateLimiter` from RateLimitedToken.
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     /// @dev Protocol-wide circuit breakers on supply changes. Mints and burns
     ///      each draw from their own global bucket via `consumeToken`,
     ///      independent of (and additive with) the per-address buckets. A
@@ -54,9 +65,19 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     bytes32 public constant EETH_MINT_LIMIT_ID = keccak256("EETH_MINT_LIMIT_ID");
     bytes32 public constant EETH_BURN_LIMIT_ID = keccak256("EETH_BURN_LIMIT_ID");
 
+    bytes32 private constant _PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
     event Paused();
     event Unpaused();
     event TransferShares( address indexed from, address indexed to, uint256 sharesValue);
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     error AddressZero();
     error IncorrectCaller();
@@ -67,6 +88,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     error InvalidSignature();
     error TransferAmountExceedsBalance();
     error ContractPaused();
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  CONSTRUCTOR  ----------------------------------
+    //--------------------------------------------------------------------------------------
 
     constructor(address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter)
         RolesLibrary(_roleRegistry)
@@ -88,6 +113,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
 
         _disableInitializers();
     }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
 
     function initialize(address _liquidityPool) external initializer {
         if (_liquidityPool == address(0)) revert AddressZero();

--- a/src/EtherFiAdmin.sol
+++ b/src/EtherFiAdmin.sol
@@ -29,40 +29,40 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         bool exists;
     }
 
-    IEtherFiOracle private DEPRECATED_etherFiOracle;
-    IStakingManager private DEPRECATED_stakingManager;
-    IAuctionManager private DEPRECATED_auctionManager;
-    IEtherFiNodesManager private DEPRECATED_etherFiNodesManager;
-    ILiquidityPool private DEPRECATED_liquidityPool;
-    IMembershipManager private DEPRECATED_membershipManager;
-    IWithdrawRequestNFT private DEPRECATED_withdrawRequestNft;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
 
-    mapping(address => bool) private DEPRECATED_admins;
+    // deprecated storage slots
+    uint256[8] private __gap_0;
 
     uint32 public lastHandledReportRefSlot;
     uint32 public lastHandledReportRefBlock;
-    uint32 public __gap_0;
+
+    // deprecated storage slots
+    uint32 public __gap_1;
 
     int32 public acceptableRebaseAprInBps;
 
     uint16 public postReportWaitTimeInSlots;
     uint32 public lastAdminExecutionBlock;
 
-    mapping(address => bool) private DEPRECATED_pausers;
+    // deprecated storage slots
+    uint256 private __gap_2;
 
     mapping(bytes32 => TaskStatus) public validatorApprovalTaskStatus;
     uint16 validatorTaskBatchSize;
 
-    address private DEPRECATED_roleRegistry;
+    // deprecated storage slots
+    uint160 private __gap_3;
 
     uint256 public lastStaleReportFinalizationBlock;
     uint256 public maxFinalizedWithdrawalAmountPerDay;
     uint256 public maxNumValidatorsToApprovePerDay;
 
-    // Protocol fees must not exceed 1/MAX_PROTOCOL_FEE_INV_RATIO of total rewards (currently 20%).
-    uint256 public constant MAX_PROTOCOL_FEE_INV_RATIO = 5;
-    uint256 public constant STALE_REPORT_FINALIZATION_COOLDOWN = 7200; // 1 day
-    uint256 public constant BASIS_POINTS_DENOMINATOR = 10_000;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
 
     IEtherFiOracle public immutable etherFiOracle;
     IStakingManager public immutable stakingManager;
@@ -80,6 +80,15 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
     uint256 public immutable maxAcceptableNumValidatorsToApprovePerDay;
     uint256 public immutable staleOracleReportBlockWindow;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    // Protocol fees must not exceed 1/MAX_PROTOCOL_FEE_INV_RATIO of total rewards (currently 20%).
+    uint256 public constant MAX_PROTOCOL_FEE_INV_RATIO = 5;
+    uint256 public constant STALE_REPORT_FINALIZATION_COOLDOWN = 7200; // 1 day
+    uint256 public constant BASIS_POINTS_DENOMINATOR = 10_000;
+
     struct ConstructorAddresses {
         address etherFiOracle;
         address stakingManager;
@@ -92,12 +101,20 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         address priorityWithdrawalQueue;
     }
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
     event AdminUpdated(address _address, bool _isAdmin);
     event AdminOperationsExecuted(address indexed _address, bytes32 indexed _reportHash);
 
     event ValidatorApprovalTaskCreated(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
     event ValidatorApprovalTaskCompleted(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
     event ValidatorApprovalTaskInvalidated(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     error InvalidMaxAcceptableFinalizedWithdrawalAmount();
     error InvalidMaxNumberOfRequestsToFinalizePerReport();
@@ -117,6 +134,10 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
     error TaskAlreadyExists();
     error InvalidValidatorSize();
     error InvalidArrayLengths();
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  CONSTRUCTOR  ----------------------------------
+    //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
@@ -152,6 +173,10 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
 
         _disableInitializers();
     }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
 
     function initialize(
         address _etherFiOracle,

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -12,6 +12,10 @@ import "./utils/RolesLibrary.sol";
 
 contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable, UUPSUpgradeable, IEtherFiOracle, RolesLibrary {
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
+
     mapping(address => IEtherFiOracle.CommitteeMemberState) public committeeMemberStates; // committee member wallet address to its State
     mapping(bytes32 => IEtherFiOracle.ConsensusState) public consensusStates; // report's hash -> Consensus State
 
@@ -31,13 +35,20 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     uint32 public numCommitteeMembers; // the total number of committee members
     uint32 public numActiveCommitteeMembers; // the number of active (enabled) committee members
 
-    IEtherFiAdmin private DEPRECATED_etherFiAdmin;
+    // deprecated storage slots
+    uint256 private __gap_0;
 
-    mapping(address => bool) private DEPRECATED_admins;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
 
     // Immutables are not part of proxy storage; stored in implementation bytecode only.
     IEtherFiAdmin public immutable etherFiAdmin;
     uint32 public immutable minQuorumSize;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     event CommitteeMemberAdded(address indexed member);
     event CommitteeMemberRemoved(address indexed member);
@@ -50,6 +61,10 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     event ReportPublished(uint32 consensusVersion, uint32 refSlotFrom, uint32 refSlotTo, uint32 refBlockFrom, uint32 refBlockTo, bytes32 indexed hash);
     event ReportSubmitted(uint32 consensusVersion, uint32 refSlotFrom, uint32 refSlotTo, uint32 refBlockFrom, uint32 refBlockTo, bytes32 indexed hash, address indexed committeeMember);
     event ReportUnpublished(bytes32 indexed hash);
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     error ConsensusAlreadyReached();
     error ReportNotNeeded();
@@ -72,12 +87,20 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     error InvalidConsensusVersion();
     error InvalidQuorum();
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  CONSTRUCTOR  ----------------------------------
+    //--------------------------------------------------------------------------------------
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(uint32 _minQuorumSize, address _etherFiAdmin, address _roleRegistry) RolesLibrary(_roleRegistry) {
         minQuorumSize = _minQuorumSize;
         etherFiAdmin = IEtherFiAdmin(_etherFiAdmin);
         _disableInitializers();
     }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
 
     function initialize(uint32 _quorumSize, uint32 _reportPeriodSlot, uint32 _reportStartSlot, uint32 _slotsPerEpoch, uint32 _secondsPerSlot, uint32 _genesisTime)
         external

--- a/src/EtherFiOracle.sol
+++ b/src/EtherFiOracle.sol
@@ -36,7 +36,8 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     uint32 public numActiveCommitteeMembers; // the number of active (enabled) committee members
 
     // deprecated storage slots
-    uint256 private __gap_0;
+    uint160 private __gap_0;
+    uint256 private __gap_1;
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  --------------------------------------

--- a/src/EtherFiRestaker.sol
+++ b/src/EtherFiRestaker.sol
@@ -30,10 +30,24 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         IStrategy elStrategy;
     }
 
-    IRewardsCoordinator public immutable rewardsCoordinator;
-    address public immutable etherFiRedemptionManager;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    // deprecated storage slots
+    uint256[8] private __gap_0;
 
-    // Immutables are not part of proxy storage; stored in implementation bytecode only.
+    mapping(address => TokenInfo) public tokenInfos;
+
+    EnumerableSet.Bytes32Set private withdrawalRootsSet;
+    
+    // deprecated storage slots
+    uint256 private __gap_1;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    IRewardsCoordinator public immutable rewardsCoordinator;
     ILiquidityPool public immutable liquidityPool;
     ILiquifier public immutable liquifier;
     ILidoWithdrawalQueue public immutable lidoWithdrawalQueue;
@@ -41,6 +55,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     IDelegationManager public immutable eigenLayerDelegationManager;
     IStrategyManager public immutable eigenLayerStrategyManager;
     IEtherFiRateLimiter public immutable rateLimiter;
+    address public immutable etherFiRedemptionManager;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     bytes32 public constant STETH_REQUEST_WITHDRAWAL_LIMIT_ID = keccak256("STETH_REQUEST_WITHDRAWAL_LIMIT_ID");
     bytes32 public constant QUEUE_WITHDRAWALS_LIMIT_ID        = keccak256("QUEUE_WITHDRAWALS_LIMIT_ID");
@@ -50,25 +69,17 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// storage reads and writes, but low enough to prevent griefing.
     uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
 
-    LiquidityPool private DEPRECATED_liquidityPool;
-    Liquifier private DEPRECATED_liquifier;
-    ILidoWithdrawalQueue private DEPRECATED_lidoWithdrawalQueue;
-    ILido private DEPRECATED_lido;
-    IDelegationManager private DEPRECATED_eigenLayerDelegationManager;
-    IStrategyManager private DEPRECATED_eigenLayerStrategyManager;
-
-    mapping(address => bool) private DEPRECATED_pausers;
-    mapping(address => bool) private DEPRECATED_admins;
-
-    mapping(address => TokenInfo) public tokenInfos;
-
-    EnumerableSet.Bytes32Set private withdrawalRootsSet;
-    mapping(bytes32 => IDelegationManager.Withdrawal) private DEPRECATED_withdrawalRootToWithdrawal;
-
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     event QueuedStEthWithdrawals(uint256[] _reqIds);
     event CompletedStEthQueuedWithdrawals(uint256[] _reqIds);
     event CompletedQueuedWithdrawal(bytes32 _withdrawalRoot);
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     error NotEnoughBalance();
     error IncorrectAmount();
@@ -79,6 +90,10 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     error AlreadyClaimed();
     error AmountOverflowsUint64Gwei();
     error WithdrawalRootNotFound();
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  CONSTRUCTOR  ----------------------------------
+    //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
@@ -102,6 +117,10 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         rateLimiter = IEtherFiRateLimiter(_rateLimiter);
         _disableInitializers();
     }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
 
     /// @notice initialize to set variables on deployment
     function initialize(address _liquidityPool, address _liquifier) initializer external {

--- a/src/LiquidityPool.sol
+++ b/src/LiquidityPool.sol
@@ -26,50 +26,27 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
 
-    IStakingManager private DEPRECATED_stakingManager;
-    IEtherFiNodesManager private DEPRECATED_nodesManager;
-    address private DEPRECATED_regulationsManager;
-    address private DEPRECATED_membershipManager;
-    address private DEPRECATED_TNFT;
-    IeETH private DEPRECATED_eETH;
-
-    bool private DEPRECATED_eEthliquidStakingOpened;
+    // deprecated storage slots
+    uint256[6] private __gap_0;
 
     uint128 public totalValueOutOfLp;
     uint128 public totalValueInLp;
-
     address public feeRecipient;
 
-    uint32 private DEPRECATED_numPendingDeposits; // number of validator deposits, which needs 'registerValidator'
+    // deprecated storage slots
+    uint32 private __gap_1;
+    uint256[10] private __gap_2;
 
-    address private DEPRECATED_bNftTreasury;
-    IWithdrawRequestNFT private DEPRECATED_withdrawRequestNFT;
-
-    BnftHolder[] private DEPRECATED_bnftHolders;
-    uint128 private DEPRECATED_maxValidatorsPerOwner;
-    uint128 private DEPRECATED_schedulingPeriodInSeconds;
-
-    HoldersUpdate private DEPRECATED_holdersUpdate;
-
-    mapping(address => bool) private DEPRECATED_admins;
-    mapping(SourceOfFunds => FundStatistics) private DEPRECATED_fundStatistics;
-    mapping(uint256 => bytes32) private DEPRECATED_depositDataRootForApprovalDeposits;
-    address private DEPRECATED_etherFiAdminContract;
-    bool private DEPRECATED_whitelistEnabled;
-    mapping(address => bool) private DEPRECATED_whitelisted;
     mapping(address => ValidatorSpawner) public validatorSpawner;
 
-    bool private DEPRECATED_restakeBnftDeposits;
+    // deprecated storage slots
+    uint8 private __gap_3;
     uint128 private DEPRECATED_ethAmountLockedForWithdrawal;
     bool public paused;
-    address private DEPRECATED_auctionManager;
-    ILiquifier private DEPRECATED_liquifier;
 
-    bool private DEPRECATED_isLpBnftHolder;
+    // deprecated storage slots
+    uint256[4] private __gap_4;
 
-    IEtherFiRedemptionManager private DEPRECATED_etherFiRedemptionManager;
-
-    IRoleRegistry private DEPRECATED_roleRegistry;
     uint256 public validatorSizeWei;
     uint256 public maxWithdrawAmount;
     uint256 public minWithdrawAmount;

--- a/src/Liquifier.sol
+++ b/src/Liquifier.sol
@@ -23,52 +23,32 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     using SafeERC20 for IERC20;
     using Math for uint256;
 
-    uint32 private DEPRECATED_eigenLayerWithdrawalClaimGasCost;
-    uint32 public timeBoundCapRefreshInterval; // seconds
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    // deprecated storage slots
+    uint32 private __gap_0;
 
+    uint32 public timeBoundCapRefreshInterval; // seconds
     bool public quoteStEthWithCurve;
 
-    uint128 private DEPRECATED_accumulatedFee;
+    // deprecated storage slots
+    uint128 private __gap_1;
 
     mapping(address => TokenInfo) public tokenInfos;
-    mapping(bytes32 => bool) private DEPRECATED_isRegisteredQueuedWithdrawals;
-    mapping(address => bool) private DEPRECATED_admins;
-
-    address private DEPRECATED_treasury;
-    ILiquidityPool private DEPRECATED_liquidityPool;
-    IStrategyManager private DEPRECATED_eigenLayerStrategyManager;
-    ILidoWithdrawalQueue private DEPRECATED_lidoWithdrawalQueue;
-
-    ICurvePool private DEPRECATED_cbEth_Eth_Pool;
-    ICurvePool private DEPRECATED_wbEth_Eth_Pool;
-    ICurvePool private DEPRECATED_stEth_Eth_Pool;
-
-    IcbETH private DEPRECATED_cbEth;
-    IwBETH private DEPRECATED_wbEth;
-    ILido private DEPRECATED_lido;
-
-    IDelegationManager private DEPRECATED_eigenLayerDelegationManager;
-
-    IPancackeV3SwapRouter private DEPRECATED_pancakeRouter;
-
-    mapping(string => bool) private DEPRECATED_flags;
+    
+    // deprecated storage slots
+    uint256[15] private __gap_2;
     
     // To support L2 native minting of weETH
     IERC20[] public dummies;
-    address private DEPRECATED_l1SyncPool;
+    
+    // deprecated storage slots
+    uint256[3] private __gap_3;
 
-    mapping(address => bool) private DEPRECATED_pausers;
-
-    address private DEPRECATED_etherfiRestaker;
-
-    uint256 public constant BASIS_POINT_SCALE = 10_000;
-    uint256 public constant SHARE_UNIT = 1e18;
-    uint32 public constant MAX_TIME_BOUND_CAP_IN_ETHER = 500_000_000;
-    uint32 public constant MAX_TOTAL_CAP_IN_ETHER = 2_000_000_000;
-
-    /// @dev Suggested gas stipend for contract receiving ETH to perform a few
-    /// storage reads and writes, but low enough to prevent griefing.
-    uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
 
     ILiquidityPool public immutable liquidityPool;
     ILidoWithdrawalQueue public immutable lidoWithdrawalQueue;
@@ -84,6 +64,23 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     uint256 public immutable stalePriceWindow;
     uint256 public immutable maxPriceDeviationInBps;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    uint256 public constant BASIS_POINT_SCALE = 10_000;
+    uint256 public constant SHARE_UNIT = 1e18;
+    uint32 public constant MAX_TIME_BOUND_CAP_IN_ETHER = 500_000_000;
+    uint32 public constant MAX_TOTAL_CAP_IN_ETHER = 2_000_000_000;
+
+    /// @dev Suggested gas stipend for contract receiving ETH to perform a few
+    /// storage reads and writes, but low enough to prevent griefing.
+    uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
     event Liquified(address _user, uint256 _toEEthAmount, address _fromToken, bool _isRestaked);
     // This event is deprecated. will be removed in the next release.
     // event RegisteredQueuedWithdrawal(bytes32 _withdrawalRoot, IStrategyManager.DeprecatedStruct_QueuedWithdrawal _queuedWithdrawal);
@@ -91,6 +88,10 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     event CompletedQueuedWithdrawal(bytes32 _withdrawalRoot);
     event QueuedStEthWithdrawals(uint256[] _reqIds);
     event CompletedStEthQueuedWithdrawals(uint256[] _reqIds);
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     error NotSupportedToken();
     error EthTransferFailed();
@@ -127,6 +128,10 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         address l1SyncPool;
     }
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  CONSTRUCTOR  ----------------------------------
+    //--------------------------------------------------------------------------------------
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minDiscountInBasisPoints, uint256 _stalePriceWindow, uint256 _maxPriceDeviationInBps) RolesLibrary(_constructorAddresses.roleRegistry) {
         if (_minDiscountInBasisPoints == 0 || _minDiscountInBasisPoints > BASIS_POINT_SCALE) revert InvalidDiscountRate();
@@ -153,6 +158,10 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         maxPriceDeviationInBps = _maxPriceDeviationInBps;
         _disableInitializers();
     }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
 
     /// @notice initialize to set variables on deployment
     function initialize(address _treasury, address _liquidityPool, address _eigenLayerStrategyManager, address _lidoWithdrawalQueue, 

--- a/src/MembershipManager.sol
+++ b/src/MembershipManager.sol
@@ -26,19 +26,14 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
 
-    IeETH private DEPRECATED_eETH;
-    ILiquidityPool private DEPRECATED_liquidityPool;
-    IMembershipNFT private DEPRECATED_membershipNFT;
-    address private DEPRECATED_treasury;
-    address private DEPRECATED_protocolRevenueManager;
+    // deprecated storage slots
+    uint256[5] private __gap_0;
 
     mapping (uint256 => uint256) public allTimeHighDepositAmount;
     mapping (uint256 => TokenDeposit) public tokenDeposits;
     mapping (uint256 => TokenData) public tokenData;
     TierDeposit[] public tierDeposits;
     TierData[] public tierData;
-
-    // [BEGIN] SLOT 261
 
     uint16 public pointsBoostFactor; // + (X / 10000) more points, if staking rewards are sacrificed
     uint16 public pointsGrowthRate; // + (X / 10000) kwei points are earned per ETH per day
@@ -48,8 +43,9 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     uint16 private mintFee; // fee = 0.001 ETH * 'mintFee'
     uint16 private burnFee; // fee = 0.001 ETH * 'burnFee'
     uint16 private upgradeFee; // fee = 0.001 ETH * 'upgradeFee'
-    uint8 private DEPRECATED_treasuryFeeSplitPercent;
-    uint8 private DEPRECATED_protocolRevenueFeeSplitPercent;
+
+    // deprecated storage slots
+    uint16 private __gap_1;
 
     uint32 public topUpCooltimePeriod;
     uint32 public withdrawalLockBlocks;
@@ -57,23 +53,27 @@ contract MembershipManager is Initializable, OwnableUpgradeable, PausableUpgrade
     uint16 private fanBoostThreshold; // = 0.001 ETH * fanBoostThreshold
     uint16 private burnFeeWaiverPeriodInDays;
 
-    // [END] SLOT 261 END
+    // deprecated storage slots
+    uint256[3] private __gap_2;
 
-    uint128 private DEPRECATED_sharesReservedForRewards;
-
-    address private DEPRECATED_admin;
-    mapping(address => bool) private DEPRECATED_admins;
-
-    // Phase 2
     TierVault[] public tierVaults;
 
-    IEtherFiAdmin private DEPRECATED_etherFiAdmin;
+    // deprecated storage slots
+    uint160 private __gap_3;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
 
     IeETH public immutable eETH;
     ILiquidityPool public immutable liquidityPool;
     IMembershipNFT public immutable membershipNFT;
     IEtherFiAdmin public immutable etherFiAdmin;
     IBlacklister public immutable blacklister;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
     uint256 public constant FEE_UNIT = 0.001 ether;

--- a/src/MembershipNFT.sol
+++ b/src/MembershipNFT.sol
@@ -16,11 +16,19 @@ import "forge-std/console.sol";
 
 contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ERC1155Upgradeable, IMembershipNFT, RolesLibrary {
 
-    IMembershipManager private DEPRECATED_membershipManager;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
+
+    // deprecated storage slots
+    uint160 private __gap_0;
+
     uint32 public nextMintTokenId;
     uint32 public maxTokenId;
     bool public mintingPaused;
-    uint24 __gap0;
+
+    // deprecated storage slots
+    uint24 private __gap_1;
 
     mapping(uint256 => NftData) public nftData;
     mapping (address => bool) public eapDepositProcessed;
@@ -29,22 +37,39 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
 
     string private contractMetadataURI; /// @dev opensea contract-level metadata
 
-    address private DEPRECATED_admin;
+    // deprecated storage slots
+    uint256[3] private __gap_2;
 
-    mapping(address => bool) private DEPRECATED_admins;
-
-    ILiquidityPool private DEPRECATED_liquidityPool;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
 
     ILiquidityPool public immutable liquidityPool;
     IMembershipManager public immutable membershipManager;
     IBlacklister public immutable blacklister;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
     uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     event TokenLocked(uint256 indexed _tokenId, uint256 until);
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
     error RequireTokenUnlocked();
     error OnlyMembershipManagerContract();
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  CONSTRUCTOR  ----------------------------------
+    //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister) RolesLibrary(_roleRegistry) {
@@ -53,6 +78,10 @@ contract MembershipNFT is Initializable, OwnableUpgradeable, UUPSUpgradeable, ER
         blacklister = IBlacklister(_blacklister);
         _disableInitializers();
     }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
 
     function initialize(string calldata _metadataURI, address _membershipManagerInstance) external initializer {
         __Ownable_init();

--- a/src/NodeOperatorManager.sol
+++ b/src/NodeOperatorManager.sol
@@ -22,6 +22,10 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
     event RemovedFromWhitelist(address userAddress);
     event UpdatedOperatorApprovals(address operator, LiquidityPool.SourceOfFunds source, bool approved);
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
     error IncorrectCaller();
     error InvalidLengths();
     error AlreadyRegistered();
@@ -32,21 +36,27 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
 
-    address private DEPRECATED_auctionManagerContractAddress;
+    // deprecated storage slots
+    uint160 private __gap_0;
 
     // user address => OperaterData Struct
     mapping(address => KeyData) public addressToOperatorData;
     mapping(address => bool) private whitelistedAddresses;
     mapping(address => bool) public registered;
 
-    mapping(address => bool) private DEPRECATED_admins;
+    // deprecated storage slots
+    uint256 private __gap_1;
+
     mapping(address => mapping(ILiquidityPool.SourceOfFunds => bool)) public operatorApprovedTags;
 
-    // Immutables are not part of proxy storage; stored in implementation bytecode only.
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
+
     address public immutable auctionManagerContractAddress;
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //---------------------------------  CONSTRUCTOR  -------------------------------------
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -54,6 +64,10 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
         auctionManagerContractAddress = _auctionManagerContractAddress;
         _disableInitializers();
     }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
 
     /// @notice initializes contract
     function initialize() external initializer {

--- a/src/WeETH.sol
+++ b/src/WeETH.sol
@@ -60,8 +60,10 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //---------------------------------  STORAGE  ----------------------------------
     //--------------------------------------------------------------------------------------
 
-    IeETH private DEPRECATED_eETH;
-    ILiquidityPool private DEPRECATED_liquidityPool;
+    // deprecated storage slots
+    uint160 private __gap_0;
+    uint160 private __gap_1;
+
     bool public paused;
 
     //--------------------------------------------------------------------------------------

--- a/src/WithdrawRequestNFT.sol
+++ b/src/WithdrawRequestNFT.sol
@@ -42,41 +42,43 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     using Math for uint256;
     using SafeERC20 for IERC20;
     using Checkpoints for Checkpoints.Trace224;
-
-    uint256 private constant BASIS_POINT_SCALE = 1e4;
-    uint256 private constant SHARE_UNIT = 1e18;
-    // this treasury address is set to ethfi buyback wallet address
-    address public immutable treasury;
     
-    ILiquidityPool private DEPRECATED_liquidityPool;
-    IeETH private DEPRECATED_eETH;
-    IMembershipManager private DEPRECATED_membershipManager;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
+
+    // deprecated storage slots
+    uint256[3] private __gap_0;
 
     mapping(uint256 => IWithdrawRequestNFT.WithdrawRequest) private _requests;
-    mapping(address => bool) private DEPRECATED_admins;
+
+    // deprecated storage slots
+    uint256 private __gap_1;
 
     uint32 public nextRequestId;
     uint32 public lastFinalizedRequestId;
     uint16 public shareRemainderSplitToTreasuryInBps;
-    uint16 private _unused_gap;
 
-    // inclusive
-    uint32 private DEPRECATED_currentRequestIdToScanFromForShareRemainder;
-    uint32 private DEPRECATED_lastRequestIdToScanUntilForShareRemainder;
-    uint256 private DEPRECATED_aggregateSumOfEEthShare;
+    // deprecated storage slots
+    uint80 private __gap_2;
+    uint256 private __gap_3;
 
     uint256 public totalRemainderEEthShares;
-
     bool public paused;
-    address private DEPRECATED_roleRegistry;
+
+    // deprecated storage slots
+    uint160 private __gap_4;
 
     uint128 public ethAmountLockedForWithdrawal;
-
     // (requestId upperBound => amountPerShareCeil(1e18) at finalize time).
     // A value of 0 marks a "legacy" range that pre-dates the share-rate-freeze upgrade;
     // `_getClaimableAmount` locally substitutes `LP.amountPerShareCeil()` for those tokenIds,
     // preserving the pre-upgrade live-rate-at-claim semantics. LP itself rejects rate=0.
     Checkpoints.Trace224 private _finalizationRates;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
 
     ILiquidityPool public immutable liquidityPool;
     IeETH public immutable eETH;
@@ -85,8 +87,20 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     uint256 public immutable minAcceptableShareRate;
     uint256 public immutable maxAcceptableShareRate;
+    // this treasury address is set to ethfi buyback wallet address
+    address public immutable treasury;
     address public immutable etherFiAdmin;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    uint256 public constant BASIS_POINT_SCALE = 1e4;
+    uint256 public constant SHARE_UNIT = 1e18;
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     event WithdrawRequestCreated(uint32 indexed requestId, uint256 amountOfEEth, uint256 shareOfEEth, address owner, uint256 fee);
     event WithdrawRequestClaimed(uint32 indexed requestId, uint256 amountOfEEth, uint256 burntShareOfEEth, address owner, uint256 fee);
     event WithdrawRequestInvalidated(uint32 indexed requestId);
@@ -96,6 +110,10 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
 
     event Paused();
     event Unpaused();
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
     error IncorrectCaller();
     error AddressZero();
@@ -127,6 +145,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     error BurnExceedsShares();
     error InvalidEEthShares();
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTRUCTOR  -------------------------------------
+    //--------------------------------------------------------------------------------------
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _treasury, address _eETH, address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister,  address _etherFiAdmin, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) RolesLibrary(_roleRegistry) {
         if (_minAcceptableShareRate == 0) revert InvalidMinAcceptableShareRate();
@@ -142,6 +163,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         _disableInitializers();
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
     function initialize(address _liquidityPoolAddress, address _eEthAddress, address _membershipManagerAddress) initializer external {
         if (_liquidityPoolAddress == address(0) || _eEthAddress == address(0) || _membershipManagerAddress == address(0)) revert AddressZero();
         __ERC721_init("Withdraw Request NFT", "WithdrawRequestNFT");

--- a/src/interfaces/IAuctionManager.sol
+++ b/src/interfaces/IAuctionManager.sol
@@ -32,6 +32,4 @@ interface IAuctionManager {
 
     function pauseContract() external;
     function unPauseContract() external;
-    
-    function transferAccumulatedRevenue() external;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> UUPS proxy storage layout must preserve slot order—incorrect gap sizing would corrupt live state on upgrade; removing `transferAccumulatedRevenue` is a breaking API change for any caller still using it.
> 
> **Overview**
> This PR **standardizes upgradeable contract layout** across many core `src` contracts by replacing scattered `DEPRECATED_*` state variables with explicit **`__gap_*` storage reservations**, and grouping declarations under consistent section headers (state, immutables, constants, events, errors, constructor, state-changing functions).
> 
> **`AuctionManager`** drops the legacy protocol-revenue path: **`transferAccumulatedRevenue`**, related state (`accumulatedRevenue`, thresholds), and **`IProtocolRevenueManager`** usage are removed; **`IAuctionManager`** no longer exposes that function.
> 
> **`EtherFiRestaker`** moves **`etherFiRedemptionManager`** to an **immutable** (constructor-set) and removes deprecated EigenLayer withdrawal-root storage in favor of gaps.
> 
> **`WithdrawRequestNFT`** promotes **`BASIS_POINT_SCALE`** / **`SHARE_UNIT`** from private to **public constants** (same values).
> 
> No intentional changes to live deposit/withdraw/oracle logic beyond storage layout and the removed auction revenue sweep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 890fc0080e935710e8f8a8cd3b47c0ca2c066e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->