### PR TITLE
yash/cleanup-tasks

### DIFF
--- a/src/deposits/Liquifier.sol
+++ b/src/deposits/Liquifier.sol
@@ -326,8 +326,8 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
                 // if stETH price is temporarily larger than underlying ETH value, we set market value as 1:1 
                 _marketValue = _min(_amount, ICurvePoolQuoter1(address(stEth_Eth_Pool)).get_dy(1, 0, _amount));
 
-                // We also validate against chainlink price feed to ensure there's no significant price deviation 
-                // If price feed is stale, we skip the check
+                // We also validate against chainlink price feed to ensure there's no significant price deviation
+                // If price feed is stale, we BLOCK the stETH deposit (revert StalePriceFeed) — we do NOT skip the check
                 // If price feed is negative or deviation is too high, we do not allow the stETH deposit at all, something is wrong with the markets and deposit
                 // via stETH will be blocked until it stablises (either because of underlying lido solvency/liquidity issue or oracle manipulation)
                 (, int256 answer, , uint256 updatedAt,) = stEthPriceFeed.latestRoundData();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only change with no executable code impact on deposits or pricing.
> 
> **Overview**
> **Documentation-only change** in `Liquifier.quoteByMarketValue` for the stETH + Curve quoting path.
> 
> Comments above the Chainlink validation now state that a **stale** stETH price feed **blocks** quoting/deposits via `StalePriceFeed` and explicitly that the feed check is **not** skipped when stale. No Solidity logic, errors, or control flow were modified in this diff—the `revert StalePriceFeed()` path was already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d7a40f6b35ea1f7aa1c7d6b7bda39c34d97971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->