### PR TITLE
Set LiquidityPool max withdraw bound to 3000 ETH

### DIFF
--- a/script/upgrades/security-upgrades/Constants.s.sol
+++ b/script/upgrades/security-upgrades/Constants.s.sol
@@ -105,9 +105,9 @@ abstract contract SecurityUpgradesConstants is Deployed {
 
     // core — LiquidityPool.requestWithdraw bounds (queued NFT-mint path). Default storage
     // is 0/0, which bricks the path; seeded via the OPERATION_MULTISIG Safe tx (Batch 3)
-    // after the upgrade batch grants it OPERATION_MULTISIG_ROLE. Dummy values for now.
+    // after the upgrade batch grants it OPERATION_MULTISIG_ROLE.
     uint256 internal constant LP_MIN_WITHDRAW_AMOUNT = 100_000 gwei; // 0.0001 ether
-    uint256 internal constant LP_MAX_WITHDRAW_AMOUNT = 1_000 ether;
+    uint256 internal constant LP_MAX_WITHDRAW_AMOUNT = 3_000 ether;
 
     // oracle — EtherFiAdmin daily finalized-withdrawal cap (operational setpoint).
     // Set post-upgrade via updateMaxFinalizedWithdrawalAmountPerDay, which is


### PR DESCRIPTION
## Summary

Replaces the placeholder `LP_MAX_WITHDRAW_AMOUNT` (1000 ether, marked "Dummy values for now") in `Constants.s.sol` with a real operational ceiling of **3000 ether**.

## Why

`LiquidityPool.requestWithdraw` reverts `InvalidWithdrawalAmount` for any request above `maxWithdrawAmount` (`src/core/LiquidityPool.sol:321`). At a 1000 ether cap, withdrawal requests above 1000 eETH would be blocked — a meaningful fraction of holders given current pool TVL (~1.87M ETH). 3000 ether is the agreed operational ceiling.

The bound is seeded post-upgrade via the OPERATION_MULTISIG Safe tx (Batch 3). `_preflight` asserts `MAX > MIN`, which this satisfies.

## Scope

Single constant change in `script/upgrades/security-upgrades/Constants.s.sol`. Stacks on #443.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single shared constant for an operational post-upgrade setpoint; it relaxes the per-request ceiling rather than changing auth or core protocol logic.
> 
> **Overview**
> Sets the **LiquidityPool** post-upgrade operational ceiling **`LP_MAX_WITHDRAW_AMOUNT`** from **1000** to **3000 ether** in `Constants.s.sol`, replacing the prior placeholder cap. That value is what Batch 3 (`executeLpWithdrawBounds`) passes to `setMaxWithdrawAmount`, so queued **`requestWithdraw`** requests above 1k eETH would no longer hit `InvalidWithdrawalAmount` once the multisig seeds bounds.
> 
> Comment-only cleanup drops the “dummy values for now” wording; **`LP_MIN_WITHDRAW_AMOUNT`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a03d6e170360bbe3d3f807c94743e551af77fcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->