### PR TITLE
yash/fix/remove-acceptable-share-rate

### DIFF
--- a/src/withdrawals/WithdrawRequestNFT.sol
+++ b/src/withdrawals/WithdrawRequestNFT.sol
@@ -84,9 +84,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     IeETH public immutable eETH;
     IMembershipManager public immutable membershipManager;
     IBlacklister public immutable blacklister;
-
-    uint256 public immutable minAcceptableShareRate;
-    uint256 public immutable maxAcceptableShareRate;
     // this treasury address is set to ethfi buyback wallet address
     address public immutable treasury;
     address public immutable etherFiAdmin;
@@ -130,17 +127,13 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
     error CannotInvalidateFinalizedRequest();
     error RequestAmountGreaterThanAvailableLiquidity();
     error InvalidShareRemainderSplit();
-    error InvalidShareRate();
     error NotTheOwner();
     error InsufficientEscrow();
     error EthTransferFailed();
     error AlreadyClaimed();
     error RequestNotFinalized();
-    error InvalidMinAcceptableShareRate();
-    error InvalidMinMaxAcceptableShareRate();
     error AlreadyInitialized();
     error NotInitialized();
-    error InvalidLiveRate();
     error BurnExceedsShares();
     error InvalidEEthShares();
 
@@ -156,20 +149,14 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
      * @param _roleRegistry The address of the role registry.
      * @param _blacklister The address of the blacklister.
      * @param _etherFiAdmin The address of the etherFi admin.
-     * @param _minAcceptableShareRate The minimum acceptable share rate.
-     * @param _maxAcceptableShareRate The maximum acceptable share rate.
      */
-    constructor(address _treasury, address _eETH, address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister,  address _etherFiAdmin, uint256 _minAcceptableShareRate, uint256 _maxAcceptableShareRate) RolesLibrary(_roleRegistry) {
-        if (_minAcceptableShareRate == 0) revert InvalidMinAcceptableShareRate();
-        if (_maxAcceptableShareRate <= _minAcceptableShareRate) revert InvalidMinMaxAcceptableShareRate();
+    constructor(address _treasury, address _eETH, address _liquidityPool, address _membershipManager, address _roleRegistry, address _blacklister,  address _etherFiAdmin) RolesLibrary(_roleRegistry) {
         treasury = _treasury;
         eETH = IeETH(_eETH);
         liquidityPool = ILiquidityPool(_liquidityPool);
         membershipManager = IMembershipManager(_membershipManager);
         blacklister = IBlacklister(_blacklister);
         etherFiAdmin = _etherFiAdmin;
-        minAcceptableShareRate = _minAcceptableShareRate;
-        maxAcceptableShareRate = _maxAcceptableShareRate;
         _disableInitializers();
     }
 
@@ -306,7 +293,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
         // Skip on no-op finalize so the checkpoint trace stays compact.
         if (requestId > lastFinalizedRequestId) {
             uint256 rate = liquidityPool.amountPerShareCeil();
-            if (rate < minAcceptableShareRate || rate > maxAcceptableShareRate) revert InvalidShareRate();
             _finalizationRates.push(uint32(requestId), uint224(rate));
         }
 
@@ -457,7 +443,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
             // Bounds-check the live rate before adopting it — this path is the only one where
             // `frozenRate` was not already gated by `finalizeRequests`'s write-time check.
             uint256 live = liquidityPool.amountPerShareCeil();
-            if (live < minAcceptableShareRate || live > maxAcceptableShareRate) revert InvalidLiveRate();
             frozenRate = uint224(live);
         }
 

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -86,8 +86,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
                 address(membershipManagerInstance),
                 address(roleRegistryInstance),
                 address(blacklisterInstance),
-                address(etherFiAdminInstance),
-                1, 4e18
+                address(etherFiAdminInstance)
             );
         withdrawRequestNFTInstance.upgradeTo(address(newWrnImpl));
         vm.stopPrank();

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -620,9 +620,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(membershipManagerV1Instance),
             address(roleRegistryInstance),
             address(blacklisterInstance),
-            address(etherFiAdminInstance),
-            1,
-            4e18
+            address(etherFiAdminInstance)
         ));
         vm.prank(withdrawRequestNFTInstance.owner());
         withdrawRequestNFTInstance.upgradeTo(newWrnImpl);
@@ -1215,8 +1213,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(membershipManagerProxy),
             address(roleRegistryInstance),
             address(blacklisterInstance),
-            address(etherFiAdminProxy),
-            1, 4e18
+            address(etherFiAdminProxy)
         );
         withdrawRequestNFTInstance.upgradeTo(address(withdrawRequestNFTImplementation));
 

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -13,7 +13,7 @@ contract WithdrawRequestNFTIntrusive is WithdrawRequestNFT {
 
     // roleRegistry must be non-zero — _authorizeUpgrade now defers to it for upgrade auth,
     // so a zero immutable would brick the swap-back step in updateParam.
-    constructor(address _roleRegistry) WithdrawRequestNFT(address(0), address(0), address(0), address(0), _roleRegistry, address(0), address(0), 1, 4e18) {}
+    constructor(address _roleRegistry) WithdrawRequestNFT(address(0), address(0), address(0), address(0), _roleRegistry, address(0), address(0)) {}
 
     /// @dev Test-only: advance `lastFinalizedRequestId` without going through `finalizeRequests`,
     ///      simulating the pre-upgrade state where no rate snapshot was captured.
@@ -361,8 +361,7 @@ contract WithdrawRequestNFTTest is TestSetup {
             address(membershipManagerInstance),
             address(roleRegistryInstance),
             address(blacklisterInstance),
-            address(etherFiAdminInstance),
-            1, 4e18
+            address(etherFiAdminInstance)
         )));
         // IMPLICIT_FEE_CLAIMER_ROLE consolidated into HOUSEKEEPING_OPERATIONS_ROLE.
         roleRegistryInstance.grantRole(roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE(), alice);

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -229,7 +229,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
             }),
             0
         ));
-        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, EETH, LIQUIDITY_POOL, MEMBERSHIP_MANAGER, ROLE_REGISTRY, address(blacklisterInstance), ETHERFI_ADMIN, 1, 4e18));
+        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, EETH, LIQUIDITY_POOL, MEMBERSHIP_MANAGER, ROLE_REGISTRY, address(blacklisterInstance), ETHERFI_ADMIN));
 
         // ------------------------------------------------------------------
         // 3. Upgrade the proxies in place
@@ -423,7 +423,7 @@ contract UpgradeStorageIntegrityTest is Test, Deployed {
             }),
             0
         ));
-        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, EETH, LIQUIDITY_POOL, MEMBERSHIP_MANAGER, ROLE_REGISTRY, address(blacklisterInstance), ETHERFI_ADMIN, 1, 4e18));
+        address newWRN = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, EETH, LIQUIDITY_POOL, MEMBERSHIP_MANAGER, ROLE_REGISTRY, address(blacklisterInstance), ETHERFI_ADMIN));
         address newPQ = address(new PriorityWithdrawalQueue(
             LIQUIDITY_POOL, EETH, WEETH, address(blacklisterInstance), ROLE_REGISTRY, TREASURY, 1 hours
         ));

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -28,7 +28,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
     }
 
     function _newWrnImpl() internal returns (address) {
-        return address(new WithdrawRequestNFT(buybackWallet, EETH, LIQUIDITY_POOL, MEMBERSHIP_MANAGER, ROLE_REGISTRY, address(blacklisterInstance), address(etherFiAdminInstance), 1, 4e18));
+        return address(new WithdrawRequestNFT(buybackWallet, EETH, LIQUIDITY_POOL, MEMBERSHIP_MANAGER, ROLE_REGISTRY, address(blacklisterInstance), address(etherFiAdminInstance)));
     }
 
     function setUp() public {

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -44,7 +44,7 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         address wrnOwner = withdrawRequestNFTInstance.owner();
         // Deploy the impl BEFORE pranking — the inlined `new` is a CREATE that
         // would otherwise consume the single-shot vm.prank (OnlyUpgradeTimelock).
-        address newWrnImpl = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(eETHInstance), address(liquidityPoolInstance), address(membershipManagerInstance), address(roleRegistryInstance), address(blacklisterInstance), address(etherFiAdminInstance), 1, 4e18));
+        address newWrnImpl = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(eETHInstance), address(liquidityPoolInstance), address(membershipManagerInstance), address(roleRegistryInstance), address(blacklisterInstance), address(etherFiAdminInstance)));
         vm.prank(wrnOwner);
         withdrawRequestNFTInstance.upgradeTo(newWrnImpl);
 

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -143,7 +143,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
             address(membershipManagerInstance),
             address(roleRegistryInstance),
             address(blacklisterInstance)
-        , address(etherFiAdminInstance), 1, 4e18));
+        , address(etherFiAdminInstance)));
         vm.prank(wrnOwner);
         withdrawRequestNFTInstance.upgradeTo(newWrnImpl);
     }

--- a/test/invariant/FrozenRateWithdrawal.invariant.t.sol
+++ b/test/invariant/FrozenRateWithdrawal.invariant.t.sol
@@ -104,19 +104,6 @@ contract FrozenRateWithdrawalInvariantTest is TestSetup {
     // =====================================================================
     // FROZEN-RATE INTEGRITY
     // =====================================================================
-
-    function invariant_frozen_rate_within_bounds() public view {
-        assertFalse(
-            handler.ghost_frozenRateOutOfBounds(),
-            "frozen rate observed outside [min, max]"
-        );
-    }
-
-    function invariant_all_checkpoints_in_bounds() public view {
-        (bool ok, uint256 firstOOB) = handler.verifyAllFinalizationCheckpointsInBounds();
-        assertTrue(ok, string.concat("frozen rate OOB for tokenId=", vm.toString(firstOOB)));
-    }
-
     function invariant_frozen_rate_persists_under_rebase() public {
         handler.verifyFrozenRatePersistence();
         assertFalse(

--- a/test/invariant/handlers/FrozenRateWithdrawalHandler.sol
+++ b/test/invariant/handlers/FrozenRateWithdrawalHandler.sol
@@ -106,9 +106,6 @@ contract FrozenRateWithdrawalHandler is StdUtils {
     ///         the edge.
     mapping(uint256 => bool) public ghost_wrnFrozenRateAtFinalizeRecorded;
 
-    /// @notice Set if any finalize-snapshotted rate fell outside [min, max].
-    bool public ghost_frozenRateOutOfBounds;
-
     /// @notice Set on any observed claim where `burnedShares > shareOfEEth`.
     bool public ghost_wrnBurnExceededShares;
 
@@ -217,14 +214,10 @@ contract FrozenRateWithdrawalHandler is StdUtils {
 
         vm.prank(etherFiAdminContract);
         try wrn.finalizeRequests(uint256(target)) {
-            // (F-003) Write-once snapshot of the frozen rate per id.
-            uint256 lo = wrn.minAcceptableShareRate();
-            uint256 hi = wrn.maxAcceptableShareRate();
             for (uint32 id = last + 1; id <= target; id++) {
                 uint256 t = uint256(id);
                 if (!ghost_wrnFrozenRateAtFinalizeRecorded[t]) {
                     uint256 frozen = uint256(wrn.frozenRateFor(t));
-                    if (frozen < lo || frozen > hi) ghost_frozenRateOutOfBounds = true;
                     ghost_wrnFrozenRateAtFinalize[t] = frozen;
                     ghost_wrnFrozenRateAtFinalizeRecorded[t] = true;
                 }
@@ -620,34 +613,6 @@ contract FrozenRateWithdrawalHandler is StdUtils {
                 return;
             }
         }
-    }
-
-    /// (F-005) Walk every checkpoint in WRN's finalization trace and
-    /// verify each rate is in bounds. The constructor's bounds check at
-    /// finalize is necessary but covers only the read-after-success; a
-    /// finalize that pushed an OOB value AND reverted would not surface
-    /// via the per-call read.
-    /// `Checkpoints.Trace224` exposes no direct iterator over the (key,
-    /// value) pairs, so we sample the trace via `lowerLookup(tokenId)`
-    /// for every tokenId the handler has tracked. Each tracked tokenId
-    /// belongs to exactly one finalize batch and every finalize batch
-    /// covers at least one tracked tokenId, so the per-tokenId loop is
-    /// equivalent to walking the trace.
-    function verifyAllFinalizationCheckpointsInBounds() external view returns (bool ok, uint256 firstOOB) {
-        uint256 lo = wrn.minAcceptableShareRate();
-        uint256 hi = wrn.maxAcceptableShareRate();
-        for (uint256 i = 0; i < wrnTokenIds.length; i++) {
-            uint256 t = wrnTokenIds[i];
-            if (!ghost_wrnFrozenRateAtFinalizeRecorded[t]) continue;
-            uint256 r = uint256(wrn.frozenRateFor(t));
-            // Legacy sentinel (= 0) is allowed for pre-upgrade IDs; we
-            // never push the sentinel in test setUp, so any 0 here is a
-            // real OOB.
-            if (r == 0 || r < lo || r > hi) {
-                return (false, t);
-            }
-        }
-        return (true, 0);
     }
 
     function pqSumFinalizedAmount() external view returns (uint256 acc) {

--- a/test/invariant/handlers/WithdrawRemainderHandler.sol
+++ b/test/invariant/handlers/WithdrawRemainderHandler.sol
@@ -256,10 +256,6 @@ contract WithdrawRemainderHandler is StdUtils {
         uint224 frozenRate = wrn.frozenRateFor(tokenId);
         if (frozenRate == 0) {
             uint256 live = lp.amountPerShareCeil();
-            if (live < wrn.minAcceptableShareRate() || live > wrn.maxAcceptableShareRate()) {
-                callCounts["wrn_claim_skipped"]++;
-                return;
-            }
             frozenRate = uint224(live);
         }
         uint256 independentForShares = Math.mulDiv(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes withdrawal finalize and claim payout math by allowing any liquidity-pool share rate at snapshot and on legacy live-rate fallback, with no on-chain circuit breaker.
> 
> **Overview**
> **WithdrawRequestNFT** no longer enforces configurable min/max acceptable share rates. The constructor drops the two rate immutables and their validation; **`finalizeRequests`** always snapshots `liquidityPool.amountPerShareCeil()` without a bounds check; and the legacy-claim path in **`_getClaimableAmount`** uses the live rate with no min/max guard. Related errors (`InvalidShareRate`, `InvalidLiveRate`, etc.) are removed.
> 
> All upgrade scripts, fork tests, integration tests, and **`WithdrawRequestNFT`** test helpers are updated to deploy the shorter constructor. Invariant coverage that asserted frozen rates stayed within `[min, max]` is deleted or simplified accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aedf156a0d1c3927a6bc7367f6021d1a9c3e0860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->