### PR TITLE
P1 security hardening for #385: pause-cooldown snapshot + distributor per-root cap

### DIFF
--- a/src/governance/utils/PausableUntil.sol
+++ b/src/governance/utils/PausableUntil.sol
@@ -8,6 +8,10 @@ abstract contract PausableUntil {
         uint256 pausedUntil;
         uint256 pauseUntilDuration;
         mapping(address => uint256) lastPauseTimestamp;
+        // Cooldown end, snapshotted at pause time against the duration in force THEN.
+        // Appended field (namespaced fixed-slot storage), so it is layout-safe to add
+        // on an upgrade. See `_pauseUntil` for why the snapshot matters (M1/M2).
+        mapping(address => uint256) cooldownUntil;
     }
 
     bytes32 private constant PAUSABLE_UNTIL_STORAGE_SLOT = 0x2c7e4bc092c2002f0baaf2f47367bc442b098266b43d189dafe4cb25f1e1fea2; // keccak256("pausableUntil.storage")
@@ -37,6 +41,12 @@ abstract contract PausableUntil {
         return _getPausableUntilStorage().lastPauseTimestamp[pauser];
     }
 
+    /// @notice Timestamp until which `pauser` is on cooldown and cannot pause again.
+    /// @dev 0 means never paused (or cooldown elapsed) — the pauser can fire immediately.
+    function cooldownUntil(address pauser) external view returns (uint256) {
+        return _getPausableUntilStorage().cooldownUntil[pauser];
+    }
+
     function _getPausableUntilStorage() internal pure returns (PausableUntilStorage storage $) {
         assembly {
             $.slot := PAUSABLE_UNTIL_STORAGE_SLOT
@@ -56,10 +66,20 @@ abstract contract PausableUntil {
     function _pauseUntil() internal {
         _requireNotPausedUntil();
         PausableUntilStorage storage $ = _getPausableUntilStorage();
-        uint256 pauseUntilDuration = $.pauseUntilDuration;
-        if ($.lastPauseTimestamp[msg.sender] + pauseUntilDuration + PAUSER_UNTIL_COOLDOWN > block.timestamp) revert PauserCooldownStillActive();
-        $.pausedUntil = block.timestamp + pauseUntilDuration;
+        uint256 duration = $.pauseUntilDuration;
+        // Cooldown is snapshotted at pause time. Checking a stored `cooldownUntil` rather
+        // than recomputing `lastPauseTimestamp + pauseUntilDuration + COOLDOWN` on each call
+        // means:
+        //  (M1) a later `setPauseUntilDuration` cannot retroactively shrink or extend an
+        //       already-running pauser's cooldown — it is fixed at the duration in force
+        //       when the pause was fired.
+        //  (M2) a never-paused pauser has `cooldownUntil == 0`, so the first pause always
+        //       succeeds regardless of `block.timestamp` (no spurious revert on chains with
+        //       a low genesis timestamp).
+        if ($.cooldownUntil[msg.sender] > block.timestamp) revert PauserCooldownStillActive();
+        $.pausedUntil = block.timestamp + duration;
         $.lastPauseTimestamp[msg.sender] = block.timestamp;
+        $.cooldownUntil[msg.sender] = block.timestamp + duration + PAUSER_UNTIL_COOLDOWN;
         emit PausedUntil($.pausedUntil);
     }
 

--- a/src/rewards/CumulativeMerkleRewardsDistributor.sol
+++ b/src/rewards/CumulativeMerkleRewardsDistributor.sol
@@ -27,6 +27,20 @@ using SafeERC20 for IERC20;
     uint256 public claimDelay;
     bool public paused;
 
+    // --- Per-root payout ceiling (security review PR #385, M9) ---
+    // `setPendingMerkleRoot` / `finalizeMerkleRoot` are EXECUTOR_OPERATIONS-gated; a
+    // compromised executor could publish a root that pays out the whole contract balance
+    // after only `claimDelay`. This ceiling, set by the 2-day Operation Timelock
+    // (`onlyAdmin`), caps cumulative payout per (token, claimable-root). A value of 0 is
+    // "uncapped" (opt-in per token) so existing flows are unaffected until governance
+    // sets a bound; once set, `claim` reverts when a root would pay out beyond it,
+    // bounding a compromised executor to the timelock-approved ceiling.
+    mapping(address token => uint256 cap) public maxClaimablePerRoot;
+    mapping(address token => mapping(bytes32 root => uint256 claimed)) public claimedPerRoot;
+
+    error RootClaimCapExceeded();
+    event MaxClaimablePerRootUpdated(address indexed token, uint256 cap);
+
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  CONSTANTS  -------------------------------------
@@ -54,6 +68,14 @@ using SafeERC20 for IERC20;
     function setClaimDelay(uint256 _claimDelay) external onlyAdmin {
         claimDelay = _claimDelay;
         emit ClaimDelayUpdated(claimDelay);
+    }
+
+    /// @notice Sets the cumulative payout ceiling per claimable Merkle root for `_token`.
+    /// @dev Operation-Timelock-gated (`onlyAdmin`). 0 = uncapped (default). Bounds the
+    ///      blast radius of a compromised EXECUTOR_OPERATIONS key publishing a malicious root.
+    function setMaxClaimablePerRoot(address _token, uint256 _cap) external onlyAdmin {
+        maxClaimablePerRoot[_token] = _cap;
+        emit MaxClaimablePerRootUpdated(_token, _cap);
     }
 /**
 * @notice Sets a new pending Merkle root for token rewards distribution
@@ -115,6 +137,17 @@ using SafeERC20 for IERC20;
 
 
         uint256 amount = cumulativeAmount - preclaimed;
+
+        // Enforce the per-root payout ceiling (0 = uncapped). Bounds total payout under a
+        // single claimable root so a compromised executor's malicious root cannot drain
+        // beyond the timelock-approved cap.
+        uint256 cap = maxClaimablePerRoot[token];
+        if (cap != 0) {
+            uint256 newRootTotal = claimedPerRoot[token][expectedMerkleRoot] + amount;
+            if (newRootTotal > cap) revert RootClaimCapExceeded();
+            claimedPerRoot[token][expectedMerkleRoot] = newRootTotal;
+        }
+
         // Send the token
         if(token == ETH_ADDRESS){
             (bool success, ) = account.call{value: amount}("");

--- a/test/CumulativeMerkleRewardsDistributor.t.sol
+++ b/test/CumulativeMerkleRewardsDistributor.t.sol
@@ -432,4 +432,30 @@ contract  CumulativeMerkleRewardsDistributorTest is TestSetup {
         vm.expectRevert(RoleRegistry.OnlyOperatingTimelock.selector);
         cumulativeMerkleRewardsDistributorInstance.recoverERC20(address(rETH), bob, 1 ether);
     }
+
+    // PR #385 M9: cumulative payout under a single claimable root is bounded by a
+    // timelock-set ceiling, so a compromised EXECUTOR's malicious root cannot drain
+    // beyond the approved cap.
+    function test_perRootClaimCap_bounds_total_payout() public {
+        vm.prank(admin); // admin holds OPERATION_TIMELOCK in TestSetup
+        cumulativeMerkleRewardsDistributorInstance.setMaxClaimablePerRoot(address(eETHInstance), 150 ether);
+
+        setMerkleRoot(address(eETHInstance));
+
+        // first claim (100) is under the cap
+        cumulativeMerkleRewardsDistributorInstance.claim(address(eETHInstance), accounts[0], 100 ether, merkleRoot, proofs[0]);
+        assertEq(cumulativeMerkleRewardsDistributorInstance.claimedPerRoot(address(eETHInstance), merkleRoot), 100 ether);
+
+        // second claim (200) would push the root's cumulative payout to 300 > 150 → revert
+        vm.expectRevert(CumulativeMerkleRewardsDistributor.RootClaimCapExceeded.selector);
+        cumulativeMerkleRewardsDistributorInstance.claim(address(eETHInstance), accounts[1], 200 ether, merkleRoot, proofs[1]);
+    }
+
+    function test_perRootClaimCap_zero_is_uncapped() public {
+        // default cap of 0 preserves existing behavior — all claims succeed
+        setMerkleRoot(address(eETHInstance));
+        cumulativeMerkleRewardsDistributorInstance.claim(address(eETHInstance), accounts[0], 100 ether, merkleRoot, proofs[0]);
+        cumulativeMerkleRewardsDistributorInstance.claim(address(eETHInstance), accounts[3], 400 ether, merkleRoot, proofs[3]);
+        assertEq(eETHInstance.balanceOf(accounts[3]), 400 ether);
+    }
 }

--- a/test/PausableUntil.t.sol
+++ b/test/PausableUntil.t.sol
@@ -196,6 +196,46 @@ contract PausableUntilTest is Test {
     }
 
     // --------------------------------------------------------
+    //  Cooldown snapshot (PR #385 M1) + zero-baseline (M2)
+    // --------------------------------------------------------
+
+    // M1: a pauser's cooldown is fixed at the duration in force when they paused; a later
+    // setPauseUntilDuration must NOT retroactively shrink it. Pause at MAX, expire the
+    // pause, drop the duration to MIN, and confirm the same pauser is STILL on cooldown
+    // (the cooldown is anchored to the original MAX duration, not the new MIN).
+    function test_cooldown_immuneToDurationChange() public {
+        vm.prank(pauserA);
+        harness.pauseUntil();
+        uint256 start = block.timestamp;
+        assertEq(harness.cooldownUntil(pauserA), start + harness.MAX_PAUSE_DURATION() + harness.PAUSER_UNTIL_COOLDOWN());
+
+        // pause expires; still within the original cooldown window
+        vm.warp(start + harness.MAX_PAUSE_DURATION() + 1);
+
+        // shrink the duration — must not move pauserA's already-snapshotted cooldown
+        harness.setPauseUntilDuration(harness.MIN_PAUSE_DURATION());
+
+        vm.prank(pauserA);
+        vm.expectRevert(PausableUntil.PauserCooldownStillActive.selector);
+        harness.pauseUntil();
+    }
+
+    // M2: a never-paused pauser (cooldownUntil == 0) can always fire the first pause,
+    // even on a chain with a low block.timestamp. Under the old recompute-based check
+    // (0 + duration + COOLDOWN > now) this spuriously reverted for the first ~37 days of
+    // unix time.
+    function test_firstPause_worksAtLowTimestamp() public {
+        PausableUntilHarness fresh = new PausableUntilHarness();
+        fresh.setPauseUntilDuration(fresh.MAX_PAUSE_DURATION());
+        vm.warp(100); // low genesis-like timestamp
+        assertEq(fresh.cooldownUntil(pauserA), 0);
+
+        vm.prank(pauserA);
+        fresh.pauseUntil(); // must not revert
+        assertEq(fresh.pausedUntil(), 100 + fresh.MAX_PAUSE_DURATION());
+    }
+
+    // --------------------------------------------------------
     //  _unpauseUntil
     // --------------------------------------------------------
 


### PR DESCRIPTION
## P1 security hardening for #385

Two follow-on fixes, each small and tested. Base: `pankaj/feat/security-upgrades`.

---

### 1. Fix the pause "cooldown" so it can't be silently shrunk or block the first pause (`PausableUntil`)

**Background:** after someone pauses a contract, they have to wait out a cooldown before they can pause again (anti-spam). The cooldown was being *recalculated live* from the current pause-duration setting, which caused two bugs.

**Bug 1 — the cooldown can be shrunk after the fact.** It's computed from the duration setting *as it is right now*, not as it was when the pause happened.

> **Example:** Alice pauses with the duration set to 30 days, so her cooldown should run ~37 days. Someone later lowers the duration setting to 8 hours. Alice's cooldown is now recomputed as ~7 days and she can pause again far earlier than intended — a different role just shortened her cooldown without touching her pause.

**Bug 2 — the very first pause can be blocked on a fresh chain.** A never-paused account is treated as "last paused at timestamp 0", so the check reads `0 + duration + cooldown > now`. On mainnet `now` is huge so it's fine, but on a new chain with a low starting timestamp the emergency pause is dead for the first ~37 days.

> **Example:** we deploy these contracts to a new L2 whose clock starts near 0. The Guardian tries the emergency pause on day 1 — it reverts with "cooldown active", even though nobody has ever paused.

**The fix:** snapshot each pauser's cooldown end *at the moment they pause* (a new `cooldownUntil` value) instead of recomputing it. A later settings change can't move it (fixes bug 1), and a never-paused account has a cooldown of 0 so the first pause always works (fixes bug 2). Behaviour is identical to before whenever the duration setting isn't changed between pauses — all existing tests pass unchanged.

---

### 2. Cap how much one rewards batch can pay out (`CumulativeMerkleRewardsDistributor`)

**Background:** rewards are published as a Merkle root (a signed list of "who can claim how much"). Publishing a root is done by an operations key. Today, claims are checked against a whitelist and against double-claiming — but there's **no ceiling on the total a single root can pay out.**

> **Example:** an attacker who steals the operations key publishes a root that says they're owed the contract's entire balance, waits out the 2-day delay, and drains it. The whitelist doesn't help if the attacker also controls a whitelisted address.

**The fix:** an admin (the 2-day timelock) can set a per-batch ceiling per token, e.g. *"never pay out more than 500 ETH under any one rewards root."* Claims that would push a root's total past the ceiling revert. It's **opt-in** — a ceiling of 0 means "no limit" (current behaviour), so nothing changes until governance sets one. Once set, a stolen operations key can't drain beyond the approved amount.

- Tests: a 150-ETH cap lets a 100-ETH claim through, then blocks a claim that would push the batch total to 300; and a 0 cap behaves exactly as before.

---

### One item we tried and deliberately dropped: pausing the withdrawal *claim* step

The review suggested gating `claimWithdraw` with the pause too. We implemented it — and it broke three existing tests named `test_claimWithdraw_succeedsWhenPaused`. Those tests are there on purpose: **claiming already-finalized withdrawals is meant to keep working during a pause**, so a halt doesn't trap users' money that the protocol already owes them. We reverted it.

If you *do* want the claim step halted during a confirmed exploit (e.g. corrupted finalization), that's a deliberate trade-off and would mean updating those tests — flagging it rather than deciding for you.

### Three token-transfer items left for a design decision (not in this PR)
These change behaviour the team wrote on purpose and would touch many token tests, so I'm flagging rather than forcing:
- **Dust-spam griefing:** a per-address rate limit is charged on *both* sender and recipient, so anyone can spam tiny transfers *to* a rate-limited address and freeze its incoming transfers. → charge sender-only, or skip (don't revert) when the recipient's limit is empty.
- **Blacklisting a router freezes everyone:** the transfer check also blocks the *caller* (`msg.sender`), so blacklisting a shared router/pool (Curve, Pendle, Aave…) breaks it for all honest users. → use a separate, multisig-only "spender" list.
- **No protection for our own addresses:** nothing stops a rate-limit/blacklist being applied to internal addresses (LP, RedemptionManager, token proxies), which would freeze the whole system. → exempt known internal addresses.

### Test status
- New tests pass: `PausableUntilTest` 32/32, `CumulativeMerkleRewardsDistributorTest` 29/29.
- Pre-existing latest-block fork failures in `WithdrawRequestNFTTest` / `EtherFiOracleTest` reproduce on the untouched base branch and are unrelated.
