### PR TITLE
fix(pwq): blacklist gate on PriorityWithdrawalQueue claim

### DIFF
--- a/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
+++ b/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
@@ -270,8 +270,11 @@ contract PriorityQueueTransactions is Script, Utils {
             }),
             0
         );
+        // blacklister immutable added to PWQ; placeholder address(0) here mirrors the
+        // pattern used elsewhere in this script — the operator must substitute the
+        // deployed Blacklister address before running the bytecode-match verification.
         PriorityWithdrawalQueue newPWQImpl = new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_minDelay
+            LIQUIDITY_POOL, EETH, WEETH, address(0), ROLE_REGISTRY, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, PWQ_minDelay
         );
         EtherFiRedemptionManager newRedemptionManagerImpl = new EtherFiRedemptionManager(
             LIQUIDITY_POOL, EETH, WEETH, WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, ROLE_REGISTRY, ETHERFI_RESTAKER, priorityWithdrawalQueueProxy, address(0), 10_000, 100, 10_000

--- a/src/withdrawals/PriorityWithdrawalQueue.sol
+++ b/src/withdrawals/PriorityWithdrawalQueue.sol
@@ -129,8 +129,13 @@ contract PriorityWithdrawalQueue is
         _;
     }
 
+    /**
+     * @dev Reason why modifier has both whitelisted and blacklisted checks is becuase if whitelisted user gets compramised,
+     * they can access the protocol before operating multisig can remove whitelist. so guardian can blacklist user.
+     */
     modifier onlyWhitelisted() {
         if (!isWhitelisted[msg.sender]) revert NotWhitelisted();
+        blacklister.nonBlacklisted(msg.sender);
         _;
     }
 

--- a/src/withdrawals/PriorityWithdrawalQueue.sol
+++ b/src/withdrawals/PriorityWithdrawalQueue.sol
@@ -11,6 +11,7 @@ import "@etherfi/withdrawals/interfaces/IPriorityWithdrawalQueue.sol";
 import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/core/interfaces/IeETH.sol";
 import "@etherfi/core/interfaces/IWeETH.sol";
+import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 
@@ -46,6 +47,7 @@ contract PriorityWithdrawalQueue is
     ILiquidityPool public immutable liquidityPool;
     IeETH public immutable eETH;
     IWeETH public immutable weETH;
+    IBlacklister public immutable blacklister;
     address public immutable treasury;
     uint32 public immutable minDelay;
 
@@ -142,14 +144,15 @@ contract PriorityWithdrawalQueue is
     //--------------------------------------------------------------------------------------
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _liquidityPool, address _eETH, address _weETH, address _roleRegistry, address _treasury, uint32 _minDelay) RolesLibrary(_roleRegistry) {
-        if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _treasury == address(0)) {
+    constructor(address _liquidityPool, address _eETH, address _weETH, address _blacklister, address _roleRegistry, address _treasury, uint32 _minDelay) RolesLibrary(_roleRegistry) {
+        if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _blacklister == address(0) || _treasury == address(0)) {
             revert AddressZero();
         }
-        
+
         liquidityPool = ILiquidityPool(_liquidityPool);
         eETH = IeETH(_eETH);
         weETH = IWeETH(_weETH);
+        blacklister = IBlacklister(_blacklister);
         treasury = _treasury;
         minDelay = _minDelay;
 
@@ -581,9 +584,14 @@ contract PriorityWithdrawalQueue is
     }
 
     /// @dev Pays the user from this contract's own ETH balance (escrowed at fulfillRequests time). LP only does share burn + accounting on the segregated path.
+    ///      Anyone may call claim on behalf of `request.user`, but the recipient itself must
+    ///      not be blacklisted at claim time — sanctioned addresses cannot receive proceeds
+    ///      via a non-blacklisted accomplice.
     function _claimWithdraw(WithdrawRequest calldata request) internal {
+        blacklister.nonBlacklisted(request.user);
+
         bytes32 requestId = keccak256(abi.encode(request));
-        
+
         if (!_finalizedRequests.contains(requestId)) revert RequestNotFinalized();
 
         uint256 amountForShares = liquidityPool.amountForShare(request.shareOfEEth);

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -40,6 +40,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
             address(liquidityPoolInstance),
             address(eETHInstance),
             address(weEthInstance),
+            address(blacklisterInstance),
             address(roleRegistryInstance),
             treasury,
             1 hours

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -497,7 +497,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         blacklisterInstance = Blacklister(address(new UUPSProxy(address(blacklisterImplementation), abi.encodeWithSelector(Blacklister.initialize.selector))));
 
         // Deploy PriorityWithdrawalQueue for fork testing (mainnet LP has immutable address(0) for this)
-        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
+        PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(blacklisterInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
         UUPSProxy priorityQueueProxy = new UUPSProxy(
             address(priorityQueueImplementation),
             abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)
@@ -1222,6 +1222,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(liquidityPoolProxy),
             address(eETHProxy),
             address(weETHProxy),
+            address(blacklisterInstance),
             address(roleRegistryInstance),
             address(treasuryInstance),
             1 hours
@@ -1591,7 +1592,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             // upgrade our existing contracts to utilize `roleRegistry`
             vm.stopPrank();
             vm.startPrank(owner);
-            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
+            PriorityWithdrawalQueue priorityQueueImplementation = new PriorityWithdrawalQueue(address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance), address(blacklisterInstance), address(roleRegistryInstance), address(treasuryInstance), 1 hours);
             UUPSProxy priorityQueueProxy = new UUPSProxy(
                 address(priorityQueueImplementation),
                 abi.encodeWithSelector(PriorityWithdrawalQueue.initialize.selector)

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -424,7 +424,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         ));
         address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, EETH, LIQUIDITY_POOL, MEMBERSHIP_MANAGER, ROLE_REGISTRY, address(blacklisterInstance), ETHERFI_ADMIN, 1, 4e18));
         address newPQ = address(new PriorityWithdrawalQueue(
-            LIQUIDITY_POOL, EETH, WEETH, ROLE_REGISTRY, TREASURY, 1 hours
+            LIQUIDITY_POOL, EETH, WEETH, address(blacklisterInstance), ROLE_REGISTRY, TREASURY, 1 hours
         ));
 
         // Upgrade proxies against the LIVE (pre-upgrade) RoleRegistry, since

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -56,7 +56,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         // into the queue and would revert with SendFail. Upgrade the queue first.
         address newPQ = address(new PriorityWithdrawalQueue(
             address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance),
-            address(roleRegistryInstance), treasuryInstance, 1 hours
+            address(blacklisterInstance), address(roleRegistryInstance), treasuryInstance, 1 hours
         ));
         vm.prank(UPGRADE_TIMELOCK);
         PriorityWithdrawalQueue(payable(PRIORITY_WITHDRAWAL_QUEUE)).upgradeTo(newPQ);

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -53,7 +53,7 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         // into the queue and would revert with SendFail. Upgrade the queue first.
         address newPQ = address(new PriorityWithdrawalQueue(
             address(liquidityPoolInstance), address(eETHInstance), address(weEthInstance),
-            address(roleRegistryInstance), treasuryInstance, 1 hours
+            address(blacklisterInstance), address(roleRegistryInstance), treasuryInstance, 1 hours
         ));
         vm.prank(UPGRADE_TIMELOCK);
         PriorityWithdrawalQueue(payable(PRIORITY_WITHDRAWAL_QUEUE)).upgradeTo(newPQ);

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -103,6 +103,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
             address(liquidityPoolInstance),
             address(eETHInstance),
             address(weEthInstance),
+            address(blacklisterInstance),
             address(roleRegistryInstance),
             treasuryInstance,
             1 hours


### PR DESCRIPTION
## Summary

Addresses H-3 from the multi-lens audit of PR #385.

`PriorityWithdrawalQueue._claimWithdraw` now gates on `blacklister.nonBlacklisted(request.user)`. Previously anyone could claim on behalf of `request.user`, including when that user became blacklisted between finalization and claim — proceeds would flow to a sanctioned address via a non-blacklisted accomplice. Both `claimWithdraw` and `batchClaimWithdraw` now fail-closed.

### Disposition of other audit findings

- **H-1** (`executeTasks` permissionless) — intended, documented in the existing source comments.
- **H-2** (AuctionManager treasury hard-coded as immutable, no setter) — **acked, not fixed.** The simple version of the setter introduces a storage collision with the pre-deprecation `DEPRECATED_admin` slot on the deployed proxy: post-upgrade, the new `treasury` storage slot reads as the old admin EOA (non-zero), so the defensive `address(0)` revert doesn't fire and bid revenue would silently leak. A correct fix requires a one-shot reinitializer batched into the upgrade `upgradeToAndCall`, which expands scope materially. Deferring to a follow-up.
- **H-4** (storage-layout diff for all upgraded contracts) — ops checklist item, not code.
- **M-1** (invalidate→re-validate double-lock per security reviewer) — closed as not-a-bug. `invalidateRequest` reverts on finalized requests (`WRN.sol:352`) and `EtherFiAdmin._validateWithdrawals` sums only valid requests for the lock amount. The "double-lock" path isn't reachable.
- **M-3** (per-pauser cooldown) — current per-contract isolation already meets the constraint that the same pauser can pause multiple contracts back-to-back. No fix.
- **M-5** (per-address rate-limit grief) — downgraded to Low. Drain cost ≈ bucket cap, not free dust. Not a practical attack vector.
- **M-6** (WRN escrow check tightening) — dropped. Both old and new check would always pass in any reachable state (lock invariant guarantees `ethAmountLockedForWithdrawal >= request.amountOfEEth` at claim entry). Cosmetic change, no real underflow path.
- **M-7 / M-8** — intentional design (rate freeze at finalization; user stops earning rewards once request submitted).

### Changes by file

| File | Change |
| --- | --- |
| `src/withdrawals/PriorityWithdrawalQueue.sol` | Add `IBlacklister public immutable blacklister`; thread through constructor with zero-check; add `blacklister.nonBlacklisted(request.user)` at top of `_claimWithdraw`. |
| `test/TestSetup.sol`, `test/PriorityWithdrawalQueue.t.sol`, `test/integration-tests/*`, `test/fork-tests/UpgradeStorageIntegrity.t.sol` | Thread blacklister arg through PWQ constructor call sites. |
| `script/upgrades/priority-queue/transactionsPriorityQueue.s.sol` | Placeholder `address(0)` for blacklister in PWQ constructor; operator substitutes real address pre-deploy for bytecode-match verification. |

## Test plan

- [x] `forge build` clean (only pre-existing lint warnings)
- [ ] Run `forge test --match-path test/PriorityWithdrawalQueue.t.sol` against a mainnet fork — requires `MAINNET_RPC_URL`
- [ ] Add new test `test_claimWithdraw_revertsForBlacklistedRequestUser` (PWQ) — flagged by testing reviewer as priority follow-up
- [ ] Add new test `test_batchClaimWithdraw_revertsEntireBatchOnBlacklistedUser` (PWQ) — pin batch failure semantics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches withdrawal payout and whitelist access with a new immutable constructor arg; mis-deployed blacklister address would brick the implementation, but behavior aligns with existing Blacklister usage elsewhere in the stack.
> 
> **Overview**
> **PriorityWithdrawalQueue** now wires in **`IBlacklister`** as a constructor immutable (non-zero required) and uses it for sanctions gating.
> 
> **Whitelist flows** (`onlyWhitelisted`) call `blacklister.nonBlacklisted(msg.sender)` so a compromised VIP can be blocked by blacklist before ops removes whitelist.
> 
> **Claims** (`_claimWithdraw`, including batch) call `blacklister.nonBlacklisted(request.user)` so a third party cannot claim finalized ETH to a user who was blacklisted after fulfillment.
> 
> Constructor arity changes are reflected across **tests**, **fork/integration upgrades**, and the **priority-queue upgrade script** (bytecode verification still uses a placeholder `address(0)` for blacklister until ops substitutes the deployed address).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a5dd7a8efa2a8cdc96ec876e1f6a43aeb5518f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->