### PR TITLE
yash/refactor/natspec

### DIFF
--- a/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
+++ b/script/upgrades/priority-queue/transactionsPriorityQueue.s.sol
@@ -255,7 +255,7 @@ contract PriorityQueueTransactions is Script, Utils {
         console2.log("");
 
         LiquidityPool newLiquidityPoolImpl = new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(0),
                 nodesManager: address(0),
                 eETH: EETH,

--- a/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
+++ b/script/upgrades/reaudit-fixes/transactions-reaudit-fixes.s.sol
@@ -10,6 +10,7 @@ import {EtherFiRedemptionManager} from "@etherfi/withdrawals/EtherFiRedemptionMa
 import {EtherFiRestaker} from "@etherfi/restaking/EtherFiRestaker.sol";
 import {EtherFiRewardsRouter} from "@etherfi/rewards/EtherFiRewardsRouter.sol";
 import {Liquifier} from "@etherfi/deposits/Liquifier.sol";
+import {ILiquifier} from "@etherfi/deposits/interfaces/ILiquifier.sol";
 import {WithdrawRequestNFT} from "@etherfi/withdrawals/WithdrawRequestNFT.sol";
 import {EtherFiViewer} from "@etherfi/helpers/EtherFiViewer.sol";
 import {StakingManager} from "@etherfi/staking/StakingManager.sol";
@@ -206,7 +207,7 @@ contract ReauditFixesTransactions is Utils {
         EtherFiRedemptionManager newEtherFiRedemptionManagerImplementation = new EtherFiRedemptionManager(address(LIQUIDITY_POOL), address(EETH), address(WEETH), address(TREASURY), address(ROLE_REGISTRY), address(ETHERFI_RESTAKER), address(0x0), address(0x0), 10_000, 100, 10_000);
         EtherFiRestaker newEtherFiRestakerImplementation = new EtherFiRestaker(address(LIQUIDITY_POOL), address(LIQUIFIER), address(EIGENLAYER_REWARDS_COORDINATOR), address(ETHERFI_REDEMPTION_MANAGER), address(ROLE_REGISTRY), address(ETHERFI_RATE_LIMITER), address(EIGENLAYER_STRATEGY_MANAGER), address(EIGENLAYER_DELEGATION_MANAGER));
         EtherFiRewardsRouter newEtherFiRewardsRouterImplementation = new EtherFiRewardsRouter(address(LIQUIDITY_POOL), address(TREASURY), address(ROLE_REGISTRY));
-        Liquifier newLiquifierImplementation = new Liquifier(Liquifier.ConstructorAddresses({
+        Liquifier newLiquifierImplementation = new Liquifier(ILiquifier.ConstructorAddresses({
             liquidityPool: address(LIQUIDITY_POOL),
             lidoWithdrawalQueue: address(LIDO_WITHDRAWAL_QUEUE),
             lido: 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84,

--- a/src/core/EETH.sol
+++ b/src/core/EETH.sol
@@ -23,7 +23,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
-
     // deprecated storage slot
     uint160 private __gap_0;
 
@@ -36,7 +35,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  --------------------------------------
     //--------------------------------------------------------------------------------------
-
     // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
     // invalidate the cached domain separator if the chain id changes.
     bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
@@ -70,7 +68,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     event Paused();
     event Unpaused();
     event TransferShares( address indexed from, address indexed to, uint256 sharesValue);
@@ -78,7 +75,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     error AddressZero();
     error IncorrectCaller();
     error BurnAmountExceedsBalance();
@@ -92,7 +88,13 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //--------------------------------------------------------------------------------------
     //-------------------------------------  CONSTRUCTOR  ----------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Constructor for EETH contract
+     * @param _liquidityPool The address of the liquidity pool contract
+     * @param _roleRegistry The address of the role registry contract
+     * @param _blacklister The address of the blacklister contract
+     * @param _rateLimiter The address of the rate limiter contract
+     */
     constructor(address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter)
         RolesLibrary(_roleRegistry)
         RateLimitedToken(_rateLimiter)
@@ -115,9 +117,12 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //---------------------------------  INITIALIZERS  -------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Initialize the EETH contract
+     * @param _liquidityPool The address of the liquidity pool contract
+     */
     function initialize(address _liquidityPool) external initializer {
         if (_liquidityPool == address(0)) revert AddressZero();
 
@@ -125,6 +130,18 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         __Ownable_init();
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  MINT/BURN FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Mint shares to a user
+     * @param _user The address of the user to mint shares to
+     * @param _share The amount of shares to mint
+     * @dev Rate Limited for mint bucket and per-address bucket
+     * Only callable by the liquidity pool contract
+     * Only callable when the contract is not paused
+     * Only callable when the user is not blacklisted
+     */
     function mintShares(address _user, uint256 _share) external onlyPoolContract whenNotPaused {
         blacklister.nonBlacklisted(_user);
         shares[_user] += _share;
@@ -139,6 +156,15 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit TransferShares(address(0), _user, _share);
     }
 
+    /**
+     * @notice Burn shares from a user
+     * @param _user The address of the user to burn shares from
+     * @param _share The amount of shares to burn
+     * @dev Rate Limited for burn bucket and per-address bucket
+     * Only callable by the liquidity pool contract
+     * Only callable when the contract is not paused
+     * Only callable when the user is not blacklisted
+     */
     function burnShares(address _user, uint256 _share) external whenNotPaused {
         if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_user);
@@ -163,6 +189,13 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     // declares the access split (Guardian = tighten, Operating Multisig = set + delete).
     // For a single user, pass a length-1 array.
 
+    /**
+     * @notice Tighten the address rate limits
+     * @param users The addresses of the users to tighten the rate limits for
+     * @param capacities The capacities of the rate limits
+     * @param refillRates The refill rates of the rate limits
+     * @dev Only callable by the guardian
+     */
     function tightenAddressRateLimits(
         address[] calldata users,
         uint64[] calldata capacities,
@@ -171,6 +204,13 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _tightenAddressRateLimits(users, capacities, refillRates);
     }
 
+    /**
+     * @notice Set the address rate limits
+     * @param users The addresses of the users to set the rate limits for
+     * @param capacities The capacities of the rate limits
+     * @param refillRates The refill rates of the rate limits
+     * @dev Only callable by the operating multisig
+     */
     function setAddressRateLimits(
         address[] calldata users,
         uint64[] calldata capacities,
@@ -179,24 +219,56 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _setAddressRateLimits(users, capacities, refillRates);
     }
 
+    /**
+     * @notice Delete the address rate limits
+     * @param users The addresses of the users to delete the rate limits for
+     * @dev Only callable by the operating multisig
+     */
     function deleteAddressRateLimits(address[] calldata users) external onlyOperatingMultisig {
         _deleteAddressRateLimits(users);
     }
 
+    //--------------------------------------------------------------------------------------
+    //------------------------------  ERC20 FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Transfer eETH to a recipient
+     * @param _recipient The address of the recipient
+     * @param _amount The amount of eETH to transfer
+     * @return bool True if the transfer is successful
+     */
     function transfer(address _recipient, uint256 _amount) external override(IeETH, IERC20Upgradeable) returns (bool) {
         _transfer(msg.sender, _recipient, _amount);
         return true;
     }
 
+    /**
+     * @notice Get the allowance for a spender
+     * @param _owner The address of the owner
+     * @param _spender The address of the spender
+     * @return uint256 The allowance
+     */
     function allowance(address _owner, address _spender) public view returns (uint256) {
         return allowances[_owner][_spender];
     }
 
+    /**
+     * @notice Approve a spender to spend eETH
+     * @param _spender The address of the spender
+     * @param _amount The amount of eETH to approve
+     * @return bool True if the approval is successful
+     */
     function approve(address _spender, uint256 _amount) external override(IeETH, IERC20Upgradeable) returns (bool) {
         _approve(msg.sender, _spender, _amount);
         return true;
     }
 
+    /**
+     * @notice Increase the allowance for a spender
+     * @param _spender The address of the spender
+     * @param _increaseAmount The amount of eETH to increase the allowance by
+     * @return bool True if the allowance is increased successfully
+     */
     function increaseAllowance(address _spender, uint256 _increaseAmount) external returns (bool) {
         address owner = msg.sender;
         uint256 currentAllowance = allowance(owner, _spender);
@@ -204,6 +276,12 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return true;
     }
 
+    /**
+     * @notice Decrease the allowance for a spender
+     * @param _spender The address of the spender
+     * @param _decreaseAmount The amount of eETH to decrease the allowance by
+     * @return bool True if the allowance is decreased successfully
+     */
     function decreaseAllowance(address _spender, uint256 _decreaseAmount) external returns (bool) {
         address owner = msg.sender;
         uint256 currentAllowance = allowance(owner, _spender);
@@ -214,6 +292,13 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return true;
     }
 
+    /**
+     * @notice Transfer eETH from a sender to a recipient
+     * @param _sender The address of the sender
+     * @param _recipient The address of the recipient
+     * @param _amount The amount of eETH to transfer
+     * @return bool True if the transfer is successful
+     */
     function transferFrom(address _sender, address _recipient, uint256 _amount) external override(IeETH, IERC20Upgradeable) returns (bool) {
         uint256 currentAllowance = allowances[_sender][msg.sender];
         if (currentAllowance < _amount) revert TransferAmountExceedsAllowance();
@@ -224,28 +309,16 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return true;
     }
 
-    function pause() external onlyOperatingMultisig {
-        paused = true;
-        emit Paused();
-    }
-
-    function unpause() external onlyOperatingMultisig {
-        paused = false;
-        emit Unpaused();
-    }
-
-    function pauseContractUntil() external onlySuperGuardian {
-        _pauseUntil();
-    }
-
-    function unpauseContractUntil() external onlyOperatingMultisig {
-        _unpauseUntil();
-    }
-
-    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
-        _setPauseUntilDuration(_pauseUntilDuration);
-    }
-
+    /**
+     * @notice Permit a spender to spend eETH
+     * @param owner The address of the owner
+     * @param spender The address of the spender
+     * @param value The amount of eETH to permit
+     * @param deadline The deadline for the permit
+     * @param v The v signature
+     * @param r The r signature
+     * @param s The s signature
+    */
     function permit(
         address owner,
         address spender,
@@ -267,25 +340,105 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _approve(owner, spender, value);
     }
 
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  PAUSING FUNCTIONS  ---------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pauses the contract indefinitely
+     * @dev Only callable by the operating multisig
+     */
+    function pause() external onlyOperatingMultisig {
+        paused = true;
+        emit Paused();
+    }
+
+    /**
+     * @notice Unpauses the contract
+     * @dev Only callable by the operating multisig
+     */
+    function unpause() external onlyOperatingMultisig {
+        paused = false;
+        emit Unpaused();
+    }
+
+    /**
+     * @notice Pauses the contract until the pauseUntilDuration
+     * @dev Only callable by the super guardian
+     */
+    function pauseContractUntil() external onlySuperGuardian {
+        _pauseUntil();
+    }
+
+    /**
+     * @notice Unpauses the contract from pauseUntil
+     * @dev Only callable by the operating multisig
+     */
+    function unpauseContractUntil() external onlyOperatingMultisig {
+        _unpauseUntil();
+    }
+
+    /**
+     * @notice Sets the pause duration for the contract
+     * @param _pauseUntilDuration The new pause duration
+     * @dev Only callable by the admin
+     */
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  RECOVERY FUNCTIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Recover ETH from the contract
+     * @param to The address to recover the ETH to
+     * @param amount The amount of ETH to recover
+     * @dev Only callable by the admin
+     */
     function recoverETH(address payable to, uint256 amount) external onlyAdmin {
         _recoverETH(to, amount);
     }
 
+    /**
+     * @notice Recover ERC20 tokens from the contract
+     * @param token The address of the ERC20 token
+     * @param to The address to recover the tokens to
+     * @param amount The amount of tokens to recover
+     * @dev Only callable by the admin
+     */
     function recoverERC20(address token, address to, uint256 amount) external onlyAdmin{
         _recoverERC20(token, to, amount);
     }
 
+    /**
+     * @notice Recover ERC721 tokens from the contract
+     * @param token The address of the ERC721 token
+     * @param to The address to recover the tokens to
+     * @param tokenId The ID of the token to recover
+     * @dev Only callable by the admin
+     */
     function recoverERC721(address token, address to, uint256 tokenId) external onlyAdmin {
         _recoverERC721(token, to, tokenId);
     }
 
-    // [INTERNAL FUNCTIONS]
-    /// @dev Order mirrors `WeETH._beforeTokenTransfer`: pause + blacklist checks
-    ///      run BEFORE the rate-limit consume so a paused/blacklisted call doesn't
-    ///      bother the external rate limiter, and so blacklist / pause states
-    ///      cannot be silently observed via rate-limit state changes (atomic revert
-    ///      makes this safe either way, but consistent ordering removes the
-    ///      duplicate-check footprint that previously lived in `_transferShares`).
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  INTERNAL FUNCTIONS  ---------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Transfer eETH from a sender to a recipient
+     * @param _sender The address of the sender
+     * @param _recipient The address of the recipient
+     * @param _amount The amount of eETH to transfer
+     * @dev Order mirrors `WeETH._beforeTokenTransfer`: pause + blacklist checks
+     * Run BEFORE the rate-limit consume so a paused/blacklisted call doesn't
+     * bother the external rate limiter, and so blacklist / pause states
+     * cannot be silently observed via rate-limit state changes (atomic revert
+     * makes this safe either way, but consistent ordering removes the
+     * duplicate-check footprint that previously lived in `_transferShares`).
+     * Only callable when the contract is not paused
+     * Only callable when the sender is not blacklisted
+     * Only callable when the recipient is not blacklisted
+     */
     function _transfer(address _sender, address _recipient, uint256 _amount) internal whenNotPaused {
         blacklister.nonBlacklisted(_sender);
         blacklister.nonBlacklisted(_recipient);
@@ -301,6 +454,12 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit Transfer(_sender, _recipient, _amount);
     }
 
+    /**
+     * @notice Approve a spender to spend eETH
+     * @param _owner The address of the owner
+     * @param _spender The address of the spender
+     * @param _amount The amount of eETH to approve
+     */
     function _approve(address _owner, address _spender, uint256 _amount) internal {
         if (_owner == address(0) || _spender == address(0)) revert AddressZero();
 
@@ -308,8 +467,12 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit Approval(_owner, _spender, _amount);
     }
 
-    /// @dev Pure share-accounting; pause / blacklist / address-zero gates live
-    ///      in the caller (`_transfer`). Internal-only; not callable elsewhere.
+    /**
+     * @notice Transfer shares from a sender to a recipient
+     * @param _sender The address of the sender
+     * @param _recipient The address of the recipient
+     * @param _sharesAmount The amount of shares to transfer
+     */
     function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal {
         if (_sharesAmount > shares[_sender]) revert TransferAmountExceedsBalance();
 
@@ -319,47 +482,24 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         emit TransferShares(_sender, _recipient, _sharesAmount);
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
+    /**
+     * @notice Use the nonce for the owner
+     * @param owner The address of the owner
+     * @return current The current nonce
+     */
     function _useNonce(address owner) internal virtual returns (uint256 current) {
         CountersUpgradeable.Counter storage nonce = _nonces[owner];
         current = nonce.current();
         nonce.increment();
     }
 
-    // [GETTERS]
-    function name() public pure returns (string memory) { return "ether.fi ETH"; }
-    function symbol() public pure returns (string memory) { return "eETH"; }
-    function decimals() public pure returns (uint8) { return 18; }
-
-    function totalSupply() public view returns (uint256) {
-        return liquidityPool.getTotalPooledEther();
-    }
-
-    function balanceOf(address _user) public view override(IeETH, IERC20Upgradeable) returns (uint256) {
-        return liquidityPool.getTotalEtherClaimOf(_user);
-    }
-
-    function getImplementation() external view returns (address) {
-        return _getImplementation();
-    }
-
-    function nonces(address owner) public view virtual override returns (uint256) {
-        return _nonces[owner].current();
-    }
-
-    function DOMAIN_SEPARATOR() external view override returns (bytes32) {
-        return _domainSeparatorV4();
-    }
-
-    function _domainSeparatorV4() internal view returns (bytes32) {
-        if (address(this) == _CACHED_THIS && block.chainid == _CACHED_CHAIN_ID) {
-            return _CACHED_DOMAIN_SEPARATOR;
-        } else {
-            return _buildDomainSeparator(_TYPE_HASH, _HASHED_NAME, _HASHED_VERSION);
-        }
-    }
-
+    /**
+     * @notice Build the domain separator
+     * @param typeHash The type hash
+     * @param nameHash The name hash
+     * @param versionHash The version hash
+     * @return bytes32 The domain separator
+     */
     function _buildDomainSeparator(
         bytes32 typeHash,
         bytes32 nameHash,
@@ -368,18 +508,120 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return keccak256(abi.encode(typeHash, nameHash, versionHash, block.chainid, address(this)));
     }
 
+    /**
+     * @notice Hash the typed data
+     * @param structHash The struct hash
+     * @return bytes32 The hashed typed data
+     */
     function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {
         return ECDSAUpgradeable.toTypedDataHash(_domainSeparatorV4(), structHash);
     }
 
-    // [MODIFIERS]
-    // Role modifiers (`onlyAdmin`, `onlyOperatingMultisig`, `onlyGuardian`, `onlySuperGuardian`,
-    // `onlyUpgradeTimelock`, ...) are inherited from RolesLibrary.
+    /**
+     * @notice Get the domain separator
+     * @return bytes32 The domain separator
+     */
+    function _domainSeparatorV4() internal view returns (bytes32) {
+        if (address(this) == _CACHED_THIS && block.chainid == _CACHED_CHAIN_ID) {
+            return _CACHED_DOMAIN_SEPARATOR;
+        } else {
+            return _buildDomainSeparator(_TYPE_HASH, _HASHED_NAME, _HASHED_VERSION);
+        }
+    }
+
+    /**
+     * @notice Authorize the upgrade
+     * @param newImplementation The address of the new implementation
+     * @dev Only callable by the upgrade timelock
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  GETTERS  --------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Get the name of the token
+     * @return string The name of the token
+     */
+    function name() public pure returns (string memory) { 
+        return "ether.fi ETH"; 
+    }
+
+    /**
+     * @notice Get the symbol of the token
+     * @return string The symbol of the token
+     */
+    function symbol() public pure returns (string memory) { 
+        return "eETH"; 
+    }
+
+    /**
+     * @notice Get the decimals of the token
+     * @return uint8 The decimals of the token
+     */
+    function decimals() public pure returns (uint8) { 
+        return 18; 
+    }
+
+    /**
+     * @notice Get the total supply of the token
+     * @return uint256 The total supply of the token
+     */
+    function totalSupply() public view returns (uint256) {
+        return liquidityPool.getTotalPooledEther();
+    }
+
+    /**
+     * @notice Get the balance of a user
+     * @param _user The address of the user
+     * @return uint256 The balance of the user
+     */
+    function balanceOf(address _user) public view override(IeETH, IERC20Upgradeable) returns (uint256) {
+        return liquidityPool.getTotalEtherClaimOf(_user);
+    }
+
+    /**
+     * @notice Get the implementation address
+     * @return address The implementation address
+     */
+    function getImplementation() external view returns (address) {
+        return _getImplementation();
+    }
+
+    /**
+     * @notice Get the nonce for an owner
+     * @param owner The address of the owner
+     * @return uint256 The nonce for the owner
+     */
+    function nonces(address owner) public view virtual override returns (uint256) {
+        return _nonces[owner].current();
+    }
+
+    /**
+     * @notice Get the domain separator
+     * @return bytes32 The domain separator
+     */
+    function DOMAIN_SEPARATOR() external view override returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  MODIFIERS  --------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Modifier to check if the caller is the liquidity pool contract
+     * @dev Only callable by the liquidity pool contract
+     */
     modifier onlyPoolContract() {
         if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
         _;
     }
 
+    /**
+     * @notice Modifier to check if the contract is not paused
+     * @dev Only callable when the contract is not paused and not paused until 
+     * the pauseUntilDuration
+     */
     modifier whenNotPaused() {
         if (paused) revert ContractPaused();
         _requireNotPausedUntil();

--- a/src/core/LiquidityPool.sol
+++ b/src/core/LiquidityPool.sol
@@ -193,13 +193,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         escrowMigrationCompleted = true;
     }
 
-    receive() external payable {
-        if (msg.value > type(uint128).max) revert InvalidAmount();
-        totalValueOutOfLp -= uint128(msg.value);
-        totalValueInLp += uint128(msg.value);
-        _checkInvariants();
-    }
-
     //--------------------------------------------------------------------------------------
     //----------------------------  DEPOSIT FUNCTIONS  -------------------------------------
     //--------------------------------------------------------------------------------------
@@ -581,6 +574,16 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         eETH.burnShares(msg.sender, _amountSharesToBurn);
         _checkMinAmountForShare();
         emit EEthSharesBurnedForNonETHWithdrawal(_amountSharesToBurn, _withdrawalValueInETH);
+    }
+
+    /**
+     * @notice Receive ETH
+     */
+    receive() external payable {
+        if (msg.value > type(uint128).max) revert InvalidAmount();
+        totalValueOutOfLp -= uint128(msg.value);
+        totalValueInLp += uint128(msg.value);
+        _checkInvariants();
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/core/LiquidityPool.sol
+++ b/src/core/LiquidityPool.sol
@@ -127,6 +127,7 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
      * @notice Constructor
      * @param _constructorAddresses The addresses of the contracts to use
      * @param _minAmountForShare The minimum amount for a share
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minAmountForShare) RolesLibrary(_constructorAddresses.roleRegistry) {
         stakingManager = IStakingManager(_constructorAddresses.stakingManager);

--- a/src/core/LiquidityPool.sol
+++ b/src/core/LiquidityPool.sol
@@ -22,10 +22,10 @@ import "@etherfi/governance/utils/PausableUntil.sol";
 
 contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuardNamespaced, PausableUntil, RolesLibrary, ILiquidityPool {
     using SafeERC20 for IERC20;
+
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
-
     // deprecated storage slots
     uint256[6] private __gap_0;
 
@@ -76,7 +76,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     event Paused();
     event Unpaused();
 
@@ -102,7 +101,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     error IncorrectCaller();
     error InvalidAmount();
     error InvalidWithdrawalAmount();
@@ -123,10 +121,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     error NotPaused();
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //----------------------------  CONSTRUCTOR  ------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _constructorAddresses The addresses of the contracts to use
+     * @param _minAmountForShare The minimum amount for a share
+     */
     constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minAmountForShare) RolesLibrary(_constructorAddresses.roleRegistry) {
         stakingManager = IStakingManager(_constructorAddresses.stakingManager);
         nodesManager = IEtherFiNodesManager(_constructorAddresses.nodesManager);
@@ -142,13 +143,19 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _disableInitializers();
     }
 
-    receive() external payable {
-        if (msg.value > type(uint128).max) revert InvalidAmount();
-        totalValueOutOfLp -= uint128(msg.value);
-        totalValueInLp += uint128(msg.value);
-        _checkInvariants();
-    }
-
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the Liquidity Pool
+     * @param _eEthAddress The address of the eETH contract
+     * @param _stakingManagerAddress The address of the staking manager contract
+     * @param _nodesManagerAddress The address of the nodes manager contract
+     * @param _membershipManagerAddress The address of the membership manager contract
+     * @param _tNftAddress The address of the tNFT contract
+     * @param _etherFiAdminContract The address of the etherFi admin contract
+     * @param _withdrawRequestNFT The address of the withdraw request NFT contract
+     */
     function initialize(address _eEthAddress, address _stakingManagerAddress, address _nodesManagerAddress, address _membershipManagerAddress, address _tNftAddress, address _etherFiAdminContract, address _withdrawRequestNFT) external initializer {
         if (_eEthAddress == address(0) || _stakingManagerAddress == address(0) || _nodesManagerAddress == address(0) || _membershipManagerAddress == address(0) || _tNftAddress == address(0)) revert DataNotSet();
         
@@ -157,7 +164,10 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         paused = true;
     }
 
-    /// @notice One-shot post-upgrade migration that sweeps existing locked ETH from LP to WithdrawRequestNFT and PriorityWithdrawalQueue.
+    /**
+    * @notice One-shot post-upgrade migration that sweeps existing locked ETH from LP to WithdrawRequestNFT and PriorityWithdrawalQueue.
+    * @dev Only callable by the upgrade timelock
+    */
     function initializeOnUpgradeV2() external onlyUpgradeTimelock {
         if (escrowMigrationCompleted) revert AlreadyMigrated();
 
@@ -183,19 +193,45 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         escrowMigrationCompleted = true;
     }
 
-    // Used by eETH staking flow
+    receive() external payable {
+        if (msg.value > type(uint128).max) revert InvalidAmount();
+        totalValueOutOfLp -= uint128(msg.value);
+        totalValueInLp += uint128(msg.value);
+        _checkInvariants();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  DEPOSIT FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Deposit ETH into the Liquidity Pool
+     * @return uint256 The amount of eETH minted to the caller
+     * @dev Used by eETH staking flow
+     */
     function deposit() external payable returns (uint256) {
         return deposit(address(0));
     }
 
-    // Used by eETH staking flow
+    /**
+     * @notice Deposit ETH into the Liquidity Pool
+     * @param _referral The address of the referral
+     * @return uint256 The amount of eETH minted to the caller
+     * @dev Used by eETH staking flow
+     */
     function deposit(address _referral) public payable nonReentrant whenNotPaused nonBlacklisted returns (uint256) {
         emit Deposit(msg.sender, msg.value, SourceOfFunds.EETH, _referral);
 
         return _deposit(msg.sender, msg.value, 0);
     }
 
-    // Used by eETH staking flow through Liquifier contract; deVamp or to pay protocol fees
+    /**
+     * @notice Deposit ETH into the Liquidity Pool
+     * @param _recipient The address of the recipient
+     * @param _amount The amount of ETH to deposit
+     * @param _referral The address of the referral
+     * @return uint256 The amount of eETH minted to the caller
+     * @dev Used by eETH staking flow through Liquifier contract; deVamp or to pay protocol fees
+     */
     function depositToRecipient(address _recipient, uint256 _amount, address _referral) public nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(liquifier) && msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_recipient);
@@ -205,7 +241,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return _deposit(_recipient, 0, _amount);
     }
 
-    // Used by ether.fan staking flow
+    /**
+     * @notice Deposit ETH into the Liquidity Pool
+     * @param _user The address of the user
+     * @param _referral The address of the referral
+     * @return uint256 The amount of eETH minted to the caller
+     * @dev Used by ether.fan staking flow
+     */
     function deposit(address _user, address _referral) external payable nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         blacklister.nonBlacklisted(_user);
@@ -215,9 +257,18 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return _deposit(msg.sender, msg.value, 0);
     }
 
-    /// @notice Burns shares and pays ETH. For NFT/queue callers, ETH is paid by the caller from its own segregated balance; LP only does accounting. Other callers receive ETH from LP.
-    /// @notice Live-rate withdraw for membershipManager and etherFiRedemptionManager.
-    ///         Burns shares at the live rate and pays ETH from the LP to `_recipient`.
+    //--------------------------------------------------------------------------------------
+    //----------------------------  WITHDRAW FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Burns shares and pays ETH. For NFT/queue callers, ETH is paid by the caller from its own segregated balance; LP only does accounting. Other callers receive ETH from LP.
+     * @param _recipient The address of the recipient
+     * @param _amount The amount of ETH to withdraw
+     * @return uint256 The amount of eETH burned
+     * @dev Only callable by the membership manager or the etherFi redemption manager
+     * Live rate withdraw for membershipManager and etherFiRedemptionManager.
+     * Burns shares at the live rate and pays ETH from the LP to `_recipient`.
+     */
     function withdraw(address _recipient, uint256 _amount) external nonReentrant whenNotPaused nonDecreasingRate returns (uint256) {
         if (msg.sender != address(membershipManager) && msg.sender != address(etherFiRedemptionManager)) {
             revert IncorrectCaller();
@@ -236,37 +287,40 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return share;
     }
 
-    /// @notice Settles a finalized claim for withdrawRequestNFT or priorityWithdrawalQueue.
-    ///         Caller supplies the snapshotted rate and the request's share allocation;
-    ///         LP derives the share burn defensively from both inputs and current live rate.
-    ///
-    /// @dev    Three guards bound caller-supplied inputs without trusting any single one:
-    ///         (1) `_amount <= _shareOfEEth * _rate / SHARE_UNIT` — caps `_amount` at the
-    ///             rate-implied value of `_shareOfEEth`. Defeats isolated `_amount` inflation
-    ///             when `_rate` is honest. (Does NOT catch proportional `_amount`/`_rate`
-    ///             co-inflation — see residual below.)
-    ///         (2) Burn at `max(amount/_rate, amount/live)` shares — Lido-pattern worse-for-
-    ///             protocol clamp. An inflated `_rate` is silently floored to live; the protocol
-    ///             burns at the honest live rate regardless of what the caller passed.
-    ///         (3) Share burn capped at `_shareOfEEth` — per-call cap on burn. Un-DoSes
-    ///             legitimate down-rebase claims (where `amount/live > shareOfEEth`).
-    ///
-    /// @dev    `_shareOfEEth` MUST be the request-time share snapshot, not a live-derived value.
-    ///         If a future caller refactor breaks this invariant, Guard 3's cap silently loosens.
-    ///         LP cannot independently verify this — the caller (WRN / PWQ) is trusted to pass
-    ///         the snapshot honestly. The downstream `eETH.shares(msg.sender) < share` solvency
-    ///         check is the only bound against caller-asserted `_shareOfEEth` exceeding the
-    ///         caller's actual share holdings; it does NOT enforce a per-request bound.
-    ///
-    /// @dev    Residual: a caller corrupted in MULTIPLE inputs simultaneously (e.g. proportional
-    ///         `_amount` and `_rate` inflation) can bypass Guard 1 and Guard 2. The remaining
-    ///         bound is `eETH.shares(msg.sender)` (aggregate caller holdings), not per-request.
-    ///         This is the documented limit of LP-local defense; tighter bounds would require
-    ///         a per-request ledger on the LP side.
-    ///
-    ///         ETH was already segregated to the caller at finalize/fulfill via
-    ///         `addEthAmountLockedForWithdrawal` / `transferLockedEthForPriority`; LP only
-    ///         performs accounting (burn + `totalValueOutOfLp -=`).
+    /**
+     * @notice Settles a finalized claim for withdrawRequestNFT or priorityWithdrawalQueue.
+     * @param _amount The amount of ETH to withdraw
+     * @param _rate The rate of the withdraw
+     * @param _shareOfEEth The share of eETH to withdraw
+     * @return uint256 The amount of eETH burned
+     * @dev Only callable by the withdrawRequestNFT or the priorityWithdrawalQueue
+     * Caller supplies the snapshotted rate and the request's share allocation;
+     * LP derives the share burn defensively from both inputs and current live rate.
+     * Three guards bound caller-supplied inputs without trusting any single one:
+     * (1) `_amount <= _shareOfEEth * _rate / SHARE_UNIT` — caps `_amount` at the
+     *     rate-implied value of `_shareOfEEth`. Defeats isolated `_amount` inflation
+     *     when `_rate` is honest. (Does NOT catch proportional `_amount`/`_rate`
+     *     co-inflation — see residual below.)
+     * (2) Burn at `max(amount/_rate, amount/live)` shares — Lido-pattern worse-for-
+     *     protocol clamp. An inflated `_rate` is silently floored to live; the protocol
+     *     burns at the honest live rate regardless of what the caller passed.
+     * (3) Share burn capped at `_shareOfEEth` — per-call cap on burn. Un-DoSes
+     *     legitimate down-rebase claims (where `amount/live > shareOfEEth`).
+     * `_shareOfEEth` MUST be the request-time share snapshot, not a live-derived value.
+     * If a future caller refactor breaks this invariant, Guard 3's cap silently loosens.
+     * LP cannot independently verify this — the caller (WRN / PWQ) is trusted to pass
+     * the snapshot honestly. The downstream `eETH.shares(msg.sender) < share` solvency
+     * check is the only bound against caller-asserted `_shareOfEEth` exceeding the
+     * caller's actual share holdings; it does NOT enforce a per-request bound.
+     * Residual: a caller corrupted in MULTIPLE inputs simultaneously (e.g. proportional
+     * `_amount` and `_rate` inflation) can bypass Guard 1 and Guard 2. The remaining
+     * bound is `eETH.shares(msg.sender)` (aggregate caller holdings), not per-request.
+     * This is the documented limit of LP-local defense; tighter bounds would require
+     * a per-request ledger on the LP side.
+     * ETH was already segregated to the caller at finalize/fulfill via
+     * `addEthAmountLockedForWithdrawal` / `transferLockedEthForPriority`; LP only
+     * performs accounting (burn + `totalValueOutOfLp -=`).
+    */
     function withdraw(uint256 _amount, uint256 _rate, uint256 _shareOfEEth) external nonReentrant returns (uint256) {
         if (msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) {
             revert IncorrectCaller();
@@ -296,11 +350,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return share;
     }
 
-    /// @notice request withdraw from pool and receive a WithdrawRequestNFT
-    /// @dev Transfers the amount of eETH from msg.senders account to the WithdrawRequestNFT contract & mints an NFT to the msg.sender
-    /// @param recipient address that will be issued the NFT
-    /// @param amount requested amount to withdraw from contract
-    /// @return uint256 requestId of the WithdrawRequestNFT
+    /**
+     * @notice request withdraw from pool and receive a WithdrawRequestNFT
+     * @param recipient The address of the recipient
+     * @param amount The amount of ETH to withdraw
+     * @return uint256 The requestId of the WithdrawRequestNFT
+     * @dev Transfers the amount of eETH from msg.senders account to the WithdrawRequestNFT contract & mints an NFT to the msg.sender
+     */
     function requestWithdraw(address recipient, uint256 amount) public nonReentrant whenNotPaused nonBlacklisted returns (uint256) {
         blacklister.nonBlacklisted(recipient);
         if (amount == 0) revert InvalidWithdrawalAmount();
@@ -311,24 +367,28 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return _requestWithdraw(recipient, amount, share, SourceOfFunds.EETH);
     }
 
-    /// @notice request withdraw from pool with signed permit data and receive a WithdrawRequestNFT
-    /// @dev accepts PermitInput signed data to approve transfer of eETH (EIP-2612) so withdraw request can happen in 1 tx
-    /// @param _owner address that will be issued the NFT
-    /// @param _amount requested amount to withdraw from contract
-    /// @param _permit signed permit data to approve transfer of eETH
-    /// @return uint256 requestId of the WithdrawRequestNFT
+    /**
+     * @notice request withdraw from pool with signed permit data and receive a WithdrawRequestNFT
+     * @param _owner The address of the owner
+     * @param _amount The amount of ETH to withdraw
+     * @param _permit The permit data to approve transfer of eETH
+     * @return uint256 The requestId of the WithdrawRequestNFT
+     * @dev accepts PermitInput signed data to approve transfer of eETH (EIP-2612) so withdraw request can happen in 1 tx
+     */
     function requestWithdrawWithPermit(address _owner, uint256 _amount, PermitInput calldata _permit) external returns (uint256)
     {
         try eETH.permit(msg.sender, address(this), _permit.value, _permit.deadline, _permit.v, _permit.r, _permit.s) {} catch {}
         return requestWithdraw(_owner, _amount);
     }
 
-    /// @notice request withdraw of some or all of the eETH backing a MembershipNFT and receive a WithdrawRequestNFT
-    /// @dev Transfers the amount of eETH from MembershipManager to the WithdrawRequestNFT contract & mints an NFT to the recipient
-    /// @param recipient address that will be issued the NFT
-    /// @param amount requested amount to withdraw from contract
-    /// @param fee fee amount not used anymore, only kept to maintain compatibility with existing code
-    /// @return uint256 requestId of the WithdrawRequestNFT
+    /**
+     * @notice request withdraw of some or all of the eETH backing a MembershipNFT and receive a WithdrawRequestNFT
+     * @param recipient The address of the recipient
+     * @param amount The amount of ETH to withdraw
+     * @param fee The fee amount not used anymore, only kept to maintain compatibility with existing code
+     * @return uint256 The requestId of the WithdrawRequestNFT
+     * @dev Transfers the amount of eETH from MembershipManager to the WithdrawRequestNFT contract & mints an NFT to the recipient
+     */
     function requestMembershipNFTWithdraw(address recipient, uint256 amount, uint256 fee) public nonReentrant whenNotPaused returns (uint256) {
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         uint256 share = sharesForAmount(amount);
@@ -338,18 +398,21 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
 
-    //---------------------------------------------------------------------------
-    //---------------------- Staking/Deposit Flow -------------------------------
-    //---------------------------------------------------------------------------
-
-    // [Liquidty Pool Staking flow]
+    //--------------------------------------------------------------------------------------
+    //---------------------- STAKING FLOW FUNCTIONS -------------------------------------
+    //--------------------------------------------------------------------------------------
+    // [Liquidity Pool Staking flow]
     // Step 1: (Off-chain) create the keys using the desktop app
     // Step 2: register validator deposit data for later confirmation from the oracle before the 1eth deposit
     // Step 3: create validators with 1 eth deposits to official deposit contract
     // Step 4: oracle approves and funds the remaining balance for the validator
-
-    /// @notice claim bids and send 1 eth deposits to deposit contract to create the provided validators.
-    /// @dev step 2 of staking flow
+    /**
+     * @notice claim bids and send 1 eth deposits to deposit contract to create the provided validators.
+     * @param _depositData The deposit data for the validators
+     * @param _bidIds The bid ids for the validators
+     * @param _etherFiNode The etherFi node for the validators
+     * @dev step 2 of staking flow
+     */
     function batchRegister(
         IStakingManager.DepositData[] calldata _depositData,
         uint256[] calldata _bidIds,
@@ -359,6 +422,13 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         stakingManager.registerBeaconValidators(_depositData, _bidIds, _etherFiNode);
     }
 
+    /**
+     * @notice create validators with 1 eth deposits to official deposit contract
+     * @param _depositData The deposit data for the validators
+     * @param _bidIds The bid ids for the validators
+     * @param _etherFiNode The etherFi node for the validators
+     * @dev step 3 of staking flow
+     */
     function batchCreateBeaconValidators(
         IStakingManager.DepositData[] calldata _depositData,
         uint256[] calldata _bidIds,
@@ -371,12 +441,16 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _accountForEthSentOut(outboundEthAmountFromLp);
     }
 
-    /// @notice send remaining eth to deposit contract to activate the provided validators
-    /// @dev step 3 of staking flow. Callable directly by oracle ops, or by EtherFiAdmin
-    ///      when forwarding from `executeValidatorApprovalTask` (which gates oracle ops at
-    ///      its own entry point and tracks task completion on-chain). Both upstream paths
-    ///      enforce oracle-ops authorization, so accepting EtherFiAdmin here doesn't widen
-    ///      the auth surface.
+    /**
+     * @notice send remaining eth to deposit contract to activate the provided validators
+     * @param _depositData The deposit data for the validators
+     * @param _validatorSizeWei The size of the validators
+     * @dev step 3 of staking flow. Callable directly by oracle ops, or by EtherFiAdmin
+     *      when forwarding from `executeValidatorApprovalTask` (which gates oracle ops at
+     *      its own entry point and tracks task completion on-chain). Both upstream paths
+     *      enforce oracle-ops authorization, so accepting EtherFiAdmin here doesn't widen
+     *      the auth surface.
+    */
     function confirmAndFundBeaconValidators(
         IStakingManager.DepositData[] calldata _depositData,
         uint256 _validatorSizeWei
@@ -393,35 +467,36 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _accountForEthSentOut(outboundEthAmountFromLp);
     }
 
-    /// @dev set the size of validators created when EtherFiAdmin.executeValidatorApprovalTask
-    ///   forwards into confirmAndFundBeaconValidators(). In a future upgrade this will be a
-    ///   parameter to that call but was done like this to limit changes to other dependent contracts.
-    function setValidatorSizeWei(uint256 _validatorSizeWei) external onlyAdmin {
-        _requireValidValidatorSize(_validatorSizeWei);
-        validatorSizeWei = _validatorSizeWei;
-    }
-
-    /// @notice The admin can register an address to become a BNFT holder
-    /// @param _user The address of the Validator Spawner to register
+    /**
+     * @notice The admin can register an address to become a BNFT holder
+     * @param _user The address of the Validator Spawner to register
+     * @dev The admin can register an address to become a BNFT holder
+     */
     function registerValidatorSpawner(address _user) public onlyAdmin {
         if (validatorSpawner[_user].registered) revert AlreadyRegistered();  
-
         validatorSpawner[_user] = ValidatorSpawner({registered: true});
-
         emit ValidatorSpawnerRegistered(_user);
     }
 
-    /// @notice Removes a Validator Spawner
-    /// @param _user the address of the Validator Spawner to remove
+    /**
+     * @notice Removes a Validator Spawner
+     * @param _user the address of the Validator Spawner to remove
+     * @dev Removes a Validator Spawner
+     */
     function unregisterValidatorSpawner(address _user) external onlyOperatingMultisig {
         if (!validatorSpawner[_user].registered) revert NotRegistered();
-
         delete validatorSpawner[_user];
-
         emit ValidatorSpawnerUnregistered(_user);
     }
 
-    /// @notice Rebase by ether.fi
+    //--------------------------------------------------------------------------------------
+    //------------------------------  OPERATIONAL FUNCTIONS  -------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Rebase by ether.fi
+     * @param _accruedRewards The amount of rewards to rebase
+     * @dev Only callable by the membership manager
+     */
     function rebase(int128 _accruedRewards) public {
         if (msg.sender != address(membershipManager)) revert IncorrectCaller();
         totalValueOutOfLp = uint128(int128(totalValueOutOfLp) + _accruedRewards);
@@ -431,77 +506,42 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         emit Rebase(getTotalPooledEther(), eETH.totalShares());
     }
 
-    /// @notice pay protocol fees including 5% to treaury, 5% to node operator and ethfund bnft holders
-    /// @param _protocolFees The amount of protocol fees to pay in ether
+    /**
+     * @notice pay protocol fees including 5% to treaury, 5% to node operator and ethfund bnft holders
+     * @param _protocolFees The amount of protocol fees to pay in ether
+     * @dev Only callable by the etherFiAdminContract
+     */
     function payProtocolFees(uint128 _protocolFees) external {
         if (msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();   
         emit ProtocolFeePaid(_protocolFees);
         depositToRecipient(feeRecipient, _protocolFees, address(0));
     }
 
-    /// @notice Set the fee recipient address
-    /// @param _feeRecipient The address to set as the fee recipient
-    function setFeeRecipient(address _feeRecipient) external onlyAdmin {
-        feeRecipient = _feeRecipient;
-        emit UpdatedFeeRecipient(_feeRecipient);
-    }
-
-    // Pauses the contract
-    function pauseContract() external onlyOperatingMultisig {
-        if (paused) revert AlreadyPaused();
-
-        paused = true;
-        emit Paused();
-    }
-
-    // Unpauses the contract
-    function unPauseContract() external onlyOperatingMultisig {
-        if (!paused) revert NotPaused();
-
-        paused = false;
-        emit Unpaused();
-    }
-
-    // Pauses contract until MAX_PAUSE_DURATION
-    function pauseContractUntil() external onlyGuardian {
-        _pauseUntil();
-    }
-
-    // Unpauses contract from pauseUntil
-    function unpauseContractUntil() external onlyOperatingMultisig {
-        _unpauseUntil();
-    }
-
-    /// @notice Sets the pause duration for the contract
-    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
-        _setPauseUntilDuration(_pauseUntilDuration);
-    }
-
-    function setMinWithdrawAmount(uint256 _minWithdrawAmount) external onlyOperatingMultisig {
-        if (_minWithdrawAmount > maxWithdrawAmount) revert InvalidAmount();
-        minWithdrawAmount = _minWithdrawAmount;
-        emit MinWithdrawAmountSet(_minWithdrawAmount);
-    }
-
-    function setMaxWithdrawAmount(uint256 _maxWithdrawAmount) external onlyOperatingMultisig {
-        if (_maxWithdrawAmount == 0 || _maxWithdrawAmount < minWithdrawAmount) revert InvalidAmount();
-        maxWithdrawAmount = _maxWithdrawAmount;
-        emit MaxWithdrawAmountSet(_maxWithdrawAmount);
-    }
-
-    /// @notice Locks ETH for finalized NFT withdrawals by transferring from LP to WithdrawRequestNFT. TVL preserved by InLp/OutOfLp rebalance; share rate unchanged.
+    /**
+     * @notice Locks ETH for finalized NFT withdrawals by transferring from LP to WithdrawRequestNFT. TVL preserved by InLp/OutOfLp rebalance; share rate unchanged.
+     * @param _amount The amount of ETH to lock
+     * @dev Only callable by the etherFiAdminContract or the withdrawRequestNFT
+     */
     function addEthAmountLockedForWithdrawal(uint128 _amount) external {
         if (msg.sender != address(etherFiAdminContract) && msg.sender != address(withdrawRequestNFT)) revert IncorrectCaller();
         _lockEth(address(withdrawRequestNFT), _amount);
     }
 
-    /// @notice Locks ETH for the priority withdrawal queue by transferring from LP to the queue contract. TVL preserved by InLp/OutOfLp rebalance.
+    /**
+     * @notice Locks ETH for the priority withdrawal queue by transferring from LP to the queue contract. TVL preserved by InLp/OutOfLp rebalance.
+     * @param _amount The amount of ETH to lock
+     * @dev Only callable by the priorityWithdrawalQueue
+     */
     function transferLockedEthForPriority(uint128 _amount) external {
         if (msg.sender != address(priorityWithdrawalQueue)) revert IncorrectCaller();
         _lockEth(address(priorityWithdrawalQueue), _amount);
     }
 
-    /// @notice Returns ETH from the priority queue back to LP on a finalized cancel. Inverse of transferLockedEthForPriority.
+    /**
+     * @notice Returns ETH from the priority queue back to LP on a finalized cancel. Inverse of transferLockedEthForPriority.
+     * @param _amount The amount of ETH to return
+     * @dev Only callable by the priorityWithdrawalQueue
+     */
     function returnLockedEth(uint128 _amount) external payable {
         if (msg.sender != address(priorityWithdrawalQueue)) revert IncorrectCaller();
         if (msg.value != _amount || _amount == 0) revert InvalidAmount();
@@ -511,12 +551,23 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _checkInvariants();
     }
 
+    /**
+     * @notice Burns eETH shares
+     * @param shares The amount of eETH shares to burn
+     * @dev Only callable by the etherFiRedemptionManager, the withdrawRequestNFT or the priorityWithdrawalQueue
+     */
     function burnEEthShares(uint256 shares) external nonDecreasingRate {
         if (msg.sender != address(etherFiRedemptionManager) && msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) revert IncorrectCaller();
         eETH.burnShares(msg.sender, shares);
         _checkMinAmountForShare();
     }
 
+    /**
+     * @notice Burns eETH shares for non-ETH withdrawal
+     * @param _amountSharesToBurn The amount of eETH shares to burn
+     * @param _withdrawalValueInETH The amount of ETH to withdraw
+     * @dev Only callable by the etherFiRedemptionManager
+     */
     function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external nonDecreasingRate {
         uint256 share = sharesForWithdrawalAmount(_withdrawalValueInETH);
         if (msg.sender != address(etherFiRedemptionManager)) revert IncorrectCaller();
@@ -533,9 +584,111 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     }
 
     //--------------------------------------------------------------------------------------
+    //------------------------------  PAUSING FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pauses the contract
+     * @dev Only callable by the operating multisig
+     */
+    function pauseContract() external onlyOperatingMultisig {
+        if (paused) revert AlreadyPaused();
+
+        paused = true;
+        emit Paused();
+    }
+
+    /**
+     * @notice Unpauses the contract
+     * @dev Only callable by the operating multisig
+     */
+    function unPauseContract() external onlyOperatingMultisig {
+        if (!paused) revert NotPaused();
+
+        paused = false;
+        emit Unpaused();
+    }
+
+    /**
+     * @notice Pauses contract until pasuUntilDuration
+     * @dev Only callable by the guardian
+     */
+    function pauseContractUntil() external onlyGuardian {
+        _pauseUntil();
+    }
+
+    /**
+     * @notice Unpauses contract from pauseUntil
+     * @dev Only callable by the operating multisig
+     */
+    function unpauseContractUntil() external onlyOperatingMultisig {
+        _unpauseUntil();
+    }
+
+    /**
+     * @notice Sets the pause duration for the contract
+     * @param _pauseUntilDuration The new pause duration
+     * @dev Only callable by the admin
+     */
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //------------------------------  SETTER FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice set the size of validators created when EtherFiAdmin.executeValidatorApprovalTask
+     * @param _validatorSizeWei The size of the validators
+     * @dev set the size of validators created when EtherFiAdmin.executeValidatorApprovalTask
+     *      forwards into confirmAndFundBeaconValidators(). In a future upgrade this will be a
+     *      parameter to that call but was done like this to limit changes to other dependent contracts.
+     */
+    function setValidatorSizeWei(uint256 _validatorSizeWei) external onlyAdmin {
+        _requireValidValidatorSize(_validatorSizeWei);
+        validatorSizeWei = _validatorSizeWei;
+    }
+
+    /**
+     * @notice Set the fee recipient address
+     * @param _feeRecipient The address to set as the fee recipient
+     * @dev Only callable by the admin
+     */
+    function setFeeRecipient(address _feeRecipient) external onlyAdmin {
+        feeRecipient = _feeRecipient;
+        emit UpdatedFeeRecipient(_feeRecipient);
+    }
+
+    /**
+     * @notice Set the minimum withdraw amount
+     * @param _minWithdrawAmount The minimum withdraw amount
+     * @dev Only callable by the operating multisig
+     */
+    function setMinWithdrawAmount(uint256 _minWithdrawAmount) external onlyOperatingMultisig {
+        if (_minWithdrawAmount > maxWithdrawAmount) revert InvalidAmount();
+        minWithdrawAmount = _minWithdrawAmount;
+        emit MinWithdrawAmountSet(_minWithdrawAmount);
+    }
+
+    /**
+     * @notice Set the maximum withdraw amount
+     * @param _maxWithdrawAmount The maximum withdraw amount
+     * @dev Only callable by the operating multisig
+     */
+    function setMaxWithdrawAmount(uint256 _maxWithdrawAmount) external onlyOperatingMultisig {
+        if (_maxWithdrawAmount == 0 || _maxWithdrawAmount < minWithdrawAmount) revert InvalidAmount();
+        maxWithdrawAmount = _maxWithdrawAmount;
+        emit MaxWithdrawAmountSet(_maxWithdrawAmount);
+    }
+
+    //--------------------------------------------------------------------------------------
     //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Deposits ETH into the Liquidity Pool
+     * @param _recipient The address of the recipient
+     * @param _amountInLp The amount of ETH to deposit into the Liquidity Pool
+     * @param _amountOutOfLp The amount of ETH to deposit into the Liquidity Pool
+     */
     function _deposit(address _recipient, uint256 _amountInLp, uint256 _amountOutOfLp) internal nonDecreasingRate returns (uint256) {
         totalValueInLp += uint128(_amountInLp);
         totalValueOutOfLp += uint128(_amountOutOfLp);
@@ -550,14 +703,25 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return share;
     }
 
-    /// @dev Shared tail for requestWithdraw / requestMembershipNFTWithdraw: moves `amount` eETH
-    ///      from the caller to the WithdrawRequestNFT, mints the request NFT, and emits Withdraw.
+    /**
+     * @notice Shared tail for requestWithdraw / requestMembershipNFTWithdraw: moves `amount` eETH
+     * @param recipient The address of the recipient
+     * @param amount The amount of eETH to move
+     * @param share The share of eETH to move
+     * @param source The source of the eETH
+     * @return requestId The requestId of the WithdrawRequestNFT
+     */
     function _requestWithdraw(address recipient, uint256 amount, uint256 share, SourceOfFunds source) internal returns (uint256 requestId) {
         IERC20(address(eETH)).safeTransferFrom(msg.sender, address(withdrawRequestNFT), amount);
         requestId = withdrawRequestNFT.requestWithdraw(uint96(amount), uint96(share), recipient);
         emit Withdraw(msg.sender, recipient, amount, source);
     }
 
+    /**
+     * @notice Calculates the shares for a deposit amount
+     * @param _depositAmount The amount of ETH to deposit
+     * @return uint256 The shares for the deposit amount
+     */
     function _sharesForDepositAmount(uint256 _depositAmount) internal view returns (uint256) {
         uint256 totalPooledEther = getTotalPooledEther() - _depositAmount;
         if (totalPooledEther == 0) {
@@ -566,16 +730,25 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return Math.mulDiv(_depositAmount, eETH.totalShares(), totalPooledEther, Math.Rounding.Down);
     }
 
+    /**
+     * @notice Sends ETH to a recipient
+     * @param _recipient The address of the recipient
+     * @param _amount The amount of ETH to send
+     */
     function _sendFund(address _recipient, uint256 _amount) internal {
         uint256 balance = address(this).balance;
         (bool sent, ) = _recipient.call{value: _amount}("");
         if (!sent || address(this).balance < balance - _amount) revert SendFail();
     }
 
-    /// @dev Shared body for `addEthAmountLockedForWithdrawal` and `transferLockedEthForPriority`.
-    ///      Both move ETH out of LP into a segregated escrow (WRNFT or PQ) while keeping TVL
-    ///      invariant by rebalancing `totalValueInLp` -> `totalValueOutOfLp`. Caller-gating
-    ///      lives in the two external entry points.
+    /**
+     * @notice Shared body for `addEthAmountLockedForWithdrawal` and `transferLockedEthForPriority`.
+     * @param _dest The address of the recipient
+     * @param _amount The amount of ETH to send
+     * @dev Both move ETH out of LP into a segregated escrow (WRNFT or PQ) while keeping TVL
+     *      invariant by rebalancing `totalValueInLp` -> `totalValueOutOfLp`. Caller-gating
+     *      lives in the two external entry points.
+     */
     function _lockEth(address _dest, uint128 _amount) internal {
         if (!escrowMigrationCompleted) revert MigrationNotComplete();
         if (totalValueInLp < _amount) revert InsufficientLiquidity();
@@ -585,18 +758,90 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         _checkInvariants();
     }
 
+    /**
+     * @notice Accounts for ETH sent out
+     * @param _amount The amount of ETH to send out
+     * @dev Accounts for ETH sent out by the WithdrawRequestNFT or the PriorityWithdrawalQueue
+     */
     function _accountForEthSentOut(uint256 _amount) internal {
         totalValueOutOfLp += uint128(_amount);
         totalValueInLp -= uint128(_amount);
         _checkInvariants();
     }
 
+    /**
+     * @notice Checks if the total value in LP is greater than the balance of the contract
+     */
+    function _checkTotalValueInLp() internal view {
+        if (totalValueInLp > address(this).balance) revert InsufficientLiquidity();
+    }
+
+    /**
+     * @notice Checks if the minimum amount for a share is greater than the amount for a share
+     */
+    function _checkMinAmountForShare() internal view {
+        if (amountForShare(SHARE_UNIT) < minAmountForShare) revert InvalidAmountForShare();
+    }
+
+    /**
+     * @notice Checks if the invariants are met
+     */
+    function _checkInvariants() internal view {
+        _checkTotalValueInLp();
+        _checkMinAmountForShare();
+    }
+
+    /**
+     * @notice Snaps the rate
+     * @return P The total pooled ether
+     * @return S The total shares
+     */
+    function _snapRate() internal view returns (uint256 P, uint256 S) {
+        P = getTotalPooledEther();
+        S = eETH.totalShares();
+    }
+
+    /**
+     * @notice Checks if the rate is non-decreasing
+     * @param P0 The total pooled ether before the rate is snapped
+     * @param S0 The total shares before the rate is snapped
+     */
+    function _checkRateNonDec(uint256 P0, uint256 S0) internal view {
+        (uint256 P1, uint256 S1) = _snapRate();
+        // Bootstrap exempt (no rate before/after to compare).
+        if (S0 != 0 && S1 != 0 && P1 * S0 < P0 * S1) revert EETHRateDeflation();
+    }
+
+    /**
+     * @notice Checks if the validator size is valid
+     * @param _validatorSizeWei The validator size
+     */
+    function _requireValidValidatorSize(uint256 _validatorSizeWei) internal view {
+        if (_validatorSizeWei < stakingManager.MIN_VALIDATOR_SIZE_WEI() || _validatorSizeWei > stakingManager.MAX_VALIDATOR_SIZE_WEI()) revert InvalidValidatorSize();
+    }
+
+    /**
+     * @notice Checks if the contract is paused
+     */
+    function _requireNotPaused() internal view virtual {
+        if (paused) revert ContractPaused();
+    }
+
+    /**
+     * @notice Authorizes the upgrade of the contract
+     * @param newImplementation The new implementation address
+     * @dev Only callable by the upgrade timelock
+     */
     function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //------------------------------------  GETTERS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Gets the total ether claim of a user
+     * @param _user The address of the user
+     * @return uint256 The total ether claim of the user
+     */
     function getTotalEtherClaimOf(address _user) external view returns (uint256) {
         uint256 staked;
         uint256 totalShares = eETH.totalShares();
@@ -606,10 +851,19 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return staked;
     }
 
+    /**
+     * @notice Gets the total pooled ether
+     * @return uint256 The total pooled ether
+     */
     function getTotalPooledEther() public view returns (uint256) {
         return totalValueOutOfLp + totalValueInLp;
     }
 
+    /**
+     * @notice Gets the shares for an amount
+     * @param _amount The amount of ETH
+     * @return uint256 The shares for the amount
+     */
     function sharesForAmount(uint256 _amount) public view returns (uint256) {
         uint256 totalPooledEther = getTotalPooledEther();
         if (totalPooledEther == 0) {
@@ -618,7 +872,12 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return Math.mulDiv(_amount, eETH.totalShares(), totalPooledEther, Math.Rounding.Down);
     }
 
-    /// @dev withdrawal rounding errors favor the protocol by rounding up
+    /**
+     * @notice Gets the shares for a withdrawal amount
+     * @param _amount The amount of ETH to withdraw
+     * @return uint256 The shares for the withdrawal amount
+     * @dev withdrawal rounding errors favor the protocol by rounding up
+     */
     function sharesForWithdrawalAmount(uint256 _amount) public view returns (uint256) {
         uint256 totalPooledEther = getTotalPooledEther();
         if (totalPooledEther == 0) {
@@ -629,6 +888,11 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return Math.mulDiv(_amount, eETH.totalShares(), totalPooledEther, Math.Rounding.Up);
     }
 
+    /**
+     * @notice Gets the amount for a share
+     * @param _share The share of eETH
+     * @return uint256 The amount for the share
+     */
     function amountForShare(uint256 _share) public view returns (uint256) {
         uint256 totalShares = eETH.totalShares();
         if (totalShares == 0) {
@@ -637,110 +901,101 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
         return Math.mulDiv(_share, getTotalPooledEther(), totalShares, Math.Rounding.Down);
     }
 
-    /// @notice ETH value of `1e18` shares, rounded UP. Single source of truth for the rate
-    ///         snapshotted by segregated callers (WithdrawRequestNFT / PriorityWithdrawalQueue)
-    ///         at finalize/fulfill. Ceiling rounding keeps the frozen rate >= `amountForShare`'s
-    ///         floor value so the round-trips at claim time satisfy:
-    ///         `shareOfEEth * rate / 1e18 >= amountForShare(shareOfEEth)` (solvency check) and
-    ///         `ceil(amount * 1e18 / rate) <= shareOfEEth` (burn-bounded-by-request).
+    /**
+     * @notice Gets the amount per share ceil
+     * @return uint256 The amount per share ceil
+     * @dev ETH value of `1e18` shares, rounded UP. Single source of truth for the rate
+     *      snapshotted by segregated callers (WithdrawRequestNFT / PriorityWithdrawalQueue)
+     *      at finalize/fulfill. Ceiling rounding keeps the frozen rate >= `amountForShare`'s
+     *      floor value so the round-trips at claim time satisfy:
+     *      `shareOfEEth * rate / 1e18 >= amountForShare(shareOfEEth)` (solvency check) and
+     *      `ceil(amount * 1e18 / rate) <= shareOfEEth` (burn-bounded-by-request).
+     */
     function amountPerShareCeil() public view returns (uint256) {
         uint256 totalShares = eETH.totalShares();
         if (totalShares == 0) return 0;
         return Math.mulDiv(SHARE_UNIT, getTotalPooledEther(), totalShares, Math.Rounding.Up);
     }
 
-    function _checkTotalValueInLp() internal view {
-        if (totalValueInLp > address(this).balance) revert InsufficientLiquidity();
-    }
-
-    function _checkMinAmountForShare() internal view {
-        if (amountForShare(SHARE_UNIT) < minAmountForShare) revert InvalidAmountForShare();
-    }
-
-    function _checkInvariants() internal view {
-        _checkTotalValueInLp();
-        _checkMinAmountForShare();
-    }
-
+    /**
+     * @notice Gets the implementation address
+     * @return address The implementation address
+     */
     function getImplementation() external view returns (address) {return _getImplementation();}
-
-    function _requireValidValidatorSize(uint256 _validatorSizeWei) internal view {
-        if (_validatorSizeWei < stakingManager.MIN_VALIDATOR_SIZE_WEI() || _validatorSizeWei > stakingManager.MAX_VALIDATOR_SIZE_WEI()) revert InvalidValidatorSize();
-    }
-
-    function _requireNotPaused() internal view virtual {
-        if (paused) revert ContractPaused();
-    }
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Modifier to check if the contract is not paused
+     * @dev Only callable when the contract is not paused and not paused until 
+     * the pauseUntilDuration
+     */
     modifier whenNotPaused() {
         _requireNotPaused();
         _requireNotPausedUntil();
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is not blacklisted
+     * @dev Only callable by the blacklister
+     */
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the etherFiAdminContract
+     * @dev Only callable by the etherFiAdminContract
+     */
     modifier onlyEtherFiAdmin() {
         if (msg.sender != address(etherFiAdminContract)) revert IncorrectCaller();
         _;
     }
 
-    /// @notice Invariant — the eETH exchange rate
-    ///         (`totalPooledEther / totalShares`) does not decrease across
-    ///         this call. Snapshots (P0, S0) before the function body, then
-    ///         (P1, S1) after, and asserts `P1 * S0 >= P0 * S1` (the
-    ///         cross-multiplied form of `P1/S1 >= P0/S0`, integer-exact).
-    ///
-    ///         APPLIED to every share-changing entry point where the rate
-    ///         is supposed to stay equal or move UP by construction:
-    ///           - deposit() / depositToRecipient / deposit(user, ref)
-    ///             — proportional mint, floor-rounded shares (rate up)
-    ///           - withdraw(address, uint256)
-    ///             — live-rate burn, ceil-rounded shares (rate up)
-    ///           - burnEEthShares
-    ///             — share-only burn, no P-side change (rate up)
-    ///           - burnEEthSharesForNonETHWithdrawal
-    ///             — already locally checks rate non-decrease; modifier is
-    ///               belt-and-suspenders
-    ///
-    ///         INTENTIONALLY NOT applied to:
-    ///           - withdraw(uint256, uint256, uint256) — frozen-rate finalized claim,
-    ///             rate-drop bounded by the three-guard design at that function's
-    ///             docblock (WRN/PQ-only)
-    ///           - rebase() — oracle path, rate-change bounded by
-    ///             EtherFiAdmin._validateRebaseApr's APR cap
-    ///
-    ///         These two are the only intentional rate-changing paths.
-    ///         Anything else that drops the rate trips the modifier.
-    ///
-    ///         Overflow note: P, S each fit in uint128 in any plausible
-    ///         protocol state; P*S ≈ 1.4e52 ≪ uint256 max. Safe by inspection.
-    ///
-    ///         Implementation note: the snapshot / check pair lives in two
-    ///         internal view helpers so the body isn't duplicated at every
-    ///         site Solidity inlines this modifier into. Same semantics,
-    ///         ~1 KB smaller runtime.
+    /**
+     * @notice Modifier to check if the eETH exchange rate is non-decreasing
+     * @dev Invariant — the eETH exchange rate
+     *      (`totalPooledEther / totalShares`) does not decrease across
+     *      this call. Snapshots (P0, S0) before the function body, then
+     *      (P1, S1) after, and asserts `P1 * S0 >= P0 * S1` (the
+     *      cross-multiplied form of `P1/S1 >= P0/S0`, integer-exact).
+     *
+     *         APPLIED to every share-changing entry point where the rate
+     *         is supposed to stay equal or move UP by construction:
+     *           - deposit() / depositToRecipient / deposit(user, ref)
+     *             — proportional mint, floor-rounded shares (rate up)
+     *           - withdraw(address, uint256)
+     *             — live-rate burn, ceil-rounded shares (rate up)
+     *           - burnEEthShares
+     *             — share-only burn, no P-side change (rate up)
+     *           - burnEEthSharesForNonETHWithdrawal
+     *             — already locally checks rate non-decrease; modifier is
+     *               belt-and-suspenders
+     *
+     *         INTENTIONALLY NOT applied to:
+     *           - withdraw(uint256, uint256, uint256) — frozen-rate finalized claim,
+     *             rate-drop bounded by the three-guard design at that function's
+     *             docblock (WRN/PQ-only)
+     *           - rebase() — oracle path, rate-change bounded by
+     *             EtherFiAdmin._validateRebaseApr's APR cap
+     *
+     *         These two are the only intentional rate-changing paths.
+     *         Anything else that drops the rate trips the modifier.
+     *
+     *         Overflow note: P, S each fit in uint128 in any plausible
+     *         protocol state; P*S ≈ 1.4e52 ≪ uint256 max. Safe by inspection.
+     *
+     *         Implementation note: the snapshot / check pair lives in two
+     *         internal view helpers so the body isn't duplicated at every
+     *         site Solidity inlines this modifier into. Same semantics,
+     *         ~1 KB smaller runtime.   
+     */
     modifier nonDecreasingRate() {
         (uint256 P0, uint256 S0) = _snapRate();
         _;
         _checkRateNonDec(P0, S0);
-    }
-
-    function _snapRate() internal view returns (uint256 P, uint256 S) {
-        P = getTotalPooledEther();
-        S = eETH.totalShares();
-    }
-
-    function _checkRateNonDec(uint256 P0, uint256 S0) internal view {
-        (uint256 P1, uint256 S1) = _snapRate();
-        // Bootstrap exempt (no rate before/after to compare).
-        if (S0 != 0 && S1 != 0 && P1 * S0 < P0 * S1) revert EETHRateDeflation();
     }
 }

--- a/src/core/LiquidityPool.sol
+++ b/src/core/LiquidityPool.sol
@@ -122,20 +122,6 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
     error AlreadyPaused();
     error NotPaused();
 
-    struct ConstructorAddresses {
-        address stakingManager;
-        address nodesManager;
-        address eETH;
-        address withdrawRequestNFT;
-        address liquifier;
-        address etherFiRedemptionManager;
-        address roleRegistry;
-        address priorityWithdrawalQueue;
-        address blacklister;
-        address etherFiAdminContract;
-        address membershipManager;
-    }
-
     //--------------------------------------------------------------------------------------
     //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
     //--------------------------------------------------------------------------------------

--- a/src/core/WeETH.sol
+++ b/src/core/WeETH.sol
@@ -19,11 +19,25 @@ import "@etherfi/governance/rate-limiting/RateLimitedToken.sol";
 contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, ERC20PermitUpgradeable, IRateProvider, AssetRecovery, RolesLibrary, RateLimitedToken {
     using SafeERC20 for IERC20;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STORAGE  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    // deprecated storage slots
+    uint160 private __gap_0;
+    uint160 private __gap_1;
+
+    bool public paused;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     IeETH public immutable eETH;
     ILiquidityPool public immutable liquidityPool;
     IBlacklister public immutable blacklister;
-    // `roleRegistry` is inherited from RolesLibrary; `rateLimiter` from RateLimitedToken.
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     /// @dev Protocol-wide circuit breakers on supply changes.
     ///      These globals fire on supply changes that are NOT a wrap/unwrap.
     ///      wrap/unwrap is a value-neutral share swap (eETH↔weETH at the live rate);
@@ -47,43 +61,53 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     ///      clear-after pattern; otherwise its mints WILL trip the global bucket.
     bytes32 private constant _WRAP_CTX_SLOT = keccak256("etherfi.weeth.wrap_ctx");
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  EVENTS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
     event Paused();
     event Unpaused();
 
-    error CannotRecoverEETH();
-    error AddressZero();
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  ERRORS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
     error ZeroAmount();
+    error ZeroAddress();
     error ContractPaused();
+    error CannotRecoverEETH();
     error WeETHUnderbacked(uint256 weETHSupply, uint256 proxyShares);
 
     //--------------------------------------------------------------------------------------
-    //---------------------------------  STORAGE  ----------------------------------
+    //----------------------------------  CONSTRUCTOR  -------------------------------------
     //--------------------------------------------------------------------------------------
-
-    // deprecated storage slots
-    uint160 private __gap_0;
-    uint160 private __gap_1;
-
-    bool public paused;
-
-    //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
-    //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor for WeETH contract
+     * @param _eETH The address of the eETH contract
+     * @param _liquidityPool The address of the liquidity pool contract
+     * @param _roleRegistry The address of the role registry contract
+     * @param _blacklister The address of the blacklister contract
+     * @param _rateLimiter The address of the rate limiter contract
+     */
     constructor(address _eETH, address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter)
         RolesLibrary(_roleRegistry)
         RateLimitedToken(_rateLimiter)
     {
-        if(_eETH == address(0) || _liquidityPool == address(0) || _blacklister == address(0) || _rateLimiter == address(0)) revert AddressZero();
+        if(_eETH == address(0) || _liquidityPool == address(0) || _blacklister == address(0) || _rateLimiter == address(0)) revert ZeroAddress();
         eETH = IeETH(_eETH);
         liquidityPool = ILiquidityPool(_liquidityPool);
         blacklister = IBlacklister(_blacklister);
         _disableInitializers();
     }
 
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  INITIALIZERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the WeETH contract
+     * @param _liquidityPool The address of the liquidity pool contract
+     * @param _eETH The address of the eETH contract
+     */
     function initialize(address _liquidityPool, address _eETH) external initializer {
-        if (_liquidityPool == address(0) || _eETH == address(0)) revert AddressZero();
+        if (_liquidityPool == address(0) || _eETH == address(0)) revert ZeroAddress();
 
         __ERC20_init("Wrapped eETH", "weETH");
         __ERC20Permit_init("Wrapped eETH");
@@ -96,21 +120,26 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return "Wrapped eETH";
     }
 
-    /// @notice Wraps eEth
-    /// @param _eETHAmount the amount of eEth to wrap
-    /// @return returns the amount of weEth the user receives
-    /// @dev Order is deposit-then-mint:
-    ///        1. Pull eETH from user → proxy. eETH.shares(proxy) increases by
-    ///           sharesForAmount(_eETHAmount).
-    ///        2. _mint(weETH) increases weETH.totalSupply by the same number.
-    ///           The `_afterTokenTransfer` hook runs at the end of _mint and
-    ///           asserts the backing invariant
-    ///           (weETH.totalSupply <= eETH.shares(proxy)); the deposit-first
-    ///           ordering means the proxy's share balance is already raised
-    ///           when the check fires, so the invariant holds with equality.
-    ///      `_WRAP_CTX_SLOT` flags the mint so `_beforeTokenTransfer` skips
-    ///      the global WEETH_MINT bucket on this value-neutral path; that's
-    ///      a separate concern from the backing invariant.
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  WRAP/UNWRAP FUNCTIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Wraps eEth
+     * @param _eETHAmount the amount of eEth to wrap
+     * @return returns the amount of weEth the user receives
+     * @dev Order is deposit-then-mint:
+     *      1. Pull eETH from user → proxy. eETH.shares(proxy) increases by
+     *         sharesForAmount(_eETHAmount).
+     *      2. _mint(weETH) increases weETH.totalSupply by the same number.
+     *         The `_afterTokenTransfer` hook runs at the end of _mint and
+     *         asserts the backing invariant
+     *         (weETH.totalSupply <= eETH.shares(proxy)); the deposit-first
+     *         ordering means the proxy's share balance is already raised
+     *         when the check fires, so the invariant holds with equality.
+     *      `_WRAP_CTX_SLOT` flags the mint so `_beforeTokenTransfer` skips
+     *      the global WEETH_MINT bucket on this value-neutral path; that's
+     *      a separate concern from the backing invariant.
+     */
     function wrap(uint256 _eETHAmount) public returns (uint256) {
         if (_eETHAmount == 0) revert ZeroAmount();
         uint256 weEthAmount = liquidityPool.sharesForAmount(_eETHAmount);
@@ -122,9 +151,12 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return weEthAmount;
     }
 
-    /// @notice Wraps eEth with PermitInput struct so user does not have to call approve on eeth contract
-    /// @param _eETHAmount the amount of eEth to wrap
-    /// @return returns the amount of weEth the user receives
+    /**
+     * @notice Wraps eEth with PermitInput struct so user does not have to call approve on eeth contract
+     * @param _eETHAmount the amount of eEth to wrap
+     * @param _permit the PermitInput struct
+     * @return returns the amount of weEth the user receives
+     */
     function wrapWithPermit(uint256 _eETHAmount, ILiquidityPool.PermitInput calldata _permit)
         external
         returns (uint256)
@@ -133,11 +165,13 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         return wrap(_eETHAmount);
     }
 
-    /// @notice Unwraps weETH
-    /// @param _weETHAmount the amount of weETH to unwrap
-    /// @return returns the amount of eEth the user receives
-    /// @dev Sets `_WRAP_CTX_SLOT = 1` around `_burn` for the same reason wrap()
-    ///      does — see the doc comment on `wrap` and `_WRAP_CTX_SLOT`.
+    /**
+     * @notice Unwraps weETH
+     * @param _weETHAmount the amount of weETH to unwrap
+     * @return returns the amount of eEth the user receives
+     * @dev Sets `_WRAP_CTX_SLOT = 1` around `_burn` for the same reason wrap()
+     *      does — see the doc comment on `wrap` and `_WRAP_CTX_SLOT`.
+     */
     function unwrap(uint256 _weETHAmount) external returns (uint256) {
         if (_weETHAmount == 0) revert ZeroAmount();
         uint256 eETHAmount = liquidityPool.amountForShare(_weETHAmount);
@@ -155,6 +189,13 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     // Thin role-gated wrappers around the internal helpers in RateLimitedToken.
     // For a single user, pass a length-1 array.
 
+    /**
+     * @notice Tightens the address rate limits
+     * @param users the addresses of the users
+     * @param capacities the capacities of the users
+     * @param refillRates the refill rates of the users
+     * @dev Only callable by the guardian
+     */
     function tightenAddressRateLimits(
         address[] calldata users,
         uint64[] calldata capacities,
@@ -163,6 +204,13 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _tightenAddressRateLimits(users, capacities, refillRates);
     }
 
+    /**
+     * @notice Sets the address rate limits
+     * @param users the addresses of the users
+     * @param capacities the capacities of the users
+     * @param refillRates the refill rates of the users
+     * @dev Only callable by the operating multisig
+     */
     function setAddressRateLimits(
         address[] calldata users,
         uint64[] calldata capacities,
@@ -171,41 +219,93 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         _setAddressRateLimits(users, capacities, refillRates);
     }
 
+    /**
+     * @notice Deletes the address rate limits
+     * @param users the addresses of the users
+     * @dev Only callable by the operating multisig
+     */
     function deleteAddressRateLimits(address[] calldata users) external onlyOperatingMultisig {
         _deleteAddressRateLimits(users);
     }
 
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  PAUSING FUNCTIONS  ---------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pauses the contract
+     * @dev Only callable by the operating multisig
+     */
     function pause() external onlyOperatingMultisig {
         paused = true;
         emit Paused();
     }
 
+    /**
+     * @notice Unpauses the contract
+     * @dev Only callable by the operating multisig
+     */
     function unpause() external onlyOperatingMultisig {
         paused = false;
         emit Unpaused();
     }
 
+    /**
+     * @notice Pauses the contract until the pauseUntilDuration
+     * @dev Only callable by the super guardian
+     */
     function pauseContractUntil() external onlySuperGuardian {
         _pauseUntil();
     }
 
+    /**
+     * @notice Unpauses the contract from pauseUntil
+     * @dev Only callable by the operating multisig
+     */
     function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
+    /**
+     * @notice Sets the pause duration for the contract
+     * @param _pauseUntilDuration The new pause duration
+     * @dev Only callable by the admin
+     */
     function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
         _setPauseUntilDuration(_pauseUntilDuration);
     }
 
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  RECOVERY FUNCTIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Recover ETH from the contract
+     * @param to The address to recover the ETH to
+     * @param amount The amount of ETH to recover
+     * @dev Only callable by the admin
+     */
     function recoverETH(address payable to, uint256 amount) external onlyAdmin {
         _recoverETH(to, amount);
     }
 
+    /**
+     * @notice Recover ERC20 tokens from the contract
+     * @param token The address of the ERC20 token
+     * @param to The address to recover the tokens to
+     * @param amount The amount of tokens to recover
+     * @dev Only callable by the admin
+     */
     function recoverERC20(address token, address to, uint256 amount) external onlyAdmin {
         if (token == address(eETH)) revert CannotRecoverEETH();
         _recoverERC20(token, to, amount);
     }
 
+    /**
+     * @notice Recover ERC721 tokens from the contract
+     * @param token The address of the ERC721 token
+     * @param to The address to recover the tokens to
+     * @param tokenId The ID of the token to recover
+     * @dev Only callable by the admin
+     */
     function recoverERC721(address token, address to, uint256 tokenId) external onlyAdmin {
         _recoverERC721(token, to, tokenId);
     }
@@ -213,9 +313,16 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //--------------------------------------------------------------------------------------
     //-------------------------------  INTERNAL FUNCTIONS  ---------------------------------
     //--------------------------------------------------------------------------------------
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
+    /**
+     * @notice Before token transfer
+     * @param from The address of the from
+     * @param to The address of the to
+     * @param amount The amount of the transfer
+     * @dev Only callable when the contract is not paused
+     * Only callable when the from is not blacklisted
+     * Only callable when the to is not blacklisted
+     * Only callable when the sender is not blacklisted
+     */
     function _beforeTokenTransfer(
         address from,
         address to,
@@ -248,26 +355,31 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         }
     }
 
-    /// @notice Invariant — weETH supply is at-least-fully-backed by eETH shares
-    ///         held in this contract (the weETH proxy).
-    /// @dev    `weETH.totalSupply <= eETH.shares(address(this))`. Runs after
-    ///         every mint/burn (skipped on transfers — they don't change
-    ///         totalSupply). The `<=` form permits benign over-collateralization
-    ///         from accidental eETH transfers to the proxy.
-    ///
-    ///         Why this holds today:
-    ///           wrap(X eETH) → safeTransferFrom moves sharesForAmount(X)
-    ///           eETH shares to the proxy AND _mint adds sharesForAmount(X)
-    ///           weETH supply. Both sides increment by the same number.
-    ///           unwrap is the symmetric decrement (_burn first, then
-    ///           transfer eETH out — the invariant trivially holds at the
-    ///           hook because supply just dropped and proxy balance is
-    ///           still high).
-    ///
-    ///         What it catches:
-    ///           Any future code path that mints weETH without pulling in
-    ///           proportional eETH shares (bridge integration, new mint
-    ///           authority, exploited path) trips the revert.
+    /**
+     * @notice Invariant — weETH supply is at-least-fully-backed by eETH shares
+     * @param from The address of the from
+     * @param to The address of the to
+     * @dev Invariant — weETH supply is at-least-fully-backed by eETH shares
+     * `weETH.totalSupply <= eETH.shares(address(this))`. Runs after
+     * every mint/burn (skipped on transfers — they don't change
+     * totalSupply). The `<=` form permits benign over-collateralization
+     * from accidental eETH transfers to the proxy.
+     *
+     * Why this holds today:
+     *           wrap(X eETH) → safeTransferFrom moves sharesForAmount(X)
+     *           eETH shares to the proxy AND _mint adds sharesForAmount(X)
+     *           weETH supply. Both sides increment by the same number.
+     *           unwrap is the symmetric decrement (_burn first, then
+     *           transfer eETH out — the invariant trivially holds at the
+     *           hook because supply just dropped and proxy balance is
+     *           still high).
+     *
+     * What it catches:
+     *           Any future code path that mints weETH without pulling in
+     *           proportional eETH shares (bridge integration, new mint
+     *           authority, exploited path) trips the revert.
+     *
+     */
     function _afterTokenTransfer(address from, address to, uint256 /*amount*/) internal virtual override {
         if (from != address(0) && to != address(0)) return;     // transfers don't change supply
         uint256 supply = totalSupply();
@@ -275,32 +387,48 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         if (supply > proxyShares) revert WeETHUnderbacked(supply, proxyShares);
     }
 
+    /**
+     * @notice Authorizes the upgrade of the contract
+     * @param newImplementation The new implementation address
+     * @dev Only callable by the upgrade timelock
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
     //--------------------------------------------------------------------------------------
     //------------------------------------  GETTERS  ---------------------------------------
     //--------------------------------------------------------------------------------------
 
-    /// @notice Fetches the amount of weEth respective to the amount of eEth sent in
-    /// @param _eETHAmount amount sent in
-    /// @return The total number of shares for the specified amount
+    /**
+     * @notice Fetches the amount of weEth respective to the amount of eEth sent in
+     * @param _eETHAmount amount sent in
+     * @return The total number of shares for the specified amount
+     */
     function getWeETHByeETH(uint256 _eETHAmount) external view returns (uint256) {
         return liquidityPool.sharesForAmount(_eETHAmount);
     }
 
-    /// @notice Fetches the amount of eEth respective to the amount of weEth sent in
-    /// @param _weETHAmount amount sent in
-    /// @return The total amount for the number of shares sent in
+    /**
+     * @notice Fetches the amount of eEth respective to the amount of weEth sent in
+     * @param _weETHAmount amount sent in
+     * @return The total amount for the number of shares sent in
+     */
     function getEETHByWeETH(uint256 _weETHAmount) public view returns (uint256) {
         return liquidityPool.amountForShare(_weETHAmount);
     }
 
-    // Amount of eETH for 1 weETH
+    /**
+     * @notice Fetches the amount of eETH for 1 weETH
+     * @return The amount of eETH for 1 weETH
+     */
     function getRate() external view returns (uint256) {
         return getEETHByWeETH(1 ether);
     }
 
+    /**
+     * @notice Fetches the implementation address
+     * @return The implementation address
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
-    // Role modifiers (`onlyAdmin`, `onlyOperatingMultisig`, `onlyGuardian`, `onlySuperGuardian`,
-    // `onlyUpgradeTimelock`, ...) are inherited from RolesLibrary.
 }

--- a/src/core/WeETH.sol
+++ b/src/core/WeETH.sol
@@ -86,6 +86,7 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
      * @param _roleRegistry The address of the role registry contract
      * @param _blacklister The address of the blacklister contract
      * @param _rateLimiter The address of the rate limiter contract
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(address _eETH, address _liquidityPool, address _roleRegistry, address _blacklister, address _rateLimiter)
         RolesLibrary(_roleRegistry)

--- a/src/core/interfaces/ILiquidityPool.sol
+++ b/src/core/interfaces/ILiquidityPool.sol
@@ -12,13 +12,6 @@ interface ILiquidityPool {
         uint8 v;
         bytes32 r;
         bytes32 s;
-    } 
-
-    enum SourceOfFunds {
-        UNDEFINED,
-        EETH,
-        ETHER_FAN,
-        DELEGATED_STAKING
     }
 
     struct FundStatistics {
@@ -39,6 +32,27 @@ interface ILiquidityPool {
 
     struct ValidatorSpawner {
         bool registered;
+    }
+
+    struct ConstructorAddresses {
+        address stakingManager;
+        address nodesManager;
+        address eETH;
+        address withdrawRequestNFT;
+        address liquifier;
+        address etherFiRedemptionManager;
+        address roleRegistry;
+        address priorityWithdrawalQueue;
+        address blacklister;
+        address etherFiAdminContract;
+        address membershipManager;
+    }
+
+    enum SourceOfFunds {
+        UNDEFINED,
+        EETH,
+        ETHER_FAN,
+        DELEGATED_STAKING
     }
 
     function totalValueOutOfLp() external view returns (uint128);

--- a/src/deposits/DepositAdapter.sol
+++ b/src/deposits/DepositAdapter.sol
@@ -6,18 +6,21 @@ import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import "@etherfi/core/interfaces/ILiquidityPool.sol";
-import "@etherfi/deposits/interfaces/ILiquifier.sol";
-import "@etherfi/core/interfaces/IeETH.sol";
-import "@etherfi/core/interfaces/IWeETH.sol";
 import "@etherfi/interfaces/IWETH.sol";
 import "@etherfi/interfaces/IwstETH.sol";
+import "@etherfi/core/interfaces/ILiquidityPool.sol";
+import "@etherfi/core/interfaces/IeETH.sol";
+import "@etherfi/core/interfaces/IWeETH.sol";
+import "@etherfi/deposits/interfaces/ILiquifier.sol";
 import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 
 contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     ILiquidityPool public immutable liquidityPool;
     ILiquifier public immutable liquifier;
     IeETH public immutable eETH;
@@ -27,22 +30,43 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
     IwstETH public immutable wstETH;
     IBlacklister public immutable blacklister;
 
-     enum SourceOfFunds {
+    enum SourceOfFunds {
         ETH,
         WETH,
         STETH,
         WSTETH
     }
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     event AdapterDeposit(address indexed sender, uint256 amount, SourceOfFunds source, address referral);
     event DustSwept(address indexed token, address indexed to, uint256 amount);
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     error AllowanceExceeded();
     error InsufficientBalance();
     error PermitExpired();
     error EthTransfersNotAccepted();
     error InvalidRecipient();
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTRUCTOR  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _liquidityPool The address of the liquidity pool
+     * @param _liquifier The address of the liquifier
+     * @param _weETH The address of the weETH contract
+     * @param _eETH The address of the eETH contract
+     * @param _wETH The address of the wETH contract
+     * @param _stETH The address of the stETH contract
+     * @param _wstETH The address of the wstETH contract
+     * @param _roleRegistry The address of the role registry
+     * @param _blacklister The address of the blacklister
+     */
     constructor(address _liquidityPool, address _liquifier, address _weETH, address _eETH, address _wETH, address _stETH, address _wstETH, address _roleRegistry, address _blacklister) RolesLibrary(_roleRegistry) {
         liquidityPool = ILiquidityPool(_liquidityPool);
         liquifier = ILiquifier(_liquifier);
@@ -56,14 +80,25 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
         _disableInitializers();
     }
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  INITIALIZERS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the contract
+     */
     function initialize() initializer external {
         __Ownable_init();
         __UUPSUpgradeable_init();
     }
 
-    /// @notice Deposit ETH for weETH
-    /// @param _referral Address to credit rewards
-    /// @return weEthAmount weETH received by the depositer
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  DEPOSIT FUNCTIONS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Deposit ETH for weETH
+     * @param _referral Address to credit rewards
+     * @return weEthAmount weETH received by the depositer
+     */
     function depositETHForWeETH(address _referral) external payable nonBlacklisted returns (uint256) {
         uint256 eETHShares = liquidityPool.deposit{value: msg.value}(_referral);
         
@@ -71,11 +106,13 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
         return _wrapAndReturn(eETHShares);
     }
 
-    /// @notice Deposit WETH for weETH
-    /// @dev WETH doesn't support permit, so this function requires an explicit approval before use
-    /// @param _amount Amount of WETH to deposit 
-    /// @param _referral Address to credit referral
-    /// @return weEthAmount weETH received by the depositer
+    /**
+     * @notice Deposit WETH for weETH
+     * @param _amount Amount of WETH to deposit 
+     * @param _referral Address to credit referral
+     * @return weEthAmount weETH received by the depositer
+     * @dev WETH doesn't support permit, so this function requires an explicit approval before use
+     */
     function depositWETHForWeETH(uint256 _amount, address _referral) external nonBlacklisted returns (uint256) {
         if (wETH.allowance(msg.sender, address(this)) < _amount) revert AllowanceExceeded();
         if (wETH.balanceOf(msg.sender) < _amount) revert InsufficientBalance();
@@ -89,12 +126,14 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
         return _wrapAndReturn(eETHShares);
     }
 
-    /// @notice Deposit stETH to liquifier for weETH
-    /// @dev Permit must be created to this contract 
-    /// @param _amount Amount of stETH to deposit
-    /// @param _referral Address to credit referral
-    /// @param _permit Permit signature
-    /// @return weEthAmount weETH received by the depositer
+    /**
+     * @notice Deposit stETH to liquifier for weETH
+     * @param _amount Amount of stETH to deposit
+     * @param _referral Address to credit referral
+     * @param _permit Permit signature
+     * @return weEthAmount weETH received by the depositer
+     * @dev Permit must be created to this contract 
+     */
     function depositStETHForWeETHWithPermit(uint256 _amount, address _referral, ILiquifier.PermitInput calldata _permit) external nonBlacklisted returns (uint256) {
         try IERC20PermitUpgradeable(address(stETH)).permit(msg.sender, address(this), _permit.value, _permit.deadline, _permit.v, _permit.r, _permit.s) {}
         catch {
@@ -113,12 +152,14 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
         return _wrapAndReturn(eETHShares);
     }
 
-    /// @notice Deposit wstETH for weETH
-    /// @dev Permit for wsETH must be created to this contract. funds are unwrapped to stETH and deposited to liquifier
-    /// @param _amount Amount of wstETH to deposit
-    /// @param _referral Address to credit referral
-    /// @param _permit Permit signature
-    /// @return weEthAmount weETH received by the depositer
+    /**
+     * @notice Deposit wstETH for weETH
+     * @param _amount Amount of wstETH to deposit
+     * @param _referral Address to credit referral
+     * @param _permit Permit signature
+     * @return weEthAmount weETH received by the depositer
+     * @dev Permit for wsETH must be created to this contract. funds are unwrapped to stETH and deposited to liquifier
+     */
     function depositWstETHForWeETHWithPermit(uint256 _amount, address _referral, ILiquifier.PermitInput calldata _permit) external nonBlacklisted returns (uint256) {
         try wstETH.permit(msg.sender, address(this), _permit.value, _permit.deadline, _permit.v, _permit.r, _permit.s) {}
         catch {
@@ -139,10 +180,41 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
         return _wrapAndReturn(eETHShares);
     }
 
+    //--------------------------------------------------------------------------------------
+    //------------------------------  OPERATIONAL FUNCTIONS  -------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Sweep dust accumulated in the adapter to a recipient.
+     * @param _token Address of the ERC20 to sweep
+     * @param _to Recipient of the swept tokens
+     * @dev Each deposit strands 1-2 wei of eETH due to floor-rounding in both
+     *      amountForShare (shares -> ETH) and wrap (ETH -> shares). This function
+     *      lets operations recover the residual balance of any ERC20 left here.
+     */
+    function sweepDust(address _token, address _to) external onlyOperatingMultisig {
+        if (_to == address(0)) revert InvalidRecipient();
+        uint256 balance = IERC20(_token).balanceOf(address(this));
+        if (balance == 0) revert InsufficientBalance();
+        IERC20(_token).safeTransfer(_to, balance);
+        emit DustSwept(_token, _to, balance);
+    }
+
+    /**
+     * @notice Receive ETH
+     * @dev Only callable when the msg.sender is the wETH contract
+     */
     receive() external payable {
         if (msg.sender != address(wETH)) revert EthTransfersNotAccepted();
     }
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  INTERNAL FUNCTIONS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Wrap eETH shares and return weETH
+     * @param _eEthShares Amount of eETH shares to wrap
+     * @return weEthAmount weETH received by the depositer
+     */
     function _wrapAndReturn(uint256 _eEthShares) internal returns (uint256) {
         uint256 eEthAmount = liquidityPool.amountForShare(_eEthShares);
         IERC20(address(eETH)).safeIncreaseAllowance(address(weETH), eEthAmount);
@@ -152,22 +224,18 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
         return weEthAmount;
     }
 
-    /// @notice Sweep dust accumulated in the adapter to a recipient.
-    /// @dev Each deposit strands 1-2 wei of eETH due to floor-rounding in both
-    ///      amountForShare (shares -> ETH) and wrap (ETH -> shares). This function
-    ///      lets operations recover the residual balance of any ERC20 left here.
-    /// @param _token Address of the ERC20 to sweep
-    /// @param _to Recipient of the swept tokens
-    function sweepDust(address _token, address _to) external onlyOperatingMultisig {
-        if (_to == address(0)) revert InvalidRecipient();
-        uint256 balance = IERC20(_token).balanceOf(address(this));
-        if (balance == 0) revert InsufficientBalance();
-        IERC20(_token).safeTransfer(_to, balance);
-        emit DustSwept(_token, _to, balance);
-    }
-
+    /**
+     * @notice Authorize contract upgrades
+     * @param newImplementation The address of the new implementation
+     */
     function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  MODIFIERS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Check if the sender is not blacklisted
+     */
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
         _;

--- a/src/deposits/DepositAdapter.sol
+++ b/src/deposits/DepositAdapter.sol
@@ -11,11 +11,11 @@ import "@etherfi/interfaces/IwstETH.sol";
 import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/core/interfaces/IeETH.sol";
 import "@etherfi/core/interfaces/IWeETH.sol";
-import "@etherfi/deposits/interfaces/ILiquifier.sol";
+import "@etherfi/deposits/interfaces/IDepositAdapter.sol";
 import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 
-contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
+contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary, IDepositAdapter {
     using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------
@@ -29,13 +29,6 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
     IERC20Upgradeable public immutable stETH;
     IwstETH public immutable wstETH;
     IBlacklister public immutable blacklister;
-
-    enum SourceOfFunds {
-        ETH,
-        WETH,
-        STETH,
-        WSTETH
-    }
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  EVENTS  ---------------------------------------
@@ -57,25 +50,17 @@ contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary {
     //--------------------------------------------------------------------------------------
     /**
      * @notice Constructor
-     * @param _liquidityPool The address of the liquidity pool
-     * @param _liquifier The address of the liquifier
-     * @param _weETH The address of the weETH contract
-     * @param _eETH The address of the eETH contract
-     * @param _wETH The address of the wETH contract
-     * @param _stETH The address of the stETH contract
-     * @param _wstETH The address of the wstETH contract
-     * @param _roleRegistry The address of the role registry
-     * @param _blacklister The address of the blacklister
+     * @param _constructorAddresses The addresses of the constructor addresses
      */
-    constructor(address _liquidityPool, address _liquifier, address _weETH, address _eETH, address _wETH, address _stETH, address _wstETH, address _roleRegistry, address _blacklister) RolesLibrary(_roleRegistry) {
-        liquidityPool = ILiquidityPool(_liquidityPool);
-        liquifier = ILiquifier(_liquifier);
-        eETH = IeETH(_eETH);
-        weETH = IWeETH(_weETH);
-        wETH = IWETH(_wETH);
-        stETH = IERC20Upgradeable(_stETH);
-        wstETH = IwstETH(_wstETH);
-        blacklister = IBlacklister(_blacklister);
+    constructor(ConstructorAddresses memory _constructorAddresses) RolesLibrary(_constructorAddresses.roleRegistry) {
+        liquidityPool = ILiquidityPool(_constructorAddresses.liquidityPool);
+        liquifier = ILiquifier(_constructorAddresses.liquifier);
+        eETH = IeETH(_constructorAddresses.eETH);
+        weETH = IWeETH(_constructorAddresses.weETH);
+        wETH = IWETH(_constructorAddresses.wETH);
+        stETH = IERC20Upgradeable(_constructorAddresses.stETH);
+        wstETH = IwstETH(_constructorAddresses.wstETH);
+        blacklister = IBlacklister(_constructorAddresses.blacklister);
 
         _disableInitializers();
     }

--- a/src/deposits/Liquifier.sol
+++ b/src/deposits/Liquifier.sol
@@ -121,6 +121,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
      * @param _minDiscountInBasisPoints The minimum discount rate in basis points
      * @param _stalePriceWindow The stale price window
      * @param _maxPriceDeviationInBps The maximum price deviation in basis points
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minDiscountInBasisPoints, uint256 _stalePriceWindow, uint256 _maxPriceDeviationInBps) RolesLibrary(_constructorAddresses.roleRegistry) {
         if (_minDiscountInBasisPoints == 0 || _minDiscountInBasisPoints > BASIS_POINT_SCALE) revert InvalidDiscountRate();

--- a/src/deposits/Liquifier.sol
+++ b/src/deposits/Liquifier.sol
@@ -49,7 +49,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  --------------------------------------
     //--------------------------------------------------------------------------------------
-
     ILiquidityPool public immutable liquidityPool;
     ILidoWithdrawalQueue public immutable lidoWithdrawalQueue;
     ILido public immutable lido;
@@ -67,7 +66,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     uint256 public constant BASIS_POINT_SCALE = 10_000;
     uint256 public constant SHARE_UNIT = 1e18;
     uint32 public constant MAX_TIME_BOUND_CAP_IN_ETHER = 500_000_000;
@@ -80,7 +78,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     event Liquified(address _user, uint256 _toEEthAmount, address _fromToken, bool _isRestaked);
     // This event is deprecated. will be removed in the next release.
     // event RegisteredQueuedWithdrawal(bytes32 _withdrawalRoot, IStrategyManager.DeprecatedStruct_QueuedWithdrawal _queuedWithdrawal);
@@ -92,7 +89,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     error NotSupportedToken();
     error EthTransferFailed();
     error AlreadyRegistered();
@@ -116,23 +112,16 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     error AddressZero();
     error InvalidTotalSupply();
 
-    struct ConstructorAddresses {
-        address liquidityPool;
-        address lidoWithdrawalQueue;
-        address lido;
-        address stEth_Eth_Pool;
-        address roleRegistry;
-        address stEthPriceFeed;
-        address blacklister;
-        address etherfiRestaker;
-        address l1SyncPool;
-    }
-
     //--------------------------------------------------------------------------------------
     //-------------------------------------  CONSTRUCTOR  ----------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _constructorAddresses The addresses of the constructor addresses
+     * @param _minDiscountInBasisPoints The minimum discount rate in basis points
+     * @param _stalePriceWindow The stale price window
+     * @param _maxPriceDeviationInBps The maximum price deviation in basis points
+     */
     constructor(ConstructorAddresses memory _constructorAddresses, uint256 _minDiscountInBasisPoints, uint256 _stalePriceWindow, uint256 _maxPriceDeviationInBps) RolesLibrary(_constructorAddresses.roleRegistry) {
         if (_minDiscountInBasisPoints == 0 || _minDiscountInBasisPoints > BASIS_POINT_SCALE) revert InvalidDiscountRate();
         if (_stalePriceWindow == 0) revert InvalidPriceWindow();
@@ -160,10 +149,18 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @notice initialize to set variables on deployment
+    /**
+     * @notice Initialize the Liquifier
+     * @param _treasury The address of the treasury
+     * @param _liquidityPool The address of the liquidity pool
+     * @param _eigenLayerStrategyManager The address of the eigen layer strategy manager
+     * @param _lidoWithdrawalQueue The address of the lido withdrawal queue
+     * @param _stEth The address of the stEth
+     * @param _stEth_Eth_Pool The address of the stEth_Eth_Pool
+     * @param _timeBoundCapRefreshInterval The time bounded cap refresh interval
+    */
     function initialize(address _treasury, address _liquidityPool, address _eigenLayerStrategyManager, address _lidoWithdrawalQueue, 
                         address _stEth, address _stEth_Eth_Pool,
                         uint32 _timeBoundCapRefreshInterval) initializer external {
@@ -175,14 +172,25 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         timeBoundCapRefreshInterval = _timeBoundCapRefreshInterval;
     }
 
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  RECEIVE FUNCTION  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Receive ETH
+     */
     receive() external payable {}
 
-    /// Deposit Liquid Staking Token such as stETH and Mint eETH
-    /// @param _token The address of the token to deposit
-    /// @param _amount The amount of the token to deposit
-    /// @param _referral The referral address
-    /// @return mintedAmount the amount of eETH minted to the caller (= msg.sender)
-    /// If the token is l2Eth, only the l2SyncPool can call this function
+    //--------------------------------------------------------------------------------------
+    //----------------------------  DEPOSIT FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Deposit Liquid Staking Token such as stETH and Mint eETH
+     * @param _token The address of the token to deposit
+     * @param _amount The amount of the token to deposit
+     * @param _referral The referral address
+     * @return mintedAmount the amount of eETH minted to the caller (= msg.sender)
+     * @dev If the token is l2Eth, only the l1SyncPool can call this function
+     */
     function depositWithERC20(address _token, uint256 _amount, address _referral) public nonReentrant whenNotPaused nonBlacklisted returns (uint256) {        
         if (!isTokenWhitelisted(_token) || (tokenInfos[_token].isL2Eth && msg.sender != l1SyncPool)) revert NotAllowed();
 
@@ -212,32 +220,78 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         return eEthShare;
     }
 
+    /**
+     * @notice Deposit Liquid Staking Token such as stETH and Mint eETH with Permit
+     * @param _token The address of the token to deposit
+     * @param _amount The amount of the token to deposit
+     * @param _referral The referral address
+     * @param _permit The permit input
+     * @return mintedAmount the amount of eETH minted to the caller (= msg.sender)
+     * @dev Only callable when contract is not paused
+     * @dev Only callable when sender is not blacklisted
+     */
     function depositWithERC20WithPermit(address _token, uint256 _amount, address _referral, PermitInput calldata _permit) external whenNotPaused nonBlacklisted returns (uint256) {
         try IERC20Permit(_token).permit(msg.sender, address(this), _permit.value, _permit.deadline, _permit.v, _permit.r, _permit.s) {} catch {}
         return depositWithERC20(_token, _amount, _referral);
     }
 
-    // Send the redeemed ETH back to the liquidity pool & Send the fee to Treasury
+    //--------------------------------------------------------------------------------------
+    //----------------------------  OPERATINAL FUNCTIONS  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Send the redeemed ETH back to the liquidity pool & Send the fee to Treasury
+     * @dev Only callable by the housekeeping operations
+     */
     function withdrawEther() external onlyHousekeepingOperations {
-        uint256 amountToLiquidityPool = _min(address(this).balance, liquidityPool.totalValueOutOfLp());
+        uint256 amountToLiquidityPool = Math.min(address(this).balance, liquidityPool.totalValueOutOfLp());
         (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: GAS_STIPEND_NO_GRIEF}("");
         if (!sent) revert EthTransferFailed();
     }
 
+    /**
+     * @notice Send the token to the etherfi restaker
+     * @param _token The address of the token to send
+     * @param _amount The amount of the token to send
+     * @dev Only callable by the housekeeping operations
+     */
     function sendToEtherFiRestaker(address _token, uint256 _amount) external onlyHousekeepingOperations {
         IERC20(_token).safeTransfer(etherfiRestaker, _amount);
     }
 
+    /**
+     * @notice Update the whitelisted token
+     * @param _token The address of the token to update
+     * @param _isWhitelisted The boolean value to set the token as whitelisted
+     * @dev Only callable by the upgrade timelock
+     */
     function updateWhitelistedToken(address _token, bool _isWhitelisted) external onlyUpgradeTimelock {
         tokenInfos[_token].isWhitelisted = _isWhitelisted;
     }
 
+    /**
+     * @notice Update the deposit cap
+     * @param _token The address of the token to update
+     * @param _timeBoundCapInEther The time bound cap in ether
+     * @param _totalCapInEther The total cap in ether
+     * @dev Only callable by the admin
+     */
     function updateDepositCap(address _token, uint32 _timeBoundCapInEther, uint32 _totalCapInEther) public onlyAdmin {
         if (_timeBoundCapInEther > MAX_TIME_BOUND_CAP_IN_ETHER || _totalCapInEther > MAX_TOTAL_CAP_IN_ETHER) revert InvalidDepositCap();
         tokenInfos[_token].timeBoundCapInEther = _timeBoundCapInEther;
         tokenInfos[_token].totalCapInEther = _totalCapInEther;
     }
 
+    /**
+     * @notice Register a new token
+     * @param _token The address of the token to register
+     * @param _target The address of the target
+     * @param _isWhitelisted The boolean value to set the token as whitelisted
+     * @param _discountInBasisPoints The discount in basis points
+     * @param _timeBoundCapInEther The time bound cap in ether
+     * @param _totalCapInEther The total cap in ether
+     * @param _isL2Eth The boolean value to set the token as l2Eth
+     * @dev Only callable by the upgrade timelock
+     */
     function registerToken(address _token, address _target, bool _isWhitelisted, uint16 _discountInBasisPoints, uint32 _timeBoundCapInEther, uint32 _totalCapInEther, bool _isL2Eth) external onlyUpgradeTimelock {
         if (_discountInBasisPoints < minDiscountRateInBps || _discountInBasisPoints > BASIS_POINT_SCALE) revert InvalidDiscountRate();
         if (_timeBoundCapInEther > MAX_TIME_BOUND_CAP_IN_ETHER || _totalCapInEther > MAX_TOTAL_CAP_IN_ETHER) revert InvalidDepositCap();
@@ -252,45 +306,42 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         tokenInfos[_token] = TokenInfo(0, 0, IStrategy(_target), _isWhitelisted, _discountInBasisPoints, uint32(block.timestamp), _timeBoundCapInEther, _totalCapInEther, 0, 0, _isL2Eth);
     }
 
+    /**
+     * @notice Update the time bound cap refresh interval
+     * @param _timeBoundCapRefreshInterval The time bound cap refresh interval
+     * @dev Only callable by the admin
+     */
     function updateTimeBoundCapRefreshInterval(uint32 _timeBoundCapRefreshInterval) external onlyAdmin {
         timeBoundCapRefreshInterval = _timeBoundCapRefreshInterval;
     }
 
+    /**
+     * @notice Update the discount in basis points
+     * @param _token The address of the token to update
+     * @param _discountInBasisPoints The discount in basis points
+     * @dev Only callable by the admin
+     */
     function updateDiscountInBasisPoints(address _token, uint16 _discountInBasisPoints) external onlyAdmin {
         if (_discountInBasisPoints < minDiscountRateInBps || _discountInBasisPoints > BASIS_POINT_SCALE) revert InvalidDiscountRate();
         tokenInfos[_token].discountInBasisPoints = _discountInBasisPoints;
     }
 
+    /**
+     * @notice Update the quote stEth with curve
+     * @param _quoteStEthWithCurve The boolean value to set the quote stEth with curve
+     * @dev Only callable by the admin
+     */
     function updateQuoteStEthWithCurve(bool _quoteStEthWithCurve) external onlyAdmin {
         quoteStEthWithCurve = _quoteStEthWithCurve;
     }
 
-    //Pauses the contract
-    function pauseContract() external onlyOperatingMultisig {
-        _pause();
-    }
-
-    //Unpauses the contract
-    function unPauseContract() external onlyOperatingMultisig {
-        _unpause();
-    }
-
-    /// @notice Pauses the contract until MAX_PAUSE_DURATION
-    function pauseContractUntil() external onlyGuardian {
-        _pauseUntil();
-    }
-
-    /// @notice Unpauses the contract from pauseUntil
-    function unpauseContractUntil() external onlyOperatingMultisig {
-        _unpauseUntil();
-    }
-
-    /// @notice Sets the pause duration for the contract
-    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
-        _setPauseUntilDuration(_pauseUntilDuration);
-    }
-
-    // ETH comes in, L2ETH is burnt
+    /**
+     * @notice Unwrap the L2ETH
+     * @param _l2Eth The address of the L2ETH to unwrap
+     * @return The amount of ETH unwrapped
+     * @dev Only callable by the l1SyncPool
+     * @dev Only callable when the token is whitelisted and isL2Eth
+     */
     function unwrapL2Eth(address _l2Eth) external payable nonReentrant returns (uint256) {
         if (msg.sender != l1SyncPool) revert IncorrectCaller();
         if (!isTokenWhitelisted(_l2Eth) || !tokenInfos[_l2Eth].isL2Eth) revert NotSupportedToken();
@@ -300,9 +351,60 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         return msg.value;
     }
 
-    /* VIEW FUNCTIONS */
+    //--------------------------------------------------------------------------------------
+    //----------------------------  PAUSING FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pauses the contract
+     * @dev Only callable by the operating multisig
+     */
+    function pauseContract() external onlyOperatingMultisig {
+        _pause();
+    }
 
-    // Given the `_amount` of `_token` token, returns the equivalent amount of ETH 
+    /**
+     * @notice Unpauses the contract
+     * @dev Only callable by the operating multisig
+     */
+    function unPauseContract() external onlyOperatingMultisig {
+        _unpause();
+    }
+
+    /**
+     * @notice Pauses the contract until pauseUntilDuration
+     * @dev Only callable by the guardian
+     */
+    function pauseContractUntil() external onlyGuardian {
+        _pauseUntil();
+    }
+
+    /**
+     * @notice Unpauses the contract from pauseUntil
+     * @dev Only callable by the operating multisig
+     */
+    function unpauseContractUntil() external onlyOperatingMultisig {
+        _unpauseUntil();
+    }
+
+    /**
+     * @notice Sets the pause duration for the contract
+     * @param _pauseUntilDuration The pause duration
+     * @dev Only callable by the admin
+     */
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  VIEW FUNCTIONS  ----------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    /**
+     * @notice Quote the fair value of the token
+     * @param _token The address of the token to quote
+     * @param _amount The amount of the token to quote
+     * @return The fair value of the token
+     */
     function quoteByFairValue(address _token, uint256 _amount) public view returns (uint256) {
         if (!isTokenWhitelisted(_token)) revert NotSupportedToken();
 
@@ -312,11 +414,24 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         revert NotSupportedToken();
     }
 
+    /**
+     * @notice Quote the strategy share for deposit
+     * @param _token The address of the token to quote
+     * @param _strategy The address of the strategy
+     * @param _share The share of the strategy
+     * @return The strategy share for deposit
+     */
     function quoteStrategyShareForDeposit(address _token, IStrategy _strategy, uint256 _share) public view returns (uint256) {
         uint256 tokenAmount = _strategy.sharesToUnderlyingView(_share);
         return quoteByMarketValue(_token, tokenAmount);
     }
 
+    /**
+     * @notice Quote the market value of the token
+     * @param _token The address of the token to quote
+     * @param _amount The amount of the token to quote
+     * @return _marketValue The market value of the token
+     */
     function quoteByMarketValue(address _token, uint256 _amount) public view returns (uint256 _marketValue) {
         if (!isTokenWhitelisted(_token)) revert NotSupportedToken();
 
@@ -324,7 +439,7 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
             if (quoteStEthWithCurve) {
                 // check market value from curve pool, stETH price is on avrage always lower than ETH (this is essentially the capital efficiency of the protocol)
                 // if stETH price is temporarily larger than underlying ETH value, we set market value as 1:1 
-                _marketValue = _min(_amount, ICurvePoolQuoter1(address(stEth_Eth_Pool)).get_dy(1, 0, _amount));
+                _marketValue = Math.min(_amount, ICurvePoolQuoter1(address(stEth_Eth_Pool)).get_dy(1, 0, _amount));
 
                 // We also validate against chainlink price feed to ensure there's no significant price deviation 
                 // If price feed is stale, we skip the check
@@ -347,21 +462,40 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         }
     }
 
-    // Calculates the amount of eETH that will be minted for a given token considering the discount rate
+    /**
+     * @notice Quote the discounted value of the token
+     * @param _token The address of the token to quote
+     * @param _amount The amount of the token to quote
+     * @return The discounted value of the token
+     */
     function quoteByDiscountedValue(address _token, uint256 _amount) public view returns (uint256) {
         uint256 marketValue = quoteByMarketValue(_token, _amount);
 
         return (BASIS_POINT_SCALE - tokenInfos[_token].discountInBasisPoints).mulDiv(marketValue, BASIS_POINT_SCALE);
     }
 
+    /**
+     * @notice Check if the token is whitelisted
+     * @param _token The address of the token to check
+     * @return True if the token is whitelisted, false otherwise
+     */
     function isTokenWhitelisted(address _token) public view returns (bool) {
         return tokenInfos[_token].isWhitelisted;
     }
 
+    /**
+     * @notice Check if the token is L2ETH
+     * @param _token The address of the token to check
+     * @return True if the token is L2ETH, false otherwise
+     */
     function isL2Eth(address _token) public view returns (bool) {
         return tokenInfos[_token].isL2Eth;
     }
 
+    /**
+     * @notice Get the total pooled ether
+     * @return total The total pooled ether
+     */
     function getTotalPooledEther() public view returns (uint256 total) {
         total = address(this).balance;
         for (uint256 i = 0; i < dummies.length; i++) {
@@ -369,10 +503,17 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         }
     }
 
-    /// deposited (restaked) ETH can have 3 states:
-    /// - restaked in EigenLayer & pending for withdrawals
-    /// - non-restaked & held by this contract
-    /// - non-restaked & not held by this contract & pending for withdrawals
+    /**
+     * @notice Get the total pooled ether splits
+     * @param _token The address of the token to get the total pooled ether splits
+     * @return restaked The amount of ether restaked
+     * @return holding The amount of ether holding
+     * @return pendingForWithdrawals The amount of ether pending for withdrawals
+     * @dev Deposited (restaked) ETH can have 3 states:
+     * - restaked in EigenLayer & pending for withdrawals
+     * - non-restaked & held by this contract
+     * - non-restaked & not held by this contract & pending for withdrawals
+     */
     function getTotalPooledEtherSplits(address _token) public view returns (uint256 restaked, uint256 holding, uint256 pendingForWithdrawals) {
         TokenInfo memory info = tokenInfos[_token];
         if (!isTokenWhitelisted(_token)) return (0, 0, 0);
@@ -380,27 +521,57 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         holding = quoteByFairValue(_token, IERC20(_token).balanceOf(address(this))); /// eth value for erc20 holdings
     }
 
+    /**
+     * @notice Get the total pooled ether
+     * @param _token The address of the token to get the total pooled ether
+     * @return The total pooled ether
+     */
     function getTotalPooledEther(address _token) public view returns (uint256) {
         (uint256 restaked, uint256 holding, uint256 pendingForWithdrawals) = getTotalPooledEtherSplits(_token);
         return restaked + holding + pendingForWithdrawals;
     }
 
+    /**
+     * @notice Get the implementation
+     * @return The implementation
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
 
+    /**
+     * @notice Get the time bound cap
+     * @param _token The address of the token to get the time bound cap
+     * @return The time bound cap
+     */
     function timeBoundCap(address _token) public view returns (uint256) {
         return uint256(1 ether) * tokenInfos[_token].timeBoundCapInEther;
     }
 
+    /**
+     * @notice Get the total cap
+     * @param _token The address of the token to get the total cap
+     * @return The total cap
+     */
     function totalCap(address _token) public view returns (uint256) {
         return uint256(1 ether) * tokenInfos[_token].totalCapInEther;
     }
 
+    /**
+     * @notice Get the total deposited
+     * @param _token The address of the token to get the total deposited
+     * @return The total deposited
+     */
     function totalDeposited(address _token) public view returns (uint256) {
         return tokenInfos[_token].totalDeposited;
     }
 
+    /**
+     * @notice Check if the deposit cap is reached
+     * @param _token The address of the token to check
+     * @param _amount The amount of the token to check
+     * @return True if the deposit cap is reached, false otherwise
+     */
     function isDepositCapReached(address _token, uint256 _amount) public view returns (bool) {
         TokenInfo memory info = tokenInfos[_token];
         uint96 totalDepositedThisPeriod_ = info.totalDepositedThisPeriod;
@@ -411,7 +582,14 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         return (totalDepositedThisPeriod_ + _amount > timeBoundCap(_token) || info.totalDeposited + _amount > totalCap(_token));
     }
 
-    /* INTERNAL FUNCTIONS */
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INTERNAL FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice After deposit
+     * @param _token The address of the token to after deposit
+     * @param _amount The amount of the token to after deposit
+     */
     function _afterDeposit(address _token, uint256 _amount) internal {
         TokenInfo storage info = tokenInfos[_token];
         if (block.timestamp >= info.timeBoundCapClockStartTime + timeBoundCapRefreshInterval) {
@@ -422,21 +600,38 @@ contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausab
         info.totalDeposited += uint96(_amount);
     }
 
+    /**
+     * @notice L2 sanity checks
+     * @param _token The address of the token to check
+     * @dev Only callable by the internal function
+     */
     function _L2SanityChecks(address _token) internal view {
         if (IERC20(_token).totalSupply() != IERC20(_token).balanceOf(address(this))) revert InvalidTotalSupply();
     }
 
-    function _min(uint256 _a, uint256 _b) internal pure returns (uint256) {
-        return (_a > _b) ? _b : _a;
-    }
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
+    /**
+     * @notice Require not paused
+     * @dev Only callable by the internal function
+     */
     function _requireNotPaused() internal override view {
         _requireNotPausedUntil();
         super._requireNotPaused();
     }
 
+    /**
+     * @notice Authorize upgrade
+     * @param newImplementation The address of the new implementation
+     * @dev Only callable by the upgrade timelock
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------------  MODIFIERS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Non blacklisted modifier
+     * @dev Only callable by the internal function
+     */
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
         _;

--- a/src/deposits/interfaces/IDepositAdapter.sol
+++ b/src/deposits/interfaces/IDepositAdapter.sol
@@ -12,8 +12,8 @@ interface IDepositAdapter {
         address wETH;
         address stETH;
         address wstETH;
-        address blacklister;
         address roleRegistry;
+        address blacklister;
     }
 
     enum SourceOfFunds {

--- a/src/deposits/interfaces/IDepositAdapter.sol
+++ b/src/deposits/interfaces/IDepositAdapter.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "@etherfi/deposits/interfaces/ILiquifier.sol";
+
+interface IDepositAdapter {
+    struct ConstructorAddresses {
+        address liquidityPool;
+        address liquifier;
+        address weETH;
+        address eETH;
+        address wETH;
+        address stETH;
+        address wstETH;
+        address blacklister;
+        address roleRegistry;
+    }
+
+    enum SourceOfFunds {
+        ETH,
+        WETH,
+        STETH,
+        WSTETH
+    }
+
+    function depositETHForWeETH(address _referral) external payable returns (uint256);
+    function depositWETHForWeETH(uint256 _amount, address _referral) external returns (uint256);
+    function depositStETHForWeETHWithPermit(uint256 _amount, address _referral, ILiquifier.PermitInput calldata _permit) external returns (uint256);
+    function depositWstETHForWeETHWithPermit(uint256 _amount, address _referral, ILiquifier.PermitInput calldata _permit) external returns (uint256);
+    function sweepDust(address _token, address _to) external;
+}

--- a/src/deposits/interfaces/ILiquifier.sol
+++ b/src/deposits/interfaces/ILiquifier.sol
@@ -154,6 +154,18 @@ interface ILiquifier {
         bool isL2Eth;
     }
 
+    struct ConstructorAddresses {
+        address liquidityPool;
+        address lidoWithdrawalQueue;
+        address lido;
+        address stEth_Eth_Pool;
+        address roleRegistry;
+        address stEthPriceFeed;
+        address blacklister;
+        address etherfiRestaker;
+        address l1SyncPool;
+    }
+
     function lido() external view returns (ILido);
     function lidoWithdrawalQueue() external view returns (ILidoWithdrawalQueue);
     function tokenInfos(address _token) external view returns (uint128, uint128, IStrategy, bool, uint16, uint32, uint32, uint32, uint96, uint96, bool);

--- a/src/governance/Blacklister.sol
+++ b/src/governance/Blacklister.sol
@@ -7,27 +7,59 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 
 contract Blacklister is Initializable, UUPSUpgradeable, RolesLibrary {
-
-    uint256 public constant BLACKLIST_DURATION = 3 days;
-
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
     mapping(address => uint256) public blacklistedUntil;
 
-    error BlacklistedUser(address user);
-    error UserAlreadyBlacklisted(address user);
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  CONSTANTS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    uint256 public constant BLACKLIST_DURATION = 3 days;
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  EVENTS  -----------------------------------------
+    //--------------------------------------------------------------------------------------
     event UserBlacklisted(address user);
     event UserUnblacklisted(address user);
     event UserBlacklistedUntil(address user, uint256 until);
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  ERRORS  -----------------------------------------
+    //--------------------------------------------------------------------------------------
+    error BlacklistedUser(address user);
+    error UserAlreadyBlacklisted(address user);
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  CONSTRUCTOR  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _roleRegistry The address of the role registry
+     */
     constructor(address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  INITIALIZER  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the contract
+     */
     function initialize() external initializer {
         __UUPSUpgradeable_init();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  BLACKLIST FUNCTIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Blacklist a user until a certain timestamp
+     * @param user The address of the user to blacklist
+     * @dev Only callable by the guardian
+     * reverts with UserAlreadyBlacklisted if the user is already blacklisted
+     */
 
     function blacklistUserUntil(address user) external onlyGuardian {
         if (blacklistedUntil[user] > block.timestamp) revert UserAlreadyBlacklisted(user);
@@ -35,25 +67,65 @@ contract Blacklister is Initializable, UUPSUpgradeable, RolesLibrary {
         emit UserBlacklistedUntil(user, block.timestamp + BLACKLIST_DURATION);
     }
 
+    /**
+     * @notice Set a user's blacklist duration
+     * @param user The address of the user to set the blacklist duration for
+     * @param until The duration until the user is blacklisted
+     * @dev Only callable by the operating multisig
+     * reverts with UserAlreadyBlacklisted if the user is already blacklisted
+     */
     function setBlacklistUntil(address user, uint256 until) external onlyOperatingMultisig {
         blacklistedUntil[user] = block.timestamp + until;
         emit UserBlacklistedUntil(user, block.timestamp + until);
     }
 
+    /**
+     * @notice Blacklist a user indefinitely
+     * @param user The address of the user to blacklist
+     * @dev Only callable by the operating multisig
+     * reverts with UserAlreadyBlacklisted if the user is already blacklisted
+     */
     function blacklistUser(address user) external onlyOperatingMultisig {
         blacklistedUntil[user] = type(uint256).max;
         emit UserBlacklisted(user);
     }
 
+    /**
+     * @notice Unblacklist a user
+     * @param user The address of the user to unblacklist
+     * @dev Only callable by the operating multisig
+     * reverts with UserNotBlacklisted if the user is not blacklisted
+     */
     function unblacklistUser(address user) external onlyOperatingMultisig {
         blacklistedUntil[user] = 0;
         emit UserUnblacklisted(user);
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  INTERNAL FUNCTIONS  -----------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Authorize contract upgrades
+     * @param newImplementation The address of the new implementation
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  GETTERS  ----------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Check if a user is not blacklisted
+     * @param user The address of the user to check
+     * @dev reverts with BlacklistedUser if the user is blacklisted
+     */
     function nonBlacklisted(address user) external view {
         if (blacklistedUntil[user] > block.timestamp) revert BlacklistedUser(user);
     }
 
+    /**
+     * @notice Get the implementation address
+     * @return The implementation address
+     */
     function getImplementation() external view returns (address) { 
         return _getImplementation(); 
     }

--- a/src/governance/RevokeAdmin.sol
+++ b/src/governance/RevokeAdmin.sol
@@ -8,42 +8,100 @@ import "@etherfi/governance/utils/RolesLibrary.sol";
 import "@etherfi/governance/interfaces/IRevokeAdmin.sol";
 
 contract RevokeAdmin is Initializable, UUPSUpgradeable, RolesLibrary, IRevokeAdmin {
-
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  CONSTRUCTOR  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _roleRegistry The address of the role registry
+     */
     constructor(address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  INITIALIZER  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the contract
+     */
     function initialize() external initializer {
         __UUPSUpgradeable_init();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  REVOKE FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Revoke the super guardian role from an account
+     * @param account The address of the account to revoke the role from
+     * @dev Only callable by the operating multisig
+     */
     function revokeSuperGuardianRole(address account) external onlyOperatingMultisig {
         _revokeFast(roleRegistry.SUPER_GUARDIAN_ROLE(), account);
     }
 
+    /**
+     * @notice Revoke the guardian role from an account
+     * @param account The address of the account to revoke the role from
+     * @dev Only callable by the operating multisig
+     */
     function revokeGuardianRole(address account) external onlyOperatingMultisig {
         _revokeFast(roleRegistry.GUARDIAN_ROLE(), account);
     }
 
+    /**
+     * @notice Revoke the oracle operations role from an account
+     * @param account The address of the account to revoke the role from
+     * @dev Only callable by the operating multisig
+     */
     function revokeOracleOperationsRole(address account) external onlyOperatingMultisig {
         _revokeFast(roleRegistry.ORACLE_OPERATIONS_ROLE(), account);
     }
 
+    /**
+     * @notice Revoke the housekeeping operations role from an account
+     * @param account The address of the account to revoke the role from
+     * @dev Only callable by the operating multisig
+     */
     function revokeHousekeepingOperationsRole(address account) external onlyOperatingMultisig {
         _revokeFast(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), account);
     }
 
+    /**
+     * @notice Revoke the executor operations role from an account
+     * @param account The address of the account to revoke the role from
+     * @dev Only callable by the operating multisig
+     */
     function revokeExecutorOperationsRole(address account) external onlyOperatingMultisig {
         _revokeFast(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), account);
     }
 
+    /**
+     * @notice Revoke the eigenpod operations role from an account
+     * @param account The address of the account to revoke the role from
+     * @dev Only callable by the operating multisig
+     */
     function revokeEigenpodOperationsRole(address account) external onlyOperatingMultisig {
         _revokeFast(roleRegistry.EIGENPOD_OPERATIONS_ROLE(), account);
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  INTERNAL FUNCTIONS  -----------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Revoke a role from an account quickly
+     * @param role The role to revoke (as bytes32)
+     * @param account The address of the account to revoke the role from
+     * @dev Only callable by the revoke admin
+     */
     function _revokeFast(bytes32 role, address account) internal {
         roleRegistry.revokeFast(role, account);
     }
+
+    /**
+     * @notice Authorize contract upgrades
+     * @param newImplementation The address of the new implementation
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 }

--- a/src/governance/RoleRegistry.sol
+++ b/src/governance/RoleRegistry.sol
@@ -10,8 +10,14 @@ import {EnumerableRoles} from "solady/auth/EnumerableRoles.sol";
 /// @dev Implements UUPS upgradeability pattern and uses Solady's EnumerableRoles for efficient role management
 /// @author EtherFi
 contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, EnumerableRoles {
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  IMMUTABLES  -------------------------------------
+    //--------------------------------------------------------------------------------------
     address public immutable revokeAdmin;
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  CONSTANTS  --------------------------------------
+    //--------------------------------------------------------------------------------------
     bytes32 public constant UPGRADE_TIMELOCK_ROLE = keccak256("UPGRADE_TIMELOCK_ROLE"); // 10 day timelock
     bytes32 public constant OPERATION_TIMELOCK_ROLE = keccak256("OPERATION_TIMELOCK_ROLE"); // 2 day timelock
     bytes32 public constant OPERATION_MULTISIG_ROLE = keccak256("OPERATION_MULTISIG_ROLE"); // 4 of 7 multisig
@@ -22,6 +28,9 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     bytes32 public constant EXECUTOR_OPERATIONS_ROLE = keccak256("EXECUTOR_OPERATIONS_ROLE"); // Executor operations role
     bytes32 public constant EIGENPOD_OPERATIONS_ROLE = keccak256("EIGENPOD_OPERATIONS_ROLE"); // Eigenpod operations role
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  ERRORS  -----------------------------------------
+    //--------------------------------------------------------------------------------------
     error OnlyUpgradeTimelock();
     error OnlyOperatingTimelock();
     error OnlyOperatingMultisig();
@@ -34,111 +43,197 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     error OnlyRevokeAdmin();
     error InvalidRoleToRevoke();
 
-    /// @notice Returns the maximum allowed role value
-    /// @dev This is used by EnumerableRoles._validateRole to ensure roles are within valid range
-    /// @return uint256 The maximum role value
-    function MAX_ROLE() public pure returns (uint256) {
-        return type(uint256).max;
-    }
-
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  CONSTRUCTOR  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _revokeAdmin The address of the revoke admin
+     */
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _revokeAdmin) {
         revokeAdmin = _revokeAdmin;
         _disableInitializers();
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  INITIALIZER  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the contract
+     * @param _owner The address of the owner
+     */
     function initialize(address _owner) public initializer {
         __Ownable2Step_init();
         __UUPSUpgradeable_init();
         _transferOwnership(_owner);
     }
 
-    /// @notice Checks if an account has any of the specified roles
-    /// @dev Reverts if the account doesn't have at least one of the roles
-    /// @param account The address to check roles for
-    /// @param encodedRoles ABI encoded roles (abi.encode(ROLE_1, ROLE_2, ...))
-    function checkRoles(address account, bytes memory encodedRoles) public view {
-        if (!_hasAnyRoles(account, encodedRoles)) __revertEnumerableRolesUnauthorized();
-    }
-
-    /// @notice Checks if an account has a specific role
-    /// @param role The role to check (as bytes32)
-    /// @param account The address to check the role for
-    /// @return bool True if the account has the role, false otherwise
-    function hasRole(bytes32 role, address account) public view returns (bool) {
-        return hasRole(account, uint256(role));
-    }
-
-    /// @notice Grants a role to an account
-    /// @dev Only callable by the contract owner (handled in setRole function)
-    /// @param role The role to grant (as bytes32)
-    /// @param account The address to grant the role to
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  ROLE FUNCTIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Grants a role to an account
+     * @param role The role to grant (as bytes32)
+     * @param account The address to grant the role to
+     * @dev Only callable by the contract owner (handled in setRole function)
+     */
     function grantRole(bytes32 role, address account) public {
         setRole(account, uint256(role), true);  
     } 
 
-    /// @notice Revokes a role from an account
-    /// @dev Only callable by the contract owner (handled in setRole function)
-    /// @param role The role to revoke (as bytes32)
-    /// @param account The address to revoke the role from
+    /**
+     * @notice Revokes a role from an account
+     * @param role The role to revoke (as bytes32)
+     * @param account The address to revoke the role from
+     * @dev Only callable by the contract owner (handled in setRole function)
+     */
     function revokeRole(bytes32 role, address account) public {
         setRole(account, uint256(role), false);  
     }
 
-    /// @notice Revokes a role from an account quickly
-    /// @dev Only callable by the revoke admin
-    /// @param role The role to revoke (as bytes32)
-    /// @param account The address to revoke the role from
+    /**
+     * @notice Revokes a role from an account quickly
+     * @param role The role to revoke (as bytes32)
+     * @param account The address to revoke the role from
+     * reverts with OnlyRevokeAdmin if the caller is not the revoke admin
+     * reverts with InvalidRoleToRevoke if the role is the upgrade timelock, operating timelock, or operating multisig
+     */
     function revokeFast(bytes32 role, address account) public {
         if (msg.sender != revokeAdmin) revert OnlyRevokeAdmin();
         if (role == UPGRADE_TIMELOCK_ROLE || role == OPERATION_TIMELOCK_ROLE || role == OPERATION_MULTISIG_ROLE) revert InvalidRoleToRevoke();
         _setRole(account, uint256(role), false);
     }
 
-    /// @notice Gets all addresses that have a specific role
-    /// @dev Wrapper around EnumerableRoles roleHolders function converting bytes32 to uint256
-    /// @param role The role to query (as bytes32)
-    /// @return address[] Array of addresses that have the specified role
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  GETTERS  ----------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Checks if an account has any of the specified roles
+     * @param account The address to check roles for
+     * @param encodedRoles ABI encoded roles (abi.encode(ROLE_1, ROLE_2, ...))
+     * @dev Reverts if the account doesn't have at least one of the roles
+     */
+    function checkRoles(address account, bytes memory encodedRoles) public view {
+        if (!_hasAnyRoles(account, encodedRoles)) __revertEnumerableRolesUnauthorized();
+    }   
+
+    /**
+     * @notice Checks if an account has a specific role
+     * @param role The role to check (as bytes32)
+     * @param account The address to check the role for
+     * @return bool True if the account has the role, false otherwise
+     */
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return hasRole(account, uint256(role));
+    }
+
+    /**
+     * @notice Returns the maximum allowed role value
+     * @dev This is used by EnumerableRoles._validateRole to ensure roles are within valid range
+     * @return The maximum role value
+     */
+    function MAX_ROLE() public pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /**
+     * @notice Gets all addresses that have a specific role
+     * @dev Wrapper around EnumerableRoles roleHolders function converting bytes32 to uint256
+     * @param role The role to query (as bytes32)
+     * @return The addresses that have the specified role
+     */
     function roleHolders(bytes32 role) public view returns (address[] memory) {
         return roleHolders(uint256(role));
     }
 
+    /**
+     * @notice Checks if an account is the upgrade timelock
+     * @dev Reverts if the account is not the upgrade timelock
+     * @param account The address to check
+     */
     function onlyUpgradeTimelock(address account) public view {
         if (!hasRole(UPGRADE_TIMELOCK_ROLE, account)) revert OnlyUpgradeTimelock();
     }
 
+    /**
+     * @notice Checks if an account is the operating timelock
+     * @dev Reverts if the account is not the operating timelock
+     * @param account The address to check
+     */
     function onlyOperatingTimelock(address account) public view {
         if (!hasRole(OPERATION_TIMELOCK_ROLE, account)) revert OnlyOperatingTimelock();
     }
 
+    /**
+     * @notice Checks if an account is the operating multisig
+     * @dev Reverts if the account is not the operating multisig
+     * @param account The address to check
+     */
     function onlyOperatingMultisig(address account) public view {
         if (!hasRole(OPERATION_MULTISIG_ROLE, account)) revert OnlyOperatingMultisig();
     }
 
+    /**
+     * @notice Checks if an account is the super guardian
+     * @dev Reverts if the account is not the super guardian
+     * @param account The address to check
+     */
     function onlySuperGuardian(address account) public view {
         if (!hasRole(SUPER_GUARDIAN_ROLE, account)) revert OnlySuperGuardian();
     }
 
+    /**
+     * @notice Checks if an account is the guardian
+     * @dev Reverts if the account is not the guardian
+     * @param account The address to check
+     */
     function onlyGuardian(address account) public view {
         if (!hasRole(GUARDIAN_ROLE, account)) revert OnlyGuardian();
     }
 
+    /**
+     * @notice Checks if an account is the oracle operations
+     * @dev Reverts if the account is not the oracle operations
+     * @param account The address to check
+     */
     function onlyOracleOperations(address account) public view {
         if (!hasRole(ORACLE_OPERATIONS_ROLE, account)) revert OnlyOracleOperations();
     }
 
+    /**
+     * @notice Checks if an account is the housekeeping operations
+     * @dev Reverts if the account is not the housekeeping operations
+     * @param account The address to check
+     */
     function onlyHousekeepingOperations(address account) public view {
         if (!hasRole(HOUSEKEEPING_OPERATIONS_ROLE, account)) revert OnlyHousekeepingOperations();
     }
 
+    /**
+     * @notice Checks if an account is the executor operations
+     * @dev Reverts if the account is not the executor operations
+     * @param account The address to check
+     */
     function onlyExecutorOperations(address account) public view {
         if (!hasRole(EXECUTOR_OPERATIONS_ROLE, account)) revert OnlyExecutorOperations();
     }
 
+    /**
+     * @notice Checks if an account is the eigenpod operations
+     * @dev Reverts if the account is not the eigenpod operations
+     * @param account The address to check
+     */
     function onlyEigenpodOperations(address account) public view {
         if (!hasRole(EIGENPOD_OPERATIONS_ROLE, account)) revert OnlyEigenpodOperations();
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  INTERNAL FUNCTIONS  -----------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Reverts if the account is not authorized
+     */
     function __revertEnumerableRolesUnauthorized() private pure {
         /// @solidity memory-safe-assembly
         assembly {
@@ -147,6 +242,11 @@ contract RoleRegistry is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
         }
     }
 
+    /**
+     * @notice Authorize contract upgrades
+     * @dev Only callable by the upgrade timelock
+     * @param newImplementation The address of the new implementation
+     */
     function _authorizeUpgrade(address newImplementation) internal override {
         onlyUpgradeTimelock(msg.sender);
     }

--- a/src/governance/utils/PausableUntil.sol
+++ b/src/governance/utils/PausableUntil.sol
@@ -4,65 +4,92 @@ pragma solidity ^0.8.27;
 import "@etherfi/governance/interfaces/IRoleRegistry.sol";
 
 abstract contract PausableUntil {
+    //--------------------------------------------------------------------------------------
+    //------------------------------  STORAGE STRUCT  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice PausableUntilStorage
+     * @dev Storage for the PausableUntil contract
+     * @param pausedUntil The timestamp when the contract is paused until
+     * @param pauseUntilDuration The duration for which the contract is paused until
+     * @param lastPauseTimestamp The timestamp when the last pause occurred
+     */
     struct PausableUntilStorage {
         uint256 pausedUntil;
         uint256 pauseUntilDuration;
         mapping(address => uint256) lastPauseTimestamp;
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  CONSTANTS  --------------------------------------
+    //--------------------------------------------------------------------------------------
     bytes32 private constant PAUSABLE_UNTIL_STORAGE_SLOT = 0x2c7e4bc092c2002f0baaf2f47367bc442b098266b43d189dafe4cb25f1e1fea2; // keccak256("pausableUntil.storage")
 
     uint256 public constant MIN_PAUSE_DURATION = 8 hours;
     uint256 public constant MAX_PAUSE_DURATION = 30 days;
     uint256 public constant PAUSER_UNTIL_COOLDOWN = 7 days;
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  EVENTS  -----------------------------------------
+    //--------------------------------------------------------------------------------------
     event PauseUntilDurationSet(uint256 pauseUntilDuration);
     event PausedUntil(uint256 pausedUntil);
     event UnpausedUntil();
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  ERRORS  -----------------------------------------
+    //--------------------------------------------------------------------------------------
     error ContractPausedUntil(uint256 pausedUntil);
     error ContractNotPausedUntil();
     error PauserCooldownStillActive();
     error InvalidPauseUntilDuration();
 
-    function pausedUntil() external view returns (uint256) {
-        return _getPausableUntilStorage().pausedUntil;
-    }
-
-    function pauseUntilDuration() external view returns (uint256) {
-        return _getPausableUntilStorage().pauseUntilDuration;
-    }
-
-    function lastPauseTimestamp(address pauser) external view returns (uint256) {
-        return _getPausableUntilStorage().lastPauseTimestamp[pauser];
-    }
-
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INTERNAL FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Get the storage of the PausableUntil contract
+     * @return $ The storage of the PausableUntil contract
+     */
     function _getPausableUntilStorage() internal pure returns (PausableUntilStorage storage $) {
         assembly {
             $.slot := PAUSABLE_UNTIL_STORAGE_SLOT
         }
     }
 
+    /**
+     * @notice Require the contract to be not paused until
+     */
     function _requireNotPausedUntil() internal view {
-        uint256 pausedUntil = _getPausableUntilStorage().pausedUntil;
-        if (pausedUntil >= block.timestamp) revert ContractPausedUntil(pausedUntil);
+        uint256 _pausedUntil = _getPausableUntilStorage().pausedUntil;
+        if (_pausedUntil >= block.timestamp) revert ContractPausedUntil(_pausedUntil);
     }
 
+    /**
+     * @notice Require the contract to be paused until
+     */
     function _requirePausedUntil() internal view {
-        uint256 pausedUntil = _getPausableUntilStorage().pausedUntil;
-        if (pausedUntil < block.timestamp) revert ContractNotPausedUntil();
+        uint256 _pausedUntil = _getPausableUntilStorage().pausedUntil;
+        if (_pausedUntil < block.timestamp) revert ContractNotPausedUntil();
     }
 
+    /**
+     * @notice Pause the contract until
+     * @dev only callable when contract is not paused until and pauser is not in cooldown
+     */
     function _pauseUntil() internal {
         _requireNotPausedUntil();
         PausableUntilStorage storage $ = _getPausableUntilStorage();
-        uint256 pauseUntilDuration = $.pauseUntilDuration;
-        if ($.lastPauseTimestamp[msg.sender] + pauseUntilDuration + PAUSER_UNTIL_COOLDOWN > block.timestamp) revert PauserCooldownStillActive();
-        $.pausedUntil = block.timestamp + pauseUntilDuration;
+        uint256 _pauseUntilDuration = $.pauseUntilDuration;
+        if ($.lastPauseTimestamp[msg.sender] + _pauseUntilDuration + PAUSER_UNTIL_COOLDOWN > block.timestamp) revert PauserCooldownStillActive();
+        $.pausedUntil = block.timestamp + _pauseUntilDuration;
         $.lastPauseTimestamp[msg.sender] = block.timestamp;
         emit PausedUntil($.pausedUntil);
     }
 
+    /**
+     * @notice Unpause the contract until
+     */
     function _unpauseUntil() internal {
         _requirePausedUntil();
         PausableUntilStorage storage $ = _getPausableUntilStorage();
@@ -70,12 +97,51 @@ abstract contract PausableUntil {
         emit UnpausedUntil();
     }
 
+    /**
+     * @notice Set the pause duration for the contract
+     * @param _pauseUntilDuration The new pause duration
+     */
     function _setPauseUntilDuration(uint256 _pauseUntilDuration) internal {
         if (_pauseUntilDuration < MIN_PAUSE_DURATION || _pauseUntilDuration > MAX_PAUSE_DURATION) revert InvalidPauseUntilDuration();
         _getPausableUntilStorage().pauseUntilDuration = _pauseUntilDuration;
         emit PauseUntilDurationSet(_pauseUntilDuration);
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  GETTERS  ----------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Get the timestamp when the contract is paused until
+     * @return The timestamp when the contract is paused until
+     */
+    function pausedUntil() external view returns (uint256) {
+        return _getPausableUntilStorage().pausedUntil;
+    }
+
+    /**
+     * @notice Get the pause duration for the contract
+     * @return The pause duration for the contract
+     */
+    function pauseUntilDuration() external view returns (uint256) {
+        return _getPausableUntilStorage().pauseUntilDuration;
+    }
+
+    /**
+     * @notice Get the last pause timestamp for a given pauser
+     * @param pauser The address of the pauser
+     * @return The last pause timestamp for the pauser
+     */
+    function lastPauseTimestamp(address pauser) external view returns (uint256) {
+        return _getPausableUntilStorage().lastPauseTimestamp[pauser];
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  MODIFIERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Modifier to check if the contract is not paused until
+     * @dev Only callable when the contract is not paused until
+     */
     modifier whenNotPausedUntil() {
         _requireNotPausedUntil();
         _;

--- a/src/governance/utils/ReentrancyGuardNamespaced.sol
+++ b/src/governance/utils/ReentrancyGuardNamespaced.sol
@@ -12,6 +12,9 @@ pragma solidity ^0.8.13;
 ///         This namespaced variant keeps `_status` at a deterministic slot so it can be
 ///         safely mixed into existing UUPS contracts without disturbing their layout.
 abstract contract ReentrancyGuardNamespaced {
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  CONSTANTS  --------------------------------------
+    //--------------------------------------------------------------------------------------
     // keccak256("etherfi.storage.ReentrancyGuard.v1")
     bytes32 private constant REENTRANCY_GUARD_SLOT =
         0xcd24049d7dcc1fde21494dba8ad7a067afb6b8f14dfe804abeeec84903344e97;
@@ -19,14 +22,17 @@ abstract contract ReentrancyGuardNamespaced {
     uint256 private constant NOT_ENTERED = 1;
     uint256 private constant ENTERED = 2;
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  ERRORS  -----------------------------------------
+    //--------------------------------------------------------------------------------------
     error ReentrancyGuardReentrantCall();
 
-    modifier nonReentrant() {
-        _nonReentrantBefore();
-        _;
-        _nonReentrantAfter();
-    }
-
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INTERNAL FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Require the contract to be not reentrant
+     */
     function _nonReentrantBefore() private {
         bytes32 slot = REENTRANCY_GUARD_SLOT;
         uint256 status;
@@ -36,8 +42,24 @@ abstract contract ReentrancyGuardNamespaced {
         assembly { sstore(slot, ENTERED) }
     }
 
+    /**
+     * @notice reset the reentrancy guard
+     */
     function _nonReentrantAfter() private {
         bytes32 slot = REENTRANCY_GUARD_SLOT;
         assembly { sstore(slot, NOT_ENTERED) }
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  MODIFIERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Modifier to check if the contract is not reentrant
+     * @dev Only callable when the contract is not reentrant
+     */
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
     }
 }

--- a/src/governance/utils/RolesLibrary.sol
+++ b/src/governance/utils/RolesLibrary.sol
@@ -4,52 +4,101 @@ pragma solidity ^0.8.27;
 import "@etherfi/governance/interfaces/IRoleRegistry.sol";
 
 abstract contract RolesLibrary {
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  IMMUTABLES  -------------------------------------
+    //--------------------------------------------------------------------------------------
     IRoleRegistry public immutable roleRegistry;
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  CONSTRUCTOR  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _roleRegistry The address of the role registry
+     */
     constructor(address _roleRegistry) {
         roleRegistry = IRoleRegistry(_roleRegistry);
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  MODIFIERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Modifier to check if the caller is the upgrade timelock
+     * @dev reverts with OnlyUpgradeTimelock if the caller is not the upgrade timelock
+     */
     modifier onlyUpgradeTimelock() {
         roleRegistry.onlyUpgradeTimelock(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the operating timelock
+     * @dev reverts with OnlyOperatingTimelock if the caller is not the operating timelock
+     */
     modifier onlyAdmin() {
         roleRegistry.onlyOperatingTimelock(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the operating multisig
+     * @dev reverts with OnlyOperatingMultisig if the caller is not the operating multisig
+     */
     modifier onlyOperatingMultisig() {
         roleRegistry.onlyOperatingMultisig(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the super guardian
+     * @dev reverts with OnlySuperGuardian if the caller is not the super guardian
+     */
     modifier onlySuperGuardian() {
         roleRegistry.onlySuperGuardian(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the guardian
+     * @dev reverts with OnlyGuardian if the caller is not the guardian
+     */
     modifier onlyGuardian() {
         roleRegistry.onlyGuardian(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the oracle operations
+     * @dev reverts with OnlyOracleOperations if the caller is not the oracle operations
+     */
     modifier onlyOracleOperations() {
         roleRegistry.onlyOracleOperations(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the housekeeping operations
+     * @dev reverts with OnlyHousekeepingOperations if the caller is not the housekeeping operations
+     */
     modifier onlyHousekeepingOperations() {
         roleRegistry.onlyHousekeepingOperations(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the executor operations
+     * @dev reverts with OnlyExecutorOperations if the caller is not the executor operations
+     */
     modifier onlyExecutorOperations() {
         roleRegistry.onlyExecutorOperations(msg.sender);
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is the eigenpod operations
+     * @dev reverts with OnlyEigenpodOperations if the caller is not the eigenpod operations
+     */
     modifier onlyEigenpodOperations() {
         roleRegistry.onlyEigenpodOperations(msg.sender);
         _;

--- a/src/oracle/EtherFiAdmin.sol
+++ b/src/oracle/EtherFiAdmin.sol
@@ -5,6 +5,7 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
+import "@etherfi/oracle/interfaces/IEtherFiAdmin.sol";
 import "@etherfi/oracle/interfaces/IEtherFiOracle.sol";
 import "@etherfi/staking/interfaces/IStakingManager.sol";
 import "@etherfi/staking/interfaces/IAuctionManager.sol";
@@ -21,18 +22,12 @@ interface IEtherFiPausable {
     function paused() external view returns (bool);
 }
 
-contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, RolesLibrary {
+contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, RolesLibrary, IEtherFiAdmin {
     using Math for uint256;
-
-    struct TaskStatus {
-        bool completed;
-        bool exists;
-    }
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
-
     // deprecated storage slots
     uint256[8] private __gap_0;
 
@@ -63,7 +58,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  --------------------------------------
     //--------------------------------------------------------------------------------------
-
     IEtherFiOracle public immutable etherFiOracle;
     IStakingManager public immutable stakingManager;
     IAuctionManager public immutable auctionManager;
@@ -83,31 +77,16 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     // Protocol fees must not exceed 1/MAX_PROTOCOL_FEE_INV_RATIO of total rewards (currently 20%).
     uint256 public constant MAX_PROTOCOL_FEE_INV_RATIO = 5;
     uint256 public constant STALE_REPORT_FINALIZATION_COOLDOWN = 7200; // 1 day
     uint256 public constant BASIS_POINTS_DENOMINATOR = 10_000;
 
-    struct ConstructorAddresses {
-        address etherFiOracle;
-        address stakingManager;
-        address auctionManager;
-        address etherFiNodesManager;
-        address liquidityPool;
-        address membershipManager;
-        address withdrawRequestNft;
-        address roleRegistry;
-        address priorityWithdrawalQueue;
-    }
-
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     event AdminUpdated(address _address, bool _isAdmin);
     event AdminOperationsExecuted(address indexed _address, bytes32 indexed _reportHash);
-
     event ValidatorApprovalTaskCreated(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
     event ValidatorApprovalTaskCompleted(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
     event ValidatorApprovalTaskInvalidated(bytes32 indexed _taskHash, bytes32 indexed _reportHash, uint256[] _validators);
@@ -115,7 +94,6 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     error InvalidMaxAcceptableFinalizedWithdrawalAmount();
     error InvalidMaxNumberOfRequestsToFinalizePerReport();
     error InvalidMaxFinalizedWithdrawalAmountPerDay();
@@ -138,8 +116,16 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
     //--------------------------------------------------------------------------------------
     //-------------------------------------  CONSTRUCTOR  ----------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _constructorAddresses The addresses of the constructor addresses
+     * @param _maxAcceptableRebaseAprInBps The maximum acceptable rebase APR in basis points
+     * @param _maxValidatorTaskBatchSize The maximum validator task batch size
+     * @param _staleOracleReportBlockWindow The stale oracle report block window
+     * @param _maxAcceptableFinalizedWithdrawalAmountPerDay The maximum acceptable finalized withdrawal amount per day
+     * @param _maxAcceptableNumValidatorsToApprovePerDay The maximum acceptable number of validators to approve per day
+     * @param _maxNumberOfRequestsToFinalizePerReport The maximum number of requests to finalize per report
+     */
     constructor(
         ConstructorAddresses memory _constructorAddresses,
         int256 _maxAcceptableRebaseAprInBps,
@@ -175,9 +161,20 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Initialize the EtherFiAdmin
+     * @param _etherFiOracle The address of the etherFiOracle contract
+     * @param _stakingManager The address of the stakingManager contract
+     * @param _auctionManager The address of the auctionManager contract
+     * @param _etherFiNodesManager The address of the etherFiNodesManager contract
+     * @param _liquidityPool The address of the liquidityPool contract
+     * @param _membershipManager The address of the membershipManager contract
+     * @param _withdrawRequestNft The address of the withdrawRequestNFT contract
+     * @param _acceptableRebaseAprInBps The acceptable rebase APR in basis points
+     * @param _postReportWaitTimeInSlots The post report wait time in slots
+     */
     function initialize(
         address _etherFiOracle,
         address _stakingManager,
@@ -196,16 +193,73 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         postReportWaitTimeInSlots = _postReportWaitTimeInSlots;
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  ADMIN FUNCTIONS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Set the validator task batch size
+     * @param _batchSize The batch size
+     */
     function setValidatorTaskBatchSize(uint16 _batchSize) external onlyAdmin {
         if (_batchSize == 0 || _batchSize > maxValidatorTaskBatchSize) revert InvalidValidatorTaskBatchSize();
         validatorTaskBatchSize = _batchSize;
     }
 
-    function canExecuteTasks(IEtherFiOracle.OracleReport calldata _report) external view returns (bool _isValid) {
-        bytes32 reportHash = etherFiOracle.generateReportHash(_report);
-        (_isValid,) = _validateReport(_report, reportHash);
+    /**
+     * @notice Update the maximum finalized withdrawal amount per day
+     * @param _maxFinalizedWithdrawalAmountPerDay The maximum finalized withdrawal amount per day
+     */
+    function updateMaxFinalizedWithdrawalAmountPerDay(uint256 _maxFinalizedWithdrawalAmountPerDay) external onlyAdmin {
+        if (_maxFinalizedWithdrawalAmountPerDay == 0 || _maxFinalizedWithdrawalAmountPerDay > maxAcceptableFinalizedWithdrawalAmountPerDay) revert InvalidMaxFinalizedWithdrawalAmountPerDay();
+        maxFinalizedWithdrawalAmountPerDay = _maxFinalizedWithdrawalAmountPerDay;
     }
 
+    /**
+     * @notice Update the maximum number of validators to approve per day
+     * @param _maxNumValidatorsToApprovePerDay The maximum number of validators to approve per day
+     */
+    function updateMaxNumValidatorsToApprovePerDay(uint256 _maxNumValidatorsToApprovePerDay) external onlyAdmin {
+        if (_maxNumValidatorsToApprovePerDay > maxAcceptableNumValidatorsToApprovePerDay) revert InvalidMaxNumValidatorsToApprovePerDay();
+        maxNumValidatorsToApprovePerDay = _maxNumValidatorsToApprovePerDay;
+    }
+
+    /**
+     * @notice Update the acceptable rebase APR in basis points
+     * @param _acceptableRebaseAprInBps The acceptable rebase APR in basis points
+     */
+    function updateAcceptableRebaseApr(int32 _acceptableRebaseAprInBps) external onlyAdmin {
+        if (_acceptableRebaseAprInBps < 0 || _acceptableRebaseAprInBps > maxAcceptableRebaseAprInBps) revert InvalidAcceptableRebaseApr();
+        acceptableRebaseAprInBps = _acceptableRebaseAprInBps;
+    }
+
+    /**
+     * @notice Update the post report wait time in slots
+     * @param _postReportWaitTimeInSlots The post report wait time in slots
+     */
+    function updatePostReportWaitTimeInSlots(uint16 _postReportWaitTimeInSlots) external onlyAdmin {
+        postReportWaitTimeInSlots = _postReportWaitTimeInSlots;
+    }
+
+    /**
+     * @notice Invalidate a validator approval task
+     * @param _reportHash The hash of the report
+     * @param _validators The validators to invalidate
+     */
+    function invalidateValidatorApprovalTask(bytes32 _reportHash, uint256[] calldata _validators) external onlyOperatingMultisig {
+        bytes32 taskHash = keccak256(abi.encode(_reportHash, _validators));
+        if (!validatorApprovalTaskStatus[taskHash].exists) revert TaskDoesNotExist();
+        if (validatorApprovalTaskStatus[taskHash].completed) revert TaskAlreadyCompleted();
+        validatorApprovalTaskStatus[taskHash].exists = false;
+        emit ValidatorApprovalTaskInvalidated(taskHash, _reportHash, _validators);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  ORACLE OPERATIONS FUNCTIONS  ----------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Execute the tasks for a report
+     * @param _report The report
+     */
     function executeTasks(IEtherFiOracle.OracleReport calldata _report) external {
         bytes32 reportHash = etherFiOracle.generateReportHash(_report);
         (bool _isValid, string memory _error) = _validateReport(_report, reportHash);
@@ -213,8 +267,8 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
 
         _handleAccruedRewards(_report);
         _handleProtocolFees(_report);
-        _handleValidators(reportHash, _report);
-        _handleWithdrawals(_report);
+        _enqueueValidatorApprovalTask(reportHash, _report);
+        _finalizeWithdrawals(_report.lastFinalizedWithdrawalRequestId, _report.finalizedWithdrawalAmount);
 
         lastHandledReportRefSlot = _report.refSlotTo;
         lastHandledReportRefBlock = _report.refBlockTo;
@@ -223,6 +277,13 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         emit AdminOperationsExecuted(msg.sender, reportHash);
     }
 
+    /**
+     * @notice Execute a validator approval task
+     * @param _reportHash The hash of the report
+     * @param _validators The validators to approve
+     * @param _pubKeys The public keys of the validators
+     * @param _signatures The signatures of the validators
+     */
     function executeValidatorApprovalTask(bytes32 _reportHash, uint256[] calldata _validators, bytes[] calldata _pubKeys, bytes[] calldata _signatures) external onlyOracleOperations {
         if (!etherFiOracle.isConsensusReached(_reportHash)) revert ConsensusNotReached();
         bytes32 taskHash = keccak256(abi.encode(_reportHash, _validators));
@@ -234,48 +295,15 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         emit ValidatorApprovalTaskCompleted(taskHash, _reportHash, _validators);
     }
 
-    /// @dev Builds DepositData[] from (validatorIds, pubKeys, signatures) and forwards to
-    ///      LiquidityPool.confirmAndFundBeaconValidators. Previously this construction lived
-    ///      in LiquidityPool.batchApproveRegistration; moved here so LP stays under the
-    ///      EIP-170 24,576-byte cap.
-    function _approveValidators(uint256[] calldata _validatorIds, bytes[] calldata _pubKeys, bytes[] calldata _signatures) internal {
-        uint256 validatorSizeWei = liquidityPool.validatorSizeWei();
-        if (validatorSizeWei < stakingManager.MIN_VALIDATOR_SIZE_WEI() || validatorSizeWei > stakingManager.MAX_VALIDATOR_SIZE_WEI()) revert InvalidValidatorSize();
-        if (_validatorIds.length == 0 || _validatorIds.length != _pubKeys.length || _validatorIds.length != _signatures.length) revert InvalidArrayLengths();
-
-        uint256 remainingEthPerValidator = validatorSizeWei - stakingManager.INITIAL_DEPOSIT_AMOUNT();
-        IStakingManager.DepositData[] memory depositData = new IStakingManager.DepositData[](_validatorIds.length);
-
-        for (uint256 i = 0; i < _validatorIds.length; i++) {
-            address eigenPod = address(IEtherFiNode(etherFiNodesManager.etherfiNodeAddress(_validatorIds[i])).getEigenPod());
-            bytes memory withdrawalCredentials = etherFiNodesManager.addressToCompoundingWithdrawalCredentials(eigenPod);
-            bytes32 depositDataRoot = stakingManager.generateDepositDataRoot(_pubKeys[i], _signatures[i], withdrawalCredentials, remainingEthPerValidator);
-
-            depositData[i] = IStakingManager.DepositData({
-                publicKey: _pubKeys[i],
-                signature: _signatures[i],
-                depositDataRoot: depositDataRoot,
-                ipfsHashForEncryptedValidatorKey: ""
-            });
-        }
-
-        liquidityPool.confirmAndFundBeaconValidators(depositData, validatorSizeWei);
-    }
-
-    function invalidateValidatorApprovalTask(bytes32 _reportHash, uint256[] calldata _validators) external onlyOperatingMultisig {
-        bytes32 taskHash = keccak256(abi.encode(_reportHash, _validators));
-        if (!validatorApprovalTaskStatus[taskHash].exists) revert TaskDoesNotExist();
-        if (validatorApprovalTaskStatus[taskHash].completed) revert TaskAlreadyCompleted();
-        validatorApprovalTaskStatus[taskHash].exists = false;
-        emit ValidatorApprovalTaskInvalidated(taskHash, _reportHash, _validators);
-    }
-
-    /// @notice Stale-oracle escape hatch. If oracle reports stop landing for staleOracleReportBlockWindow
-    ///         blocks past the last handled report, anyone can call this to finalize as many pending
-    ///         withdraw requests as the LP's current ETH balance can cover, in request-id order.
-    ///         Permissionless on purpose: a frozen oracle should not be able to freeze user redemptions.
-    /// @dev    Reverts with OracleReportNotStale if the window has not elapsed, or NoWithdrawalsToFinalize
-    ///         if no valid pending requests can be covered.
+    /**
+     * @notice Finalizes the withdrawals when the oracle is stale
+     * @dev Stale-oracle escape hatch. If oracle reports stop landing for staleOracleReportBlockWindow
+     *      blocks past the last handled report, anyone can call this to finalize as many pending
+     *      withdraw requests as the LP's current ETH balance can cover, in request-id order.
+     *      Permissionless on purpose: a frozen oracle should not be able to freeze user redemptions.
+     *      Reverts with OracleReportNotStale if the window has not elapsed, or NoWithdrawalsToFinalize
+     *      if no valid pending requests can be covered.
+     */
     function finalizeWithdrawalsWhenStale() external {
         if (block.number < etherFiOracle.lastPublishedReportRefBlock() + staleOracleReportBlockWindow) revert OracleReportNotStale();
         if (block.number < lastStaleReportFinalizationBlock + STALE_REPORT_FINALIZATION_COOLDOWN) revert StaleReportFinalizationCooldown();
@@ -305,7 +333,47 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         lastStaleReportFinalizationBlock = block.number;
     }
 
-    //protocol owns the eth that was distributed to NO and treasury in eigenpods and etherfinodes 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INTERNAL FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Approves the validators
+     * @param _validatorIds The validator ids
+     * @param _pubKeys The public keys of the validators
+     * @param _signatures The signatures of the validators
+     * @dev Builds DepositData[] from (validatorIds, pubKeys, signatures) and forwards to
+     *      LiquidityPool.confirmAndFundBeaconValidators. Previously this construction lived
+     *      in LiquidityPool.batchApproveRegistration; moved here so LP stays under the
+     *      EIP-170 24,576-byte cap.
+     */
+    function _approveValidators(uint256[] calldata _validatorIds, bytes[] calldata _pubKeys, bytes[] calldata _signatures) internal {
+        uint256 validatorSizeWei = liquidityPool.validatorSizeWei();
+        if (validatorSizeWei < stakingManager.MIN_VALIDATOR_SIZE_WEI() || validatorSizeWei > stakingManager.MAX_VALIDATOR_SIZE_WEI()) revert InvalidValidatorSize();
+        if (_validatorIds.length == 0 || _validatorIds.length != _pubKeys.length || _validatorIds.length != _signatures.length) revert InvalidArrayLengths();
+
+        uint256 remainingEthPerValidator = validatorSizeWei - stakingManager.INITIAL_DEPOSIT_AMOUNT();
+        IStakingManager.DepositData[] memory depositData = new IStakingManager.DepositData[](_validatorIds.length);
+
+        for (uint256 i = 0; i < _validatorIds.length; i++) {
+            address eigenPod = address(IEtherFiNode(etherFiNodesManager.etherfiNodeAddress(_validatorIds[i])).getEigenPod());
+            bytes memory withdrawalCredentials = etherFiNodesManager.addressToCompoundingWithdrawalCredentials(eigenPod);
+            bytes32 depositDataRoot = stakingManager.generateDepositDataRoot(_pubKeys[i], _signatures[i], withdrawalCredentials, remainingEthPerValidator);
+
+            depositData[i] = IStakingManager.DepositData({
+                publicKey: _pubKeys[i],
+                signature: _signatures[i],
+                depositDataRoot: depositDataRoot,
+                ipfsHashForEncryptedValidatorKey: ""
+            });
+        }
+
+        liquidityPool.confirmAndFundBeaconValidators(depositData, validatorSizeWei);
+    }
+
+    /**
+     * @notice Pays the protocol fees
+     * @param _report The report
+     */
     function _handleProtocolFees(IEtherFiOracle.OracleReport calldata _report) internal { 
         if(_report.protocolFees == 0) {
             return;
@@ -313,6 +381,10 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         liquidityPool.payProtocolFees(uint128(_report.protocolFees));
     }
 
+    /**
+     * @notice Rebases the protocol
+     * @param _report The report
+     */
     function _handleAccruedRewards(IEtherFiOracle.OracleReport calldata _report) internal {
         if (_report.accruedRewards == 0) {
             return;
@@ -321,6 +393,11 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         membershipManager.rebase(_report.accruedRewards);
     }
 
+    /**
+     * @notice Enqueues a validator approval task
+     * @param _reportHash The hash of the report
+     * @param _report The report
+     */
     function _enqueueValidatorApprovalTask(bytes32 _reportHash, IEtherFiOracle.OracleReport calldata _report) internal {
         if(_report.validatorsToApprove.length == 0) {
             return;
@@ -342,20 +419,24 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
             emit ValidatorApprovalTaskCreated(taskHash, _reportHash, batchValidators);
         }
     }
-
-    function _handleValidators(bytes32 _reportHash, IEtherFiOracle.OracleReport calldata _report) internal {
-        _enqueueValidatorApprovalTask(_reportHash, _report);
-    }
-
-    function _handleWithdrawals(IEtherFiOracle.OracleReport calldata _report) internal {
-        _finalizeWithdrawals(_report.lastFinalizedWithdrawalRequestId, _report.finalizedWithdrawalAmount);
-    }
     
+    /**
+     * @notice Finalizes the withdraw requests
+     * @param _lastFinalizedRequestId The last finalized request id
+     * @param _finalizedWithdrawalAmount The finalized withdrawal amount
+     */
     function _finalizeWithdrawals(uint32 _lastFinalizedRequestId, uint128 _finalizedWithdrawalAmount) internal {
         withdrawRequestNft.finalizeRequests(_lastFinalizedRequestId);
         liquidityPool.addEthAmountLockedForWithdrawal(_finalizedWithdrawalAmount);
     }
 
+    /**
+     * @notice Validates the report
+     * @param _report The report
+     * @param _reportHash The hash of the report
+     * @return _isValid True if the report is valid, false otherwise
+     * @return _error The error message
+     */
     function _validateReport(IEtherFiOracle.OracleReport calldata _report, bytes32 _reportHash) internal view returns (bool, string memory) {
         bool ok;
         string memory err;
@@ -388,6 +469,13 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         return (true, "");
     }
 
+    /**
+     * @notice Validates the report freshness
+     * @param _report The report
+     * @param _reportHash The hash of the report
+     * @return _isValid True if the report freshness is valid, false otherwise
+     * @return _error The error message
+     */
     function _validateReportFreshness(IEtherFiOracle.OracleReport calldata _report, bytes32 _reportHash) internal view returns (bool, string memory) {
         uint32 current_slot = etherFiOracle.computeSlotAtTimestamp(block.timestamp);
         if (!etherFiOracle.isConsensusReached(_reportHash)) return (false, "EtherFiAdmin: report didn't reach consensus");
@@ -397,6 +485,13 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         return (true, "");
     }
 
+    /**
+     * @notice Validates the rebase APR
+     * @param _report The report
+     * @param elapsedTime The elapsed time
+     * @return _isValid True if the rebase APR is valid, false otherwise
+     * @return _error The error message
+     */
     function _validateRebaseApr(IEtherFiOracle.OracleReport calldata _report, uint256 elapsedTime) internal view returns (bool, string memory) {
         int256 currentTVL = int128(uint128(liquidityPool.getTotalPooledEther()));
 
@@ -413,6 +508,12 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         return (true, "");
     }
 
+    /**
+     * @notice Validates the protocol fees
+     * @param _report The report
+     * @return _isValid True if the protocol fees are valid, false otherwise
+     * @return _error The error message
+     */
     function _validateProtocolFees(IEtherFiOracle.OracleReport calldata _report) internal pure returns (bool, string memory) {
         if (_report.protocolFees < 0) return (false, "EtherFiAdmin: protocol fees can't be negative");
         int128 totalRewards = _report.protocolFees + _report.accruedRewards;
@@ -421,12 +522,26 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         return (true, "");
     }
 
+    /**
+     * @notice Validates the validator approvals
+     * @param _report The report
+     * @param elapsedTime The elapsed time
+     * @return _isValid True if the validator approvals are valid, false otherwise
+     * @return _error The error message
+     */
     function _validateValidatorApprovals(IEtherFiOracle.OracleReport calldata _report, uint256 elapsedTime) internal view returns (bool, string memory) {
         uint256 numValidatorsToApprovePerDay = _report.validatorsToApprove.length.mulDiv(1 days, elapsedTime);
         if (numValidatorsToApprovePerDay > maxNumValidatorsToApprovePerDay) return (false, "EtherFiAdmin: number of validators to approve exceeds max");
         return (true, "");
     }
 
+    /**
+     * @notice Validates the withdrawals
+     * @param _report The report
+     * @param elapsedTime The elapsed time
+     * @return _isValid True if the withdrawals are valid, false otherwise
+     * @return _error The error message
+     */
     function _validateWithdrawals(IEtherFiOracle.OracleReport calldata _report, uint256 elapsedTime) internal view returns (bool, string memory) {
         uint256 finalizedWithdrawalAmountPerDay = uint256(_report.finalizedWithdrawalAmount).mulDiv(1 days, elapsedTime);
         if (finalizedWithdrawalAmountPerDay > maxFinalizedWithdrawalAmountPerDay) return (false, "EtherFiAdmin: finalized withdrawal amount exceeds max");
@@ -447,36 +562,46 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
         return (true, "");
     }
 
+    /**
+     * @notice Authorizes the upgrade of the contract
+     * @param newImplementation The new implementation
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  VIEW FUNCTIONS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Checks if the report can be executed
+     * @param _report The report
+     * @return _isValid True if the report can be executed, false otherwise
+     */
+    function canExecuteTasks(IEtherFiOracle.OracleReport calldata _report) external view returns (bool _isValid) {
+        bytes32 reportHash = etherFiOracle.generateReportHash(_report);
+        (_isValid,) = _validateReport(_report, reportHash);
+    }
+
+    /**
+     * @notice Gets the slot for the next report to process
+     * @return The slot for the next report to process
+     */
     function slotForNextReportToProcess() public view returns (uint32) {
         return (lastHandledReportRefSlot == 0) ? 0 : lastHandledReportRefSlot + 1;
     }
 
+    /**
+     * @notice Gets the block for the next report to process
+     * @return The block for the next report to process
+     */
     function blockForNextReportToProcess() public view returns (uint32) {
         return (lastHandledReportRefBlock == 0) ? 0 : lastHandledReportRefBlock + 1;
     }
 
-    function updateMaxFinalizedWithdrawalAmountPerDay(uint256 _maxFinalizedWithdrawalAmountPerDay) external onlyAdmin {
-        if (_maxFinalizedWithdrawalAmountPerDay == 0 || _maxFinalizedWithdrawalAmountPerDay > maxAcceptableFinalizedWithdrawalAmountPerDay) revert InvalidMaxFinalizedWithdrawalAmountPerDay();
-        maxFinalizedWithdrawalAmountPerDay = _maxFinalizedWithdrawalAmountPerDay;
-    }
-
-    function updateMaxNumValidatorsToApprovePerDay(uint256 _maxNumValidatorsToApprovePerDay) external onlyAdmin {
-        if (_maxNumValidatorsToApprovePerDay > maxAcceptableNumValidatorsToApprovePerDay) revert InvalidMaxNumValidatorsToApprovePerDay();
-        maxNumValidatorsToApprovePerDay = _maxNumValidatorsToApprovePerDay;
-    }
-
-    function updateAcceptableRebaseApr(int32 _acceptableRebaseAprInBps) external onlyAdmin {
-        if (_acceptableRebaseAprInBps < 0 || _acceptableRebaseAprInBps > maxAcceptableRebaseAprInBps) revert InvalidAcceptableRebaseApr();
-        acceptableRebaseAprInBps = _acceptableRebaseAprInBps;
-    }
-
-    function updatePostReportWaitTimeInSlots(uint16 _postReportWaitTimeInSlots) external onlyAdmin {
-        postReportWaitTimeInSlots = _postReportWaitTimeInSlots;
-    }
-
+    /**
+     * @notice Gets the implementation
+     * @return The implementation
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 }

--- a/src/oracle/EtherFiAdmin.sol
+++ b/src/oracle/EtherFiAdmin.sol
@@ -125,6 +125,7 @@ contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, Rol
      * @param _maxAcceptableFinalizedWithdrawalAmountPerDay The maximum acceptable finalized withdrawal amount per day
      * @param _maxAcceptableNumValidatorsToApprovePerDay The maximum acceptable number of validators to approve per day
      * @param _maxNumberOfRequestsToFinalizePerReport The maximum number of requests to finalize per report
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(
         ConstructorAddresses memory _constructorAddresses,

--- a/src/oracle/EtherFiOracle.sol
+++ b/src/oracle/EtherFiOracle.sol
@@ -91,6 +91,7 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
      * @param _minQuorumSize The minimum quorum size
      * @param _etherFiAdmin The address of the EtherFiAdmin contract
      * @param _roleRegistry The address of the RoleRegistry contract
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(uint32 _minQuorumSize, address _etherFiAdmin, address _roleRegistry) RolesLibrary(_roleRegistry) {
         minQuorumSize = _minQuorumSize;

--- a/src/oracle/EtherFiOracle.sol
+++ b/src/oracle/EtherFiOracle.sol
@@ -15,7 +15,6 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
-
     mapping(address => IEtherFiOracle.CommitteeMemberState) public committeeMemberStates; // committee member wallet address to its State
     mapping(bytes32 => IEtherFiOracle.ConsensusState) public consensusStates; // report's hash -> Consensus State
 
@@ -42,15 +41,12 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  --------------------------------------
     //--------------------------------------------------------------------------------------
-
-    // Immutables are not part of proxy storage; stored in implementation bytecode only.
     IEtherFiAdmin public immutable etherFiAdmin;
     uint32 public immutable minQuorumSize;
 
     //--------------------------------------------------------------------------------------
-    //---------------------------------  CONSTANTS  ---------------------------------------
+    //---------------------------------  EVENTS  -------------------------------------------
     //--------------------------------------------------------------------------------------
-
     event CommitteeMemberAdded(address indexed member);
     event CommitteeMemberRemoved(address indexed member);
     event CommitteeMemberUpdated(address indexed member, bool enabled);
@@ -66,7 +62,6 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     error ConsensusAlreadyReached();
     error ReportNotNeeded();
     error NotRegistered();
@@ -91,8 +86,12 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     //--------------------------------------------------------------------------------------
     //-------------------------------------  CONSTRUCTOR  ----------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _minQuorumSize The minimum quorum size
+     * @param _etherFiAdmin The address of the EtherFiAdmin contract
+     * @param _roleRegistry The address of the RoleRegistry contract
+     */
     constructor(uint32 _minQuorumSize, address _etherFiAdmin, address _roleRegistry) RolesLibrary(_roleRegistry) {
         minQuorumSize = _minQuorumSize;
         etherFiAdmin = IEtherFiAdmin(_etherFiAdmin);
@@ -100,9 +99,17 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //----------------------------  INITIALIZERS  ----------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Initialize the EtherFiOracle
+     * @param _quorumSize The quorum size
+     * @param _reportPeriodSlot The report period slot
+     * @param _reportStartSlot The report start slot
+     * @param _slotsPerEpoch The slots per epoch
+     * @param _secondsPerSlot The seconds per slot
+     * @param _genesisTime The genesis time
+     */
     function initialize(uint32 _quorumSize, uint32 _reportPeriodSlot, uint32 _reportStartSlot, uint32 _slotsPerEpoch, uint32 _secondsPerSlot, uint32 _genesisTime)
         external
         initializer
@@ -119,6 +126,14 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         BEACON_GENESIS_TIME = _genesisTime;
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  SUBMIT REPORT FUNCTION  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Submit a report
+     * @param _report The report
+     * @return True if the report was submitted, false otherwise
+     */
     function submitReport(OracleReport calldata _report) external whenNotPaused returns (bool) {
         bytes32 reportHash = generateReportHash(_report);
         if (consensusStates[reportHash].consensusReached) revert ConsensusAlreadyReached();
@@ -156,8 +171,186 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         return consensusReached;
     }
 
-    // For generating the next report, the starting & ending points need to be specified.
-    // The report should include data for the specified slot and block ranges (inclusive)
+    //--------------------------------------------------------------------------------------
+    //------------------------------  ADMIN FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Add a committee member
+     * @param _address The address of the committee member
+     * @param _quorumSize The quorum size
+     */
+    function addCommitteeMember(address _address, uint32 _quorumSize) public onlyAdmin {
+        if (committeeMemberStates[_address].registered) revert AlreadyRegistered();
+        numCommitteeMembers++;
+        numActiveCommitteeMembers++;
+        committeeMemberStates[_address] = CommitteeMemberState(true, true, 0, 0);
+        quorumSize = _quorumSize;
+        _checkQuorum();
+        emit CommitteeMemberAdded(_address);
+    }
+
+    /**
+     * @notice Remove a committee member
+     * @param _address The address of the committee member
+     * @param _quorumSize The quorum size
+     */
+    function removeCommitteeMember(address _address, uint32 _quorumSize) public onlyAdmin {
+        if (!committeeMemberStates[_address].registered) revert NotRegistered();
+        numCommitteeMembers--;
+        if (committeeMemberStates[_address].enabled) numActiveCommitteeMembers--;
+        delete committeeMemberStates[_address];
+        quorumSize = _quorumSize;
+        _checkQuorum();
+        emit CommitteeMemberRemoved(_address);
+    }
+
+    /**
+     * @notice Manage a committee member
+     * @param _address The address of the committee member
+     * @param _enabled True if the committee member is enabled, false otherwise
+     * @param _quorumSize The quorum size
+     */
+    function manageCommitteeMember(address _address, bool _enabled, uint32 _quorumSize) public onlyOperatingMultisig {
+        if (!committeeMemberStates[_address].registered) revert NotRegistered();
+        if (committeeMemberStates[_address].enabled == _enabled) revert AlreadyInTargetState();
+        committeeMemberStates[_address].enabled = _enabled;
+        if (_enabled) {
+            numActiveCommitteeMembers++;
+        } else {
+            numActiveCommitteeMembers--;
+        }
+        quorumSize = _quorumSize;
+        _checkQuorum();
+        emit CommitteeMemberUpdated(_address, _enabled);
+    }
+
+    /**
+     * @notice Set the quorum size
+     * @param _quorumSize The quorum size
+     */
+    function setQuorumSize(uint32 _quorumSize) public onlyAdmin {
+        quorumSize = _quorumSize;
+        _checkQuorum();
+        emit QuorumUpdated(_quorumSize);
+    }
+
+    /**
+     * @notice Set the oracle report period
+     * @param _reportPeriodSlot The report period slot
+     */
+    function setOracleReportPeriod(uint32 _reportPeriodSlot) public onlyAdmin {
+        if (_reportPeriodSlot == 0 || _reportPeriodSlot % SLOTS_PER_EPOCH != 0) revert InvalidReportPeriod();
+        reportPeriodSlot = _reportPeriodSlot;
+
+        emit OracleReportPeriodUpdated(_reportPeriodSlot);
+    }
+
+    /**
+     * @notice Set the consensus version
+     * @param _consensusVersion The consensus version
+     */
+    function setConsensusVersion(uint32 _consensusVersion) public onlyAdmin {
+        if (_consensusVersion <= consensusVersion) revert InvalidConsensusVersion();
+        consensusVersion = _consensusVersion;
+
+        emit ConsensusVersionUpdated(_consensusVersion);
+    }
+
+    /**
+     * @notice Unpublish a report
+     * @param _report The report
+     */
+    function unpublishReport(OracleReport calldata _report) public onlyOperatingMultisig {
+        bytes32 _hash = generateReportHash(_report);
+        if (!consensusStates[_hash].consensusReached) revert ConsensusNotReached();
+        if (_report.refSlotTo <= etherFiAdmin.lastHandledReportRefSlot()) revert ReportExecuted();
+        consensusStates[_hash].support = 0;
+        consensusStates[_hash].consensusReached = false;
+        lastPublishedReportRefSlot = _report.refSlotFrom - 1;
+        lastPublishedReportRefBlock = _report.refBlockFrom - 1;
+        emit ReportUnpublished(_hash);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //------------------------------  PAUSING FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pause the contract
+     * @dev Only callable by the operating multisig
+     */
+    function pauseContract() external onlyOperatingMultisig {
+        _pause();
+    }
+
+    /**
+     * @notice Unpause the contract
+     * @dev Only callable by the operating multisig
+     */
+    function unPauseContract() external onlyOperatingMultisig {
+        _unpause();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INTERNAL FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Check if the slot is finalized
+     * @param _slot The slot
+     * @return True if the slot is finalized, false otherwise
+     */
+    function _isFinalized(uint32 _slot) internal view returns (bool) {
+        uint32 currSlot = computeSlotAtTimestamp(block.timestamp);
+        uint32 currEpoch = (currSlot / SLOTS_PER_EPOCH);
+        uint32 slotEpoch = (_slot / SLOTS_PER_EPOCH);
+        return slotEpoch + 2 < currEpoch;
+    }
+
+    /**
+     * @notice Publish a report
+     * @param _report The report
+     * @param _hash The hash of the report
+     */
+    function _publishReport(OracleReport calldata _report, bytes32 _hash) internal {
+        lastPublishedReportRefSlot = _report.refSlotTo;
+        lastPublishedReportRefBlock = _report.refBlockTo;
+
+        // emit report published event
+        emit ReportPublished(
+            _report.consensusVersion,
+            _report.refSlotFrom,
+            _report.refSlotTo,
+            _report.refBlockFrom,
+            _report.refBlockTo,
+            _hash
+            );
+    }
+
+    /**
+     * @notice Check the quorum
+     * @dev If the quorum size is less than the minimum quorum size, or the number of active committee members is less than the quorum size, 
+     *      or the number of active committee members is greater than or equal to 2 times the quorum size, revert InvalidQuorum
+     */
+    function _checkQuorum() internal view {
+        if (quorumSize < minQuorumSize || numActiveCommitteeMembers < quorumSize || numActiveCommitteeMembers >= 2 * quorumSize) revert InvalidQuorum();
+    }
+
+    /**
+     * @notice Authorize the upgrade
+     * @param newImplementation The new implementation address
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  VIEW FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Get the block stamp for the next report
+     * @return slotFrom The slot from
+     * @return slotTo The slot to
+     * @return blockFrom The block from
+     * @dev For generating the next report, the starting & ending points need to be specified.
+     *      The report should include data for the specified slot and block ranges (inclusive)
+     */
     function blockStampForNextReport() public view returns (uint32 slotFrom, uint32 slotTo, uint32 blockFrom) {
         slotFrom = lastPublishedReportRefSlot == 0 ? reportStartSlot : lastPublishedReportRefSlot + 1;
         slotTo = slotForNextReport();
@@ -165,6 +358,11 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         // `blockTo` can't be decided since a slot may not have any block (`missed slot`)
     }
 
+    /**
+     * @notice Check if the report should be submitted
+     * @param _member The member address
+     * @return True if the report should be submitted, false otherwise
+     */
     function shouldSubmitReport(address _member) public view returns (bool) {
         if (!committeeMemberStates[_member].registered) revert NotRegistered();
         if (!committeeMemberStates[_member].enabled) revert MemberDisabled();
@@ -176,6 +374,10 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         return slot > committeeMemberStates[_member].lastReportRefSlot;
     }
 
+    /**
+     * @notice Verify a report
+     * @param _report The report
+     */
     function verifyReport(OracleReport calldata _report) public view {
         if (_report.consensusVersion != consensusVersion) revert WrongConsensusVersion();
 
@@ -194,44 +396,41 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         if (reportEpoch + 2 >= currEpoch) revert EpochNotFinalized();
     }
 
+    /**
+     * @notice Check if the consensus has reached
+     * @param _hash The hash of the report
+     * @return True if the consensus has reached, false otherwise
+     */
     function isConsensusReached(bytes32 _hash) public view returns (bool) {
         return consensusStates[_hash].consensusReached;
     }
 
+    /**
+     * @notice Get the consensus timestamp
+     * @param _hash The hash of the report
+     * @return The consensus timestamp
+     */
     function getConsensusTimestamp(bytes32 _hash) public view returns (uint32) {
         if (!consensusStates[_hash].consensusReached) revert ConsensusNotReached();
         return consensusStates[_hash].consensusTimestamp;
     }
 
+    /**
+     * @notice Get the consensus slot
+     * @param _hash The hash of the report
+     * @return The consensus slot
+     */
     function getConsensusSlot(bytes32 _hash) public view returns (uint32) {
         if (!consensusStates[_hash].consensusReached) revert ConsensusNotReached();
         return computeSlotAtTimestamp(consensusStates[_hash].consensusTimestamp);
     }
 
-    function _isFinalized(uint32 _slot) internal view returns (bool) {
-        uint32 currSlot = computeSlotAtTimestamp(block.timestamp);
-        uint32 currEpoch = (currSlot / SLOTS_PER_EPOCH);
-        uint32 slotEpoch = (_slot / SLOTS_PER_EPOCH);
-        return slotEpoch + 2 < currEpoch;
-    }
-
-    function _publishReport(OracleReport calldata _report, bytes32 _hash) internal {
-        lastPublishedReportRefSlot = _report.refSlotTo;
-        lastPublishedReportRefBlock = _report.refBlockTo;
-
-        // emit report published event
-        emit ReportPublished(
-            _report.consensusVersion,
-            _report.refSlotFrom,
-            _report.refSlotTo,
-            _report.refBlockFrom,
-            _report.refBlockTo,
-            _hash
-            );
-    }
-
-    // Given the last published report AND the current slot number,
-    // Return the next report's `slotTo` that we are waiting for
+    /**
+     * @notice Get the next report's slot to
+     * @return The next report's slot to
+     * @dev Given the last published report AND the current slot number,
+     *      Return the next report's `slotTo` that we are waiting for
+     */
     function slotForNextReport() public view returns (uint32) {
         uint32 currSlot = computeSlotAtTimestamp(block.timestamp);
         uint32 pastSlot = reportStartSlot < lastPublishedReportRefSlot ? lastPublishedReportRefSlot + 1 : reportStartSlot;
@@ -241,10 +440,20 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         return __slotForNextReport - 1;
     }
 
+    /**
+     * @notice Compute the slot at a given timestamp
+     * @param timestamp The timestamp
+     * @return The slot at the given timestamp
+     */
     function computeSlotAtTimestamp(uint256 timestamp) public view returns (uint32) {
         return uint32((timestamp - BEACON_GENESIS_TIME) / SECONDS_PER_SLOT);
     }
 
+    /**
+     * @notice Generate the report hash
+     * @param _report The report
+     * @return The report hash
+     */
     function generateReportHash(OracleReport calldata _report) public pure returns (bytes32) {
         bytes32 chunk1 = keccak256(
             abi.encode(
@@ -273,90 +482,19 @@ contract EtherFiOracle is Initializable, OwnableUpgradeable, PausableUpgradeable
         return keccak256(abi.encode(chunk1, chunk2, chunk3));
     }
 
+    /**
+     * @notice Get the beacon genesis timestamp
+     * @return The beacon genesis timestamp
+     */
     function beaconGenesisTimestamp() external view returns (uint32) {
         return BEACON_GENESIS_TIME;
     }
 
-    function addCommitteeMember(address _address, uint32 _quorumSize) public onlyAdmin {
-        if (committeeMemberStates[_address].registered) revert AlreadyRegistered();
-        numCommitteeMembers++;
-        numActiveCommitteeMembers++;
-        committeeMemberStates[_address] = CommitteeMemberState(true, true, 0, 0);
-        quorumSize = _quorumSize;
-        _checkQuorum();
-        emit CommitteeMemberAdded(_address);
-    }
-
-    function removeCommitteeMember(address _address, uint32 _quorumSize) public onlyAdmin {
-        if (!committeeMemberStates[_address].registered) revert NotRegistered();
-        numCommitteeMembers--;
-        if (committeeMemberStates[_address].enabled) numActiveCommitteeMembers--;
-        delete committeeMemberStates[_address];
-        quorumSize = _quorumSize;
-        _checkQuorum();
-        emit CommitteeMemberRemoved(_address);
-    }
-
-    function manageCommitteeMember(address _address, bool _enabled, uint32 _quorumSize) public onlyOperatingMultisig {
-        if (!committeeMemberStates[_address].registered) revert NotRegistered();
-        if (committeeMemberStates[_address].enabled == _enabled) revert AlreadyInTargetState();
-        committeeMemberStates[_address].enabled = _enabled;
-        if (_enabled) {
-            numActiveCommitteeMembers++;
-        } else {
-            numActiveCommitteeMembers--;
-        }
-        quorumSize = _quorumSize;
-        _checkQuorum();
-        emit CommitteeMemberUpdated(_address, _enabled);
-    }
-
-    function setQuorumSize(uint32 _quorumSize) public onlyAdmin {
-        quorumSize = _quorumSize;
-        _checkQuorum();
-        emit QuorumUpdated(_quorumSize);
-    }
-
-    function setOracleReportPeriod(uint32 _reportPeriodSlot) public onlyAdmin {
-        if (_reportPeriodSlot == 0 || _reportPeriodSlot % SLOTS_PER_EPOCH != 0) revert InvalidReportPeriod();
-        reportPeriodSlot = _reportPeriodSlot;
-
-        emit OracleReportPeriodUpdated(_reportPeriodSlot);
-    }
-
-    function setConsensusVersion(uint32 _consensusVersion) public onlyAdmin {
-        if (_consensusVersion <= consensusVersion) revert InvalidConsensusVersion();
-        consensusVersion = _consensusVersion;
-
-        emit ConsensusVersionUpdated(_consensusVersion);
-    }
-
-    function unpublishReport(OracleReport calldata _report) public onlyOperatingMultisig {
-        bytes32 _hash = generateReportHash(_report);
-        if (!consensusStates[_hash].consensusReached) revert ConsensusNotReached();
-        if (_report.refSlotTo <= etherFiAdmin.lastHandledReportRefSlot()) revert ReportExecuted();
-        consensusStates[_hash].support = 0;
-        consensusStates[_hash].consensusReached = false;
-        lastPublishedReportRefSlot = _report.refSlotFrom - 1;
-        lastPublishedReportRefBlock = _report.refBlockFrom - 1;
-        emit ReportUnpublished(_hash);
-    }
-
-    function pauseContract() external onlyOperatingMultisig {
-        _pause();
-    }
-
-    function unPauseContract() external onlyOperatingMultisig {
-        _unpause();
-    }
-
+    /**
+     * @notice Get the implementation address
+     * @return The implementation address
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
-
-    function _checkQuorum() internal view {
-        if (quorumSize < minQuorumSize || numActiveCommitteeMembers < quorumSize || numActiveCommitteeMembers >= 2 * quorumSize) revert InvalidQuorum();
-    }
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 }

--- a/src/oracle/interfaces/IEtherFiAdmin.sol
+++ b/src/oracle/interfaces/IEtherFiAdmin.sol
@@ -2,6 +2,23 @@
 pragma solidity ^0.8.13;
 
 interface IEtherFiAdmin {
+    struct TaskStatus {
+        bool completed;
+        bool exists;
+    }
+
+    struct ConstructorAddresses {
+        address etherFiOracle;
+        address stakingManager;
+        address auctionManager;
+        address etherFiNodesManager;
+        address liquidityPool;
+        address membershipManager;
+        address withdrawRequestNft;
+        address roleRegistry;
+        address priorityWithdrawalQueue;
+    }
+
     function lastHandledReportRefSlot() external view returns (uint32);
     function lastHandledReportRefBlock() external view returns (uint32);
     function lastAdminExecutionBlock() external view returns (uint32);

--- a/src/restaking/EtherFiRestaker.sol
+++ b/src/restaking/EtherFiRestaker.sol
@@ -7,6 +7,7 @@ import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import "@etherfi/deposits/Liquifier.sol";
@@ -20,15 +21,12 @@ import "@etherfi/eigenlayer-interfaces/IRewardsCoordinator.sol";
 import "@etherfi/deposits/interfaces/ILiquifier.sol";
 import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/governance/rate-limiting/interfaces/IEtherFiRateLimiter.sol";
+import "@etherfi/restaking/interfaces/IEtherFiRestaker.sol";
 
-contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, RolesLibrary {
+contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, RolesLibrary, IEtherFiRestaker {
     using SafeERC20 for IERC20;
+    using Math for uint256;
     using EnumerableSet for EnumerableSet.Bytes32Set;
-
-    struct TokenInfo {
-        // EigenLayer
-        IStrategy elStrategy;
-    }
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
@@ -46,7 +44,6 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  --------------------------------------
     //--------------------------------------------------------------------------------------
-
     IRewardsCoordinator public immutable rewardsCoordinator;
     ILiquidityPool public immutable liquidityPool;
     ILiquifier public immutable liquifier;
@@ -60,11 +57,9 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     bytes32 public constant STETH_REQUEST_WITHDRAWAL_LIMIT_ID = keccak256("STETH_REQUEST_WITHDRAWAL_LIMIT_ID");
     bytes32 public constant QUEUE_WITHDRAWALS_LIMIT_ID        = keccak256("QUEUE_WITHDRAWALS_LIMIT_ID");
     bytes32 public constant DEPOSIT_INTO_STRATEGY_LIMIT_ID    = keccak256("DEPOSIT_INTO_STRATEGY_LIMIT_ID");
-
     /// @dev Suggested gas stipend for contract receiving ETH to perform a few
     /// storage reads and writes, but low enough to prevent griefing.
     uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
@@ -72,7 +67,6 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     event QueuedStEthWithdrawals(uint256[] _reqIds);
     event CompletedStEthQueuedWithdrawals(uint256[] _reqIds);
     event CompletedQueuedWithdrawal(bytes32 _withdrawalRoot);
@@ -80,7 +74,6 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     error NotEnoughBalance();
     error IncorrectAmount();
     error EthTransferFailed();
@@ -94,8 +87,17 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  CONSTRUCTOR  ----------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _liquidityPool The address of the liquidity pool
+     * @param _liquifier The address of the liquifier
+     * @param _rewardsCoordinator The address of the rewards coordinator
+     * @param _etherFiRedemptionManager The address of the etherFi redemption manager
+     * @param _roleRegistry The address of the role registry
+     * @param _rateLimiter The address of the rate limiter
+     * @param _eigenLayerStrategyManager The address of the eigenLayer strategy manager
+     * @param _eigenLayerDelegationManager The address of the eigenLayer delegation manager
+     */
     constructor(
         address _liquidityPool,
         address _liquifier,
@@ -119,10 +121,13 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @notice initialize to set variables on deployment
+    /**
+     * @notice Initialize the EtherFiRestaker
+     * @param _liquidityPool The address of the liquidity pool
+     * @param _liquifier The address of the liquifier
+     */
     function initialize(address _liquidityPool, address _liquifier) initializer external {
         __Ownable_init();
         __Pausable_init();
@@ -134,30 +139,42 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         });
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  RECEIVE FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Receive ETH
+     */
     receive() external payable {}
 
-    // |--------------------------------------------------------------------------------------------|
-    // |                                   Handling Lido's stETH                                    |
-    // |--------------------------------------------------------------------------------------------|
-
-    /// @notice Transfer stETH to a recipient for instant withdrawal
-    /// @param recipient The address to receive stETH
-    /// @param amount The amount of stETH to transfer
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STETH MANAGEMENT FUNCTIONS  ----------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Transfer stETH to a recipient for instant withdrawal
+     * @param recipient The address to receive stETH
+     * @param amount The amount of stETH to transfer
+     */
     function transferStETH(address recipient, uint256 amount) external {
         if(msg.sender != etherFiRedemptionManager) revert IncorrectCaller();
         if (amount > lido.balanceOf(address(this))) revert InsufficientBalance();
         IERC20(address(lido)).safeTransfer(recipient, amount);
     }
 
-    /// Initiate the redemption of stETH for ETH
-    /// @notice Request for all stETH holdings
+    /**
+     * @notice Initiate the redemption of stETH for ETH
+     * @return The request ids
+     */
     function stEthRequestWithdrawal() external returns (uint256[] memory) {
         uint256 amount = lido.balanceOf(address(this));
         return stEthRequestWithdrawal(amount);
     }
 
-    /// @notice Request for a specific amount of stETH holdings
-    /// @param _amount the amount of stETH to request
+    /**
+     * @notice Request for a specific amount of stETH holdings
+     * @param _amount the amount of stETH to request
+     * @return The request ids
+     */
     function stEthRequestWithdrawal(uint256 _amount) public onlyExecutorOperations returns (uint256[] memory) {
         rateLimiter.consume(STETH_REQUEST_WITHDRAWAL_LIMIT_ID, _amountToGwei(_amount));
 
@@ -189,9 +206,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return reqIds;
     }
 
-    /// @notice Claim a batch of withdrawal requests if they are finalized sending the ETH to the this contract back
-    /// @param _requestIds array of request ids to claim
-    /// @param _hints checkpoint hint for each id. Can be obtained with `findCheckpointHints()`
+    /**
+     * @notice Claim a batch of withdrawal requests if they are finalized sending the ETH to the this contract back
+     * @param _requestIds array of request ids to claim
+     * @param _hints checkpoint hint for each id. Can be obtained with `findCheckpointHints()`
+     */
     function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external onlyHousekeepingOperations {
         lidoWithdrawalQueue.claimWithdrawals(_requestIds, _hints);
 
@@ -200,27 +219,30 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         emit CompletedStEthQueuedWithdrawals(_requestIds);
     }
 
-    // Send the ETH back to the liquidity pool
+    /**
+     * @notice Send the ETH back to the liquidity pool
+     */
     function withdrawEther() public onlyHousekeepingOperations {
         _withdrawEther();
     }
 
-    function _withdrawEther() internal {
-        uint256 amountToLiquidityPool = _min(address(this).balance, liquidityPool.totalValueOutOfLp());
-        (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: GAS_STIPEND_NO_GRIEF}("");
-        if (!sent) revert EthTransferFailed();
-    }
-
-    // |--------------------------------------------------------------------------------------------|
-    // |                                    EigenLayer Restaking                                    |
-    // |--------------------------------------------------------------------------------------------|
-
-    /// Set the claimer of the restaking rewards of this contract
+    //--------------------------------------------------------------------------------------
+    //------------------------------  RESTAKING FUNCTIONS  ---------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Set the claimer of the restaking rewards of this contract
+     * @param _claimer The address of the claimer
+     */
     function setRewardsClaimer(address _claimer) external onlyAdmin {
         rewardsCoordinator.setClaimerFor(_claimer);
     }
 
-    // delegate to an AVS operator
+    /**
+     * @notice Delegate to an AVS operator
+     * @param operator The address of the operator
+     * @param approverSignatureAndExpiry The signature and expiry of the approver
+     * @param approverSalt The salt of the approver
+     */
     function delegateTo(
         address operator,
         IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry,
@@ -229,7 +251,10 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         eigenLayerDelegationManager.delegateTo(operator, approverSignatureAndExpiry, approverSalt);
     }
 
-    // undelegate from the current AVS operator & un-restake all
+    /**
+     * @notice Undelegate from the current AVS operator & un-restake all
+     * @return The withdrawal roots
+     */
     function undelegate() external onlyOperatingMultisig returns (bytes32[] memory) {
         bytes32[] memory withdrawalRoots = eigenLayerDelegationManager.undelegate(address(this));
 
@@ -240,11 +265,12 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return withdrawalRoots;
     }
 
-    function isDelegated() external view returns (bool) {
-        return eigenLayerDelegationManager.isDelegated(address(this));
-    }
-
-    // deposit the token in holding into the restaking strategy
+    /**
+     * @notice Deposit the token in holding into the restaking strategy
+     * @param token The address of the token
+     * @param amount The amount of token to deposit
+     * @return The shares deposited
+     */
     function depositIntoStrategy(address token, uint256 amount) external onlyExecutorOperations returns (uint256) {
         rateLimiter.consume(DEPOSIT_INTO_STRATEGY_LIMIT_ID, _amountToGwei(amount));
 
@@ -256,10 +282,12 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return shares;
     }
 
-    /// queue withdrawals for un-restaking the token
-    /// Made easy for operators
-    /// @param token the token to withdraw
-    /// @param amount the amount of token to withdraw
+    /**
+     * @notice Queue withdrawals for un-restaking the token
+     * @param token The address of the token
+     * @param amount The amount of token to withdraw
+     * @return The withdrawal roots
+     */
     function queueWithdrawals(address token, uint256 amount) public onlyExecutorOperations returns (bytes32[] memory) {
         rateLimiter.consume(QUEUE_WITHDRAWALS_LIMIT_ID, _amountToGwei(amount));
 
@@ -273,10 +301,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return withdrawalRoots;
     }
 
-    /// Advanced version
-    /// @notice Used to complete the specified `queuedWithdrawals`. The function caller must match `queuedWithdrawals[...].withdrawer`
-    /// @param _queuedWithdrawals The QueuedWithdrawals to complete.
-    /// @param _tokens Array of tokens for each QueuedWithdrawal. See `completeQueuedWithdrawal` for the usage of a single array.
+    /**
+     * @notice Complete the specified `queuedWithdrawals`
+     * @param _queuedWithdrawals The QueuedWithdrawals to complete
+     * @param _tokens Array of tokens for each QueuedWithdrawal
+     */
     function completeQueuedWithdrawals(
         IDelegationManager.Withdrawal[] memory _queuedWithdrawals,
         IERC20[][] memory _tokens
@@ -296,28 +325,128 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         eigenLayerDelegationManager.completeQueuedWithdrawals(_queuedWithdrawals, _tokens, receiveAsTokens);
     }
 
-    /// Enumerate the pending withdrawal roots
+    //--------------------------------------------------------------------------------------
+    //------------------------------  PAUSING FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pause the contract
+     */
+    function pauseContract() external onlyOperatingMultisig {
+        _pause();
+    }
+
+    /**
+     * @notice Unpause the contract
+     */
+    function unPauseContract() external onlyOperatingMultisig {
+        _unpause();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
+    //--------------------------------------------------------------------------------------
+
+    /**
+     * @notice Convert wei to gwei for rate-limiter buckets, with overflow check.
+     * @param amountWei The amount of wei to convert
+     * @return The amount of gwei
+     * @dev Rounds up so that any non-zero wei amount consumes at least 1 gwei from
+     * the bucket — prevents sub-gwei dust from bypassing the rate limiter.
+     */
+    function _amountToGwei(uint256 amountWei) internal pure returns (uint64) {
+        uint256 amountGwei = (amountWei + 1e9 - 1) / 1e9;
+        if (amountGwei > type(uint64).max) revert AmountOverflowsUint64Gwei();
+        return uint64(amountGwei);
+    }
+
+    /**
+     * @notice Queue withdrawals for un-restaking the token
+     * @param _token The address of the token
+     * @param _shares The shares of the token to withdraw
+     * @return The withdrawal roots
+     */
+    function _queueWithdrawalsByShares(address _token, uint256 _shares) internal returns (bytes32[] memory) {
+        IDelegationManagerTypes.QueuedWithdrawalParams[] memory params = new IDelegationManagerTypes.QueuedWithdrawalParams[](1);
+        IStrategy[] memory strategies = new IStrategy[](1);
+        uint256[] memory shares = new uint256[](1);
+
+        strategies[0] = tokenInfos[_token].elStrategy;
+        shares[0] = _shares;
+        params[0] = IDelegationManagerTypes.QueuedWithdrawalParams({
+            strategies: strategies,
+            depositShares: shares,
+            __deprecated_withdrawer: address(this)
+        });
+
+        return eigenLayerDelegationManager.queueWithdrawals(params);
+    }
+
+    /**
+     * @notice Send the ETH back to the liquidity pool
+     */
+    function _withdrawEther() internal {
+        uint256 amountToLiquidityPool = Math.min(address(this).balance, liquidityPool.totalValueOutOfLp());
+        (bool sent, ) = payable(address(liquidityPool)).call{value: amountToLiquidityPool, gas: GAS_STIPEND_NO_GRIEF}("");
+        if (!sent) revert EthTransferFailed();
+    }
+
+    /**
+     * @notice Authorize the upgrade
+     * @param newImplementation The address of the new implementation
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  GETTERS  -------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Enumerate the pending withdrawal roots
+     * @return The pending withdrawal roots
+     */
     function pendingWithdrawalRoots() external view returns (bytes32[] memory) {
         return withdrawalRootsSet.values();
     }
 
-    /// Check if a withdrawal is pending for a given withdrawal root
+    /**
+     * @notice Check if a withdrawal is pending for a given withdrawal root
+     * @param _withdrawalRoot The withdrawal root to check
+     * @return The boolean value indicating if the withdrawal is pending
+     */
     function isPendingWithdrawal(bytes32 _withdrawalRoot) external view returns (bool) {
         return withdrawalRootsSet.contains(_withdrawalRoot);
     }
 
-    // |--------------------------------------------------------------------------------------------|
-    // |                                    VIEW functions                                          |
-    // |--------------------------------------------------------------------------------------------|
+    /**
+     * @notice Check if the contract is delegated
+     * @return The boolean value indicating if the contract is delegated
+     */
+    function isDelegated() external view returns (bool) {
+        return eigenLayerDelegationManager.isDelegated(address(this));
+    }
+
+    /**
+     * @notice Get the total pooled ether
+     * @return total the total pooled ether
+     */
     function getTotalPooledEther() external view returns (uint256 total) {
         total = address(this).balance + getTotalPooledEther(address(lido));
     }
 
+    /**
+     * @notice Get the total pooled ether for a given token
+     * @param _token The address of the token
+     * @return The total pooled ether
+     */
     function getTotalPooledEther(address _token) public view returns (uint256) {
         (uint256 restaked, uint256 unrestaking, uint256 holding, uint256 pendingForWithdrawals) = getTotalPooledEtherSplits(_token);
         return restaked + unrestaking + holding + pendingForWithdrawals;
     }
 
+    /**
+     * @notice Get the restaked amount for a given token
+     * @param _token The address of the token
+     * @return The restaked amount
+     */
     function getRestakedAmount(address _token) public view returns (uint256) {
         TokenInfo memory info = tokenInfos[_token];
         IStrategy[] memory strategies = new IStrategy[](1);
@@ -333,14 +462,27 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return restaked;
     }
 
+    /**
+     * @notice Get the EigenLayer restaking strategy for a given token
+     * @param _token The address of the token
+     * @return The EigenLayer restaking strategy
+     */
     function getEigenLayerRestakingStrategy(address _token) public view returns (IStrategy) {
         return tokenInfos[_token].elStrategy;
     }
 
-    /// each asset in holdings can have 3 states:
-    /// - in Eigenlayer, either restaked or pending for un-restaking
-    /// - non-restaked & held by this contract
-    /// - non-restaked & not held by this contract & pending in redemption for ETH
+    /**
+     * @notice Get the total pooled ether splits for a given token
+     * @param _token The address of the token
+     * @return restaked The amount of token restaked in EigenLayer
+     * @return unrestaking The amount of token restaked in EigenLayer pending for withdrawals
+     * @return holding The amount of token held by this contract
+     * @return pendingForWithdrawals The amount of token pending for withdrawal
+     * @dev Deposited (restaked) ETH can have 3 states:
+     * - restaked in EigenLayer & pending for withdrawals
+     * - non-restaked & held by this contract
+     * - non-restaked & not held by this contract & pending for withdrawals
+     */
     function getTotalPooledEtherSplits(address _token) public view returns (
         uint256 restaked,
         uint256 unrestaking,
@@ -358,7 +500,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         pendingForWithdrawals = liquifier.quoteByFairValue(_token, getAmountPendingForRedemption(_token));
     }
 
-    // get the amount of token restaked in EigenLayer pending for withdrawals
+    /**
+     * @notice Get the amount of token restaked in EigenLayer pending for withdrawals
+     * @param _token The address of the token
+     * @return The amount of token restaked in EigenLayer pending for withdrawals
+     */
     function getAmountInEigenLayerPendingForWithdrawals(address _token) public view returns (uint256) {
         TokenInfo memory info = tokenInfos[_token];
         if (info.elStrategy == IStrategy(address(0))) return 0;
@@ -382,7 +528,11 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         return info.elStrategy.sharesToUnderlyingView(totalShares);
     }
 
-    // get the amount of token pending for redemption. e.g., pending in Lido's withdrawal queue
+    /**
+     * @notice Get the amount of token pending for redemption. e.g., pending in Lido's withdrawal queue
+     * @param _token The address of the token
+     * @return The amount of token pending for redemption
+     */
     function getAmountPendingForRedemption(address _token) public view returns (uint256) {
         uint256 total = 0;
         if (_token == address(lido)) {
@@ -396,47 +546,4 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
         }
         return total;
     }
-
-    // Pauses the contract
-    function pauseContract() external onlyOperatingMultisig {
-        _pause();
-    }
-
-    // Unpauses the contract
-    function unPauseContract() external onlyOperatingMultisig {
-        _unpause();
-    }
-
-    // INTERNAL functions
-
-    /// @dev Convert wei to gwei for rate-limiter buckets, with overflow check.
-    /// Rounds up so that any non-zero wei amount consumes at least 1 gwei from
-    /// the bucket — prevents sub-gwei dust from bypassing the rate limiter.
-    function _amountToGwei(uint256 amountWei) internal pure returns (uint64) {
-        uint256 amountGwei = (amountWei + 1e9 - 1) / 1e9;
-        if (amountGwei > type(uint64).max) revert AmountOverflowsUint64Gwei();
-        return uint64(amountGwei);
-    }
-
-    function _queueWithdrawalsByShares(address _token, uint256 _shares) internal returns (bytes32[] memory) {
-        IDelegationManagerTypes.QueuedWithdrawalParams[] memory params = new IDelegationManagerTypes.QueuedWithdrawalParams[](1);
-        IStrategy[] memory strategies = new IStrategy[](1);
-        uint256[] memory shares = new uint256[](1);
-
-        strategies[0] = tokenInfos[_token].elStrategy;
-        shares[0] = _shares;
-        params[0] = IDelegationManagerTypes.QueuedWithdrawalParams({
-            strategies: strategies,
-            depositShares: shares,
-            __deprecated_withdrawer: address(this)
-        });
-
-        return eigenLayerDelegationManager.queueWithdrawals(params);
-    }
-
-    function _min(uint256 _a, uint256 _b) internal pure returns (uint256) {
-        return (_a > _b) ? _b : _a;
-    }
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 }

--- a/src/restaking/EtherFiRestaker.sol
+++ b/src/restaking/EtherFiRestaker.sol
@@ -97,6 +97,7 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
      * @param _rateLimiter The address of the rate limiter
      * @param _eigenLayerStrategyManager The address of the eigenLayer strategy manager
      * @param _eigenLayerDelegationManager The address of the eigenLayer delegation manager
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(
         address _liquidityPool,

--- a/src/restaking/RestakingRewardsRouter.sol
+++ b/src/restaking/RestakingRewardsRouter.sol
@@ -10,11 +10,20 @@ import "@etherfi/governance/utils/RolesLibrary.sol";
 contract RestakingRewardsRouter is UUPSUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    address public recipientAddress;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
     address public immutable liquidityPool;
     address public immutable rewardTokenAddress;
 
-    address public recipientAddress;
-
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  EVENTS  -------------------------------------------
+    //--------------------------------------------------------------------------------------
     event EthSent(address indexed from, address indexed to, address indexed sender, uint256 value);
     event RecipientAddressSet(address indexed recipient);
     event Erc20Recovered(
@@ -23,10 +32,22 @@ contract RestakingRewardsRouter is UUPSUpgradeable, RolesLibrary {
         uint256 amount
     );
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  ERRORS  -------------------------------------------
+    //--------------------------------------------------------------------------------------
     error InvalidAddress();
     error NoRecipientSet();
     error TransferFailed();
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTRUCTOR  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _roleRegistry The address of the role registry
+     * @param _rewardTokenAddress The address of the reward token
+     * @param _liquidityPool The address of the liquidity pool
+     */
     constructor(
         address _roleRegistry,
         address _rewardTokenAddress,
@@ -41,23 +62,45 @@ contract RestakingRewardsRouter is UUPSUpgradeable, RolesLibrary {
         liquidityPool = _liquidityPool;
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the RestakingRewardsRouter
+     */
+    function initialize() public initializer {
+        __UUPSUpgradeable_init();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  RECEIVE FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Receive ETH
+     */
     receive() external payable {
         (bool success, ) = liquidityPool.call{value: msg.value}("");
         if (!success) revert TransferFailed();
         emit EthSent(address(this), liquidityPool, msg.sender, msg.value);
     }
 
-    function initialize() public initializer {
-        __UUPSUpgradeable_init();
-    }
-
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  ADMIN FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Set the recipient address
+     * @param _recipient The address of the recipient
+     */
     function setRecipientAddress(address _recipient) external onlyAdmin {
         if (_recipient == address(0)) revert InvalidAddress();
         recipientAddress = _recipient;
         emit RecipientAddressSet(_recipient);
     }
 
-    /// @dev Manual transfer function to recover reward tokens that may have accumulated in the contract
+    /**
+     * @notice Recover ERC20 tokens
+     * @dev Manual transfer function to recover reward tokens
+     */
     function recoverERC20() external onlyHousekeepingOperations {
         if (recipientAddress == address(0)) revert NoRecipientSet();
 
@@ -72,8 +115,22 @@ contract RestakingRewardsRouter is UUPSUpgradeable, RolesLibrary {
         }
     }
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  INTERNAL FUNCTIONS  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Authorize upgrade
+     * @param newImplementation The address of the new implementation
+     */
     function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  GETTERS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Get the implementation
+     * @return The implementation
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }

--- a/src/restaking/interfaces/IEtherFiRestaker.sol
+++ b/src/restaking/interfaces/IEtherFiRestaker.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.13;
 import "@etherfi/deposits/interfaces/ILiquifier.sol";
 
 interface IEtherFiRestaker {
+    struct TokenInfo {
+        // EigenLayer
+        IStrategy elStrategy;
+    }
+
     function stEthRequestWithdrawal(uint256 _amount) external returns (uint256[] memory);
     function stEthClaimWithdrawals(uint256[] calldata _requestIds, uint256[] calldata _hints) external;
     function depositIntoStrategy(address token, uint256 amount) external returns (uint256);

--- a/src/rewards/CumulativeMerkleRewardsDistributor.sol
+++ b/src/rewards/CumulativeMerkleRewardsDistributor.sol
@@ -10,13 +10,11 @@ import {RolesLibrary} from "@etherfi/governance/utils/RolesLibrary.sol";
 import {ICumulativeMerkleRewardsDistributor}  from "@etherfi/rewards/interfaces/ICumulativeMerkleRewardsDistributor.sol";
 
 contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, OwnableUpgradeable, UUPSUpgradeable, PausableUntil, AssetRecovery, RolesLibrary {
-using SafeERC20 for IERC20;
-
+    using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
-
     mapping(address token => uint256 timestamp) public lastPendingMerkleUpdatedToTimestamp;
     mapping(address token => uint256 blockNo) public lastRewardsCalculatedToBlock;
     mapping(address token => bytes32 merkleRoot) public claimableMerkleRoots;
@@ -27,23 +25,28 @@ using SafeERC20 for IERC20;
     uint256 public claimDelay;
     bool public paused;
 
-
     //--------------------------------------------------------------------------------------
     //-------------------------------------  CONSTANTS  -------------------------------------
     //--------------------------------------------------------------------------------------
-
     address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
-//--------------------------------------------------------------------------------------
-//----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
-//--------------------------------------------------------------------------------------
-
+    //--------------------------------------------------------------------------------------
+    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _roleRegistry The address of the role registry
+     */
     constructor(address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
     }
 
-    receive() external payable {}
-
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the CumulativeMerkleRewardsDistributor
+     */
     function initialize() external initializer {
         __Ownable_init();
         __UUPSUpgradeable_init();
@@ -51,30 +54,59 @@ using SafeERC20 for IERC20;
         claimDelay = 2 days; // 48 hours
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  RECEIVE FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Receive ETH
+     */
+    receive() external payable {}
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  ADMIN FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Set the claim delay
+     * @param _claimDelay The claim delay
+     */
     function setClaimDelay(uint256 _claimDelay) external onlyAdmin {
         claimDelay = _claimDelay;
         emit ClaimDelayUpdated(claimDelay);
     }
-/**
-* @notice Sets a new pending Merkle root for token rewards distribution
-* @dev Only callable by accounts with EXECUTOR_OPERATIONS_ROLE role
-* @dev The pending root must be finalized after CLAIM_DELAY blocks before it becomes active
-* @param _token Address of the reward token (use ETH_ADDRESS for ETH rewards)
-* @param _merkleRoot New Merkle root containing the reward data
-**/
+
+    /**
+     * @notice Update the whitelisted recipient
+     * @param user The address of the recipient
+     * @param isWhitelisted The boolean value indicating if the recipient is whitelisted
+     */
+    function updateWhitelistedRecipient(address user, bool isWhitelisted) external onlyAdmin {
+        whitelistedRecipient[user] = isWhitelisted;
+        emit RecipientStatusUpdated(user, isWhitelisted);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  OPERATIONAL FUNCTIONS  ------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+    * @notice Sets a new pending Merkle root for token rewards distribution
+    * @dev Only callable by accounts with EXECUTOR_OPERATIONS_ROLE role
+    * @dev The pending root must be finalized after CLAIM_DELAY blocks before it becomes active
+    * @param _token Address of the reward token (use ETH_ADDRESS for ETH rewards)
+    * @param _merkleRoot New Merkle root containing the reward data
+    */
     function setPendingMerkleRoot(address _token, bytes32 _merkleRoot) external whenNotPaused onlyExecutorOperations {
         pendingMerkleRoots[_token] = _merkleRoot;
         lastPendingMerkleUpdatedToTimestamp[_token] = block.timestamp;
         emit PendingMerkleRootUpdated(_token, _merkleRoot);
     }
 
-/**
-* @notice Finalizes a pending Merkle root after the required delay period
-* @dev Only callable by accounts with EXECUTOR_OPERATIONS_ROLE role
-* @dev Must wait CLAIM_DELAY blocks after setPendingMerkleRoot before finalizing
-* @param _token Address of the reward token (use ETH_ADDRESS for ETH rewards)
-* @param _finalizedBlock Block number up to which rewards are calculated
-*/
+    /**
+    * @notice Finalizes a pending Merkle root after the required delay period
+    * @dev Only callable by accounts with EXECUTOR_OPERATIONS_ROLE role
+    * @dev Must wait CLAIM_DELAY blocks after setPendingMerkleRoot before finalizing
+    * @param _token Address of the reward token (use ETH_ADDRESS for ETH rewards)
+    * @param _finalizedBlock Block number up to which rewards are calculated
+    */
     function finalizeMerkleRoot(address _token, uint256 _finalizedBlock) external whenNotPaused onlyExecutorOperations {
         if(!(block.timestamp >= lastPendingMerkleUpdatedToTimestamp[_token] + claimDelay)) revert InsufficentDelay();
         if(_finalizedBlock < lastRewardsCalculatedToBlock[_token] || _finalizedBlock > block.number) revert InvalidFinalizedBlock();
@@ -84,6 +116,9 @@ using SafeERC20 for IERC20;
         emit ClaimableMerkleRootUpdated(_token, oldClaimableMerkleRoot, claimableMerkleRoots[_token], _finalizedBlock);
     }
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  CLAIM FUNCTION  -------------------------------------
+    //--------------------------------------------------------------------------------------
     /**
     * @notice Claims rewards for an account using Merkle proof verification
     * @dev Supports both ERC20 tokens and ETH (using ETH_ADDRESS)
@@ -127,50 +162,79 @@ using SafeERC20 for IERC20;
         emit Claimed(token, account, amount);
     }
 
-    function updateWhitelistedRecipient(address user, bool isWhitelisted) external onlyAdmin {
-        whitelistedRecipient[user] = isWhitelisted;
-        emit RecipientStatusUpdated(user, isWhitelisted);
-    }
-
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  PAUSING FUNCTIONS  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pause the contract
+     */
     function pause() external onlyOperatingMultisig {
         paused = true;
         emit Paused(msg.sender);
     }
 
+    /**
+     * @notice Unpause the contract
+     */
     function unpause() external onlyOperatingMultisig {
         paused = false;
         emit UnPaused(msg.sender);
     }
 
+    /**
+     * @notice Pause the contract until the pauseUntilDuration
+     */
     function pauseContractUntil() external onlyGuardian {
         _pauseUntil();
     }
 
+    /**
+     * @notice Unpause the contract from pauseUntil
+     */
     function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
+    /**
+     * @notice Set the pause duration for the contract
+     * @param _pauseUntilDuration The pause duration
+     */
     function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
         _setPauseUntilDuration(_pauseUntilDuration);
     }
 
+    //--------------------------------------------------------------------------------------
+    //------------------------------  RECOVERY FUNCTIONS  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Recover ETH from the contract
+     * @param to The address to recover the ETH to
+     * @param amount The amount of ETH to recover
+     */
     function recoverETH(address payable to, uint256 amount) external onlyAdmin {
         _recoverETH(to, amount);
     }
 
+    /**
+     * @notice Recover ERC20 tokens from the contract
+     * @param token The address of the ERC20 token
+     * @param to The address to recover the tokens to
+     * @param amount The amount of tokens to recover
+     */
     function recoverERC20(address token, address to, uint256 amount) external onlyAdmin {
         _recoverERC20(token, to, amount);
     }
 
-    function getImplementation() external view returns (address) {return _getImplementation();}
-
-
     //--------------------------------------------------------------------------------------
     //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
     //--------------------------------------------------------------------------------------
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
+    /**
+     * @notice Verify the Merkle proof
+     * @param proof The Merkle proof
+     * @param root The Merkle root
+     * @param leaf The leaf
+     * @return valid The boolean value indicating if the proof is valid
+     */
     function _verifyAsm(bytes32[] calldata proof, bytes32 root, bytes32 leaf) private pure returns (bool valid) {
         if(proof.length > 1000) revert InvalidProof();
         assembly ("memory-safe") { // solhint-disable-line no-inline-assembly
@@ -196,14 +260,36 @@ using SafeERC20 for IERC20;
         }
     }
 
-        function _requireNotPaused() internal view virtual {
-            if(paused) revert ContractPaused();
+    /**
+     * @notice Require the contract to be not paused
+     */
+    function _requireNotPaused() internal view virtual {
+        if(paused) revert ContractPaused();
+    }
+
+    /**
+     * @notice Authorize contract upgrades
+     * @param newImplementation The address of the new implementation
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  GETTERS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Get the implementation
+     * @return The implementation
+     */
+    function getImplementation() external view returns (address) {
+        return _getImplementation();
     }
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Modifier to check if the contract is not paused
+     */
     modifier whenNotPaused() {
         _requireNotPaused();
         _requireNotPausedUntil();

--- a/src/rewards/EtherFiRewardsRouter.sol
+++ b/src/rewards/EtherFiRewardsRouter.sol
@@ -12,33 +12,69 @@ import "@etherfi/core/interfaces/ILiquidityPool.sol";
 contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
     address public immutable treasury;
     address public immutable liquidityPool;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  EVENTS  -------------------------------------------
+    //--------------------------------------------------------------------------------------
     event EthReceived(address indexed from, uint256 value);
     event EthSent(address indexed from, address indexed to, uint256 value);
     event UpdatedTreasury(address indexed treasury);
     event Erc20Sent(address indexed caller, address indexed token, uint256 amount);
     event Erc721Sent(address indexed caller, address indexed token, uint256 tokenId);
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  ERRORS  -------------------------------------------
+    //--------------------------------------------------------------------------------------
     error ContractBalanceIsZero();
     error EthTransferFailed();
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTRUCTOR  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _liquidityPool The address of the liquidity pool
+     * @param _treasury The address of the treasury
+     * @param _roleRegistry The address of the role registry
+     */
     constructor(address _liquidityPool, address _treasury, address _roleRegistry) RolesLibrary(_roleRegistry) {
         _disableInitializers();
         liquidityPool = _liquidityPool;
         treasury = _treasury;
     }
 
-    receive() external payable {
-        emit EthReceived(msg.sender, msg.value);
-    }
-
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the EtherFiRewardsRouter
+     */
     function initialize() public initializer {
         __Ownable_init();
         __UUPSUpgradeable_init();
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  RECEIVE FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Receive ETH
+     */
+    receive() external payable {
+        emit EthReceived(msg.sender, msg.value);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  WITHDRAW FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Withdraw ETH to the liquidity pool
+     */
     function withdrawToLiquidityPool() external {
 
         uint256 contractBalance = address(this).balance;
@@ -51,12 +87,25 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable, RolesLibra
         emit EthSent(address(this), liquidityPool, balance);
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  RECOVERY FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Recover ERC20 tokens
+     * @param _token The address of the token
+     * @param _amount The amount of tokens
+     */
     function recoverERC20(address _token, uint256 _amount) external onlyOperatingMultisig {
         IERC20(_token).safeTransfer(treasury, _amount);
 
         emit Erc20Sent(msg.sender, _token, _amount);
     }
 
+    /**
+     * @notice Recover ERC721 tokens
+     * @param _token The address of the token
+     * @param _tokenId The ID of the token
+     */
     function recoverERC721(address _token, uint256 _tokenId) external onlyOperatingMultisig {
 
         IERC721(_token).transferFrom(address(this), treasury, _tokenId);
@@ -64,8 +113,22 @@ contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable, RolesLibra
         emit Erc721Sent(msg.sender, _token, _tokenId);
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INTERNAL FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Authorize upgrade
+     * @param newImplementation The address of the new implementation
+     */
     function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  GETTERS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Get the implementation
+     * @return The implementation
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }

--- a/src/withdrawals/EtherFiRedemptionManager.sol
+++ b/src/withdrawals/EtherFiRedemptionManager.sol
@@ -102,6 +102,7 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
      * @param _liquidityPool The address of the liquidity pool
      * @param _eEth The address of the eETH token
      * @param _weEth The address of the weETH token
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(
         address _liquidityPool, 

--- a/src/withdrawals/EtherFiRedemptionManager.sol
+++ b/src/withdrawals/EtherFiRedemptionManager.sol
@@ -22,6 +22,7 @@ import "@etherfi/governance/utils/RolesLibrary.sol";
 
 import "@etherfi/governance/rate-limiting/libraries/BucketLimiter.sol";
 
+import "@etherfi/withdrawals/interfaces/IEtherFiRedemptionManager.sol";
 import "@etherfi/withdrawals/interfaces/IPriorityWithdrawalQueue.sol";
 import "@etherfi/governance/interfaces/IBlacklister.sol";
 
@@ -31,26 +32,23 @@ import "@etherfi/governance/interfaces/IBlacklister.sol";
     - It has a rate limiter to limit the total amount that can be redeemed in a given time period.
 */
 
-struct RedemptionInfo {
-    BucketLimiter.Limit limit;
-    uint16 exitFeeSplitToTreasuryInBps;
-    uint16 exitFeeInBps;
-    uint16 lowWatermarkInBpsOfTvl;
-}
-
-contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, PausableUntil, ReentrancyGuardUpgradeable, UUPSUpgradeable, RolesLibrary {
+contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, PausableUntil, ReentrancyGuardUpgradeable, UUPSUpgradeable, RolesLibrary, IEtherFiRedemptionManager {
     using SafeERC20 for IERC20;
     using Math for uint256;
-
-    uint256 private constant BUCKET_UNIT_SCALE = 1e12;
-    uint256 private constant BASIS_POINT_SCALE = 1e4;
 
     /// @dev Suggested gas stipend for contract receiving ETH to perform a few
     /// storage reads and writes, but low enough to prevent griefing.
     uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
-
     address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  STATE-VARIABLES  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    mapping(address => RedemptionInfo) public tokenToRedemptionInfo;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  --------------------------------------
+    //--------------------------------------------------------------------------------------
     address public immutable treasury;
     IeETH public immutable eEth;
     IWeETH public immutable weEth;
@@ -64,11 +62,20 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     uint256 public immutable maxExitFeeInBps;
     uint256 public immutable maxLowWatermarkInBpsOfTvl;
 
-    mapping(address => RedemptionInfo) public tokenToRedemptionInfo;
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    uint256 private constant BUCKET_UNIT_SCALE = 1e12;
+    uint256 private constant BASIS_POINT_SCALE = 1e4;
 
-
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  EVENTS  -------------------------------------------
+    //--------------------------------------------------------------------------------------
     event Redeemed(address indexed receiver, uint256 redemptionAmount, uint256 feeAmountToTreasury, uint256 feeAmountToStakers, address token);
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  ERRORS  -------------------------------------------
+    //--------------------------------------------------------------------------------------
     error InvalidAmount();
     error InvalidOutputToken();
     error InvalidBps();
@@ -85,10 +92,17 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     error RateLimitExceeded();
     error AmountTooLarge();
 
-
     receive() external payable {}
 
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTRUCTOR  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _liquidityPool The address of the liquidity pool
+     * @param _eEth The address of the eETH token
+     * @param _weEth The address of the weETH token
+     */
     constructor(
         address _liquidityPool, 
         address _eEth, address _weEth, 
@@ -118,6 +132,15 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         _disableInitializers();
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the EtherFiRedemptionManager
+     * @param _exitFeeSplitToTreasuryInBps The exit fee split to treasury in basis points
+     * @param _exitFeeInBps The exit fee in basis points
+     * @param _lowWatermarkInBpsOfTvl The low watermark in basis points of the total value of the liquidity pool
+     */
     function initialize(uint16 _exitFeeSplitToTreasuryInBps, uint16 _exitFeeInBps, uint16 _lowWatermarkInBpsOfTvl, uint256 _bucketCapacity, uint256 _bucketRefillRate) external initializer {
         if (_exitFeeInBps > BASIS_POINT_SCALE || _exitFeeSplitToTreasuryInBps > BASIS_POINT_SCALE || _lowWatermarkInBpsOfTvl > BASIS_POINT_SCALE) revert InvalidBps();
 
@@ -140,6 +163,9 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         }
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  REDEEM FUNCTIONS  --------------------------------------
+    //--------------------------------------------------------------------------------------
     /**
      * @notice Redeems eETH for outputToken (ETH or stETH).
      * @param eEthAmount The amount of eETH to redeem after the exit fee.
@@ -184,6 +210,115 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
         _redeemWeEth(weEthAmount, receiver, outputToken);
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  ADMIN FUNCTIONS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Sets the maximum size of the bucket that can be consumed in a given time period.
+     * @param capacity The capacity of the bucket.
+     * @param token The token to set the capacity for
+     */
+    function setCapacity(uint256 capacity, address token) external onlyAdmin {
+        // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
+        uint64 bucketUnit = _convertToBucketUnit(capacity, Math.Rounding.Down);
+        BucketLimiter.setCapacity(tokenToRedemptionInfo[token].limit, bucketUnit);
+    }
+
+    /**
+     * @notice Sets the rate at which the bucket is refilled per second.
+     * @param refillRate The rate at which the bucket is refilled per second.
+     * @param token The token to set the refill rate for
+     */
+    function setRefillRatePerSecond(uint256 refillRate, address token) external onlyAdmin {
+        // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
+        uint64 bucketUnit = _convertToBucketUnit(refillRate, Math.Rounding.Down);
+        BucketLimiter.setRefillRate(tokenToRedemptionInfo[token].limit, bucketUnit);
+    }
+
+    /**
+     * @notice Sets the exit fee.
+     * @param _exitFeeInBps The exit fee.
+     * @param token The token to set the exit fee for
+     */
+    function setExitFeeBasisPoints(uint16 _exitFeeInBps, address token) external onlyAdmin {
+        if (_exitFeeInBps > maxExitFeeInBps) revert ExceedsMaxExitFee();
+        tokenToRedemptionInfo[token].exitFeeInBps = _exitFeeInBps;
+    }
+
+    /**
+     * @notice Sets the low watermark in basis points of the total value of the liquidity pool.
+     * @param _lowWatermarkInBpsOfTvl The low watermark in basis points of the total value of the liquidity pool.
+     * @param token The token to set the low watermark for (ETH or stETH).
+     */
+    function setLowWatermarkInBpsOfTvl(uint16 _lowWatermarkInBpsOfTvl, address token) external onlyAdmin {
+        if (_lowWatermarkInBpsOfTvl > maxLowWatermarkInBpsOfTvl) revert ExceedsMaxLowWatermark();
+        tokenToRedemptionInfo[token].lowWatermarkInBpsOfTvl = _lowWatermarkInBpsOfTvl;
+    }
+
+    /**
+     * @notice Sets the exit fee split to treasury in basis points.
+     * @param _exitFeeSplitToTreasuryInBps The exit fee split to treasury in basis points.
+     * @param token The token to set the exit fee split to treasury for (ETH or stETH).
+     */
+    function setExitFeeSplitToTreasuryInBps(uint16 _exitFeeSplitToTreasuryInBps, address token) external onlyAdmin {
+        if (_exitFeeSplitToTreasuryInBps > maxExitFeeSplitToTreasuryInBps) revert ExceedsMaxExitFeeSplit();
+        tokenToRedemptionInfo[token].exitFeeSplitToTreasuryInBps = _exitFeeSplitToTreasuryInBps;
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  PAUSING FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pauses the contract.
+     * @dev Only callable by the operating multisig
+     */
+    function pauseContract() external onlyOperatingMultisig {
+        _pause();
+    }
+
+    /**
+     * @notice Unpauses the contract.
+     * @dev Only callable by the operating multisig
+     */
+    function unPauseContract() external onlyOperatingMultisig {
+        _unpause();
+    }
+
+    /**
+     * @notice Pauses the contract until the pauseUntilDuration.
+     * @dev Only callable by the guardian
+     */
+    function pauseContractUntil() external onlyGuardian {
+        _pauseUntil();
+    }
+
+    /**
+     * @notice Unpauses the contract from pauseUntil.
+     * @dev Only callable by the operating multisig
+     */
+    function unpauseContractUntil() external onlyOperatingMultisig {
+        _unpauseUntil();
+    }
+
+    /**
+     * @notice Sets the pause duration for the contract.
+     * @param _pauseUntilDuration The pause duration for the contract.
+     * @dev Only callable by the admin
+     */
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  INTERNAL FUNCTIONS  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Processes ETH-specific redemption logic.
+     * @param receiver The address to receive the redeemed ETH.
+     * @param eEthAmountToReceiver The amount of ETH to receiver.
+     * @param sharesToBurn The amount of eETH shares to burn.
+     * @param feeShareToStakers The amount of eETH shares to burn for stakers.
+     */
     function _processETHRedemption(
         address receiver,
         uint256 eEthAmountToReceiver,
@@ -212,6 +347,10 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
 
     /**
      * @notice Processes stETH-specific redemption logic.
+     * @param receiver The address to receive the redeemed stETH.
+     * @param stEthAmountToReceiver The amount of stETH to receiver.
+     * @param sharesToBurn The amount of eETH shares to burn.
+     * @param feeShareToStakers The amount of eETH shares to burn for stakers.
      */
     function _processStETHRedemption(
         address receiver,
@@ -273,12 +412,134 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     }
 
     /**
+     * @notice Redeems eETH.
+     * @param eEthAmount The amount of eETH to redeem.
+     * @param receiver The address to receive the redeemed eETH.
+     * @param outputToken The token to redeem to (ETH or stETH).
+     */
+    function _redeemEEth(uint256 eEthAmount, address receiver, address outputToken) internal {
+        if (eEthAmount > eEth.balanceOf(msg.sender)) revert InsufficientBalance();
+        if (!canRedeem(eEthAmount, outputToken)) revert ExceededRedeemable();
+
+        (uint256 eEthShares, uint256 eEthAmountToReceiver, uint256 eEthFeeAmountToTreasury, uint256 sharesToBurn, uint256 feeShareToTreasury) = _calcRedemption(eEthAmount, outputToken);
+
+        IERC20(address(eEth)).safeTransferFrom(msg.sender, address(this), eEthAmount);
+
+        _redeem(eEthAmount, eEthShares, receiver, eEthAmountToReceiver, eEthFeeAmountToTreasury, sharesToBurn, feeShareToTreasury, outputToken);
+    }
+
+    /**
+     * @notice Redeems weETH.
+     * @param weEthAmount The amount of weETH to redeem.
+     * @param receiver The address to receive the redeemed weETH.
+     * @param outputToken The token to redeem to (ETH or stETH).
+     */
+    function _redeemWeEth(uint256 weEthAmount, address receiver, address outputToken) internal {
+        uint256 eEthAmount = weEth.getEETHByWeETH(weEthAmount);
+        if (weEthAmount > weEth.balanceOf(msg.sender)) revert InsufficientBalance();
+        if (!canRedeem(eEthAmount, outputToken)) revert ExceededRedeemable();
+
+        (uint256 eEthShares, uint256 eEthAmountToReceiver, uint256 eEthFeeAmountToTreasury, uint256 sharesToBurn, uint256 feeShareToTreasury) = _calcRedemption(eEthAmount, outputToken);
+
+        IERC20(address(weEth)).safeTransferFrom(msg.sender, address(this), weEthAmount);
+        weEth.unwrap(weEthAmount);
+
+        _redeem(eEthAmount, eEthShares, receiver, eEthAmountToReceiver, eEthFeeAmountToTreasury, sharesToBurn, feeShareToTreasury, outputToken);
+    }
+
+    /**
+     * @notice Updates the rate limit.
+     * @param amount The amount to update the rate limit for.
+     * @param token The token to update the rate limit for (ETH or stETH).
+     */
+    function _updateRateLimit(uint256 amount, address token) internal {
+        uint64 bucketUnit = _convertToBucketUnit(amount, Math.Rounding.Up);
+        if (!BucketLimiter.consume(tokenToRedemptionInfo[token].limit, bucketUnit)) revert RateLimitExceeded();
+    }
+
+    /**
+     * @notice Converts the amount to a bucket unit.
+     * @param amount The amount to convert to a bucket unit.
+     * @param rounding The rounding mode.
+     * @return The bucket unit.
+     */
+    function _convertToBucketUnit(uint256 amount, Math.Rounding rounding) internal pure returns (uint64) {
+        if (amount >= type(uint64).max * BUCKET_UNIT_SCALE) revert AmountTooLarge();
+        return (rounding == Math.Rounding.Up) ? SafeCast.toUint64((amount + BUCKET_UNIT_SCALE - 1) / BUCKET_UNIT_SCALE) : SafeCast.toUint64(amount / BUCKET_UNIT_SCALE);
+    }
+
+    /**
+     * @notice Converts the bucket unit to an amount.
+     * @param bucketUnit The bucket unit to convert to an amount.
+     * @return The amount.
+     */
+    function _convertFromBucketUnit(uint64 bucketUnit) internal pure returns (uint256) {
+        return bucketUnit * BUCKET_UNIT_SCALE;
+    }
+
+    /**
+     * @notice Calculates the redemption amount.
+     * @param ethAmount The amount of ETH to redeem.
+     * @param token The token to redeem to (ETH or stETH).
+     * @return eEthShares The amount of eETH shares to redeem.
+     * @return eEthAmountToReceiver The amount of ETH to receiver.
+     * @return eEthFeeAmountToTreasury The amount of eETH to treasury.
+     * @return sharesToBurn The amount of eETH shares to burn.
+     * @return feeShareToTreasury The amount of eETH shares to burn for stakers.
+     */
+    function _calcRedemption(uint256 ethAmount, address token) internal view returns (uint256 eEthShares, uint256 eEthAmountToReceiver, uint256 eEthFeeAmountToTreasury, uint256 sharesToBurn, uint256 feeShareToTreasury) {
+        eEthShares = liquidityPool.sharesForAmount(ethAmount);
+        eEthAmountToReceiver = liquidityPool.amountForShare(eEthShares.mulDiv(BASIS_POINT_SCALE - tokenToRedemptionInfo[token].exitFeeInBps, BASIS_POINT_SCALE)); // ethShareToReceiver
+
+        sharesToBurn = liquidityPool.sharesForWithdrawalAmount(eEthAmountToReceiver);
+        uint256 eEthShareFee = eEthShares - sharesToBurn;
+        feeShareToTreasury = eEthShareFee.mulDiv(tokenToRedemptionInfo[token].exitFeeSplitToTreasuryInBps, BASIS_POINT_SCALE);
+        eEthFeeAmountToTreasury = liquidityPool.amountForShare(feeShareToTreasury);
+    }
+
+    /**
+     * @notice Calculates the fee amount.
+     * @param assets The amount of assets to calculate the fee for.
+     * @param feeBasisPoints The fee basis points.
+     * @return The fee amount.
+     */
+    function _fee(uint256 assets, uint256 feeBasisPoints) internal pure virtual returns (uint256) {
+        return assets.mulDiv(feeBasisPoints, BASIS_POINT_SCALE, Math.Rounding.Up);
+    }
+
+    /**
+     * @notice Route OZ's whenNotPaused through the pause-until check as well, so any function
+     *         gated by whenNotPaused is automatically blocked during a timed pause too.
+     */
+    function _requireNotPaused() internal view override {
+        _requireNotPausedUntil();
+        super._requireNotPaused();
+    }
+
+    /**
+     * @notice Authorizes the upgrade.
+     * @param newImplementation The new implementation address.
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //----------------------------  GETTERS  ------------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Returns the low watermark in basis points of the total value of the liquidity pool.
+     * @param token The token to get the low watermark for (ETH or stETH).
+     * @return The low watermark in basis points of the total value of the liquidity pool.
      * @dev if the contract has less than the low watermark, it will not allow any instant redemption.
      */
     function lowWatermarkInETH(address token) public view returns (uint256) {
         return liquidityPool.getTotalPooledEther().mulDiv(tokenToRedemptionInfo[token].lowWatermarkInBpsOfTvl, BASIS_POINT_SCALE);
     }
 
+    /**
+     * @notice Returns the instant liquidity amount for the given token.
+     * @param token The token to get the instant liquidity amount for (ETH or stETH).
+     * @return The instant liquidity amount.
+     */
     function getInstantLiquidityAmount(address token) public view returns (uint256) {
         if(token == ETH_ADDRESS) {
             // Post-escrow-migration, locked ETH has physically left LP into the holder
@@ -290,7 +551,9 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     }
 
     /**
-     * @dev Returns the total amount that can be redeemed.
+     * @notice Returns the total amount that can be redeemed.
+     * @param token The token to get the total redeemable amount for (ETH or stETH).
+     * @return The total redeemable amount.
      */
     function totalRedeemableAmount(address token) external view returns (uint256) {
         uint256 liquidEthAmount = getInstantLiquidityAmount(token);
@@ -306,9 +569,10 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     }
 
     /**
-     * @dev Returns whether the given amount can be redeemed.
+     * @notice Returns whether the given amount can be redeemed.
      * @param amount The ETH or stETH amount to check
      * @param token The token to check to redeem
+     * @return Whether the given amount can be redeemed.
      */
     function canRedeem(uint256 amount, address token) public view returns (bool) {
         uint256 liquidEthAmount = getInstantLiquidityAmount(token);
@@ -326,146 +590,34 @@ contract EtherFiRedemptionManager is Initializable, PausableUpgradeable, Pausabl
     }
 
     /**
-     * @dev Sets the maximum size of the bucket that can be consumed in a given time period.
-     * @param capacity The capacity of the bucket.
-     * @param token The token to set the capacity for
+     * @notice Preview taking an exit fee on redeem.
+     * @param shares The amount of eETH shares to redeem.
+     * @param token The token to redeem to (ETH or stETH).
+     * @return The amount of ETH to receiver after the exit fee.
      */
-    function setCapacity(uint256 capacity, address token) external onlyAdmin {
-        // max capacity = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether, which is practically enough
-        uint64 bucketUnit = _convertToBucketUnit(capacity, Math.Rounding.Down);
-        BucketLimiter.setCapacity(tokenToRedemptionInfo[token].limit, bucketUnit);
-    }
-
-    /**
-     * @dev Sets the rate at which the bucket is refilled per second.
-     * @param refillRate The rate at which the bucket is refilled per second.
-     * @param token The token to set the refill rate for
-     */
-    function setRefillRatePerSecond(uint256 refillRate, address token) external onlyAdmin {
-        // max refillRate = max(uint64) * 1e12 ~= 16 * 1e18 * 1e12 = 16 * 1e12 ether per second, which is practically enough
-        uint64 bucketUnit = _convertToBucketUnit(refillRate, Math.Rounding.Down);
-        BucketLimiter.setRefillRate(tokenToRedemptionInfo[token].limit, bucketUnit);
-    }
-
-    /**
-     * @dev Sets the exit fee.
-     * @param _exitFeeInBps The exit fee.
-     * @param token The token to set the exit fee for
-     */
-    function setExitFeeBasisPoints(uint16 _exitFeeInBps, address token) external onlyAdmin {
-        if (_exitFeeInBps > maxExitFeeInBps) revert ExceedsMaxExitFee();
-        tokenToRedemptionInfo[token].exitFeeInBps = _exitFeeInBps;
-    }
-
-    function setLowWatermarkInBpsOfTvl(uint16 _lowWatermarkInBpsOfTvl, address token) external onlyAdmin {
-        if (_lowWatermarkInBpsOfTvl > maxLowWatermarkInBpsOfTvl) revert ExceedsMaxLowWatermark();
-        tokenToRedemptionInfo[token].lowWatermarkInBpsOfTvl = _lowWatermarkInBpsOfTvl;
-    }
-
-    function setExitFeeSplitToTreasuryInBps(uint16 _exitFeeSplitToTreasuryInBps, address token) external onlyAdmin {
-        if (_exitFeeSplitToTreasuryInBps > maxExitFeeSplitToTreasuryInBps) revert ExceedsMaxExitFeeSplit();
-        tokenToRedemptionInfo[token].exitFeeSplitToTreasuryInBps = _exitFeeSplitToTreasuryInBps;
-    }
-
-    function pauseContract() external onlyOperatingMultisig {
-        _pause();
-    }
-
-    function unPauseContract() external onlyOperatingMultisig {
-        _unpause();
-    }
-
-    function pauseContractUntil() external onlyGuardian {
-        _pauseUntil();
-    }
-
-    function unpauseContractUntil() external onlyOperatingMultisig {
-        _unpauseUntil();
-    }
-
-    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
-        _setPauseUntilDuration(_pauseUntilDuration);
-    }
-
-    function _redeemEEth(uint256 eEthAmount, address receiver, address outputToken) internal {
-        if (eEthAmount > eEth.balanceOf(msg.sender)) revert InsufficientBalance();
-        if (!canRedeem(eEthAmount, outputToken)) revert ExceededRedeemable();
-
-        (uint256 eEthShares, uint256 eEthAmountToReceiver, uint256 eEthFeeAmountToTreasury, uint256 sharesToBurn, uint256 feeShareToTreasury) = _calcRedemption(eEthAmount, outputToken);
-
-        IERC20(address(eEth)).safeTransferFrom(msg.sender, address(this), eEthAmount);
-
-        _redeem(eEthAmount, eEthShares, receiver, eEthAmountToReceiver, eEthFeeAmountToTreasury, sharesToBurn, feeShareToTreasury, outputToken);
-    }
-
-    function _redeemWeEth(uint256 weEthAmount, address receiver, address outputToken) internal {
-        uint256 eEthAmount = weEth.getEETHByWeETH(weEthAmount);
-        if (weEthAmount > weEth.balanceOf(msg.sender)) revert InsufficientBalance();
-        if (!canRedeem(eEthAmount, outputToken)) revert ExceededRedeemable();
-
-        (uint256 eEthShares, uint256 eEthAmountToReceiver, uint256 eEthFeeAmountToTreasury, uint256 sharesToBurn, uint256 feeShareToTreasury) = _calcRedemption(eEthAmount, outputToken);
-
-        IERC20(address(weEth)).safeTransferFrom(msg.sender, address(this), weEthAmount);
-        weEth.unwrap(weEthAmount);
-
-        _redeem(eEthAmount, eEthShares, receiver, eEthAmountToReceiver, eEthFeeAmountToTreasury, sharesToBurn, feeShareToTreasury, outputToken);
-    }
-
-
-    function _updateRateLimit(uint256 amount, address token) internal {
-        uint64 bucketUnit = _convertToBucketUnit(amount, Math.Rounding.Up);
-        if (!BucketLimiter.consume(tokenToRedemptionInfo[token].limit, bucketUnit)) revert RateLimitExceeded();
-    }
-
-    function _convertToBucketUnit(uint256 amount, Math.Rounding rounding) internal pure returns (uint64) {
-        if (amount >= type(uint64).max * BUCKET_UNIT_SCALE) revert AmountTooLarge();
-        return (rounding == Math.Rounding.Up) ? SafeCast.toUint64((amount + BUCKET_UNIT_SCALE - 1) / BUCKET_UNIT_SCALE) : SafeCast.toUint64(amount / BUCKET_UNIT_SCALE);
-    }
-
-    function _convertFromBucketUnit(uint64 bucketUnit) internal pure returns (uint256) {
-        return bucketUnit * BUCKET_UNIT_SCALE;
-    }
-
-
-    function _calcRedemption(uint256 ethAmount, address token) internal view returns (uint256 eEthShares, uint256 eEthAmountToReceiver, uint256 eEthFeeAmountToTreasury, uint256 sharesToBurn, uint256 feeShareToTreasury) {
-        eEthShares = liquidityPool.sharesForAmount(ethAmount);
-        eEthAmountToReceiver = liquidityPool.amountForShare(eEthShares.mulDiv(BASIS_POINT_SCALE - tokenToRedemptionInfo[token].exitFeeInBps, BASIS_POINT_SCALE)); // ethShareToReceiver
-
-        sharesToBurn = liquidityPool.sharesForWithdrawalAmount(eEthAmountToReceiver);
-        uint256 eEthShareFee = eEthShares - sharesToBurn;
-        feeShareToTreasury = eEthShareFee.mulDiv(tokenToRedemptionInfo[token].exitFeeSplitToTreasuryInBps, BASIS_POINT_SCALE);
-        eEthFeeAmountToTreasury = liquidityPool.amountForShare(feeShareToTreasury);
-    }
-
-    /**
-     * @dev Preview taking an exit fee on redeem. See {IERC4626-previewRedeem}.
-     */
-    // redeemable amount after exit fee
     function previewRedeem(uint256 shares, address token) public view returns (uint256) {
         uint256 amountInEth = liquidityPool.amountForShare(shares);
         return amountInEth - _fee(amountInEth, tokenToRedemptionInfo[token].exitFeeInBps);
     }
 
-    function _fee(uint256 assets, uint256 feeBasisPoints) internal pure virtual returns (uint256) {
-        return assets.mulDiv(feeBasisPoints, BASIS_POINT_SCALE, Math.Rounding.Up);
-    }
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
+    /**
+     * @notice Returns the implementation address.
+     * @return The implementation address.
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
-    }
+    }   
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  MODIFIERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Modifier to check if the receiver is not blacklisted.
+     * @param receiver The address to check if it is blacklisted.
+     */
     modifier nonBlacklisted(address receiver) {
         blacklister.nonBlacklisted(msg.sender);
         blacklister.nonBlacklisted(receiver);
         _;
-    }
-
-    /// @dev Route OZ's whenNotPaused through the pause-until check as well, so any function
-    ///      gated by whenNotPaused is automatically blocked during a timed pause too.
-    function _requireNotPaused() internal view override {
-        _requireNotPausedUntil();
-        super._requireNotPaused();
     }
 }

--- a/src/withdrawals/PriorityWithdrawalQueue.sol
+++ b/src/withdrawals/PriorityWithdrawalQueue.sol
@@ -15,9 +15,11 @@ import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 
-/// @title PriorityWithdrawalQueue
-/// @notice Manages priority withdrawals for whitelisted users
-/// @dev Implements priority withdrawal queue pattern
+/**
+ * @title PriorityWithdrawalQueue
+ * @notice Manages priority withdrawals for whitelisted users
+ * @dev Implements priority withdrawal queue pattern
+ */
 contract PriorityWithdrawalQueue is 
     Initializable, 
     UUPSUpgradeable, 
@@ -31,30 +33,8 @@ contract PriorityWithdrawalQueue is
     using Math for uint256;
 
     //--------------------------------------------------------------------------------------
-    //---------------------------------  CONSTANTS  ----------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    uint96 public constant MIN_AMOUNT = 0.01 ether;
-    uint96 public constant MAX_AMOUNT = 1000 ether;
-    uint256 private constant _BASIS_POINT_SCALE = 1e4;
-    uint256 public constant SHARE_UNIT = 1e18;
-    uint256 private constant _TOLERANCE_BUFFER = 10; // in wei to account for rounding errors
-
-    //--------------------------------------------------------------------------------------
-    //---------------------------------  IMMUTABLES  ---------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    ILiquidityPool public immutable liquidityPool;
-    IeETH public immutable eETH;
-    IWeETH public immutable weETH;
-    IBlacklister public immutable blacklister;
-    address public immutable treasury;
-    uint32 public immutable minDelay;
-
-    //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
-
     /// @notice EnumerableSet to store all active withdraw request IDs
     EnumerableSet.Bytes32Set private _withdrawRequests;
 
@@ -68,6 +48,25 @@ contract PriorityWithdrawalQueue is
     bool public paused;
     uint96 public totalRemainderShares;
     uint128 public ethAmountLockedForPriorityWithdrawal;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    ILiquidityPool public immutable liquidityPool;
+    IeETH public immutable eETH;
+    IWeETH public immutable weETH;
+    IBlacklister public immutable blacklister;
+    address public immutable treasury;
+    uint32 public immutable minDelay;
+
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  CONSTANTS  ----------------------------------------
+    //--------------------------------------------------------------------------------------
+    uint96 public constant MIN_AMOUNT = 0.01 ether;
+    uint96 public constant MAX_AMOUNT = 1000 ether;
+    uint256 private constant _BASIS_POINT_SCALE = 1e4;
+    uint256 public constant SHARE_UNIT = 1e18;
+    uint256 private constant _TOLERANCE_BUFFER = 10; // in wei to account for rounding errors
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
@@ -120,35 +119,18 @@ contract PriorityWithdrawalQueue is
     error MigrationNotComplete();
 
     //--------------------------------------------------------------------------------------
-    //-----------------------------------  MODIFIERS  --------------------------------------
+    //---------------------------------  CONSTRUCTOR  --------------------------------------
     //--------------------------------------------------------------------------------------
-
-    modifier whenNotPaused() {
-        if (paused) revert ContractPaused();
-        _requireNotPausedUntil();
-        _;
-    }
-
     /**
-     * @dev Reason why modifier has both whitelisted and blacklisted checks is becuase if whitelisted user gets compramised,
-     * they can access the protocol before operating multisig can remove whitelist. so guardian can blacklist user.
+     * @notice Constructor
+     * @param _liquidityPool The address of the liquidity pool.
+     * @param _eETH The address of the eETH token.
+     * @param _weETH The address of the weETH token.
+     * @param _blacklister The address of the blacklister.
+     * @param _roleRegistry The address of the role registry.
+     * @param _treasury The address of the treasury.
+     * @param _minDelay The minimum delay for a withdrawal request.
      */
-    modifier onlyWhitelisted() {
-        if (!isWhitelisted[msg.sender]) revert NotWhitelisted();
-        blacklister.nonBlacklisted(msg.sender);
-        _;
-    }
-
-    modifier onlyRequestUser(address requestUser) {
-        if (requestUser != msg.sender) revert NotRequestOwner();
-        _;
-    }
-
-    //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
-    //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _liquidityPool, address _eETH, address _weETH, address _blacklister, address _roleRegistry, address _treasury, uint32 _minDelay) RolesLibrary(_roleRegistry) {
         if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _blacklister == address(0) || _treasury == address(0)) {
             revert AddressZero();
@@ -164,14 +146,12 @@ contract PriorityWithdrawalQueue is
         _disableInitializers();
     }
 
-    receive() external payable {
-        if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
-        if (liquidityPool.escrowMigrationCompleted()) {
-            ethAmountLockedForPriorityWithdrawal += uint128(msg.value);
-        }
-        _checkEthAmountLockedForPriorityWithdrawal();
-    }
-
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  INITIALIZERS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the contract
+     */
     function initialize() external initializer {
         __UUPSUpgradeable_init();
         __ReentrancyGuard_init();
@@ -181,13 +161,29 @@ contract PriorityWithdrawalQueue is
     }
 
     //--------------------------------------------------------------------------------------
-    //------------------------------  USER FUNCTIONS  --------------------------------------
+    //----------------------------  RECEIVE FUNCTIONS  -------------------------------------
     //--------------------------------------------------------------------------------------
+    /**
+     * @notice Receive ETH
+     * @dev Only callable by the liquidity pool after escrow migration is complete.
+     */
+    receive() external payable {
+        if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
+        if (liquidityPool.escrowMigrationCompleted()) {
+            ethAmountLockedForPriorityWithdrawal += uint128(msg.value);
+        }
+        _checkEthAmountLockedForPriorityWithdrawal();
+    }
 
-    /// @notice Request a withdrawal of eETH
-    /// @param amountOfEEth Amount of eETH to withdraw
-    /// @param amountWithFee ETH amount the user receives after fee deduction (amountOfEEth - fee)
-    /// @return requestId The hash-based ID of the created withdrawal request
+    //--------------------------------------------------------------------------------------
+    //------------------------------  WITHDRAW FUNCTIONS  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Request a withdrawal of eETH
+     * @param amountOfEEth Amount of eETH to withdraw
+     * @param amountWithFee ETH amount the user receives after fee deduction (amountOfEEth - fee)
+     * @return requestId The hash-based ID of the created withdrawal request
+     */
     function requestWithdraw(
         uint96 amountOfEEth,
         uint96 amountWithFee
@@ -201,6 +197,13 @@ contract PriorityWithdrawalQueue is
         _verifyRequestPostConditions(lpEthBefore, queueEEthSharesBefore, amountOfEEth);
     }
 
+    /**
+     * @notice Request a withdrawal of eETH with EIP-2612 permit
+     * @param amountOfEEth Amount of eETH to withdraw
+     * @param amountWithFee ETH amount the user receives after fee deduction (amountOfEEth - fee)
+     * @param permit The permit params for eETH approval
+     * @return requestId The hash-based ID of the created withdrawal request
+     */
     function requestWithdrawWithPermit(
         uint96 amountOfEEth,
         uint96 amountWithFee,
@@ -222,10 +225,12 @@ contract PriorityWithdrawalQueue is
         _verifyRequestPostConditions(lpEthBefore, queueEEthSharesBefore, amountOfEEth);
     }
 
-    /// @notice Request a withdrawal using weETH (unwraps to eETH internally)
-    /// @param weEthAmount Amount of weETH to withdraw
-    /// @param amountWithFee ETH amount the user receives after fee deduction
-    /// @return requestId The hash-based ID of the created withdrawal request
+    /**
+     * @notice Request a withdrawal using weETH (unwraps to eETH internally)
+     * @param weEthAmount Amount of weETH to withdraw
+     * @param amountWithFee ETH amount the user receives after fee deduction
+     * @return requestId The hash-based ID of the created withdrawal request
+     */
     function requestWithdrawWithWeETH(
         uint96 weEthAmount,
         uint96 amountWithFee
@@ -241,11 +246,13 @@ contract PriorityWithdrawalQueue is
         _verifyRequestPostConditions(lpEthBefore, queueEEthSharesBefore, eEthAmount);
     }
 
-    /// @notice Request a withdrawal using weETH with EIP-2612 permit
-    /// @param weEthAmount Amount of weETH to withdraw
-    /// @param amountWithFee ETH amount the user receives after fee deduction
-    /// @param permit The permit params for weETH approval
-    /// @return requestId The hash-based ID of the created withdrawal request
+    /**
+     * @notice Request a withdrawal using weETH with EIP-2612 permit
+     * @param weEthAmount Amount of weETH to withdraw
+     * @param amountWithFee ETH amount the user receives after fee deduction
+     * @param permit The permit params for weETH approval
+     * @return requestId The hash-based ID of the created withdrawal request
+     */
     function requestWithdrawWithWeETHAndPermit(
         uint96 weEthAmount,
         uint96 amountWithFee,
@@ -268,9 +275,11 @@ contract PriorityWithdrawalQueue is
         _verifyRequestPostConditions(lpEthBefore, queueEEthSharesBefore, eEthAmount);
     }
 
-    /// @notice Cancel a pending withdrawal request
-    /// @param request The withdrawal request to cancel
-    /// @return requestId The cancelled request ID
+    /**
+     * @notice Cancel a pending withdrawal request
+     * @param request The withdrawal request to cancel
+     * @return requestId The cancelled request ID
+     */
     function cancelWithdraw(
         WithdrawRequest calldata request
     ) external nonReentrant whenNotPaused onlyRequestUser(request.user) returns (bytes32 requestId) {
@@ -287,10 +296,10 @@ contract PriorityWithdrawalQueue is
         _verifyCancelPostConditions(lpEthBefore, queueEEthSharesBefore, userEEthSharesBefore, request.user, expectedLpEthDelta);
     }
 
-    /// @notice Claim ETH for a finalized withdrawal request
-    /// @dev Anyone can call this to claim on behalf of the user. Funds are sent to request.user.
-    ///      ETH delivery forwards gas to request.user, so third parties should avoid claiming for untrusted recipients.
-    /// @param request The withdrawal request to claim
+    /**
+     * @notice Claim ETH for a finalized withdrawal request
+     * @param request The withdrawal request to claim
+     */
     function claimWithdraw(WithdrawRequest calldata request) external nonReentrant {
         if (request.creationTime + minDelay > block.timestamp) revert NotMatured();
 
@@ -302,10 +311,10 @@ contract PriorityWithdrawalQueue is
         _verifyClaimPostConditions(lpEthBefore, queueEEthSharesBefore, queueEthBefore, userEthBefore, request.user);
     }
 
-    /// @notice Batch claim multiple withdrawal requests
-    /// @dev Anyone can call this to claim on behalf of users. Funds are sent to each request.user.
-    ///      Each ETH delivery forwards gas to request.user, so batching untrusted recipients can be griefed.
-    /// @param requests Array of withdrawal requests to claim
+    /**
+     * @notice Batch claim multiple withdrawal requests
+     * @param requests Array of withdrawal requests to claim
+     */
     function batchClaimWithdraw(WithdrawRequest[] calldata requests) external nonReentrant {
         for (uint256 i = 0; i < requests.length; ++i) {
             if (requests[i].creationTime + minDelay > block.timestamp) revert NotMatured();
@@ -317,13 +326,15 @@ contract PriorityWithdrawalQueue is
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  REQUEST MANAGER FUNCTIONS  ------------------------------
+    //----------------------------  OPERATIONAL FUNCTIONS  ---------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @notice Request manager finalizes withdrawal requests after maturity.
-    /// @dev Locks ETH per request by calling LP.transferLockedEthForPriority — escrowed in this contract until claim or cancel.
-    ///      Gated on escrowMigrationCompleted: receive() only bumps ethAmountLockedForPriorityWithdrawal post-migration,
-    ///      so finalizing before that would leave the lock counter at zero and brick the resulting requests.
+    /**
+     * @notice Finalizes withdrawal requests after maturity.
+     * @dev Locks ETH per request by calling LP.transferLockedEthForPriority — escrowed in this contract until claim or cancel.
+     *      Gated on escrowMigrationCompleted: receive() only bumps ethAmountLockedForPriorityWithdrawal post-migration,
+     *      so finalizing before that would leave the lock counter at zero and brick the resulting requests.
+     * @param requests Array of withdrawal requests to finalize
+     */
     function fulfillRequests(WithdrawRequest[] calldata requests) external onlyOracleOperations whenNotPaused {
         if (!liquidityPool.escrowMigrationCompleted()) revert MigrationNotComplete();
         uint256 totalAmountToLock = 0;
@@ -350,35 +361,13 @@ contract PriorityWithdrawalQueue is
         }
     }
 
-    //--------------------------------------------------------------------------------------
-    //-----------------------------------  ADMIN FUNCTIONS  --------------------------------
-    //--------------------------------------------------------------------------------------
-
-    function addToWhitelist(address user) external onlyAdmin {
-        if (user == address(0)) revert AddressZero();
-        isWhitelisted[user] = true;
-        emit WhitelistUpdated(user, true);
-    }
-
-    function removeFromWhitelist(address user) external onlyOperatingMultisig {
-        isWhitelisted[user] = false;
-        emit WhitelistUpdated(user, false);
-    }
-
-    function batchUpdateWhitelist(address[] calldata users, bool[] calldata statuses) external onlyAdmin {
-        if (users.length != statuses.length) revert ArrayLengthMismatch();
-        for (uint256 i = 0; i < users.length; ++i) {
-            if (users[i] == address(0)) revert AddressZero();
-            isWhitelisted[users[i]] = statuses[i];
-            emit WhitelistUpdated(users[i], statuses[i]);
-        }
-    }
-
-    /// @notice Invalidate and cancel withdrawal requests in any state
-    /// @dev Can target both pending and finalized requests.
-    ///      For finalized requests, this also prevents subsequent claims.
-    /// @param requests Array of requests to invalidate
-    /// @return invalidatedRequestIds Array of request IDs that were invalidated
+    /**
+     * @notice Invalidate and cancel withdrawal requests in any state
+     * @param requests Array of requests to invalidate
+     * @return invalidatedRequestIds Array of request IDs that were invalidated
+     * @dev Can target both pending and finalized requests.
+     *      For finalized requests, this also prevents subsequent claims.
+     */
     function invalidateRequests(WithdrawRequest[] calldata requests) external onlyOracleOperations returns (bytes32[] memory invalidatedRequestIds) {
         invalidatedRequestIds = new bytes32[](requests.length);
         for (uint256 i = 0; i < requests.length; ++i) {
@@ -392,11 +381,13 @@ contract PriorityWithdrawalQueue is
         }
     }
 
-    /// @notice Handle remainder shares (from rounding differences)
-    /// @dev Splits the remainder into two parts:
-    ///      - Treasury: gets a percentage of the remainder based on shareRemainderSplitToTreasuryInBps
-    ///      - Burn: the rest of the remainder is burned
-    /// @param eEthAmount Amount of eETH remainder to handle
+    /**
+     * @notice Handle remainder shares (from rounding differences)
+     * @param eEthAmount Amount of eETH remainder to handle
+     * @dev Splits the remainder into two parts:
+     *      - Treasury: gets a percentage of the remainder based on shareRemainderSplitToTreasuryInBps
+     *      - Burn: the rest of the remainder is burned
+     */
     function handleRemainder(uint256 eEthAmount) external onlyHousekeepingOperations {
         if (eEthAmount == 0) revert BadInput();
         if (eEthAmount > liquidityPool.amountForShare(totalRemainderShares)) revert BadInput();
@@ -422,32 +413,91 @@ contract PriorityWithdrawalQueue is
         emit RemainderHandled(uint96(eEthAmountToTreasury), uint96(eEthSharesToBurn));
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  ADMIN FUNCTIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Add a user to the whitelist
+     * @param user The address of the user to add to the whitelist
+     */
+    function addToWhitelist(address user) external onlyAdmin {
+        if (user == address(0)) revert AddressZero();
+        isWhitelisted[user] = true;
+        emit WhitelistUpdated(user, true);
+    }
+
+    /**
+     * @notice Remove a user from the whitelist
+     * @param user The address of the user to remove from the whitelist
+     */
+    function removeFromWhitelist(address user) external onlyOperatingMultisig {
+        isWhitelisted[user] = false;
+        emit WhitelistUpdated(user, false);
+    }
+
+    /**
+     * @notice Batch update the whitelist
+     * @param users Array of addresses to update the whitelist for
+     * @param statuses Array of boolean values indicating the new whitelist status
+     */
+    function batchUpdateWhitelist(address[] calldata users, bool[] calldata statuses) external onlyAdmin {
+        if (users.length != statuses.length) revert ArrayLengthMismatch();
+        for (uint256 i = 0; i < users.length; ++i) {
+            if (users[i] == address(0)) revert AddressZero();
+            isWhitelisted[users[i]] = statuses[i];
+            emit WhitelistUpdated(users[i], statuses[i]);
+        }
+    }
+
+    /**
+     * @notice Update the share remainder split to treasury
+     * @param _shareRemainderSplitToTreasuryInBps The new share remainder split to treasury in basis points
+     */
     function updateShareRemainderSplitToTreasury(uint16 _shareRemainderSplitToTreasuryInBps) external onlyAdmin {
         if (_shareRemainderSplitToTreasuryInBps > _BASIS_POINT_SCALE) revert BadInput();
         shareRemainderSplitToTreasuryInBps = _shareRemainderSplitToTreasuryInBps;
         emit ShareRemainderSplitUpdated(_shareRemainderSplitToTreasuryInBps);
     }
 
+    //--------------------------------------------------------------------------------------
+    //------------------------------  PAUSE FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pause the contract
+     */
     function pauseContract() external onlyOperatingMultisig {
         if (paused) revert ContractPaused();
         paused = true;
         emit Paused(msg.sender);
     }
 
+    /**
+     * @notice Unpause the contract
+     */
     function unPauseContract() external onlyOperatingMultisig {
         if (!paused) revert ContractNotPaused();
         paused = false;
         emit Unpaused(msg.sender);
     }
 
+    /**
+     * @notice Pause the contract until the pauseUntilDuration
+     */
     function pauseContractUntil() external onlyGuardian {
         _pauseUntil();
     }
 
+    /**
+     * @notice Unpause the contract from pauseUntil
+     */
     function unpauseContractUntil() external onlyOperatingMultisig {
         _unpauseUntil();
     }
 
+    /**
+     * @notice Set the pause duration for the contract
+     * @param _pauseUntilDuration The new pause duration
+     */
     function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
         _setPauseUntilDuration(_pauseUntilDuration);
     }
@@ -455,21 +505,24 @@ contract PriorityWithdrawalQueue is
     //--------------------------------------------------------------------------------------
     //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @dev Snapshot balances before state changes for post-hook verification
-    /// @return lpEthBefore ETH balance of LiquidityPool
-    /// @return queueEEthSharesBefore eETH shares held by this contract
-    /// @return queueEthBefore ETH balance of this contract (used for claim verification)
+    /**
+     * @notice Snapshot balances before state changes for post-hook verification
+     * @return lpEthBefore ETH balance of LiquidityPool
+     * @return queueEEthSharesBefore eETH shares held by this contract
+     * @return queueEthBefore ETH balance of this contract (used for claim verification)
+     */
     function _snapshotBalances() internal view returns (uint256 lpEthBefore, uint256 queueEEthSharesBefore, uint256 queueEthBefore) {
         lpEthBefore = liquidityPool.totalValueInLp();
         queueEEthSharesBefore = eETH.shares(address(this));
         queueEthBefore = address(this).balance;
     }
 
-    /// @dev Verify post-conditions after a request is created
-    /// @param lpEthBefore ETH balance of LiquidityPool before operation
-    /// @param queueEEthSharesBefore eETH shares held by queue before operation
-    /// @param amountOfEEth Amount of eETH that was transferred
+    /**
+     * @notice Verify post-conditions after a request is created
+     * @param lpEthBefore ETH balance of LiquidityPool before operation
+     * @param queueEEthSharesBefore eETH shares held by queue before operation
+     * @param amountOfEEth Amount of eETH that was transferred
+     */
     function _verifyRequestPostConditions(
         uint256 lpEthBefore, 
         uint256 queueEEthSharesBefore,
@@ -480,12 +533,14 @@ contract PriorityWithdrawalQueue is
         if (liquidityPool.totalValueInLp() != lpEthBefore) revert UnexpectedBalanceChange();
     }
 
-    /// @dev Verify post-conditions after a cancel operation
-    /// @param lpEthBefore ETH balance of LiquidityPool before operation
-    /// @param queueEEthSharesBefore eETH shares held by queue before operation
-    /// @param userEEthSharesBefore eETH shares held by user before operation
-    /// @param user The user who cancelled
-    /// @param expectedLpEthDelta 0 for pending cancel; request.amountOfEEth for finalized cancel (ETH returned to LP)
+    /**
+     * @notice Verify post-conditions after a cancel operation
+     * @param lpEthBefore ETH balance of LiquidityPool before operation
+     * @param queueEEthSharesBefore eETH shares held by queue before operation
+     * @param userEEthSharesBefore eETH shares held by user before operation
+     * @param user The user who cancelled
+     * @param expectedLpEthDelta 0 for pending cancel; request.amountOfEEth for finalized cancel (ETH returned to LP)
+     */
     function _verifyCancelPostConditions(
         uint256 lpEthBefore,
         uint256 queueEEthSharesBefore,
@@ -498,12 +553,14 @@ contract PriorityWithdrawalQueue is
         if (eETH.shares(user) <= userEEthSharesBefore) revert UnexpectedBalanceChange();
     }
 
-    /// @dev Verify post-conditions after a claim operation
-    /// @param lpEthBefore ETH balance of LiquidityPool before operation
-    /// @param queueEEthSharesBefore eETH shares held by queue before operation
-    /// @param queueEthBefore ETH balance of this contract before operation
-    /// @param userEthBefore ETH balance of user before operation
-    /// @param user The user who claimed
+    /**
+     * @notice Verify post-conditions after a claim operation
+     * @param lpEthBefore ETH balance of LiquidityPool before operation
+     * @param queueEEthSharesBefore eETH shares held by queue before operation
+     * @param queueEthBefore ETH balance of this contract before operation
+     * @param userEthBefore ETH balance of user before operation
+     * @param user The user who claimed
+     */
     function _verifyClaimPostConditions(
         uint256 lpEthBefore,
         uint256 queueEEthSharesBefore,
@@ -519,6 +576,14 @@ contract PriorityWithdrawalQueue is
         if (user.balance <= userEthBefore) revert UnexpectedBalanceChange();
     }
 
+    /**
+     * @notice Queue a withdrawal request
+     * @param user The user who is requesting the withdrawal
+     * @param amountOfEEth Amount of eETH that was requested
+     * @param amountWithFee ETH amount the user receives after fee deduction (amountOfEEth - fee)
+     * @return requestId The hash-based ID of the created withdrawal request
+     * @return req The withdrawal request
+     */
     function _queueWithdrawRequest(
         address user,
         uint96 amountOfEEth,
@@ -558,6 +623,11 @@ contract PriorityWithdrawalQueue is
         );
     }
 
+    /**
+     * @notice Dequeue a withdrawal request
+     * @param request The withdrawal request to dequeue
+     * @return requestId The hash-based ID of the dequeued withdrawal request
+     */
     function _dequeueWithdrawRequest(WithdrawRequest calldata request) internal returns (bytes32 requestId) {
         requestId = keccak256(abi.encode(request));
         
@@ -588,10 +658,13 @@ contract PriorityWithdrawalQueue is
         emit WithdrawRequestCancelled(requestId, request.user, uint96(amountForShares), request.shareOfEEth, request.nonce, uint32(block.timestamp));
     }
 
-    /// @dev Pays the user from this contract's own ETH balance (escrowed at fulfillRequests time). LP only does share burn + accounting on the segregated path.
-    ///      Anyone may call claim on behalf of `request.user`, but the recipient itself must
-    ///      not be blacklisted at claim time — sanctioned addresses cannot receive proceeds
-    ///      via a non-blacklisted accomplice.
+    /**
+     * @notice Pays the user from this contract's own ETH balance (escrowed at fulfillRequests time). LP only does share burn + accounting on the segregated path.
+     * @param request The withdrawal request to claim
+     * @dev Anyone may call claim on behalf of `request.user`, but the recipient itself must
+     *      not be blacklisted at claim time — sanctioned addresses cannot receive proceeds
+     *      via a non-blacklisted accomplice.
+     */
     function _claimWithdraw(WithdrawRequest calldata request) internal {
         blacklister.nonBlacklisted(request.user);
 
@@ -639,16 +712,32 @@ contract PriorityWithdrawalQueue is
         emit WithdrawRequestClaimed(requestId, request.user, uint96(amountToWithdraw), uint96(burnedShares), request.nonce, uint32(block.timestamp));
     }
 
-    function _checkEthAmountLockedForPriorityWithdrawal() internal {
+    /**
+     * @notice Checks if the ETH amount locked for priority withdrawal is sufficient
+     * @dev Reverts if the ETH amount locked for priority withdrawal is greater than the ETH balance of the contract
+     */
+    function _checkEthAmountLockedForPriorityWithdrawal() internal view {
         if (ethAmountLockedForPriorityWithdrawal > address(this).balance) revert InsufficientLiquidity();
     }
 
+    /**
+     * @notice Authorizes the upgrade of the contract
+     * @param newImplementation The new implementation address
+     */
     function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //------------------------------------  GETTERS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Generates a withdrawal request ID
+     * @param _user The user who is requesting the withdrawal
+     * @param _amountOfEEth Amount of eETH that was requested
+     * @param _shareOfEEth eETH shares at time of request
+     * @param _amountWithFee ETH amount the user receives after fee deduction (amountOfEEth - fee)
+     * @param _nonce Unique nonce to prevent hash collisions
+     * @param _creationTime Timestamp when request was created
+     */
     function generateWithdrawRequestId(
         address _user,
         uint96 _amountOfEEth,
@@ -668,6 +757,11 @@ contract PriorityWithdrawalQueue is
         requestId = keccak256(abi.encode(req));
     }
 
+    /**
+     * @notice Generates a withdrawal request ID
+     * @param request The withdrawal request to generate the ID for
+     * @return requestId The hash-based ID of the withdrawal request
+     */
     function getRequestId(WithdrawRequest calldata request) external pure returns (bytes32) {
         return generateWithdrawRequestId(
             request.user,
@@ -679,22 +773,45 @@ contract PriorityWithdrawalQueue is
         );
     }
 
+    /**
+     * @notice Gets all withdrawal request IDs
+     * @return requestIds Array of withdrawal request IDs
+     */
     function getRequestIds() external view returns (bytes32[] memory) {
         return _withdrawRequests.values();
     }
 
+    /**
+     * @notice Gets all finalized withdrawal request IDs
+     * @return requestIds Array of finalized withdrawal request IDs
+     */
     function getFinalizedRequestIds() external view returns (bytes32[] memory) {
         return _finalizedRequests.values();
     }
 
+    /**
+     * @notice Checks if a withdrawal request exists
+     * @param requestId The hash-based ID of the withdrawal request
+     * @return exists True if the request exists, false otherwise
+     */
     function requestExists(bytes32 requestId) external view returns (bool) {
         return _withdrawRequests.contains(requestId) || _finalizedRequests.contains(requestId);
     }
 
+    /**
+     * @notice Checks if a withdrawal request is finalized
+     * @param requestId The hash-based ID of the withdrawal request
+     * @return isFinalized True if the request is finalized, false otherwise
+     */
     function isFinalized(bytes32 requestId) external view returns (bool) {
         return _finalizedRequests.contains(requestId);
     }
 
+    /**
+     * @notice Gets the claimable amount for a withdrawal request
+     * @param request The withdrawal request to get the claimable amount for
+     * @return claimableAmount The claimable amount for the withdrawal request
+     */
     function getClaimableAmount(WithdrawRequest calldata request) external view returns (uint256) {
         bytes32 requestId = keccak256(abi.encode(request));
         if (!_finalizedRequests.contains(requestId)) return 0;
@@ -703,15 +820,60 @@ contract PriorityWithdrawalQueue is
         return request.amountWithFee;
     }
 
+    /**
+     * @notice Gets the total number of active withdrawal requests
+     * @return totalActiveRequests The total number of active withdrawal requests
+     */
     function totalActiveRequests() external view returns (uint256) {
         return _withdrawRequests.length();
     }
 
+    /**
+     * @notice Gets the remainder amount
+     * @return remainderAmount The remainder amount
+     */
     function getRemainderAmount() external view returns (uint256) {
         return liquidityPool.amountForShare(totalRemainderShares);
     }
 
+    /**
+     * @notice Gets the implementation address
+     * @return implementation The implementation address
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  MODIFIERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Modifier to check if the contract is not paused.
+     * @dev Route OZ's whenNotPaused through the pause-until check as well, so any function
+     *      gated by whenNotPaused is automatically blocked during a timed pause too.
+     */
+    modifier whenNotPaused() {
+        if (paused) revert ContractPaused();
+        _requireNotPausedUntil();
+        _;
+    }
+
+    /**
+     * @dev Reason why modifier has both whitelisted and blacklisted checks is becuase if whitelisted user gets compramised,
+     * they can access the protocol before operating multisig can remove whitelist. so guardian can blacklist user.
+     */
+    modifier onlyWhitelisted() {
+        if (!isWhitelisted[msg.sender]) revert NotWhitelisted();
+        blacklister.nonBlacklisted(msg.sender);
+        _;
+    }
+
+    /**
+     * @notice Modifier to check if the request user is the same as the message sender.
+     * @param requestUser The address of the request user.
+     */
+    modifier onlyRequestUser(address requestUser) {
+        if (requestUser != msg.sender) revert NotRequestOwner();
+        _;
     }
 }

--- a/src/withdrawals/PriorityWithdrawalQueue.sol
+++ b/src/withdrawals/PriorityWithdrawalQueue.sol
@@ -130,6 +130,7 @@ contract PriorityWithdrawalQueue is
      * @param _roleRegistry The address of the role registry.
      * @param _treasury The address of the treasury.
      * @param _minDelay The minimum delay for a withdrawal request.
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(address _liquidityPool, address _eETH, address _weETH, address _blacklister, address _roleRegistry, address _treasury, uint32 _minDelay) RolesLibrary(_roleRegistry) {
         if (_liquidityPool == address(0) || _eETH == address(0) || _weETH == address(0) || _blacklister == address(0) || _treasury == address(0)) {

--- a/src/withdrawals/WeETHWithdrawAdapter.sol
+++ b/src/withdrawals/WeETHWithdrawAdapter.sol
@@ -34,36 +34,43 @@ contract WeETHWithdrawAdapter is
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
+    bool public paused;
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  IMMUTABLES  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     IWeETH public immutable weETH;
     IeETH public immutable eETH;
     ILiquidityPool public immutable liquidityPool;
     IWithdrawRequestNFT public immutable withdrawRequestNFT;
     IBlacklister public immutable blacklister;
 
-    bool public paused;
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    event Paused(address account);
+    event Unpaused(address account);
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  --------------------------------------
     //--------------------------------------------------------------------------------------
-
     error ZeroAmount();
     error ZeroAddress();
     error ContractPaused();
     error InvalidAmount();
 
     //--------------------------------------------------------------------------------------
-    //-------------------------------------  EVENTS  --------------------------------------
+    //---------------------------------  CONSTRUCTOR  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
-    event Paused(address account);
-    event Unpaused(address account);
-
-    //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
-    //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _weETH The address of the weETH token.
+     * @param _eETH The address of the eETH token.
+     * @param _liquidityPool The address of the liquidity pool.
+     * @param _withdrawRequestNFT The address of the withdraw request NFT.
+     * @param _roleRegistry The address of the role registry.
+     * @param _blacklister The address of the blacklister.
+     */
     constructor(
         address _weETH,
         address _eETH,
@@ -89,6 +96,9 @@ contract WeETHWithdrawAdapter is
         _disableInitializers();
     }
 
+    //--------------------------------------------------------------------------------------
+    //---------------------------------  INITIALIZERS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
     /**
      * @notice Initialize the adapter contract with initial owner
      * @param _initialOwner Address that will be set as the contract owner
@@ -101,6 +111,9 @@ contract WeETHWithdrawAdapter is
         paused = false;
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  WITHDRAW FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
     /**
      * @notice Request withdrawal using weETH tokens
      * @param weETHAmount Amount of weETH to withdraw
@@ -158,12 +171,9 @@ contract WeETHWithdrawAdapter is
         return requestWithdraw(weETHAmount, recipient);
     }
 
-
-
     //--------------------------------------------------------------------------------------
-    //----------------------------------  ADMIN FUNCTIONS  --------------------------------
+    //--------------------------------  PAUSING FUNCTIONS  ---------------------------------
     //--------------------------------------------------------------------------------------
-
     /**
      * @notice Pause the contract
      */
@@ -207,9 +217,23 @@ contract WeETHWithdrawAdapter is
     }
 
     //--------------------------------------------------------------------------------------
+    //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Check if contract is not paused
+     */
+    function _requireNotPaused() internal view {
+        if (paused) revert ContractPaused();
+    }
+
+    /**
+     * @notice Authorize contract upgrades
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
     //------------------------------------  GETTERS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     /**
      * @notice Get the current implementation address
      * @return The implementation contract address
@@ -228,31 +252,20 @@ contract WeETHWithdrawAdapter is
     }
 
     //--------------------------------------------------------------------------------------
-    //------------------------------  INTERNAL FUNCTIONS  ----------------------------------
-    //--------------------------------------------------------------------------------------
-
-    /**
-     * @notice Authorize contract upgrades
-     */
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
-    /**
-     * @notice Check if contract is not paused
-     */
-    function _requireNotPaused() internal view {
-        if (paused) revert ContractPaused();
-    }
-
-    //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Modifier to check if the contract is not paused
+     */
     modifier whenNotPaused() {
         _requireNotPaused();
         _requireNotPausedUntil();
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is not blacklisted
+     */
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
         _;

--- a/src/withdrawals/WeETHWithdrawAdapter.sol
+++ b/src/withdrawals/WeETHWithdrawAdapter.sol
@@ -70,6 +70,7 @@ contract WeETHWithdrawAdapter is
      * @param _withdrawRequestNFT The address of the withdraw request NFT.
      * @param _roleRegistry The address of the role registry.
      * @param _blacklister The address of the blacklister.
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(
         address _weETH,

--- a/src/withdrawals/WithdrawRequestNFT.sol
+++ b/src/withdrawals/WithdrawRequestNFT.sol
@@ -158,6 +158,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
      * @param _etherFiAdmin The address of the etherFi admin.
      * @param _minAcceptableShareRate The minimum acceptable share rate.
      * @param _maxAcceptableShareRate The maximum acceptable share rate.
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(address _treasury, address _eETH, address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister,  address _etherFiAdmin, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) RolesLibrary(_roleRegistry) {
         if (_minAcceptableShareRate == 0) revert InvalidMinAcceptableShareRate();

--- a/src/withdrawals/WithdrawRequestNFT.sol
+++ b/src/withdrawals/WithdrawRequestNFT.sol
@@ -17,27 +17,29 @@ import "@etherfi/governance/utils/ReentrancyGuardNamespaced.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 
-/// @title WithdrawRequestNFT — share-rate-freeze invariants
-/// @notice
-/// Once `finalizeRequests(lastRequestId)` runs, the rate used to compute the claim payout
-/// for tokenIds <= lastRequestId is frozen at the rate snapshotted in that finalize batch.
-/// Subsequent rebases do NOT move the claim payout — this is the H-02 fix.
-///
-/// Invariants:
-///  I1. `_finalizationRates` keys are strictly increasing. Enforced by the
-///      `requestId > lastFinalizedRequestId` guard in `finalizeRequests` and by
-///      `Checkpoints.push` semantics.
-///  I2. `_finalizationRates.lowerLookup(tokenId)` returns the rate of the smallest
-///      finalize batch covering `tokenId`. For pre-upgrade legacy tokenIds, it returns 0
-///      (the sentinel); the claim path locally substitutes `LP.amountPerShareCeil()` for
-///      backwards compatibility with old semantics. LP itself rejects rate=0.
-///  I3. For any finalized `tokenId`, `getClaimableAmount(tokenId)` is invariant under
-///      `LP.rebase()` after the finalize block. Property-tested via
-///      `test_invariant_claimAmountIndependentOfPostFinalizeRebase`.
-///  I4. The rate snapshot uses ceiling rounding (`Math.mulDiv(1e18, TPE, TS, Up)`) so
-///      `shareOfEEth * rate / 1e18 >= LP.amountForShare(shareOfEEth)` and
-///      `ceil(amount * 1e18 / rate) <= shareOfEEth`. These keep solvency checks and
-///      the share burn within the request's own share allocation.
+/**
+ * @title WithdrawRequestNFT — share-rate-freeze invariants
+ * @notice
+ * @dev Once `finalizeRequests(lastRequestId)` runs, the rate used to compute the claim payout
+ * for tokenIds <= lastRequestId is frozen at the rate snapshotted in that finalize batch.
+ * Subsequent rebases do NOT move the claim payout — this is the H-02 fix.
+ *
+ *  Invariants:
+ *   I1. `_finalizationRates` keys are strictly increasing. Enforced by the
+ *        `requestId > lastFinalizedRequestId` guard in `finalizeRequests` and by
+ *        `Checkpoints.push` semantics.
+ *   I2. `_finalizationRates.lowerLookup(tokenId)` returns the rate of the smallest
+ *        finalize batch covering `tokenId`. For pre-upgrade legacy tokenIds, it returns 0
+ *        (the sentinel); the claim path locally substitutes `LP.amountPerShareCeil()` for
+ *        backwards compatibility with old semantics. LP itself rejects rate=0.
+ *   I3. For any finalized `tokenId`, `getClaimableAmount(tokenId)` is invariant under
+ *        `LP.rebase()` after the finalize block. Property-tested via
+ *        `test_invariant_claimAmountIndependentOfPostFinalizeRebase`.
+ *   I4. The rate snapshot uses ceiling rounding (`Math.mulDiv(1e18, TPE, TS, Up)`) so
+ *        `shareOfEEth * rate / 1e18 >= LP.amountForShare(shareOfEEth)` and
+ *        `ceil(amount * 1e18 / rate) <= shareOfEEth`. These keep solvency checks and
+ *        the share burn within the request's own share allocation.
+ */
 contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardNamespaced, PausableUntil, RolesLibrary, IWithdrawRequestNFT {
     using Math for uint256;
     using SafeERC20 for IERC20;
@@ -46,7 +48,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
-
     // deprecated storage slots
     uint256[3] private __gap_0;
 
@@ -79,7 +80,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  --------------------------------------
     //--------------------------------------------------------------------------------------
-
     ILiquidityPool public immutable liquidityPool;
     IeETH public immutable eETH;
     IMembershipManager public immutable membershipManager;
@@ -94,7 +94,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     uint256 public constant BASIS_POINT_SCALE = 1e4;
     uint256 public constant SHARE_UNIT = 1e18;
 
@@ -114,7 +113,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     error IncorrectCaller();
     error AddressZero();
     error AlreadyPaused();
@@ -149,7 +147,18 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTRUCTOR  -------------------------------------
     //--------------------------------------------------------------------------------------
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _treasury The address of the treasury.
+     * @param _eETH The address of the eETH token.
+     * @param _liquidityPool The address of the liquidity pool.
+     * @param _membershipManager The address of the membership manager.
+     * @param _roleRegistry The address of the role registry.
+     * @param _blacklister The address of the blacklister.
+     * @param _etherFiAdmin The address of the etherFi admin.
+     * @param _minAcceptableShareRate The minimum acceptable share rate.
+     * @param _maxAcceptableShareRate The maximum acceptable share rate.
+     */
     constructor(address _treasury, address _eETH, address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister,  address _etherFiAdmin, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) RolesLibrary(_roleRegistry) {
         if (_minAcceptableShareRate == 0) revert InvalidMinAcceptableShareRate();
         if (_maxAcceptableShareRate <= _minAcceptableShareRate) revert InvalidMinMaxAcceptableShareRate();
@@ -165,8 +174,14 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
     //--------------------------------------------------------------------------------------
+    /**
+     * @notice Initialize the contract
+     * @param _liquidityPoolAddress The address of the liquidity pool.
+     * @param _eEthAddress The address of the eETH token.
+     * @param _membershipManagerAddress The address of the membership manager.
+     */
     function initialize(address _liquidityPoolAddress, address _eEthAddress, address _membershipManagerAddress) initializer external {
         if (_liquidityPoolAddress == address(0) || _eEthAddress == address(0) || _membershipManagerAddress == address(0)) revert AddressZero();
         __ERC721_init("Withdraw Request NFT", "WithdrawRequestNFT");
@@ -176,29 +191,41 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         nextRequestId = 1;
     }
 
-    /// @notice One-time initializer for the share-rate-freeze upgrade.
-    /// @dev Pushes a sentinel checkpoint at the current `lastFinalizedRequestId` with value 0.
-    ///      Every requestId <= that key looks up to this sentinel (value 0), which the claim
-    ///      path resolves locally to the live rate via `LP.amountPerShareCeil()` — preserving
-    ///      legacy behavior for requests finalized before this upgrade. New finalizations push
-    ///      real rate snapshots, so post-upgrade tokenIds always resolve to a non-zero rate.
+    /**
+     * @notice One-time initializer for the share-rate-freeze upgrade.
+     * @dev Pushes a sentinel checkpoint at the current `lastFinalizedRequestId` with value 0.
+     *      Every requestId <= that key looks up to this sentinel (value 0), which the claim
+     *      path resolves locally to the live rate via `LP.amountPerShareCeil()` — preserving
+     *      legacy behavior for requests finalized before this upgrade. New finalizations push
+     *      real rate snapshots, so post-upgrade tokenIds always resolve to a non-zero rate.
+     */
     function initializeShareRateFreezeUpgrade() external onlyUpgradeTimelock {
         if (_finalizationRates.length() != 0) revert AlreadyInitialized();
         _finalizationRates.push(uint32(lastFinalizedRequestId), 0);
     }
 
+    //--------------------------------------------------------------------------------------
+    //----------------------------  RECEIVE FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Receive ETH
+     */
     receive() external payable {
         if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
         ethAmountLockedForWithdrawal += uint128(msg.value);
         _checkEthAmountLockedForWithdrawal();
     }
 
-    /// @notice creates a withdraw request and issues an associated NFT to the recipient
-    /// @dev liquidity pool contract will call this function when a user requests withdraw
-    /// @param amountOfEEth amount of eETH requested for withdrawal
-    /// @param shareOfEEth share of eETH requested for withdrawal
-    /// @param recipient address to recieve with WithdrawRequestNFT
-    /// @return uint256 id of the withdraw request
+    //--------------------------------------------------------------------------------------
+    //----------------------------  WITHDRAW FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Creates a withdraw request and issues an associated NFT to the recipient
+     * @param amountOfEEth Amount of eETH requested for withdrawal
+     * @param shareOfEEth Share of eETH requested for withdrawal
+     * @param recipient Address to recieve with WithdrawRequestNFT
+     * @return uint256 id of the withdraw request
+     */
     function requestWithdraw(uint96 amountOfEEth, uint96 shareOfEEth, address recipient) external onlyLiquidityPool whenNotPaused returns (uint256) {
         uint256 requestId = nextRequestId++;
 
@@ -210,88 +237,34 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         return requestId;
     }
 
-    function getClaimableAmount(uint256 tokenId) public view returns (uint256) {
-        (uint256 amountToTransfer, ) = _getClaimableAmount(tokenId);
-        return amountToTransfer;
-    }
-
-    /// @dev Returns `(amountToTransfer, frozenRate)`. `frozenRate` is the rate snapshotted
-    ///      at the request's finalize batch. For pre-upgrade legacy requests (covered only by the
-    ///      sentinel checkpoint with value 0), the live rate from `LP.amountPerShareCeil()` is
-    ///      substituted locally — preserving legacy claim semantics (live-rate at claim). The
-    ///      returned `frozenRate` is therefore guaranteed non-zero, which is what `LP.withdraw`
-    ///      now requires (`InvalidRate` reverts on zero).
-    function _getClaimableAmount(uint256 tokenId) internal view returns (uint256, uint224) {
-        if (tokenId > lastFinalizedRequestId) revert RequestNotFinalized();
-        if (ownerOf(tokenId) == address(0)) revert AlreadyClaimed();
-
-        IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
-
-        // Smallest checkpoint whose key >= tokenId — the finalization batch this request belongs to.
-        uint224 frozenRate = _finalizationRates.lowerLookup(uint32(tokenId));
-        if (frozenRate == 0) {
-            // Pre-upgrade legacy request — sentinel returned 0. Fall back to the live rate so
-            // claim semantics match the pre-upgrade behavior. New (post-upgrade) finalizations
-            // always push a non-zero snapshot, so this branch only fires for legacy tokenIds.
-            // Bounds-check the live rate before adopting it — this path is the only one where
-            // `frozenRate` was not already gated by `finalizeRequests`'s write-time check.
-            uint256 live = liquidityPool.amountPerShareCeil();
-            if (live < minAcceptableShareRate || live > maxAcceptableShareRate) revert InvalidLiveRate();
-            frozenRate = uint224(live);
-        }
-
-        uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, SHARE_UNIT);
-
-        // send the lesser value of the originally requested amount of eEth or the frozen-rate value of the shares
-        uint256 amountToTransfer = Math.min(request.amountOfEEth, amountForShares);
-        return (amountToTransfer, frozenRate);
-    }
-
-    /// @notice called by the NFT owner to claim their ETH
-    /// @dev burns the NFT and transfers ETH from the liquidity pool to the owner, withdraw request must be valid and finalized
-    /// @param tokenId the id of the withdraw request and associated NFT
+    /**
+     * @notice called by the NFT owner to claim their ETH
+     * @param tokenId The ID of the withdrawal request
+     * @dev burns the NFT and transfers ETH from the liquidity pool to the owner, withdraw request must be valid and finalized
+     */
     function claimWithdraw(uint256 tokenId) external nonReentrant nonBlacklisted {
         return _claimWithdraw(tokenId, ownerOf(tokenId));
     }
-    
-    /// @dev Pays the recipient from this contract's own ETH balance (segregated at finalize via
-    ///      LP.addEthAmountLockedForWithdrawal). Burns shares against the rate frozen at finalize
-    ///      via `LP.withdraw(amount, rate)`. `_getClaimableAmount` always resolves `frozenRate` to
-    ///      a non-zero value (live-rate fallback for pre-upgrade legacy ids), satisfying LP's
-    ///      `InvalidRate` guard.
-    function _claimWithdraw(uint256 tokenId, address recipient) internal {
-        if (ownerOf(tokenId) != msg.sender) revert NotTheOwner();
-        IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
-        if (!request.isValid) revert RequestNotValid();
 
-        (uint256 amountToWithdraw, uint224 frozenRate) = _getClaimableAmount(tokenId);
-
-        _burn(tokenId);
-        delete _requests[tokenId];
-
-        if (ethAmountLockedForWithdrawal < amountToWithdraw) revert InsufficientEscrow();
-        ethAmountLockedForWithdrawal -= uint128(request.amountOfEEth);
-
-        uint256 burnedShares = liquidityPool.withdraw(amountToWithdraw, uint256(frozenRate), request.shareOfEEth);
-        // LP caps `burnedShares <= request.shareOfEEth` (Guard 3). Defensive duplication.
-        if (burnedShares > request.shareOfEEth) revert BurnExceedsShares();
-        totalRemainderEEthShares += request.shareOfEEth - burnedShares;
-
-        (bool ok, ) = payable(recipient).call{value: amountToWithdraw}("");
-        if (!ok) revert EthTransferFailed();
-
-        _checkEthAmountLockedForWithdrawal();
-
-        emit WithdrawRequestClaimed(uint32(tokenId), amountToWithdraw, burnedShares, recipient, 0);
-    }
-
+    /**
+     * @notice Claims multiple withdraw requests
+     * @param tokenIds The IDs of the withdrawal requests
+     * @dev burns the NFTs and transfers ETH from the liquidity pool to the owners, withdraw requests must be valid and finalized
+     */
     function batchClaimWithdraw(uint256[] calldata tokenIds) external nonReentrant nonBlacklisted {
         for (uint256 i = 0; i < tokenIds.length; i++) {
             _claimWithdraw(tokenIds[i], ownerOf(tokenIds[i]));
         }
     }
 
-    // Seize the request simply by transferring it to another recipient
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  ADMIN FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Seizes a withdrawal request simply by transferring it to another recipient
+     * @param requestId The ID of the withdrawal request
+     * @param recipient The address of the recipient
+     */
     function seizeInvalidRequest(uint256 requestId, address recipient) external onlyUpgradeTimelock {
         if (_requests[requestId].isValid) revert RequestValid();
         if (!_exists(requestId)) revert RequestNotFound();
@@ -301,30 +274,23 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         emit WithdrawRequestSeized(uint32(requestId));
     }
 
-    function getRequest(uint256 requestId) external view returns (IWithdrawRequestNFT.WithdrawRequest memory) {
-        return _requests[requestId];
+    /**
+     * @notice Updates the share remainder split to treasury in basis points
+     * @param _shareRemainderSplitToTreasuryInBps The new share remainder split to treasury in basis points
+     */
+    function updateShareRemainderSplitToTreasuryInBps(uint16 _shareRemainderSplitToTreasuryInBps) external onlyAdmin {
+        if (_shareRemainderSplitToTreasuryInBps > BASIS_POINT_SCALE) revert InvalidShareRemainderSplit();
+        shareRemainderSplitToTreasuryInBps = _shareRemainderSplitToTreasuryInBps;
     }
 
-    function isFinalized(uint256 requestId) public view returns (bool) {
-        return requestId <= lastFinalizedRequestId;
-    }
-
-    /// @notice Frozen `amountForShare(1e18)` for the finalization batch covering `tokenId`,
-    ///         or 0 if `tokenId` predates the share-rate-freeze upgrade (live-rate fallback).
-    function frozenRateFor(uint256 tokenId) external view returns (uint224) {
-        return _finalizationRates.lowerLookup(uint32(tokenId));
-    }
-
-    /// @notice Number of finalization-rate checkpoints (including the legacy sentinel, if pushed).
-    function finalizationRatesLength() external view returns (uint256) {
-        return _finalizationRates.length();
-    }
-
-    function isValid(uint256 requestId) public view returns (bool) {
-        if (!_exists(requestId)) revert RequestNotFound();
-        return _requests[requestId].isValid;
-    }
-
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  OPERATIONAL FUNCTIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Finalizes a withdrawal request
+     * @param requestId The ID of the withdrawal request
+     * @dev finalizes the withdrawal request
+     */
     function finalizeRequests(uint256 requestId) external {
         if (msg.sender != address(etherFiAdmin)) revert IncorrectCaller();
         // Defends against the upgrade-ordering trap: if `initializeShareRateFreezeUpgrade`
@@ -347,65 +313,15 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         lastFinalizedRequestId = uint32(requestId);
     }
 
-    /// @dev Admin can only invalidate requests that have NOT been finalized yet
-    function invalidateRequest(uint256 requestId) external onlyGuardian {
-        if (requestId <= lastFinalizedRequestId) revert CannotInvalidateFinalizedRequest();
-        if (!isValid(requestId)) revert RequestNotValid();
-        _requests[requestId].isValid = false;
-
-        emit WithdrawRequestInvalidated(uint32(requestId));
-    }
-
-    function validateRequest(uint256 requestId) external onlyAdmin {
-        if (!_exists(requestId)) revert RequestNotFound();
-        if (_requests[requestId].isValid) revert RequestValid();
-        if (requestId <= lastFinalizedRequestId) {
-            uint256 amount = _requests[requestId].amountOfEEth;
-            if (amount > liquidityPool.totalValueInLp()) revert RequestAmountGreaterThanAvailableLiquidity();
-            liquidityPool.addEthAmountLockedForWithdrawal(uint128(amount));
-        }
-        _requests[requestId].isValid = true;
-
-        emit WithdrawRequestValidated(uint32(requestId));
-    }
-
-    function updateShareRemainderSplitToTreasuryInBps(uint16 _shareRemainderSplitToTreasuryInBps) external onlyAdmin {
-        if (_shareRemainderSplitToTreasuryInBps > BASIS_POINT_SCALE) revert InvalidShareRemainderSplit();
-        shareRemainderSplitToTreasuryInBps = _shareRemainderSplitToTreasuryInBps;
-    }
-
-    function pauseContract() external onlyOperatingMultisig {
-        if (paused) revert AlreadyPaused();
-        paused = true;
-        emit Paused();
-    }
-
-    function unPauseContract() external onlyOperatingMultisig {
-        if (!paused) revert NotPaused();
-
-
-        paused = false;
-        emit Unpaused();
-    }
-
-    function pauseContractUntil() external onlyGuardian {
-        _pauseUntil();
-    }
-
-    function unpauseContractUntil() external onlyOperatingMultisig {
-        _unpauseUntil();
-    }
-
-    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
-        _setPauseUntilDuration(_pauseUntilDuration);
-    }
-
-    /// @dev Handles the remainder of the eEth shares after the claim of the withdraw request
-    /// the remainder eETH share for a request = request.shareOfEEth - request.amountOfEEth / (eETH amount to eETH shares rate)
-    /// - Splits the remainder into two parts:
-    ///  - Treasury: treasury gets a split of the remainder
-    ///   - Burn: the rest of the remainder is burned
-    /// @param _eEthAmount: the remainder of the eEth amount
+    /**
+     * @notice Handles the remainder of the eEth shares after the claim of the withdraw request
+     * @param _eEthAmount The remainder of the eEth amount
+     * @dev handles the remainder of the eEth shares after the claim of the withdraw request
+     *      the remainder eETH share for a request = request.shareOfEEth - request.amountOfEEth / (eETH amount to eETH shares rate)
+     *      - Splits the remainder into two parts:
+     *      - Treasury: treasury gets a split of the remainder
+     *      - Burn: the rest of the remainder is burned
+     */
     function handleRemainder(uint256 _eEthAmount) external onlyHousekeepingOperations {
         if (_eEthAmount == 0) revert EETHAmountCannotBeZero(); 
         if (getEEthRemainderAmount() < _eEthAmount) revert NotEnoughEEthRemainder();
@@ -438,15 +354,166 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         }
     }
 
-    function getEEthRemainderAmount() public view returns (uint256) {
-        return liquidityPool.amountForShare(totalRemainderEEthShares);
+    /**
+     * @notice Invalidates a withdrawal request
+     * @param requestId The ID of the withdrawal request
+     * @dev Admin can only invalidate requests that have NOT been finalized yet
+     */
+    function invalidateRequest(uint256 requestId) external onlyGuardian {
+        if (requestId <= lastFinalizedRequestId) revert CannotInvalidateFinalizedRequest();
+        if (!isValid(requestId)) revert RequestNotValid();
+        _requests[requestId].isValid = false;
+
+        emit WithdrawRequestInvalidated(uint32(requestId));
     }
 
-    // the withdraw request NFT is transferrable
-    // - if the request is valid, it can be transferred by the owner of the NFT
-    // - if the request is invalid, it can be transferred only by the owner of the WithdarwRequestNFT contract
-    // - the transfer is not allowed if the from or to is blacklisted
-    function _beforeTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) internal override {
+    /**
+     * @notice Validates a withdrawal request
+     * @param requestId The ID of the withdrawal request
+     */
+    function validateRequest(uint256 requestId) external onlyAdmin {
+        if (!_exists(requestId)) revert RequestNotFound();
+        if (_requests[requestId].isValid) revert RequestValid();
+        if (requestId <= lastFinalizedRequestId) {
+            uint256 amount = _requests[requestId].amountOfEEth;
+            if (amount > liquidityPool.totalValueInLp()) revert RequestAmountGreaterThanAvailableLiquidity();
+            liquidityPool.addEthAmountLockedForWithdrawal(uint128(amount));
+        }
+        _requests[requestId].isValid = true;
+
+        emit WithdrawRequestValidated(uint32(requestId));
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  PAUSING FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Pauses the contract
+     */
+    function pauseContract() external onlyOperatingMultisig {
+        if (paused) revert AlreadyPaused();
+        paused = true;
+        emit Paused();
+    }
+
+    /**
+     * @notice Unpauses the contract
+     */
+    function unPauseContract() external onlyOperatingMultisig {
+        if (!paused) revert NotPaused();
+
+
+        paused = false;
+        emit Unpaused();
+    }
+
+    /**
+     * @notice Pauses the contract until the pauseUntilDuration
+     */
+    function pauseContractUntil() external onlyGuardian {
+        _pauseUntil();
+    }
+
+    /**
+     * @notice Unpauses the contract from pauseUntil
+     */
+    function unpauseContractUntil() external onlyOperatingMultisig {
+        _unpauseUntil();
+    }
+
+    /**
+     * @notice Sets the pause duration for the contract
+     * @param _pauseUntilDuration The new pause duration
+     */
+    function setPauseUntilDuration(uint256 _pauseUntilDuration) external onlyAdmin {
+        _setPauseUntilDuration(_pauseUntilDuration);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  INTERNAL FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Gets the claimable amount for a withdrawal request
+     * @param tokenId The ID of the withdrawal request
+     * @return amountToTransfer The amount of eETH that can be claimed
+     * @return frozenRate The rate snapshotted at the request's finalize batch
+     * @dev For pre-upgrade legacy requests (covered only by the sentinel checkpoint with value 0), 
+     *      the live rate from `LP.amountPerShareCeil()` is substituted locally — preserving legacy 
+     *      claim semantics (live-rate at claim). The returned `frozenRate` is therefore guaranteed 
+     *      non-zero, which is what `LP.withdraw` now requires (`InvalidRate` reverts on zero).
+     */
+    function _getClaimableAmount(uint256 tokenId) internal view returns (uint256, uint224) {
+        if (tokenId > lastFinalizedRequestId) revert RequestNotFinalized();
+        if (ownerOf(tokenId) == address(0)) revert AlreadyClaimed();
+
+        IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
+
+        // Smallest checkpoint whose key >= tokenId — the finalization batch this request belongs to.
+        uint224 frozenRate = _finalizationRates.lowerLookup(uint32(tokenId));
+        if (frozenRate == 0) {
+            // Pre-upgrade legacy request — sentinel returned 0. Fall back to the live rate so
+            // claim semantics match the pre-upgrade behavior. New (post-upgrade) finalizations
+            // always push a non-zero snapshot, so this branch only fires for legacy tokenIds.
+            // Bounds-check the live rate before adopting it — this path is the only one where
+            // `frozenRate` was not already gated by `finalizeRequests`'s write-time check.
+            uint256 live = liquidityPool.amountPerShareCeil();
+            if (live < minAcceptableShareRate || live > maxAcceptableShareRate) revert InvalidLiveRate();
+            frozenRate = uint224(live);
+        }
+
+        uint256 amountForShares = Math.mulDiv(uint256(request.shareOfEEth), frozenRate, SHARE_UNIT);
+
+        // send the lesser value of the originally requested amount of eEth or the frozen-rate value of the shares
+        uint256 amountToTransfer = Math.min(request.amountOfEEth, amountForShares);
+        return (amountToTransfer, frozenRate);
+    }
+
+    /**
+     * @notice Pays the recipient from this contract's own ETH balance (segregated at finalize via
+     * @param tokenId The ID of the withdrawal request
+     * @param recipient The address of the recipient
+     * @dev Burns shares against the rate frozen at finalize via `LP.withdraw(amount, rate)`. 
+     *      `_getClaimableAmount` always resolves `frozenRate` to a non-zero value (live-rate fallback for pre-upgrade legacy ids), 
+     *      satisfying LP's `InvalidRate` guard.
+     */
+    function _claimWithdraw(uint256 tokenId, address recipient) internal {
+        if (ownerOf(tokenId) != msg.sender) revert NotTheOwner();
+        IWithdrawRequestNFT.WithdrawRequest memory request = _requests[tokenId];
+        if (!request.isValid) revert RequestNotValid();
+
+        (uint256 amountToWithdraw, uint224 frozenRate) = _getClaimableAmount(tokenId);
+
+        _burn(tokenId);
+        delete _requests[tokenId];
+
+        if (ethAmountLockedForWithdrawal < amountToWithdraw) revert InsufficientEscrow();
+        ethAmountLockedForWithdrawal -= uint128(request.amountOfEEth);
+
+        uint256 burnedShares = liquidityPool.withdraw(amountToWithdraw, uint256(frozenRate), request.shareOfEEth);
+        // LP caps `burnedShares <= request.shareOfEEth` (Guard 3). Defensive duplication.
+        if (burnedShares > request.shareOfEEth) revert BurnExceedsShares();
+        totalRemainderEEthShares += request.shareOfEEth - burnedShares;
+
+        (bool ok, ) = payable(recipient).call{value: amountToWithdraw}("");
+        if (!ok) revert EthTransferFailed();
+
+        _checkEthAmountLockedForWithdrawal();
+
+        emit WithdrawRequestClaimed(uint32(tokenId), amountToWithdraw, burnedShares, recipient, 0);
+    }
+
+    /**
+     * @notice Before token transfer
+     * @param from The address of the from
+     * @param to The address of the to
+     * @param firstTokenId The first token ID
+     * @param batchSize The batch size
+     * @dev the withdraw request NFT is transferrable
+     *      - if the request is valid, it can be transferred by the owner of the NFT
+     *      - if the request is invalid, it can be transferred only by the owner of the WithdarwRequestNFT contract
+     *      - the transfer is not allowed if the from or to is blacklisted
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) internal view override {
         blacklister.nonBlacklisted(from);
         blacklister.nonBlacklisted(to);
         for (uint256 i = 0; i < batchSize; i++) {
@@ -455,31 +522,128 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         }
     }
 
+    /**
+     * @notice Checks if the ETH amount locked for withdrawal is sufficient
+     * @dev Reverts if the ETH amount locked for withdrawal is greater than the ETH balance of the contract
+     */
     function _checkEthAmountLockedForWithdrawal() internal view {
         if (address(this).balance < ethAmountLockedForWithdrawal) revert InsufficientEscrow();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
-    function getImplementation() external view returns (address) {
-        return _getImplementation();
-    }
-
+    /**
+     * @notice Checks if the contract is not paused
+     * @dev Reverts if the contract is paused
+     */
     function _requireNotPaused() internal view virtual {
         if (paused) revert ContractPaused();
     }
 
+    /**
+     * @notice Authorizes the upgrade of the contract
+     * @param newImplementation The new implementation address
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //--------------------------------------  GETTERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Gets a withdrawal request
+     * @param requestId The ID of the withdrawal request
+     * @return request The withdrawal request
+     */
+    function getRequest(uint256 requestId) external view returns (IWithdrawRequestNFT.WithdrawRequest memory) {
+        return _requests[requestId];
+    }
+
+    /**
+     * @notice Gets the claimable amount for a withdrawal request
+     * @param tokenId The ID of the withdrawal request
+     * @return amountToTransfer The amount of eETH that can be claimed
+     */
+    function getClaimableAmount(uint256 tokenId) public view returns (uint256) {
+        (uint256 amountToTransfer, ) = _getClaimableAmount(tokenId);
+        return amountToTransfer;
+    }
+
+    /**
+     * @notice Checks if a withdrawal request is finalized
+     * @param requestId The ID of the withdrawal request
+     * @return isFinalized True if the request is finalized, false otherwise
+     */
+    function isFinalized(uint256 requestId) public view returns (bool) {
+        return requestId <= lastFinalizedRequestId;
+    }
+
+    /**
+     * @notice Gets the frozen rate for a withdrawal request
+     * @param tokenId The ID of the withdrawal request
+     * @return frozenRate The frozen rate for the withdrawal request
+     */
+    function frozenRateFor(uint256 tokenId) external view returns (uint224) {
+        return _finalizationRates.lowerLookup(uint32(tokenId));
+    }
+
+    /**
+     * @notice Gets the number of finalization rates
+     * @return finalizationRatesLength The number of finalization rates
+     */
+    function finalizationRatesLength() external view returns (uint256) {
+        return _finalizationRates.length();
+    }
+
+    /**
+     * @notice Checks if a withdrawal request is valid
+     * @param requestId The ID of the withdrawal request
+     * @return isValid True if the request is valid, false otherwise
+     */
+    function isValid(uint256 requestId) public view returns (bool) {
+        if (!_exists(requestId)) revert RequestNotFound();
+        return _requests[requestId].isValid;
+    }
+
+    /**
+     * @notice Gets the remainder of the eEth amount
+     * @return eEthRemainderAmount The remainder of the eEth amount
+     */
+    function getEEthRemainderAmount() public view returns (uint256) {
+        return liquidityPool.amountForShare(totalRemainderEEthShares);
+    }
+
+    /**
+     * @notice Gets the implementation address
+     * @return implementation The implementation address
+     */
+    function getImplementation() external view returns (address) {
+        return _getImplementation();
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------------  MODIFIERS  --------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Modifier to check if the caller is the liquidity pool
+     * @dev Reverts if the caller is not the liquidity pool
+     */
     modifier onlyLiquidityPool() {
         if (msg.sender != address(liquidityPool)) revert IncorrectCaller();
         _;
     }
 
+    /**
+     * @notice Modifier to check if the contract is not paused
+     * @dev Reverts if the contract is paused
+     */
     modifier whenNotPaused() {
         _requireNotPaused();
         _requireNotPausedUntil();
         _;
     }
 
+    /**
+     * @notice Modifier to check if the caller is not blacklisted
+     * @dev Reverts if the caller is blacklisted
+     */
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
         _;

--- a/src/withdrawals/interfaces/IEtherFiRedemptionManager.sol
+++ b/src/withdrawals/interfaces/IEtherFiRedemptionManager.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import "@etherfi/governance/rate-limiting/libraries/BucketLimiter.sol";
+
 interface IEtherFiRedemptionManager {
-    function redeem(uint256 amount, address receiver, address outputToken) external;
+    struct RedemptionInfo {
+        BucketLimiter.Limit limit;
+        uint16 exitFeeSplitToTreasuryInBps;
+        uint16 exitFeeInBps;
+        uint16 lowWatermarkInBpsOfTvl;
+    }
+
+    function redeemEEth(uint256 eEthAmount, address receiver, address outputToken) external;
     function redeemWeEth(uint256 weEthAmount, address receiver, address outputToken) external;
-    function setClaimDelay(uint256 _claimDelay) external;
-    function setPendingMerkleRoot(address _token, bytes32 _merkleRoot) external;
-    function finalizeMerkleRoot(address _token, uint256 _finalizedBlock) external;
-    function claimableMerkleRoots(address _token) external view returns (bytes32);
-    function lastRewardsCalculatedToBlock(address _token) external view returns (uint256);
-    function lastPendingMerkleUpdatedToTimestamp(address _token) external view returns (uint256);
-    function claimDelay() external view returns (uint256);
-    function pendingMerkleRoots(address _token) external view returns (bytes32);
     function pauseContract() external;
     function unPauseContract() external;
     function pauseContractUntil() external;

--- a/test/Blacklist.t.sol
+++ b/test/Blacklist.t.sol
@@ -11,6 +11,7 @@ import "@etherfi/membership/MembershipManager.sol";
 import "@etherfi/withdrawals/WithdrawRequestNFT.sol";
 import "@etherfi/governance/Blacklister.sol";
 import "@etherfi/core/interfaces/ILiquidityPool.sol";
+import "@etherfi/deposits/interfaces/IDepositAdapter.sol";
 import "@etherfi/deposits/interfaces/ILiquifier.sol";
 import "@etherfi/core/interfaces/IeETH.sol";
 import "@etherfi/core/interfaces/IWeETH.sol";
@@ -33,15 +34,17 @@ contract BlacklistTest is TestSetup {
         // The exact token wirings don't matter for blacklist checks since the
         // modifier runs before any state-changing logic.
         DepositAdapter impl = new DepositAdapter(
-            address(liquidityPoolInstance),
-            address(liquifierInstance),
-            address(weEthInstance),
-            address(eETHInstance),
-            address(0),
-            address(0),
-            address(0),
-            address(roleRegistryInstance),
-            address(blacklisterInstance)
+            IDepositAdapter.ConstructorAddresses({
+                liquidityPool: address(liquidityPoolInstance),
+                liquifier: address(liquifierInstance),
+                weETH: address(weEthInstance),
+                eETH: address(eETHInstance),
+                wETH: address(0),
+                stETH: address(0),
+                wstETH: address(0),
+                blacklister: address(blacklisterInstance),
+                roleRegistry: address(roleRegistryInstance)
+            })
         );
         UUPSProxy proxy = new UUPSProxy(address(impl), "");
         depositAdapter = DepositAdapter(payable(address(proxy)));

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1015,8 +1015,8 @@ contract EtherFiOracleTest is TestSetup {
         etherFiAdminInstance.updateAcceptableRebaseApr(int32(maxApr + 1));
     }
 
-    function _defaultEtherFiAdminCtorAddrs() internal view returns (EtherFiAdmin.ConstructorAddresses memory) {
-        return EtherFiAdmin.ConstructorAddresses({
+    function _defaultEtherFiAdminCtorAddrs() internal view returns (IEtherFiAdmin.ConstructorAddresses memory) {
+        return IEtherFiAdmin.ConstructorAddresses({
             etherFiOracle: address(etherFiOracleInstance),
             stakingManager: address(stakingManagerInstance),
             auctionManager: address(auctionInstance),

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -205,6 +205,12 @@ contract EtherFiOracleTest is TestSetup {
     }
 
     function test_consensus() public {
+        // Seed TVL so the report's positive accruedRewards stays within the 25 bps
+        // LiquidityPool positive rebase cap (a zero-TVL pool rejects any positive rebase).
+        vm.deal(alice, 1000 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1000 ether}();
+
         // Now it's period 2!
         _moveClock(1024 + 2 * slotsPerEpoch);
 
@@ -442,22 +448,28 @@ contract EtherFiOracleTest is TestSetup {
     }
 
     function test_huge_positive_rebaes() public {
-        // TVL after `launch_validator` is 60 ETH
-        // EtherFIAdmin limits the APR per rebase as 100 % == 10000 bps
-        // launch_validator();
+        // Seed a realistic TVL so the APR formula is non-trivial. EtherFiAdmin still
+        // limits the per-report APR (acceptableRebaseAprInBps == 10000 bps == 100%);
+        // note that LiquidityPool independently caps a single positive rebase at 25 bps
+        // of TVL, so the "below 100% APR" leg also has to stay under that cap.
+        vm.deal(alice, 1000 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1000 ether}();
 
         IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
 
         _moveClock(1 days / 12);
 
-        // Change in APR is below 100%
-        report.accruedRewards = int128(64 ether - 1 ether) / int128(365);
+        // 1 ETH on 1000 ETH TVL: 10 bps (< the 25 bps LP cap) and ~36% annualized
+        // (< the 100% APR cap) — accepted.
+        report.accruedRewards = 1 ether;
         _executeAdminTasks(report);
 
         _moveClock(1 days / 12);
 
-        // Change in APR is above 100%, which reverts
-        report.accruedRewards = int128(64 ether + 1 ether) / int128(365);
+        // A huge positive rebase blows past the acceptable APR and is rejected by the
+        // oracle TVL-change guard before it ever reaches the LiquidityPool rebase.
+        report.accruedRewards = 10 ether;
         _executeAdminTasks(report, "EtherFiAdmin: TVL changed too much");
     }
 
@@ -467,22 +479,26 @@ contract EtherFiOracleTest is TestSetup {
 
     // Note: Working with MembershipManager which is to be deprecated
     function test_huge_negative_rebaes() public {
-        // TVL after `launch_validator` is 60 ETH
-        // EtherFIAdmin limits the APR per rebase as 100 % == 10000 bps
-        // launch_validator();
+        // Seed a realistic TVL so the APR formula is non-trivial. The negative
+        // (slashing) direction is NOT bounded by the LiquidityPool positive cap — it is
+        // governed by the oracle's APR guard (acceptableRebaseAprInBps == 100%).
+        vm.deal(alice, 1000 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1000 ether}();
 
         IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
 
         _moveClock(1 days / 12);
 
-        // Change in APR is below 100%
-        report.accruedRewards = int128(63 ether) / int128(365);
+        // Small positive rebase within both caps to advance the handled slot.
+        report.accruedRewards = 1 ether;
         _executeAdminTasks(report);
 
         _moveClock(1 days / 12);
 
-        // Change in APR is above 100%, which reverts
-        report.accruedRewards = int128(-65 ether) / int128(365);
+        // A huge negative rebase exceeds the acceptable APR (in absolute terms) and is
+        // rejected by the oracle TVL-change guard.
+        report.accruedRewards = -10 ether;
         _executeAdminTasks(report, "EtherFiAdmin: TVL changed too much");
     }
 
@@ -527,6 +543,12 @@ contract EtherFiOracleTest is TestSetup {
     }
 
     function test_postReportWaitTimeInSlots() public {
+        // Seed TVL so the report's positive accruedRewards stays within the 25 bps
+        // LiquidityPool positive rebase cap (a zero-TVL pool rejects any positive rebase).
+        vm.deal(alice, 1000 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1000 ether}();
+
         bytes[] memory emptyBytes = new bytes[](0);
         vm.prank(owner);
         etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
@@ -809,6 +831,12 @@ contract EtherFiOracleTest is TestSetup {
     }
 
     function test_slotForNextReport_edgeCases() public {
+        // Seed TVL so the report's positive accruedRewards stays within the 25 bps
+        // LiquidityPool positive rebase cap (a zero-TVL pool rejects any positive rebase).
+        vm.deal(alice, 1000 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1000 ether}();
+
         vm.prank(owner);
         etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 
@@ -828,6 +856,12 @@ contract EtherFiOracleTest is TestSetup {
     }
 
     function test_blockStampForNextReport() public {
+        // Seed TVL so the report's positive accruedRewards stays within the 25 bps
+        // LiquidityPool positive rebase cap (a zero-TVL pool rejects any positive rebase).
+        vm.deal(alice, 1000 ether);
+        vm.prank(alice);
+        liquidityPoolInstance.deposit{value: 1000 ether}();
+
         vm.prank(owner);
         etherFiOracleInstance.manageCommitteeMember(bob, false, 1);
 

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -338,8 +338,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         vm.stopPrank();
 
         // Apply rebase
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(int128(rebase));
+        _rebaseUncapped(int128(rebase));
 
         // Set fee and watermark configurations
         vm.prank(owner);
@@ -516,8 +515,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
         uint256 one_percent_of_tvl = liquidityPoolInstance.getTotalPooledEther() / 100;
 
-        vm.prank(address(membershipManagerV1Instance));
-        liquidityPoolInstance.rebase(int128(uint128(one_percent_of_tvl))); // 10 eETH earned 1 ETH
+        _rebaseUncapped(int128(uint128(one_percent_of_tvl))); // 10 eETH earned 1 ETH
 
         vm.startPrank(user);
         uint256 weEthAmount = weEthInstance.balanceOf(user);
@@ -686,8 +684,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
         uint256 one_percent_of_tvl = liquidityPoolInstance.getTotalPooledEther() / 100;
 
-        vm.prank(address(membershipManagerV1Instance));
-        liquidityPoolInstance.rebase(int128(uint128(one_percent_of_tvl))); // 10 eETH earned 1 ETH
+        _rebaseUncapped(int128(uint128(one_percent_of_tvl))); // 10 eETH earned 1 ETH
 
         vm.startPrank(user);
         uint256 weEthAmount = weEthInstance.balanceOf(user);
@@ -1621,8 +1618,7 @@ contract EtherFiRedemptionManagerTest is TestSetup {
 
         // Apply rebase
         uint256 one_percent_of_tvl = liquidityPoolInstance.getTotalPooledEther() / 100;
-        vm.prank(address(membershipManagerV1Instance));
-        liquidityPoolInstance.rebase(int128(uint128(one_percent_of_tvl)));
+        _rebaseUncapped(int128(uint128(one_percent_of_tvl)));
 
         vm.startPrank(user);
         uint256 weEthAmount = weEthInstance.balanceOf(user);

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -5,6 +5,7 @@ import "@tests/TestSetup.sol";
 import "forge-std/Test.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
+import "@etherfi/core/interfaces/ILiquidityPool.sol";
 
 contract LiquidityPoolTest is TestSetup {
     using stdStorage for StdStorage;
@@ -30,8 +31,8 @@ contract LiquidityPoolTest is TestSetup {
     /// @dev Build LiquidityPool ConstructorAddresses overriding the priority queue and
     /// blacklister; other fields fall back to test setup addresses. Returns a struct
     /// suitable for `new LiquidityPool(...)`.
-    function _lpCtorAddrs(address pwq, address blacklister) internal view returns (LiquidityPool.ConstructorAddresses memory) {
-        return LiquidityPool.ConstructorAddresses({
+    function _lpCtorAddrs(address pwq, address blacklister) internal view returns (ILiquidityPool.ConstructorAddresses memory) {
+        return ILiquidityPool.ConstructorAddresses({
             stakingManager: address(stakingManagerInstance),
             nodesManager: address(managerInstance),
             eETH: address(eETHInstance),

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -672,9 +672,9 @@ contract LiquifierTest is TestSetup {
     function _ctorAddrs(address roleRegistry_, address priceFeed_, address blacklister_)
         internal
         pure
-        returns (Liquifier.ConstructorAddresses memory)
+        returns (ILiquifier.ConstructorAddresses memory)
     {
-        return Liquifier.ConstructorAddresses({
+        return ILiquifier.ConstructorAddresses({
             liquidityPool: address(0xA1),
             lidoWithdrawalQueue: address(0xA2),
             lido: address(0xA3),

--- a/test/LiquifierStEthPriceFeed.t.sol
+++ b/test/LiquifierStEthPriceFeed.t.sol
@@ -55,7 +55,7 @@ contract LiquifierStEthPriceFeedTest is Test {
         feed = new MockChainlinkPriceFeed(int256(1 ether), block.timestamp);
         curve = new MockCurvePool();
 
-        Liquifier.ConstructorAddresses memory addrs = Liquifier.ConstructorAddresses({
+        ILiquifier.ConstructorAddresses memory addrs = ILiquifier.ConstructorAddresses({
             liquidityPool: address(0xA1),
             lidoWithdrawalQueue: address(0xA2),
             lido: stEth,

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -6,6 +6,7 @@ import "forge-std/console2.sol";
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
+import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/withdrawals/PriorityWithdrawalQueue.sol";
 import "@etherfi/withdrawals/interfaces/IPriorityWithdrawalQueue.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
@@ -55,7 +56,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
         // Upgrade LiquidityPool to latest version (needed for setPriorityWithdrawalQueue)
         vm.startPrank(owner);
         LiquidityPool newLpImpl = new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(stakingManagerInstance),
                 nodesManager: address(managerInstance),
                 eETH: address(eETHInstance),

--- a/test/ProtocolInvariants.t.sol
+++ b/test/ProtocolInvariants.t.sol
@@ -49,8 +49,7 @@ contract ProtocolInvariantsTest is TestSetup {
         // without this seed, the three "after rebase" fuzz tests below
         // would silently degenerate into plain wrap/deposit tests because
         // their `outOfLp / 3` bound would be zero.
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(int128(int256(uint256(10 ether))));
+        _rebaseUncapped(int128(int256(uint256(10 ether))));
     }
 
     // =====================================================================
@@ -335,8 +334,7 @@ contract ProtocolInvariantsTest is TestSetup {
         int256 cap = int256(outOfLp / 3);
         if (cap < 1) cap = 1;
         rebaseDelta = int128(bound(int256(rebaseDelta), -cap, cap));
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(rebaseDelta);
+        _rebaseUncapped(rebaseDelta);
 
         uint256 aliceEEth = eETHInstance.balanceOf(alice);
         if (aliceEEth < 4) return; // nothing meaningful to wrap; skip the case
@@ -534,8 +532,7 @@ contract ProtocolInvariantsTest is TestSetup {
         uint256 cap = outOfLp / 3;
         if (cap < 1) cap = 1;
         rebaseGain = uint128(bound(uint256(rebaseGain), 1, cap));
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(int128(rebaseGain));
+        _rebaseUncapped(int128(rebaseGain));
         depositAmt = uint128(bound(uint256(depositAmt), 1 gwei, 100_000 ether));
 
         address user = _actor(uint64(uint256(keccak256(abi.encode(rebaseGain, depositAmt)))));
@@ -561,8 +558,7 @@ contract ProtocolInvariantsTest is TestSetup {
         uint256 cap = outOfLp / 3;
         if (cap < 1) cap = 1;
         rebaseLoss = uint128(bound(uint256(rebaseLoss), 1, cap));
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(-int128(rebaseLoss));
+        _rebaseUncapped(-int128(rebaseLoss));
         depositAmt = uint128(bound(uint256(depositAmt), 1 gwei, 100_000 ether));
 
         address user = _actor(uint64(uint256(keccak256(abi.encode(rebaseLoss, depositAmt)))));
@@ -645,8 +641,7 @@ contract ProtocolInvariantsTest is TestSetup {
         // packed (uint128 totalValueOutOfLp | uint128 totalValueInLp) at slot
         // for `totalValueOutOfLp` declared first.
         // Avoid storage poking — instead drive totalValueOutOfLp via rebase.
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(int128(50 ether));
+        _rebaseUncapped(int128(50 ether));
 
         // ERM's stock and the OutOfLp budget are now > 0; fuzz a reasonable
         // value to burn against.
@@ -686,8 +681,7 @@ contract ProtocolInvariantsTest is TestSetup {
         liquidityPoolInstance.deposit{value: 200 ether}();
         vm.prank(alice);
         eETHInstance.transfer(address(etherFiRedemptionManagerInstance), 100 ether);
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(int128(50 ether));
+        _rebaseUncapped(int128(50 ether));
 
         valueETH = uint128(bound(uint256(valueETH), 1 ether, 10 ether));
         uint256 minShares = liquidityPoolInstance.sharesForWithdrawalAmount(valueETH);

--- a/test/RestakingRewardsRouter.t.sol
+++ b/test/RestakingRewardsRouter.t.sol
@@ -52,7 +52,7 @@ contract RestakingRewardsRouterTest is Test {
 
         // Deploy LiquidityPool
         liquidityPoolImpl = new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(0),
                 nodesManager: address(0),
                 eETH: address(0),

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -17,6 +17,7 @@ import "@tests/common/ArrayTestHelper.sol";
 import "@etherfi/staking/interfaces/IStakingManager.sol";
 import "@etherfi/staking/interfaces/IEtherFiNode.sol";
 import "@etherfi/core/interfaces/ILiquidityPool.sol";
+import "@etherfi/deposits/interfaces/IDepositAdapter.sol";
 import "@etherfi/deposits/interfaces/ILiquifier.sol";
 import "@etherfi/staking/EtherFiNodesManager.sol";
 import "@etherfi/staking/StakingManager.sol";
@@ -47,6 +48,7 @@ import "@tests/TestERC20.sol";
 import "@etherfi/archive/MembershipManagerV0.sol";
 import "@etherfi/oracle/EtherFiOracle.sol";
 import "@etherfi/oracle/EtherFiAdmin.sol";
+import "@etherfi/oracle/interfaces/IEtherFiAdmin.sol";
 import "@etherfi/governance/EtherFiTimelock.sol";
 
 import "@etherfi/archive/BucketRateLimiter.sol";
@@ -565,16 +567,21 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         // Upgrade DepositAdapter on the fork so tests exercise the post-refactor
         // custom-error reverts instead of the still-deployed string-revert impl.
+        // Preserve the live token immutables (wETH/stETH/wstETH) by reading them
+        // off the deployed proxy — these are needed by the deposit paths, and the
+        // values differ per fork (mainnet vs testnet).
         address newDepositAdapterImpl = address(new DepositAdapter(
-            address(liquidityPoolInstance),
-            address(liquifierInstance),
-            address(weEthInstance),
-            address(eETHInstance),
-            0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2,
-            address(stEth),
-            0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0,
-            address(roleRegistryInstance),
-            address(blacklisterInstance)
+            IDepositAdapter.ConstructorAddresses({
+                liquidityPool: address(liquidityPoolInstance),
+                liquifier: address(liquifierInstance),
+                weETH: address(weEthInstance),
+                eETH: address(eETHInstance),
+                wETH: address(depositAdapterInstance.wETH()),
+                stETH: address(depositAdapterInstance.stETH()),
+                wstETH: address(depositAdapterInstance.wstETH()),
+                blacklister: address(blacklisterInstance),
+                roleRegistry: address(roleRegistryInstance)
+            })
         ));
         vm.prank(depositAdapterInstance.owner());
         depositAdapterInstance.upgradeTo(newDepositAdapterImpl);
@@ -585,7 +592,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // afterwards the new impl's `onlyUpgradeTimelock` takes over (and we
         // grant the role to relevant addresses below).
         address newLpImpl = address(new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(stakingManagerInstance),
                 nodesManager: address(managerInstance),
                 eETH: address(eETHInstance),
@@ -634,7 +641,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // route through the new impl's `onlyUpgradeTimelock`, which we grant
         // below.
         address newAdminImpl = address(new EtherFiAdmin(
-            EtherFiAdmin.ConstructorAddresses({
+            IEtherFiAdmin.ConstructorAddresses({
                 etherFiOracle: address(etherFiOracleInstance),
                 stakingManager: address(stakingManagerInstance),
                 auctionManager: address(auctionInstance),
@@ -673,7 +680,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             stEthChainlinkFeed = address(new MockChainlinkPriceFeed(int256(1 ether), 0));
         }
         address newLiquifierImpl = address(new Liquifier(
-            Liquifier.ConstructorAddresses({
+            ILiquifier.ConstructorAddresses({
                 liquidityPool: address(liquidityPoolInstance),
                 lidoWithdrawalQueue: address(lidoWithdrawalQueue),
                 lido: address(stEth),
@@ -797,7 +804,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         if (forkEnum == MAINNET_FORK || forkEnum == TESTNET_FORK) {
             // Deploy the new impl BEFORE pranking — see note above; the inlined
             // `new` would otherwise consume the single-shot vm.prank.
-            address newLiquifierImpl = address(new Liquifier(Liquifier.ConstructorAddresses({
+            address newLiquifierImpl = address(new Liquifier(ILiquifier.ConstructorAddresses({
                 liquidityPool: address(liquidityPoolInstance),
                 lidoWithdrawalQueue: address(lidoWithdrawalQueue),
                 lido: address(stEth),
@@ -997,7 +1004,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // =====================================================================
 
         // Liquifier first — EtherFiRestaker's constructor reads from it.
-        liquifierImplementation = new Liquifier(Liquifier.ConstructorAddresses({
+        liquifierImplementation = new Liquifier(ILiquifier.ConstructorAddresses({
             liquidityPool: address(liquidityPoolProxy),
             lidoWithdrawalQueue: address(lidoWithdrawalQueue),
             lido: address(stEth),
@@ -1107,7 +1114,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         addressProviderInstance = new AddressProvider(address(owner));
 
         liquidityPoolImplementation = new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(0x0),
                 nodesManager: address(0x0),
                 eETH: address(0x0),
@@ -1143,7 +1150,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // Re-deploy the impl now that etherFiRestakerProxy is known and upgrade the
         // already-initialized proxy in place. Creating a fresh proxy here would drop
         // the initialized owner set in Phase 3 and break later upgradeTo calls.
-        liquifierImplementation = new Liquifier(Liquifier.ConstructorAddresses({
+        liquifierImplementation = new Liquifier(ILiquifier.ConstructorAddresses({
             liquidityPool: address(liquidityPoolProxy),
             lidoWithdrawalQueue: address(lidoWithdrawalQueue),
             lido: address(stEth),
@@ -1170,9 +1177,9 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         vm.expectRevert("Initializable: contract is already initialized");
         weEthImplementation.initialize(payable(address(liquidityPoolProxy)), address(eETHProxy));
         weEthInstance.upgradeTo(address(weEthImplementation));
-        vm.expectRevert(WeETH.AddressZero.selector);
+        vm.expectRevert(WeETH.ZeroAddress.selector);
         weEthInstance.initialize(address(0), address(eETHProxy));
-        vm.expectRevert(WeETH.AddressZero.selector);
+        vm.expectRevert(WeETH.ZeroAddress.selector);
         weEthInstance.initialize(payable(address(liquidityPoolProxy)), address(0));
         weEthInstance.initialize(payable(address(liquidityPoolProxy)), address(eETHProxy));
 
@@ -1234,7 +1241,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         // EtherFiAdmin
         etherFiAdminImplementation = new EtherFiAdmin(
-            EtherFiAdmin.ConstructorAddresses({
+            IEtherFiAdmin.ConstructorAddresses({
                 etherFiOracle: address(etherFiOracleProxy),
                 stakingManager: address(stakingManagerProxy),
                 auctionManager: address(auctionManagerProxy),
@@ -1292,7 +1299,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         // LiquidityPool — every dep is now a known proxy address
         liquidityPoolImplementation = new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(stakingManagerProxy),
                 nodesManager: address(etherFiNodeManagerProxy),
                 eETH: address(eETHProxy),
@@ -1534,7 +1541,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
     function _upgrade_etherfiAdmin() internal {
         address newAdminImpl = address(new EtherFiAdmin(
-            EtherFiAdmin.ConstructorAddresses({
+            IEtherFiAdmin.ConstructorAddresses({
                 etherFiOracle: address(etherFiOracleInstance),
                 stakingManager: address(stakingManagerInstance),
                 auctionManager: address(auctionInstance),
@@ -1557,7 +1564,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         etherFiOracleInstance.upgradeTo(newOracleImpl);
 
         address newAdminImpl = address(new EtherFiAdmin(
-            EtherFiAdmin.ConstructorAddresses({
+            IEtherFiAdmin.ConstructorAddresses({
                 etherFiOracle: address(etherFiOracleInstance),
                 stakingManager: address(stakingManagerInstance),
                 auctionManager: address(auctionInstance),
@@ -2254,7 +2261,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
     function _upgrade_liquidity_pool_contract() internal {
         address newImpl = address(new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(stakingManagerInstance),
                 nodesManager: address(managerInstance),
                 eETH: address(eETHInstance),
@@ -2275,7 +2282,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
     }
 
     function _upgrade_liquifier() internal {
-        address newImpl = address(new Liquifier(Liquifier.ConstructorAddresses({
+        address newImpl = address(new Liquifier(ILiquifier.ConstructorAddresses({
             liquidityPool: address(liquidityPoolInstance),
             lidoWithdrawalQueue: address(lidoWithdrawalQueue),
             lido: address(stEth),

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -1887,6 +1887,33 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         etherFiAdminInstance.executeTasks(_report);
     }
 
+    /// @notice Applies a rebase that may exceed the per-report 25 bps positive cap
+    ///         (LiquidityPool.MAX_POSITIVE_REBASE_BPS) by splitting a positive rebase
+    ///         into sub-cap chunks. `rebase` is purely additive (totalValueOutOfLp += amount),
+    ///         so applying the chunks back-to-back leaves the final TVL and share rate
+    ///         identical to a single rebase of `_amount` — every post-rebase assertion holds.
+    ///         Negative/zero rebases are applied in a single call (no positive cap applies).
+    /// @dev Pranks the LP's registered membership manager, so it works in both the unit
+    ///      setup and mainnet-fork setups regardless of which instance is wired in.
+    function _rebaseUncapped(int128 _amount) internal {
+        address mm = liquidityPoolInstance.membershipManager();
+        if (_amount <= 0) {
+            vm.prank(mm);
+            liquidityPoolInstance.rebase(_amount);
+            return;
+        }
+        uint256 remaining = uint256(uint128(_amount));
+        while (remaining > 0) {
+            uint256 maxIncrease = (liquidityPoolInstance.getTotalPooledEther()
+                * liquidityPoolInstance.MAX_POSITIVE_REBASE_BPS()) / 10_000;
+            require(maxIncrease > 0, "_rebaseUncapped: TVL too small for a positive rebase");
+            uint256 chunk = remaining < maxIncrease ? remaining : maxIncrease;
+            vm.prank(mm);
+            liquidityPoolInstance.rebase(int128(uint128(chunk)));
+            remaining -= chunk;
+        }
+    }
+
     function _emptyOracleReport() internal view returns (IEtherFiOracle.OracleReport memory report) {
         uint256[] memory emptyVals = new uint256[](0);
         uint32[] memory emptyVals32 = new uint32[](0);

--- a/test/WeETH.t.sol
+++ b/test/WeETH.t.sol
@@ -210,8 +210,7 @@ contract WeETHTest is TestSetup {
 
         //----------------------------------------------------------------------------------------------------------
 
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(10 ether);
+        _rebaseUncapped(10 ether);
 
         _transferTo(address(liquidityPoolInstance), 10 ether);
 
@@ -234,8 +233,7 @@ contract WeETHTest is TestSetup {
 
         //----------------------------------------------------------------------------------------------------------
 
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(50 ether);
+        _rebaseUncapped(50 ether);
 
         _transferTo(address(liquidityPoolInstance), 50 ether);   
         assertEq(liquidityPoolInstance.getTotalPooledEther(), 110 ether);
@@ -276,8 +274,7 @@ contract WeETHTest is TestSetup {
         vm.stopPrank();
 
         // Rewards enter LP
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(1 ether);
+        _rebaseUncapped(1 ether);
         _transferTo(address(liquidityPoolInstance), 1 ether);
         assertEq(address(liquidityPoolInstance).balance, 4 ether);
 

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -182,8 +182,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // Rebase with accrued_rewards = 10 ether for the deposited 10 ether
         // -> 1 ether eETH shares = 2 ether ETH
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(10 ether);
+        _rebaseUncapped(10 ether);
 
         assertEq(withdrawRequestNFTInstance.balanceOf(bob), 1, "Bobs balance should be 1");
         assertEq(withdrawRequestNFTInstance.ownerOf(requestId), bob, "Bobs should own the NFT");
@@ -210,8 +209,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // First, do a positive rebase to increase totalValueOutOfLp
         // This simulates validators earning rewards
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(60 ether);
+        _rebaseUncapped(60 ether);
 
         assertEq(liquidityPoolInstance.getTotalPooledEther(), 10 ether + 60 ether);
 
@@ -282,8 +280,6 @@ contract WithdrawRequestNFTTest is TestSetup {
         liquidityPoolInstance.deposit{value: 9}();
         vm.stopPrank();
 
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(2);
 
         vm.startPrank(bob);
         uint256 balance = eETHInstance.balanceOf(bob);
@@ -467,8 +463,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
 
         // Simulate rebase after request but before claim
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(int128(uint128(rebaseAmount)));
+        _rebaseUncapped(int128(uint128(rebaseAmount)));
 
         // Calculate expected withdrawal amounts after rebase
         uint256 sharesValue = liquidityPoolInstance.amountForShare(request.shareOfEEth);
@@ -1115,8 +1110,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
         // Rebase to create remainder
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(5 ether);
+        _rebaseUncapped(5 ether);
 
         _finalizeWithdrawalRequest(requestId);
 
@@ -1143,8 +1137,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // First positive rebase pumps TVOL so we have headroom to rebase negative later.
         // After: TPE=15, shares=10e18, rate=1.5
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(5 ether);
+        _rebaseUncapped(5 ether);
 
         // Request A — priced at rate=1.5; another positive rebase before finalize leaves share
         // remainder during claim (burnedShares = ceil(amountOfEEth/frozenRate) < shareOfEEth).
@@ -1154,8 +1147,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 reqA = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
         // Second positive rebase: rate climbs to ~2.0
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(5 ether);
+        _rebaseUncapped(5 ether);
 
         _finalizeWithdrawalRequest(reqA);
         vm.prank(bob);
@@ -1242,8 +1234,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.stopPrank();
 
         // Seed TVOL so the later negative rebase has headroom (rebase touches TVOL, not TVIL).
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(10 ether);
+        _rebaseUncapped(10 ether);
 
         // Two requests — finalize+claim one to generate remainder shares while the other
         // keeps `ethAmountLockedForWithdrawal` non-zero.
@@ -1354,8 +1345,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
         // Rebase to create remainder
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(5 ether);
+        _rebaseUncapped(5 ether);
 
         _finalizeWithdrawalRequest(requestId);
 
@@ -1902,8 +1892,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.stopPrank();
 
         // Positive rebase first so a subsequent negative rebase still leaves positive shares value.
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(10 ether); // 20 ether / 10 shares = 2 ether per share
+        _rebaseUncapped(10 ether); // 20 ether / 10 shares = 2 ether per share
 
         vm.prank(bob);
         eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
@@ -1949,8 +1938,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // Positive rebase post-finalize — frozen rate is unchanged, and the `min(amount, shares*rate)` clamp
         // still keeps payout at the originally requested amount.
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(20 ether);
+        _rebaseUncapped(20 ether);
 
         uint256 claimable = withdrawRequestNFTInstance.getClaimableAmount(requestId);
         WithdrawRequestNFT.WithdrawRequest memory request = withdrawRequestNFTInstance.getRequest(requestId);
@@ -1979,14 +1967,12 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint224 rateA = withdrawRequestNFTInstance.frozenRateFor(r1);
 
         // Rebase, then finalize r2 at rate B
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(15 ether);
+        _rebaseUncapped(15 ether);
         _finalizeWithdrawalRequest(r2);
         uint224 rateB = withdrawRequestNFTInstance.frozenRateFor(r2);
 
         // Rebase again, then finalize r3 at rate C
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(15 ether);
+        _rebaseUncapped(15 ether);
         _finalizeWithdrawalRequest(r3);
         uint224 rateC = withdrawRequestNFTInstance.frozenRateFor(r3);
 
@@ -2051,8 +2037,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.stopPrank();
 
         // Build up totalValueOutOfLp via a positive rebase so a later negative rebase doesn't underflow.
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(10 ether); // rate ≈ 2 ETH per share
+        _rebaseUncapped(10 ether); // rate ≈ 2 ETH per share
 
         vm.startPrank(bob);
         eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
@@ -2160,8 +2145,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.stopPrank();
 
         // Build up TPE so a later negative rebase has headroom and doesn't underflow.
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(20 ether); // 40 ETH TPE / 20 shares → ~2 ETH/share
+        _rebaseUncapped(20 ether); // 40 ETH TPE / 20 shares → ~2 ETH/share
 
         vm.prank(bob);
         eETHInstance.approve(address(liquidityPoolInstance), 1 ether);
@@ -2177,8 +2161,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         assertGt(frozenRate, 0, "frozenRate must be set after finalize");
 
         // 4. apply positive rebase
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(10 ether);
+        _rebaseUncapped(10 ether);
 
         // 5. assert getClaimableAmount unchanged after positive rebase
         assertEq(
@@ -2262,8 +2245,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         startHoax(bob);
         liquidityPoolInstance.deposit{value: 10 ether}();
         vm.stopPrank();
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(10 ether);
+        _rebaseUncapped(10 ether);
 
         vm.startPrank(bob);
         eETHInstance.approve(address(liquidityPoolInstance), 1 ether);

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -106,7 +106,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         // Wire LP immutables to the real mainnet proxy addresses so calls into
         // eETH / withdrawRequestNFT / etc. land on live contracts rather than 0x0.
         LiquidityPool liquidityPoolImpl = new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(stakingManager),
                 nodesManager: address(etherFiNodesManager),
                 eETH: 0x35fA164735182de50811E8e2E824cFb9B6118ac2,

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 import "@scripts/deploys/Deployed.s.sol";
 import "@etherfi/core/LiquidityPool.sol";
+import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/withdrawals/WithdrawRequestNFT.sol";
 import "@etherfi/withdrawals/PriorityWithdrawalQueue.sol";
 import "@etherfi/governance/utils/ReentrancyGuardNamespaced.sol";
@@ -213,7 +214,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
         // 2. Deploy new implementation contracts (with the added guard)
         // ------------------------------------------------------------------
         address newLP  = address(new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: STAKING_MANAGER,
                 nodesManager: ETHERFI_NODES_MANAGER,
                 eETH: EETH,
@@ -407,7 +408,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
     ///      receive(); the master queue impl has no receive() and would revert.
     function _doUpgrade() internal {
         address newLP = address(new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: STAKING_MANAGER,
                 nodesManager: ETHERFI_NODES_MANAGER,
                 eETH: EETH,
@@ -462,7 +463,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
     ///      the modifier no-op.
     function test_postUpgrade_guardBlocksReentry() public {
         address newLP = address(new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: STAKING_MANAGER,
                 nodesManager: ETHERFI_NODES_MANAGER,
                 eETH: EETH,

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -13,6 +13,7 @@ import "@etherfi/staking/interfaces/IEtherFiNode.sol";
 
 import "@etherfi/staking/StakingManager.sol";
 import "@etherfi/core/LiquidityPool.sol";
+import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/staking/EtherFiNodesManager.sol";
 import "@etherfi/staking/EtherFiNode.sol";
 import "@etherfi/staking/NodeOperatorManager.sol";
@@ -68,7 +69,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
         // Wire LP immutables to real mainnet proxy addresses so calls into
         // eETH / withdrawRequestNFT / etc. land on live contracts.
         LiquidityPool liquidityPoolImpl = new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(stakingManager),
                 nodesManager: address(etherFiNodesManager),
                 eETH: 0x35fA164735182de50811E8e2E824cFb9B6118ac2,

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -10,7 +10,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
     function _newLpImpl() internal returns (address) {
         return address(new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: STAKING_MANAGER,
                 nodesManager: ETHERFI_NODES_MANAGER,
                 eETH: EETH,

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -167,8 +167,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         // total_remainder ≈ bob_locked × p. With bob_locked = 200 ETH and p = 0.5%,
         // expected remainder ≈ 1 ETH, well above the 0.05 floor below.
         int128 rebaseAmount = int128(int256(liquidityPoolInstance.getTotalPooledEther() / 200));
-        vm.prank(address(membershipManagerV1Instance));
-        liquidityPoolInstance.rebase(rebaseAmount);
+        _rebaseUncapped(rebaseAmount);
 
         // Finalize and claim all requests
         for (uint256 i = 0; i < 20; i++) {

--- a/test/integration-tests/MinAmountForShare.t.sol
+++ b/test/integration-tests/MinAmountForShare.t.sol
@@ -39,7 +39,7 @@ contract MinAmountForShareForkTest is TestSetup, Deployed {
     /// preserve that so we don't introduce unrelated changes through the fork upgrade.
     function _upgradeLpWithMinAmount(uint256 minAmount) internal {
         LiquidityPool newImpl = new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(stakingManagerInstance),
                 nodesManager: address(managerInstance),
                 eETH: address(eETHInstance),

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -22,7 +22,7 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
 
         // Upgrade LiquidityPool to the consolidated role model — the on-chain impl
         // still checks LIQUIDITY_POOL_ADMIN_ROLE on registerValidatorSpawner.
-        LiquidityPool newLpImpl = new LiquidityPool(LiquidityPool.ConstructorAddresses({
+        LiquidityPool newLpImpl = new LiquidityPool(ILiquidityPool.ConstructorAddresses({
             stakingManager: address(stakingManagerInstance),
             nodesManager: address(managerInstance),
             eETH: address(eETHInstance),

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -114,7 +114,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
         );
         pQueue = PriorityWithdrawalQueue(payable(address(proxy)));
         liquidityPoolInstance.upgradeTo(address(new LiquidityPool(
-            LiquidityPool.ConstructorAddresses({
+            ILiquidityPool.ConstructorAddresses({
                 stakingManager: address(stakingManagerInstance),
                 nodesManager: address(managerInstance),
                 eETH: address(eETHInstance),

--- a/test/invariant/WithdrawRemainder.invariant.t.sol
+++ b/test/invariant/WithdrawRemainder.invariant.t.sol
@@ -85,8 +85,7 @@ contract WithdrawRemainderInvariantTest is TestSetup {
         // request -> negative-rebase -> finalize -> claim chain that
         // produces a positive stranded-ETH delta (the property the suite
         // is built to assert).
-        vm.prank(address(membershipManagerInstance));
-        liquidityPoolInstance.rebase(int128(int256(uint256(200 ether))));
+        _rebaseUncapped(int128(int256(uint256(200 ether))));
 
         handler = new WithdrawRemainderHandler(
             liquidityPoolInstance,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly comments, reordering, and constructor/API surface for new deployments; proxy storage and on-chain behavior appear unchanged aside from WeETH error rename and DepositAdapter constructor shape.
> 
> **Overview**
> This PR is a **documentation and interface-layout refactor** across core tokens, `LiquidityPool`, deposit/governance utilities, and upgrade verification scripts—not a change to withdrawal, rebase, or rate-limit logic.
> 
> **NatSpec and file structure:** `EETH`, `WeETH`, `LiquidityPool`, `Liquifier`, `DepositAdapter`, `Blacklister`, `RevokeAdmin`, `RoleRegistry`, and shared governance helpers gain section headers and `@notice`/`@dev` blocks on public/external functions. Several internal helpers are **reordered** (e.g. EIP-712 helpers in `EETH`, rate-snapshot helpers in `LiquidityPool`) without altering their behavior.
> 
> **Constructor config moved to interfaces:** `ConstructorAddresses` (and related enums like `SourceOfFunds` for the pool) move from concrete contracts into **`ILiquidityPool`**, **`ILiquifier`**, and the new **`IDepositAdapter`**. `DepositAdapter` now **`implements IDepositAdapter`** and takes a single `ConstructorAddresses` struct in its constructor instead of many positional address arguments. Upgrade scripts (`transactionsPriorityQueue.s.sol`, `transactions-reaudit-fixes.s.sol`) are updated to use `ILiquidityPool.ConstructorAddresses` / `ILiquifier.ConstructorAddresses` for bytecode checks.
> 
> **Minor cleanups:** `Liquifier` drops a local `_min` in favor of OpenZeppelin `Math.min`; `WeETH` renames `AddressZero` to **`ZeroAddress`** for zero-address checks. `PausableUntil` renames shadowed locals in internal pause logic (same semantics).
> 
> **Deploy/integration note:** Any off-chain tooling or scripts that still construct `DepositAdapter` with the old multi-argument constructor or decode `WeETH`’s old error name must be updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6923a23d7d03461481c7d2e6090348eca700908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->