### PR TITLE
Fix stale comment + record rationale for removing WRNFT share-rate bounds

### DIFF
--- a/src/withdrawals/WithdrawRequestNFT.sol
+++ b/src/withdrawals/WithdrawRequestNFT.sol
@@ -441,8 +441,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrad
             // Pre-upgrade legacy request — sentinel returned 0. Fall back to the live rate so
             // claim semantics match the pre-upgrade behavior. New (post-upgrade) finalizations
             // always push a non-zero snapshot, so this branch only fires for legacy tokenIds.
-            // Bounds-check the live rate before adopting it — this path is the only one where
-            // `frozenRate` was not already gated by `finalizeRequests`'s write-time check.
             uint256 live = liquidityPool.amountPerShareCeil();
             frozenRate = uint224(live);
         }


### PR DESCRIPTION
Follow-up to #450, targeted at its branch so it can be folded in before #450 merges.

## What this changes

Removes two now-incorrect comment lines in `WithdrawRequestNFT._getClaimableAmount`. #450 deleted the `min`/`max` bounds check on the legacy live-rate fallback, but left a comment that still claimed the rate is bounds-checked there. The comment now described a check that no longer exists; this drops it so the comment matches the code.

No code behavior change — comment only.

## Why removing the bounds check is safe (for the record)

#450 removes the `[minAcceptableShareRate, maxAcceptableShareRate]` guards from `finalizeRequests` and the legacy fallback. This is safe because the claim path is already fully bounded by the `LiquidityPool.withdraw(amount, rate, shareOfEEth)` guards added in #439:

- Payout is capped at the request's original `amountOfEEth` (`min(amountOfEEth, shareOfEEth * frozenRate / SHARE_UNIT)`), so an inflated frozen rate cannot over-pay.
- Shares burned are floored to the live rate (`max(amount/frozenRate, amount/live)`), so an inflated frozen rate cannot under-burn.
- A too-low frozen rate only under-pays the user; it is not a protocol solvency risk.

The frozen-rate bounds had therefore become redundant defense-in-depth on top of the LP guards. Removing them is a cleanup, not a reduction in solvency protection.

Context: #439's review explicitly kept the legacy-path bounds check at the time. This note records that the subsequent LP-side guards make it redundant, so the removal is intentional rather than a regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no contract logic or access-control impact.
> 
> **Overview**
> Removes **stale comments** in `WithdrawRequestNFT._getClaimableAmount` that still described a `[min,max]` share-rate bounds check on the legacy live-rate fallback after that check was removed in #450.
> 
> **No runtime or logic changes** — only documentation aligned with current behavior. Legacy tokenIds still use `liquidityPool.amountPerShareCeil()` when the sentinel checkpoint is zero; claim limits remain enforced via `LiquidityPool.withdraw` and the existing `min(amountOfEEth, share * rate)` payout math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04130262b12bd3ce4b738415b18855e30f35b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->