### PR TITLE
Test + docs: pin withdraw(_amountOfEEth) accounting (follow-up to #454)

### DIFF
--- a/src/core/LiquidityPool.sol
+++ b/src/core/LiquidityPool.sol
@@ -288,8 +288,10 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
 
     /**
      * @notice Settles a finalized claim for withdrawRequestNFT or priorityWithdrawalQueue.
-     * @param _amount The amount of ETH to withdraw
-     * @param _amountOfEEth The amount of eETH to remove from value out of lp
+     * @param _amount The amount of ETH paid to the claimer
+     * @param _amountOfEEth The fulfill-time credit to remove from `totalValueOutOfLp`. Must
+     *        equal what was credited at fulfill/lock, not `_amount` (the two diverge on a
+     *        down-rebase). See the trust-model note below.
      * @param _rate The rate of the withdraw
      * @param _shareOfEEth The share of eETH to withdraw
      * @return uint256 The amount of eETH burned
@@ -320,6 +322,10 @@ contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, Re
      * ETH was already segregated to the caller at finalize/fulfill via
      * `addEthAmountLockedForWithdrawal` / `transferLockedEthForPriority`; LP only
      * performs accounting (burn + `totalValueOutOfLp -=`).
+     * `_amountOfEEth` is trusted caller state, not bounded by Guards 1-3; the checked
+     * `totalValueOutOfLp -= _amountOfEEth` is the only backstop (reverts on over-assertion).
+     * A negative rebase that drops `totalValueOutOfLp` below it reverts the claim
+     * (finalized-withdrawal DoS, bounded by EtherFiAdmin's rebase-APR cap).
     */
     function withdraw(uint256 _amount, uint256 _amountOfEEth, uint256 _rate, uint256 _shareOfEEth) external nonReentrant returns (uint256) {
         if (msg.sender != address(withdrawRequestNFT) && msg.sender != address(priorityWithdrawalQueue)) {

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -2549,4 +2549,40 @@ contract LiquidityPoolTest is TestSetup {
         vm.expectRevert(LiquidityPool.InvalidAmount.selector);
         liquidityPoolInstance.withdraw(amount, amount, rate, shareOfEEth);
     }
+
+    /// @dev Regression for PR #454: `withdraw` must debit `totalValueOutOfLp` by
+    ///      `_amountOfEEth` (the value credited at fulfill/lock), NOT by `_amount` (the
+    ///      ETH actually paid). On a down-rebase between finalize and claim the two diverge
+    ///      (`_amount < _amountOfEEth`); the pre-fix code debited `_amount`, leaving a
+    ///      permanent upward drift in `totalValueOutOfLp` and over-counting
+    ///      `getTotalPooledEther`. Every other `withdraw` test passes the two args equal,
+    ///      so none distinguishes the fix — this one pins the divergent case at the LP
+    ///      boundary where the bug lived. With the old code this asserts a debit of
+    ///      `amountPaid` (the bug) and fails on the second assertion below.
+    function test_withdraw_debitsAmountOfEEth_notAmountPaid() public {
+        // `_seedNftEscrow` locks `amountOfEEth` into totalValueOutOfLp, mirroring the
+        // fulfill-time `addEthAmountLockedForWithdrawal(request.amountOfEEth)` credit.
+        uint128 amountOfEEth = 100 ether;
+        _seedNftEscrow(1000 ether, amountOfEEth);
+
+        // Simulate a down-rebase: the finalized claim pays out less ETH than was locked.
+        uint256 amountPaid  = 80 ether;   // < amountOfEEth
+        uint256 shareOfEEth = 100 ether;  // generous; Guard 3 does not bind
+        uint256 rate        = 1e18;       // Guard 1 admits amountPaid <= shareOfEEth*rate/1e18
+        assertTrue(amountPaid != uint256(amountOfEEth), "setup must exercise the divergent case");
+
+        uint256 outLpBefore = liquidityPoolInstance.totalValueOutOfLp();
+
+        vm.prank(address(withdrawRequestNFTInstance));
+        liquidityPoolInstance.withdraw(amountPaid, uint256(amountOfEEth), rate, shareOfEEth);
+
+        uint256 debit = outLpBefore - liquidityPoolInstance.totalValueOutOfLp();
+
+        // The debit unwinds exactly the fulfill-time credit, restoring the baseline...
+        assertEq(debit, uint256(amountOfEEth),
+            "withdraw must debit totalValueOutOfLp by _amountOfEEth (the fulfill credit)");
+        // ...and must NOT track the smaller ETH amount paid out (the pre-fix bug).
+        assertTrue(debit != amountPaid,
+            "regression: debit must not follow _amount when it diverges from _amountOfEEth");
+    }
 }

--- a/test/LpRebaseWrnClaimUnderflow.t.sol
+++ b/test/LpRebaseWrnClaimUnderflow.t.sol
@@ -16,7 +16,7 @@ import "./TestSetup.sol";
 ///         has driven `totalValueOutOfLp` below `amount`, the contract's
 ///         checked subtraction
 ///
-///             totalValueOutOfLp -= uint128(_amount);     // LiquidityPool.sol:297
+///             totalValueOutOfLp -= uint128(_amountOfEEth);   // LiquidityPool.sol
 ///
 ///         underflows and the entire claim transaction reverts with
 ///         `Panic(0x11)`. This is a **user-facing DoS on a finalized

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -365,8 +365,13 @@ contract WithdrawEscrowE2ETest is TestSetup {
             "step4: LP raw ETH unchanged at claim");
         assertEq(liquidityPoolInstance.totalValueInLp(), preLp.inLp,
             "step4: totalValueInLp unchanged at claim");
-        // totalValueOutOfLp decrements by claimable (the actual ETH paid), not raw withdrawAmt
-        // — share-rate round-trip can drift by 2 wei at the live mainnet share rate
+        // totalValueOutOfLp decrements by request.amountOfEEth (the value credited at
+        // fulfill), not by the ETH actually paid. Here that credit == withdrawAmt
+        // (step2 asserts request.amountOfEEth == withdrawAmt) and there is no rebase between
+        // finalize and claim, so the two coincide. The 5-wei tolerance absorbs the share-rate
+        // round-trip drift in withdrawAmt itself. The down-rebase case, where the credit and
+        // the paid amount diverge, is pinned at the LP boundary in
+        // LiquidityPool.t.sol:test_withdraw_debitsAmountOfEEth_notAmountPaid.
         assertApproxEqAbs(liquidityPoolInstance.totalValueOutOfLp(),
             preLp.outLp - uint128(withdrawAmt), 5,
             "step4: totalValueOutOfLp after claim");


### PR DESCRIPTION
Stacked on #454. Addresses the four review findings on that PR without changing its behavior.

#454 makes `LiquidityPool.withdraw` debit `totalValueOutOfLp` by `_amountOfEEth` (the value credited at fulfill/lock) instead of `_amount` (the ETH actually paid on claim). That fix is correct — but it shipped without a guard that distinguishes the two, and left a few stale comments. This PR closes those gaps.

## Changes

**1. Regression test (the main gap).** Every existing `withdraw` test passes the two amounts equal (`withdraw(amount, amount, ...)`), so none would have failed against the pre-fix code. `test_withdraw_debitsAmountOfEEth_notAmountPaid` pins the divergent down-rebase case (`_amount < _amountOfEEth`) at the LP boundary where the bug lived: it asserts the debit equals the fulfill-time credit (`_amountOfEEth`) and explicitly does **not** track the smaller ETH paid. Runs offline (no fork).

**2. `_amountOfEEth` natspec.** Documents that it must equal the fulfill-time credit (not `_amount`), how WRN and PWQ each supply it, and that — unlike `_amount`/`_rate`/`_shareOfEEth` — it is trusted caller-supplied state not bounded by Guards 1–3. The checked subtraction is the only LP-local backstop.

**3. Negative-rebase underflow note.** Records that the fix shifts the documented finalized-withdrawal DoS threshold from `_amount` to the (larger) `_amountOfEEth`, and fixes the stale `LiquidityPool.sol:297` / `_amount` reference in the `LpRebaseWrnClaimUnderflow` finding header. Bounded by the rebase-APR cap in EtherFiAdmin.

**4. Stale comment in `WithdrawEscrowE2E` step4.** The comment said totalValueOutOfLp "decrements by claimable (the actual ETH paid)" — that's the pre-fix behavior. Corrected to describe the fulfill-time-credit debit and to point at the new LP-boundary regression test for the divergent case.

## Verification

`forge build` clean. Full withdraw suite (18 tests incl. the new one) passes offline:

```
Suite result: ok. 18 passed; 0 failed; 0 skipped
```

The `WithdrawEscrowE2E` change is comment-only (that file is a mainnet-fork test).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production logic changes—only documentation, comments, and a unit regression test for accounting already fixed in #454.
> 
> **Overview**
> Follow-up to **#454** (no change to `LiquidityPool.withdraw` behavior): it **documents and tests** that `totalValueOutOfLp` must be reduced by **`_amountOfEEth`** (fulfill/lock credit), not **`_amount`** (ETH paid on claim).
> 
> **`LiquidityPool.sol` natspec** clarifies `_amount` vs `_amountOfEEth`, that `_amountOfEEth` is trusted caller state outside Guards 1–3, and that a negative rebase can **DoS** finalized claims if `totalValueOutOfLp` falls below that debit (bounded by admin rebase APR).
> 
> **`test_withdraw_debitsAmountOfEEth_notAmountPaid`** is a new offline regression where `_amount < _amountOfEEth` (down-rebase-style) and asserts the LP debit matches the fulfill credit.
> 
> **Comment fixes:** `LpRebaseWrnClaimUnderflow` header now references `_amountOfEEth`; **`WithdrawEscrowE2E`** step4 comment matches fulfill-credit accounting and points at the new LP test for the divergent case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc4795335b3caa66584dae5b0336548ab87677b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->