### PR TITLE
yash/fix/transfer-rate-limits

### DIFF
--- a/src/core/EETH.sol
+++ b/src/core/EETH.sol
@@ -52,13 +52,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
     /// @dev Protocol-wide circuit breakers on supply changes. Mints and burns
-    ///      each draw from their own global bucket via `consumeToken`,
-    ///      independent of (and additive with) the per-address buckets. A
-    ///      compromise that bypasses per-address gating (e.g. attacker minting
-    ///      to a fresh wallet with no bucket) still has to fit inside the
-    ///      global cap. Transfers are intentionally NOT globally rate-limited
-    ///      — they don't change supply and the per-address path is the right
-    ///      tool there.
+    ///      each draw from their own global bucket via `consumeToken`. The global
+    ///      cap bounds how much supply can be created or destroyed in a window, so
+    ///      a compromised mint/burn path still has to fit inside it. Transfers are
+    ///      intentionally NOT rate-limited — they don't change supply.
     bytes32 public constant EETH_MINT_LIMIT_ID = keccak256("EETH_MINT_LIMIT_ID");
     bytes32 public constant EETH_BURN_LIMIT_ID = keccak256("EETH_BURN_LIMIT_ID");
 
@@ -133,7 +130,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
      * @notice Mint shares to a user
      * @param _user The address of the user to mint shares to
      * @param _share The amount of shares to mint
-     * @dev Rate Limited for mint bucket and per-address bucket
+     * @dev Rate Limited for the global mint bucket
      * Only callable by the liquidity pool contract
      * Only callable when the contract is not paused
      * Only callable when the user is not blacklisted
@@ -144,9 +141,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         totalShares += _share;
 
         uint256 amount = liquidityPool.amountForShare(_share);
-        uint64 amt = toBucketUnit(amount);
-        rateLimiter.consumeToken(EETH_MINT_LIMIT_ID, amt);
-        rateLimiter.consumeForAddressIfConfigured(_user, amt);
+        rateLimiter.consumeToken(EETH_MINT_LIMIT_ID, toBucketUnit(amount));
 
         emit Transfer(address(0), _user, amount);
         emit TransferShares(address(0), _user, _share);
@@ -156,7 +151,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
      * @notice Burn shares from a user
      * @param _user The address of the user to burn shares from
      * @param _share The amount of shares to burn
-     * @dev Rate Limited for burn bucket and per-address bucket
+     * @dev Rate Limited for the global burn bucket
      * Only callable by the liquidity pool contract
      * Only callable when the contract is not paused
      * Only callable when the user is not blacklisted
@@ -169,59 +164,10 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         totalShares -= _share;
 
         uint256 amount = liquidityPool.amountForShare(_share);
-        uint64 amt = toBucketUnit(amount);
-        rateLimiter.consumeToken(EETH_BURN_LIMIT_ID, amt);
-        rateLimiter.consumeForAddressIfConfigured(_user, amt);
+        rateLimiter.consumeToken(EETH_BURN_LIMIT_ID, toBucketUnit(amount));
 
         emit Transfer(_user, address(0), amount);
         emit TransferShares(_user, address(0), _share);
-    }
-
-    //--------------------------------------------------------------------------------------
-    //----------------------  PER-ADDRESS RATE LIMIT MANAGEMENT  ---------------------------
-    //--------------------------------------------------------------------------------------
-    // Thin role-gated wrappers around the internal helpers in RateLimitedToken — the
-    // rate-limit semantics live in the helper / EtherFiRateLimiter; this contract just
-    // declares the access split (Guardian = tighten, Operating Multisig = set + delete).
-    // For a single user, pass a length-1 array.
-
-    /**
-     * @notice Tighten the address rate limits
-     * @param users The addresses of the users to tighten the rate limits for
-     * @param capacities The capacities of the rate limits
-     * @param refillRates The refill rates of the rate limits
-     * @dev Only callable by the guardian
-     */
-    function tightenAddressRateLimits(
-        address[] calldata users,
-        uint64[] calldata capacities,
-        uint64[] calldata refillRates
-    ) external onlyGuardian {
-        _tightenAddressRateLimits(users, capacities, refillRates);
-    }
-
-    /**
-     * @notice Set the address rate limits
-     * @param users The addresses of the users to set the rate limits for
-     * @param capacities The capacities of the rate limits
-     * @param refillRates The refill rates of the rate limits
-     * @dev Only callable by the operating multisig
-     */
-    function setAddressRateLimits(
-        address[] calldata users,
-        uint64[] calldata capacities,
-        uint64[] calldata refillRates
-    ) external onlyOperatingMultisig {
-        _setAddressRateLimits(users, capacities, refillRates);
-    }
-
-    /**
-     * @notice Delete the address rate limits
-     * @param users The addresses of the users to delete the rate limits for
-     * @dev Only callable by the operating multisig
-     */
-    function deleteAddressRateLimits(address[] calldata users) external onlyOperatingMultisig {
-        _deleteAddressRateLimits(users);
     }
 
     //--------------------------------------------------------------------------------------
@@ -392,11 +338,7 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
      * @param _recipient The address of the recipient
      * @param _amount The amount of eETH to transfer
      * @dev Order mirrors `WeETH._beforeTokenTransfer`: pause + blacklist checks
-     * Run BEFORE the rate-limit consume so a paused/blacklisted call doesn't
-     * bother the external rate limiter, and so blacklist / pause states
-     * cannot be silently observed via rate-limit state changes (atomic revert
-     * makes this safe either way, but consistent ordering removes the
-     * duplicate-check footprint that previously lived in `_transferShares`).
+     * run first. Transfers are NOT rate-limited — they don't change supply.
      * Only callable when the contract is not paused
      * Only callable when the sender is not blacklisted
      * Only callable when the recipient is not blacklisted
@@ -406,10 +348,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         blacklister.nonBlacklisted(_recipient);
         blacklister.nonBlacklisted(msg.sender);
         if (_sender == address(0) || _recipient == address(0)) revert AddressZero();
-
-        uint64 amt = toBucketUnit(_amount);
-        rateLimiter.consumeForAddressIfConfigured(_sender,    amt);
-        rateLimiter.consumeForAddressIfConfigured(_recipient, amt);
 
         uint256 _sharesToTransfer = liquidityPool.sharesForAmount(_amount);
         _transferShares(_sender, _recipient, _sharesToTransfer);

--- a/src/core/WeETH.sol
+++ b/src/core/WeETH.sol
@@ -175,51 +175,6 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------  PER-ADDRESS RATE LIMIT MANAGEMENT  ---------------------------
-    //--------------------------------------------------------------------------------------
-    // Thin role-gated wrappers around the internal helpers in RateLimitedToken.
-    // For a single user, pass a length-1 array.
-
-    /**
-     * @notice Tightens the address rate limits
-     * @param users the addresses of the users
-     * @param capacities the capacities of the users
-     * @param refillRates the refill rates of the users
-     * @dev Only callable by the guardian
-     */
-    function tightenAddressRateLimits(
-        address[] calldata users,
-        uint64[] calldata capacities,
-        uint64[] calldata refillRates
-    ) external onlyGuardian {
-        _tightenAddressRateLimits(users, capacities, refillRates);
-    }
-
-    /**
-     * @notice Sets the address rate limits
-     * @param users the addresses of the users
-     * @param capacities the capacities of the users
-     * @param refillRates the refill rates of the users
-     * @dev Only callable by the operating multisig
-     */
-    function setAddressRateLimits(
-        address[] calldata users,
-        uint64[] calldata capacities,
-        uint64[] calldata refillRates
-    ) external onlyOperatingMultisig {
-        _setAddressRateLimits(users, capacities, refillRates);
-    }
-
-    /**
-     * @notice Deletes the address rate limits
-     * @param users the addresses of the users
-     * @dev Only callable by the operating multisig
-     */
-    function deleteAddressRateLimits(address[] calldata users) external onlyOperatingMultisig {
-        _deleteAddressRateLimits(users);
-    }
-
-    //--------------------------------------------------------------------------------------
     //--------------------------------  PAUSING FUNCTIONS  ---------------------------------
     //--------------------------------------------------------------------------------------
     /**
@@ -289,7 +244,6 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         blacklister.nonBlacklisted(to);
         blacklister.nonBlacklisted(msg.sender);
 
-        uint64 amt = toBucketUnit(amount);
         bytes32 slot = _WRAP_CTX_SLOT;
         uint256 wrapCtx;
         assembly { wrapCtx := tload(slot) }
@@ -297,17 +251,12 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         if (from == address(0)) {
             // mint: value-neutral wraps skip the global; everything else (bridge,
             // future mint authority, exploit) trips the global circuit breaker.
-            if (wrapCtx == 0) rateLimiter.consumeToken(WEETH_MINT_LIMIT_ID, amt);
-            rateLimiter.consumeForAddressIfConfigured(to, amt);
+            if (wrapCtx == 0) rateLimiter.consumeToken(WEETH_MINT_LIMIT_ID, toBucketUnit(amount));
         } else if (to == address(0)) {
             // burn: same — unwrap is value-neutral; anything else trips global BURN.
-            if (wrapCtx == 0) rateLimiter.consumeToken(WEETH_BURN_LIMIT_ID, amt);
-            rateLimiter.consumeForAddressIfConfigured(from, amt);
-        } else {
-            // transfer: no supply change, per-address only.
-            rateLimiter.consumeForAddressIfConfigured(from, amt);
-            rateLimiter.consumeForAddressIfConfigured(to,   amt);
+            if (wrapCtx == 0) rateLimiter.consumeToken(WEETH_BURN_LIMIT_ID, toBucketUnit(amount));
         }
+        // transfer (from != 0 && to != 0): no supply change, not rate-limited.
     }
 
     /**

--- a/src/governance/rate-limiting/EtherFiRateLimiter.sol
+++ b/src/governance/rate-limiting/EtherFiRateLimiter.sol
@@ -11,9 +11,9 @@ import "@etherfi/governance/rate-limiting/libraries/BucketLimiter.sol";
 
 contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeable, DeprecatedOZPausable, Pausable {
 
-    /// @dev Hardcoded callers for the per-address bucket API. Only the eETH and weETH
-    ///      proxies can create/update/delete/consume per-address buckets; gating is
-    ///      enforced via the `onlyToken` modifier rather than an admin-managed mapping
+    /// @dev Hardcoded callers for the token-only `consumeToken` entry point. Only the
+    ///      eETH and weETH proxies may consume from the global mint/burn buckets; gating
+    ///      is enforced via the `onlyToken` modifier rather than an admin-managed mapping
     ///      so the surface stays minimal and the trust boundary is obvious on-chain.
     address public immutable eETH;
     address public immutable weETH;
@@ -23,11 +23,6 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     //---------------------------------------------------------------------------
     mapping(bytes32 bucketId => BucketLimiter.Limit) limits;
     mapping(bytes32 bucketId => mapping(address consumer => bool allowed)) consumers;
-
-    /// @dev token (eETH/weETH) -> user -> their rate-limit bucket. `lastRefill == 0`
-    ///      is the unique "never created" sentinel because BucketLimiter.create always
-    ///      stamps `lastRefill = block.timestamp` on a real chain.
-    mapping(address token => mapping(address user => BucketLimiter.Limit)) addressLimits;
 
     //-------------------------------------------------------------------------
     //-------------------------  Deployment  ----------------------------------
@@ -100,62 +95,6 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
         emit RemainingUpdated(id, remaining);
     }
 
-    //-------------------------------------------------------------------------
-    //----------------------  Per-address buckets  ----------------------------
-    //-------------------------------------------------------------------------
-
-    /// @notice Create or tighten a per-user bucket under the calling token's namespace.
-    /// @dev Callable only by eETH/weETH; the token contract gates this to the Guardian.
-    ///      If a bucket already exists, both `capacity` and `refillRate` must be ≤ their
-    ///      current values — Guardian can only tighten, never loosen. A fresh bucket can
-    ///      be created with any starting parameters because there's no looser prior state
-    ///      to compare against (no bucket == unrestricted). `capacity = 0` on an existing
-    ///      bucket is the tightest move and acts as a hard freeze (consume reverts).
-    ///
-    ///      Remaining-balance behavior: `BucketLimiter.setCapacity` / `setRefillRate`
-    ///      apply any pending refill FIRST (against the previous cap/rate), then enforce
-    ///      the new lower bounds. So a long-drained bucket can effectively be refreshed
-    ///      to (refilled-previous-state) then capped down to `newCapacity`. Net effect:
-    ///      `remaining` is bounded above by both the refilled-previous-state and the new
-    ///      capacity. The user can never end up with MORE consumable than they could
-    ///      have spent in one consume against the previous cap, so tightening still only
-    ///      restricts the user's max burst — it cannot loosen them.
-    function tightenAddressLimit(address user, uint64 capacity, uint64 refillRate) external onlyToken {
-        BucketLimiter.Limit storage lim = addressLimits[msg.sender][user];
-        if (lim.lastRefill == 0) {
-            // `lastRefill == 0` is the "never created" sentinel — BucketLimiter.create
-            // stamps block.timestamp, which is non-zero on any real chain.
-            addressLimits[msg.sender][user] = BucketLimiter.create(capacity, refillRate);
-        } else {
-            if (capacity   > lim.capacity)   revert NotTightening();
-            if (refillRate > lim.refillRate) revert NotTightening();
-            BucketLimiter.setCapacity(lim, capacity);
-            BucketLimiter.setRefillRate(lim, refillRate);
-        }
-        emit AddressLimitTightened(msg.sender, user, capacity, refillRate);
-    }
-
-    /// @notice Set or update a per-user bucket with no tightening constraint.
-    /// @dev Callable only by eETH/weETH; the token contract gates this to the
-    ///      Operating Multisig. This is the only path that can raise capacity or
-    ///      refill rate after Guardian has tightened (or frozen) a user, and it
-    ///      fully resets the bucket — `remaining` returns to the new capacity rather
-    ///      than being preserved. Multisig is the trust escape hatch: a single call
-    ///      here must be able to restore a user to a fully-usable state.
-    function setAddressLimit(address user, uint64 capacity, uint64 refillRate) external onlyToken {
-        addressLimits[msg.sender][user] = BucketLimiter.create(capacity, refillRate);
-        emit AddressLimitSet(msg.sender, user, capacity, refillRate);
-    }
-
-    /// @notice Delete a per-user bucket; the user returns to the unrestricted default.
-    /// @dev Callable only by eETH/weETH; the token contract gates this to the
-    ///      Operating Multisig. Distinct from `tightenAddressLimit(user, 0, 0)` —
-    ///      that freezes the user (consume reverts), this removes the limit entirely.
-    function deleteAddressLimit(address user) external onlyToken {
-        delete addressLimits[msg.sender][user];
-        emit AddressLimitDeleted(msg.sender, user);
-    }
-
     //--------------------------------------------------------------------------------------
     //-----------------------------------  Core  -------------------------------------------
     //--------------------------------------------------------------------------------------
@@ -171,17 +110,16 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
     /// @notice Consume capacity from a global rate limit; reverts on insufficient capacity.
     /// @param id The rate limit identifier
     /// @param amount The amount to consume in gwei
-    /// @dev Token-only entry point for transfer/mint/burn paths. Intentionally skips
+    /// @dev Token-only entry point for the global mint/burn buckets. Intentionally skips
     ///      `whenNotPaused` — pausing the rate limiter must not halt token transfers;
     ///      operators pause the token contract itself for a hard stop. `onlyToken`
     ///      restricts callers to eETH/weETH, and `_consume` still enforces the consumer
     ///      whitelist, so the token must also be admin-whitelisted on the target bucket.
     ///
     ///      CAPACITY == 0 SEMANTICS: `capacity == 0` on an existing bucket reverts
-    ///      LimitExceeded (symmetric with `consumeForAddressIfConfigured` below). To
-    ///      soft-disable a global rate limit without un-whitelisting the consumer,
-    ///      set capacity to type(uint64).max — effectively unlimited, the consume
-    ///      always succeeds.
+    ///      LimitExceeded. To soft-disable a global rate limit without un-whitelisting
+    ///      the consumer, set capacity to type(uint64).max — effectively unlimited, the
+    ///      consume always succeeds.
     function consumeToken(bytes32 id, uint64 amount) external onlyToken {
         _consume(id, amount);
     }
@@ -190,26 +128,6 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
         if (!limitExists(id)) revert UnknownLimit();
         if (!consumers[id][msg.sender]) revert InvalidConsumer();
         if (!BucketLimiter.consume(limits[id], amount)) revert LimitExceeded();
-    }
-
-    /// @notice Consume from a per-address bucket; no-op if the user has no bucket configured.
-    /// @dev Callable only by eETH/weETH. `lastRefill == 0` uniquely identifies "never
-    ///      created" (unrestricted user) and short-circuits to a no-op.
-    ///
-    ///      CAPACITY == 0 SEMANTICS: `capacity == 0` on an existing bucket reverts
-    ///      LimitExceeded (symmetric with `consumeToken` above). This is the
-    ///      freeze path the Guardian uses via `tightenAddressLimit(user, 0, 0)`; the
-    ///      Multisig clears it via `deleteAddressLimit` (returns to "never created" →
-    ///      no-op) or `setAddressLimit` (creates fresh with non-zero cap). The two
-    ///      distinct sentinel states — deleted (lastRefill == 0) vs frozen (cap == 0,
-    ///      lastRefill > 0) — keep the Guardian/Multisig access split meaningful.
-    ///
-    ///      Intentionally skips `whenNotPaused`: pausing the rate limiter must not halt
-    ///      token transfers.
-    function consumeForAddressIfConfigured(address user, uint64 amount) external onlyToken {
-        BucketLimiter.Limit storage lim = addressLimits[msg.sender][user];
-        if (lim.lastRefill == 0) return;
-        if (!BucketLimiter.consume(lim, amount)) revert LimitExceeded();
     }
 
     /// @notice Checks if a specific amount can be consumed from a rate limit
@@ -243,23 +161,6 @@ contract EtherFiRateLimiter is IEtherFiRateLimiter, Initializable, UUPSUpgradeab
         if (!limitExists(id)) revert UnknownLimit();
         BucketLimiter.Limit memory limit = limits[id];
         return (limit.capacity, limit.remaining, limit.refillRate, limit.lastRefill);
-    }
-
-    /// @notice Returns the complete state of a per-address bucket.
-    /// @dev Returns the raw struct — callers can check `lastRefill == 0` to detect
-    ///      "no bucket configured" (unrestricted user).
-    function getAddressLimit(address token, address user)
-        external
-        view
-        returns (uint64 capacity, uint64 remaining, uint64 refillRate, uint256 lastRefill)
-    {
-        BucketLimiter.Limit memory lim = addressLimits[token][user];
-        return (lim.capacity, lim.remaining, lim.refillRate, lim.lastRefill);
-    }
-
-    /// @notice Returns true if a per-address bucket has been created for (token, user).
-    function addressLimitExists(address token, address user) external view returns (bool) {
-        return addressLimits[token][user].lastRefill != 0;
     }
 
     /// @notice Checks if a consumer is allowed to use a specific rate limit

--- a/src/governance/rate-limiting/RateLimitedToken.sol
+++ b/src/governance/rate-limiting/RateLimitedToken.sol
@@ -6,19 +6,14 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@etherfi/governance/rate-limiting/interfaces/IEtherFiRateLimiter.sol";
 
 /// @title  RateLimitedToken
-/// @notice Token-side helpers for the per-address rate-limit feature on EtherFiRateLimiter.
-///         Holds the `rateLimiter` immutable, the gwei conversion helper, and `internal`
-///         primitives for the six per-address bucket operations. eETH and weETH inherit
-///         this and wrap the internals with their own role-gated `external` functions —
-///         this contract intentionally exposes no `external` surface and performs no
-///         access control. Access control is the inheriting token's responsibility (via
-///         the modifiers in RolesLibrary), so the rate-limit semantics stay single-sourced
-///         while role-gating decisions remain co-located with the rest of the token's
-///         access model.
+/// @notice Token-side helper for the global mint/burn rate-limit buckets on
+///         EtherFiRateLimiter. Holds the `rateLimiter` immutable and the gwei
+///         conversion helper used when consuming from those buckets. eETH and weETH
+///         inherit this; the actual consume calls live in the token mint/burn paths.
+///         This contract intentionally exposes no `external` surface and performs no
+///         access control.
 abstract contract RateLimitedToken {
     IEtherFiRateLimiter public immutable rateLimiter;
-
-    error LengthMismatch();
 
     constructor(address _rateLimiter) {
         rateLimiter = IEtherFiRateLimiter(_rateLimiter);
@@ -37,49 +32,5 @@ abstract contract RateLimitedToken {
     function toBucketUnit(uint256 amount) internal pure returns (uint64) {
         uint256 gweiAmount = Math.ceilDiv(amount, 1 gwei);
         return gweiAmount > type(uint64).max ? type(uint64).max : uint64(gweiAmount);
-    }
-
-    //--------------------------------------------------------------------------
-    //                        Internal Guardian-side helpers
-    //--------------------------------------------------------------------------
-
-    /// @dev Token must gate this to the Guardian. See EtherFiRateLimiter for the
-    ///      tightening invariant: new capacity / refill ≤ current; `cap = 0` = freeze.
-    ///      Use a length-1 array for the single-user case — there's no separate
-    ///      single-address entry point.
-    function _tightenAddressRateLimits(
-        address[] calldata users,
-        uint64[] calldata capacities,
-        uint64[] calldata refillRates
-    ) internal {
-        if (users.length != capacities.length || users.length != refillRates.length) revert LengthMismatch();
-        for (uint256 i; i < users.length; ++i) {
-            rateLimiter.tightenAddressLimit(users[i], capacities[i], refillRates[i]);
-        }
-    }
-
-    //--------------------------------------------------------------------------
-    //                       Internal Multisig-side helpers
-    //--------------------------------------------------------------------------
-
-    /// @dev Token must gate this to the Operating Multisig. Fully resets the bucket
-    ///      (`remaining` returns to capacity); this is the unfreeze / raise path.
-    function _setAddressRateLimits(
-        address[] calldata users,
-        uint64[] calldata capacities,
-        uint64[] calldata refillRates
-    ) internal {
-        if (users.length != capacities.length || users.length != refillRates.length) revert LengthMismatch();
-        for (uint256 i; i < users.length; ++i) {
-            rateLimiter.setAddressLimit(users[i], capacities[i], refillRates[i]);
-        }
-    }
-
-    /// @dev Token must gate this to the Operating Multisig. Deletes the bucket entirely;
-    ///      the user returns to the unrestricted default.
-    function _deleteAddressRateLimits(address[] calldata users) internal {
-        for (uint256 i; i < users.length; ++i) {
-            rateLimiter.deleteAddressLimit(users[i]);
-        }
     }
 }

--- a/src/governance/rate-limiting/interfaces/IEtherFiRateLimiter.sol
+++ b/src/governance/rate-limiting/interfaces/IEtherFiRateLimiter.sol
@@ -16,17 +16,9 @@ interface IEtherFiRateLimiter {
     function canConsume(bytes32 id, uint64 amount) external view returns (bool);
     function consumable(bytes32 id) external view returns (uint64);
 
-    // per-address (callable only by eETH/weETH; gated upstream to Guardian or Multisig)
-    function tightenAddressLimit(address user, uint64 capacity, uint64 refillRate) external;
-    function setAddressLimit(address user, uint64 capacity, uint64 refillRate) external;
-    function deleteAddressLimit(address user) external;
-    function consumeForAddressIfConfigured(address user, uint64 amount) external;
-
 
     // view functions
     function getLimit(bytes32 id) external view returns (uint64 capacity, uint64 remaining, uint64 refillRate, uint256 lastRefill);
-    function getAddressLimit(address token, address user) external view returns (uint64 capacity, uint64 remaining, uint64 refillRate, uint256 lastRefill);
-    function addressLimitExists(address token, address user) external view returns (bool);
     function isConsumerAllowed(bytes32 id, address consumer) external view returns (bool);
     function limitExists(bytes32 id) external view returns (bool);
 
@@ -40,10 +32,6 @@ interface IEtherFiRateLimiter {
     event RemainingUpdated(bytes32 indexed id, uint256 remaining);
     event ConsumerUpdated(bytes32 indexed id, address indexed consumer, bool allowed);
 
-    event AddressLimitTightened(address indexed token, address indexed user, uint64 capacity, uint64 refillRate);
-    event AddressLimitSet(address indexed token, address indexed user, uint64 capacity, uint64 refillRate);
-    event AddressLimitDeleted(address indexed token, address indexed user);
-
     //--------------------------------------------------------------------------
     //-----------------------------  Errors  -----------------------------------
     //--------------------------------------------------------------------------
@@ -52,5 +40,4 @@ interface IEtherFiRateLimiter {
     error LimitExceeded();
     error UnknownLimit();
     error OnlyToken();
-    error NotTightening();
 }

--- a/test/TokenRateLimit.t.sol
+++ b/test/TokenRateLimit.t.sol
@@ -3,22 +3,14 @@ pragma solidity ^0.8.13;
 
 import "@tests/TestSetup.sol";
 import "@etherfi/governance/rate-limiting/interfaces/IEtherFiRateLimiter.sol";
-import "@etherfi/governance/rate-limiting/RateLimitedToken.sol";
 
 contract TokenRateLimitTest is TestSetup {
     uint64 private constant ONE_ETHER_GWEI = 1 ether / 1 gwei; // 1e9
 
-    // `admin` is granted OPERATION_TIMELOCK, OPERATION_MULTISIG, and GUARDIAN roles
-    // by TestSetup. `attacker` here is granted GUARDIAN only — separates Guardian
-    // capabilities from Multisig capabilities in the access-control tests.
-    address internal guardianOnly;
-    address internal multisigOnly;
-    address internal unauthorized = address(0xDEAD);
-
     function setUp() public {
         setUpTests();
 
-        // Fund alice + bob with eETH so transfer/burn/wrap tests have balance to move.
+        // Fund alice + bob + chad with eETH so transfer/burn/wrap tests have balance to move.
         vm.deal(alice, 100 ether);
         vm.deal(bob, 100 ether);
         vm.deal(chad, 100 ether);
@@ -28,516 +20,84 @@ contract TokenRateLimitTest is TestSetup {
         liquidityPoolInstance.deposit{value: 50 ether}();
         vm.prank(chad);
         liquidityPoolInstance.deposit{value: 50 ether}();
+    }
 
-        // Carve out role-isolated test addresses so we can prove the access split.
-        guardianOnly = address(0xCAFE);
-        multisigOnly = address(0xBEEF);
-        vm.startPrank(owner);
-        roleRegistryInstance.grantRole(roleRegistryInstance.GUARDIAN_ROLE(), guardianOnly);
-        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), multisigOnly);
+    // =====================================================================
+    // Transfers are unrestricted — per-address rate limiting has been removed.
+    // Any transfer size succeeds and touches no rate-limit bucket.
+    // =====================================================================
+
+    function test_eETH_large_transfer_passes_unrestricted() public {
+        // Even with both eETH global buckets choked to 1 gwei, a large transfer
+        // must go through: the transfer path consumes no bucket whatsoever.
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
+        rateLimiterInstance.setRemaining(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
+        rateLimiterInstance.setCapacity(eETHInstance.EETH_BURN_LIMIT_ID(), 1);
+        rateLimiterInstance.setRemaining(eETHInstance.EETH_BURN_LIMIT_ID(), 1);
         vm.stopPrank();
-    }
-
-    // =====================================================================
-    // Single-user wrappers around the batch-only token entry points. EETH and
-    // WeETH only expose batch functions; these helpers handle the length-1
-    // array boilerplate so tests stay readable. Callers still do their own
-    // vm.prank(...) before invoking — the helpers are NOT pranking wrappers.
-    // =====================================================================
-    function _tightenEth(address user, uint64 cap, uint64 refill) internal {
-        (address[] memory u, uint64[] memory c, uint64[] memory r) = _one(user, cap, refill);
-        eETHInstance.tightenAddressRateLimits(u, c, r);
-    }
-    function _setEth(address user, uint64 cap, uint64 refill) internal {
-        (address[] memory u, uint64[] memory c, uint64[] memory r) = _one(user, cap, refill);
-        eETHInstance.setAddressRateLimits(u, c, r);
-    }
-    function _deleteEth(address user) internal {
-        address[] memory u = new address[](1);
-        u[0] = user;
-        eETHInstance.deleteAddressRateLimits(u);
-    }
-    function _tightenWeeth(address user, uint64 cap, uint64 refill) internal {
-        (address[] memory u, uint64[] memory c, uint64[] memory r) = _one(user, cap, refill);
-        weEthInstance.tightenAddressRateLimits(u, c, r);
-    }
-    function _one(address user, uint64 cap, uint64 refill)
-        internal
-        pure
-        returns (address[] memory users, uint64[] memory caps, uint64[] memory refills)
-    {
-        users = new address[](1);
-        users[0] = user;
-        caps = new uint64[](1);
-        caps[0] = cap;
-        refills = new uint64[](1);
-        refills[0] = refill;
-    }
-
-    // =====================================================================
-    // Sentinel / state-machine tests on the rate limiter directly
-    // =====================================================================
-
-    function test_addressLimit_unconfigured_is_unrestricted() public {
-        // No bucket exists for alice — transfers go through unrestricted.
-        assertFalse(rateLimiterInstance.addressLimitExists(address(eETHInstance), alice));
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 10 ether);
-    }
-
-    function test_addressLimit_lastRefill_sentinel_distinguishes_not_created_from_frozen() public {
-        (, , , uint256 lastRefillBefore) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(lastRefillBefore, 0, "not-created has lastRefill==0");
-
-        // Freeze alice (capacity=0).
-        vm.prank(admin);
-        _tightenEth(alice, 0, 0);
-
-        (uint64 cap, , , uint256 lastRefillAfter) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(cap, 0, "frozen has capacity==0");
-        assertGt(lastRefillAfter, 0, "frozen has lastRefill > 0");
-        assertTrue(rateLimiterInstance.addressLimitExists(address(eETHInstance), alice));
-    }
-
-    // =====================================================================
-    // Access control — eETH/weETH are the only callers; Guardian vs Multisig split
-    // =====================================================================
-
-    function test_rateLimiter_onlyToken_rejects_external_callers() public {
-        vm.expectRevert(IEtherFiRateLimiter.OnlyToken.selector);
-        rateLimiterInstance.tightenAddressLimit(alice, 1, 1);
-
-        vm.expectRevert(IEtherFiRateLimiter.OnlyToken.selector);
-        rateLimiterInstance.setAddressLimit(alice, 1, 1);
-
-        vm.expectRevert(IEtherFiRateLimiter.OnlyToken.selector);
-        rateLimiterInstance.deleteAddressLimit(alice);
-
-        vm.expectRevert(IEtherFiRateLimiter.OnlyToken.selector);
-        rateLimiterInstance.consumeForAddressIfConfigured(alice, 1);
-
-        // Even the operating timelock cannot bypass — only the two immutable token addresses.
-        vm.prank(admin);
-        vm.expectRevert(IEtherFiRateLimiter.OnlyToken.selector);
-        rateLimiterInstance.tightenAddressLimit(alice, 1, 1);
-    }
-
-    function test_eETH_tighten_requires_guardian() public {
-        vm.prank(unauthorized);
-        vm.expectRevert();
-        _tightenEth(alice, 1, 1);
-
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 1, 1);
-    }
-
-    function test_eETH_setAddressRateLimit_requires_multisig() public {
-        // Guardian only — must NOT be able to call the multisig-gated set.
-        vm.prank(guardianOnly);
-        vm.expectRevert();
-        _setEth(alice, 1, 1);
-
-        vm.prank(multisigOnly);
-        _setEth(alice, 1, 1);
-    }
-
-    function test_eETH_deleteAddressRateLimit_requires_multisig() public {
-        // Create via Guardian path, then attempt delete from Guardian — must revert.
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 5, 1);
-
-        vm.prank(guardianOnly);
-        vm.expectRevert();
-        _deleteEth(alice);
-
-        vm.prank(multisigOnly);
-        _deleteEth(alice);
-        assertFalse(rateLimiterInstance.addressLimitExists(address(eETHInstance), alice));
-    }
-
-    // =====================================================================
-    // Tightening invariant — Guardian can only ever move buckets stricter
-    // =====================================================================
-
-    function test_guardian_first_create_accepts_any_params() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, type(uint64).max, type(uint64).max);
-        (uint64 cap, , uint64 refill, ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(cap, type(uint64).max);
-        assertEq(refill, type(uint64).max);
-    }
-
-    function test_guardian_cannot_raise_capacity() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 10, 1);
-
-        vm.prank(guardianOnly);
-        vm.expectRevert(IEtherFiRateLimiter.NotTightening.selector);
-        _tightenEth(alice, 11, 1);
-    }
-
-    function test_guardian_cannot_raise_refillRate() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 10, 1);
-
-        vm.prank(guardianOnly);
-        vm.expectRevert(IEtherFiRateLimiter.NotTightening.selector);
-        _tightenEth(alice, 10, 2);
-    }
-
-    function test_guardian_can_lower_capacity_and_refill() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 10, 5);
-
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 4, 1);
-
-        (uint64 cap, , uint64 refill, ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(cap, 4);
-        assertEq(refill, 1);
-    }
-
-    function test_guardian_idempotent_resubmit_succeeds() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 10, 5);
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 10, 5);
-    }
-
-    function test_guardian_freeze_then_only_multisig_can_unfreeze() public {
-        // Create with capacity.
-        vm.prank(multisigOnly);
-        _setEth(alice, uint64(10 ether / 1 gwei), 0);
-
-        // Guardian freezes.
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 0, 0);
-
-        // Frozen → consume reverts on next transfer.
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.transfer(bob, 1 ether);
-
-        // Guardian cannot lift the freeze.
-        vm.prank(guardianOnly);
-        vm.expectRevert(IEtherFiRateLimiter.NotTightening.selector);
-        _tightenEth(alice, 1, 1);
-
-        // Multisig can.
-        vm.prank(multisigOnly);
-        _setEth(alice, uint64(10 ether / 1 gwei), 0);
 
         vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
+        eETHInstance.transfer(bob, 40 ether);
     }
 
-    function test_multisig_can_set_any_params() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 5, 1);
-
-        // Multisig raises capacity above prior — no constraint.
-        vm.prank(multisigOnly);
-        _setEth(alice, 100, 10);
-
-        (uint64 cap, , uint64 refill, ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(cap, 100);
-        assertEq(refill, 10);
-    }
-
-    // =====================================================================
-    // Remaining preservation: Guardian's tighten preserves remaining (capped to
-    // new capacity); Multisig's set fully resets.
-    // =====================================================================
-
-    function test_guardian_tighten_preserves_remaining_and_caps_to_new_capacity() public {
-        // Capacity 10 gwei, no refill (created by Multisig so we start unconstrained).
-        vm.prank(multisigOnly);
-        _setEth(alice, 10, 0);
-
-        // Drain 6 by transferring 6 gwei worth of eETH.
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 6 * 1 gwei);
-        (, uint64 remainingAfterConsume, , ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(remainingAfterConsume, 4, "10 - 6 = 4 remaining");
-
-        // Guardian tightens capacity to 8 — remaining must stay 4 (preserve), not reset to 8.
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 8, 0);
-        (uint64 cap1, uint64 rem1, , ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(cap1, 8);
-        assertEq(rem1, 4, "remaining preserved across tighten when new cap > remaining");
-
-        // Tighten capacity below remaining → remaining capped down to new capacity.
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 2, 0);
-        (uint64 cap2, uint64 rem2, , ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(cap2, 2);
-        assertEq(rem2, 2, "remaining capped down to new capacity");
-    }
-
-    function test_multisig_set_fully_resets_remaining() public {
-        // Drain alice's bucket.
-        vm.prank(multisigOnly);
-        _setEth(alice, 10, 0);
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 6 * 1 gwei);
-
-        // Multisig set acts as a full refresh — remaining returns to new capacity.
-        vm.prank(multisigOnly);
-        _setEth(alice, 10, 0);
-        (uint64 cap, uint64 rem, , ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        assertEq(cap, 10);
-        assertEq(rem, 10, "multisig set fully resets remaining (escape hatch)");
-    }
-
-    // =====================================================================
-    // Hot-path: transfers consume from sender AND recipient buckets
-    // =====================================================================
-
-    function test_eETH_transfer_consumes_sender_bucket() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, ONE_ETHER_GWEI, 0);
-
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
-
-        // Next transfer of any positive amount exhausts the bucket.
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.transfer(bob, 1 gwei);
-    }
-
-    function test_eETH_transfer_consumes_recipient_bucket() public {
-        // Tag bob (the recipient) only. Alice has no bucket.
-        vm.prank(guardianOnly);
-        _tightenEth(bob, ONE_ETHER_GWEI, 0);
-
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
-
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.transfer(bob, 1 gwei);
-    }
-
-    function test_eETH_self_transfer_charges_bucket_twice() public {
-        // Self-transfer attack defense: each side of a self-transfer hits the same bucket.
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 2 * ONE_ETHER_GWEI, 0);
-
-        // 1-ether self-transfer consumes 2 ether of bucket (sender + recipient).
-        vm.prank(alice);
-        eETHInstance.transfer(alice, 1 ether);
-
-        // Bucket fully drained — next 1-gwei self-transfer reverts.
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.transfer(alice, 1 gwei);
-    }
-
-    function test_eETH_tagged_user_cannot_dos_untagged_user() public {
-        // Tag alice with a tiny bucket; chad is untagged.
-        vm.prank(guardianOnly);
-        _tightenEth(alice, ONE_ETHER_GWEI, 0);
-
-        // Alice self-transfers to exhaust her bucket.
-        vm.prank(alice);
-        eETHInstance.transfer(alice, 0.5 ether);
-
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.transfer(alice, 0.6 ether);
-
-        // Chad's transfer is completely unaffected — this is the whole point.
-        vm.prank(chad);
-        eETHInstance.transfer(bob, 10 ether);
-    }
-
-    function test_eETH_mint_consumes_recipient_bucket() public {
-        vm.prank(guardianOnly);
-        _tightenEth(chad, ONE_ETHER_GWEI, 0);
-
-        // First 1 ether deposit fits.
-        vm.deal(chad, 100 ether);
-        vm.prank(chad);
-        liquidityPoolInstance.deposit{value: 1 ether}();
-
-        // Next deposit pushes past chad's mint bucket → revert in eETH.mintShares.
-        vm.prank(chad);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        liquidityPoolInstance.deposit{value: 1 gwei}();
-    }
-
-    function test_eETH_burn_consumes_user_bucket() public {
-        // burnShares mutates totalShares before computing amountForShare, so each
-        // 1-ether share consumes slightly more than 1 ETH of bucket. 2 ETH capacity
-        // fits the first burn but not two — same trick the prior bucket test used.
-        vm.prank(guardianOnly);
-        _tightenEth(alice, 2 * ONE_ETHER_GWEI, 0);
-
-        uint256 oneEthShare = liquidityPoolInstance.sharesForAmount(1 ether);
-        vm.prank(address(liquidityPoolInstance));
-        eETHInstance.burnShares(alice, oneEthShare);
-
-        vm.prank(address(liquidityPoolInstance));
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.burnShares(alice, oneEthShare);
-    }
-
-    // =====================================================================
-    // Refill behavior
-    // =====================================================================
-
-    function test_eETH_bucket_refills_over_time() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, ONE_ETHER_GWEI, uint64(0.1 ether / 1 gwei));
-
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
-
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.transfer(bob, 0.1 ether);
-
-        vm.warp(block.timestamp + 1);
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 0.1 ether);
-    }
-
-    // =====================================================================
-    // Delete returns user to unrestricted
-    // =====================================================================
-
-    function test_delete_restores_unrestricted_transfers() public {
-        vm.prank(guardianOnly);
-        _tightenEth(alice, ONE_ETHER_GWEI, 0);
-
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.transfer(bob, 1 gwei);
-
-        vm.prank(multisigOnly);
-        _deleteEth(alice);
-        assertFalse(rateLimiterInstance.addressLimitExists(address(eETHInstance), alice));
-
-        // Alice is back to fully unrestricted.
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 10 ether);
-    }
-
-    // =====================================================================
-    // Namespace isolation: eETH bucket and weETH bucket are independent
-    // =====================================================================
-
-    function test_namespaces_are_isolated_across_eETH_and_weETH() public {
-        // Tag alice on eETH only.
-        vm.prank(guardianOnly);
-        _tightenEth(alice, ONE_ETHER_GWEI, 0);
-
-        // Wrap routes alice → weETH contract on eETH side (consumes alice's eETH bucket)
-        // then mints to alice on weETH side (no weETH bucket on alice → unrestricted).
+    function test_weETH_large_transfer_passes_unrestricted() public {
+        // Wrap a chunk while buckets are unbounded, then choke the weETH globals
+        // and prove a large weETH transfer still passes.
         vm.startPrank(alice);
         eETHInstance.approve(address(weEthInstance), type(uint256).max);
-        uint256 weAmount = weEthInstance.wrap(1 ether);
+        uint256 weAmount = weEthInstance.wrap(40 ether);
         vm.stopPrank();
 
-        // Alice's eETH bucket is now drained by the wrap (1 ether sender-leg).
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        eETHInstance.transfer(bob, 1 gwei);
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(weEthInstance.WEETH_MINT_LIMIT_ID(), 1);
+        rateLimiterInstance.setRemaining(weEthInstance.WEETH_MINT_LIMIT_ID(), 1);
+        rateLimiterInstance.setCapacity(weEthInstance.WEETH_BURN_LIMIT_ID(), 1);
+        rateLimiterInstance.setRemaining(weEthInstance.WEETH_BURN_LIMIT_ID(), 1);
+        vm.stopPrank();
 
-        // But alice can move weETH freely — different namespace.
         vm.prank(alice);
         weEthInstance.transfer(bob, weAmount);
     }
 
-    function test_weETH_transfer_consumes_sender_and_recipient() public {
-        // Give alice some weETH first (no buckets configured → unrestricted wrap).
-        vm.startPrank(alice);
-        eETHInstance.approve(address(weEthInstance), type(uint256).max);
-        uint256 weAmount = weEthInstance.wrap(2 ether);
+    function test_global_transfers_are_NOT_globally_limited() public {
+        // Tighten both eETH global IDs to 1 gwei each; transfers must still go
+        // through because the transfer path does not consume MINT/BURN.
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
+        rateLimiterInstance.setRemaining(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
+        rateLimiterInstance.setCapacity(eETHInstance.EETH_BURN_LIMIT_ID(), 1);
+        rateLimiterInstance.setRemaining(eETHInstance.EETH_BURN_LIMIT_ID(), 1);
         vm.stopPrank();
 
-        // Tag alice on weETH only.
-        uint64 cap = uint64(weAmount / 2 / 1 gwei);
-        vm.prank(guardianOnly);
-        _tightenWeeth(alice, cap, 0);
-
-        // First transfer fits in the bucket.
         vm.prank(alice);
-        weEthInstance.transfer(bob, weAmount / 2);
-
-        // Next one exceeds → revert.
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        weEthInstance.transfer(bob, 1);
-    }
-
-    function test_weETH_wrap_consumes_recipient_bucket_via_mint() public {
-        // Tag alice on weETH only — wrap mints weETH to alice (to-leg of _beforeTokenTransfer).
-        vm.prank(guardianOnly);
-        _tightenWeeth(alice, ONE_ETHER_GWEI, 0);
-
-        vm.startPrank(alice);
-        eETHInstance.approve(address(weEthInstance), type(uint256).max);
-        // The amount of weETH minted equals sharesForAmount(1 ether). Under
-        // typical fork state this is < 1 ether, but in fresh-state tests with
-        // 1:1 share ratio it is exactly 1 ether → fits the bucket.
-        weEthInstance.wrap(1 ether);
-
-        // Next wrap exhausts alice's weETH bucket.
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        weEthInstance.wrap(1 gwei);
-        vm.stopPrank();
+        eETHInstance.transfer(bob, 1 ether);
     }
 
     // =====================================================================
-    // Batch entry points
+    // Access control — eETH/weETH are the only callers of consumeToken.
     // =====================================================================
 
-    function test_eETH_batch_tighten_applies_each_user() public {
-        address[] memory users      = new address[](2);
-        uint64[]  memory capacities = new uint64[](2);
-        uint64[]  memory refills    = new uint64[](2);
-        users[0] = alice; capacities[0] = 10; refills[0] = 1;
-        users[1] = bob;   capacities[1] = 20; refills[1] = 2;
+    function test_rateLimiter_consumeToken_onlyToken_rejects_external_callers() public {
+        bytes32 mintId = eETHInstance.EETH_MINT_LIMIT_ID();
 
-        vm.prank(guardianOnly);
-        eETHInstance.tightenAddressRateLimits(users, capacities, refills);
+        vm.expectRevert(IEtherFiRateLimiter.OnlyToken.selector);
+        rateLimiterInstance.consumeToken(mintId, 1);
 
-        (uint64 aCap, , uint64 aRefill, ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), alice);
-        (uint64 bCap, , uint64 bRefill, ) = rateLimiterInstance.getAddressLimit(address(eETHInstance), bob);
-        assertEq(aCap, 10);
-        assertEq(aRefill, 1);
-        assertEq(bCap, 20);
-        assertEq(bRefill, 2);
-    }
-
-    function test_eETH_batch_mismatched_lengths_reverts() public {
-        address[] memory users      = new address[](2);
-        uint64[]  memory capacities = new uint64[](1);
-        uint64[]  memory refills    = new uint64[](2);
-        users[0] = alice; users[1] = bob;
-        capacities[0] = 1;
-        refills[0] = 1; refills[1] = 1;
-
-        vm.prank(guardianOnly);
-        vm.expectRevert(RateLimitedToken.LengthMismatch.selector);
-        eETHInstance.tightenAddressRateLimits(users, capacities, refills);
+        // Even the operating timelock cannot bypass — only the two immutable token addresses.
+        vm.prank(admin);
+        vm.expectRevert(IEtherFiRateLimiter.OnlyToken.selector);
+        rateLimiterInstance.consumeToken(mintId, 1);
     }
 
     // =====================================================================
-    // Global MINT/BURN circuit-breaker buckets (independent of per-address)
+    // Global MINT/BURN circuit-breaker buckets
     // =====================================================================
     //
     // Setup notes:
     // - TestSetup bootstraps the 4 global IDs at type(uint64).max so generic
     //   tests don't hit them. We tighten the specific ID under test via the
     //   rate limiter's admin API (pranked as admin / OPERATION_TIMELOCK).
-    // - These tests use addresses with NO per-address bucket, so any revert is
-    //   guaranteed to come from the global side.
 
     function test_global_eETH_mint_bucket_throttles_protocol_wide_mints() public {
         // Cap the global mint bucket at exactly 1 ether/gwei, no refill.
@@ -552,7 +112,7 @@ contract TokenRateLimitTest is TestSetup {
         vm.prank(chad);
         liquidityPoolInstance.deposit{value: 1 ether}();
 
-        // Bucket exhausted — next mint (different user, no per-address bucket) reverts.
+        // Bucket exhausted — next mint reverts.
         vm.deal(dan, 1 ether);
         vm.prank(dan);
         vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
@@ -577,14 +137,52 @@ contract TokenRateLimitTest is TestSetup {
         eETHInstance.burnShares(alice, oneEthShare);
     }
 
+    function test_global_eETH_mint_and_burn_buckets_are_independent() public {
+        // Tighten only MINT to a tiny non-zero cap. NOTE: capacity == 0 on a
+        // global bucket means "disabled (no-op)" per consumeToken — NOT frozen.
+        // Use 1 gwei as the smallest non-zero cap to actually throttle.
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
+        rateLimiterInstance.setRefillRate(eETHInstance.EETH_MINT_LIMIT_ID(), 0);
+        rateLimiterInstance.setRemaining(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
+        vm.stopPrank();
+
+        vm.deal(dan, 1 ether);
+        vm.prank(dan);
+        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+
+        // Burn path unaffected (BURN bucket still at type(uint64).max).
+        uint256 oneEthShare = liquidityPoolInstance.sharesForAmount(1 ether);
+        vm.prank(address(liquidityPoolInstance));
+        eETHInstance.burnShares(alice, oneEthShare);
+    }
+
+    function test_cap0_reverts_LimitExceeded_on_global_consume() public {
+        // `cap == 0` on an existing global bucket reverts LimitExceeded on every
+        // consume. To soft-disable a global rate limit without un-whitelisting the
+        // consumer, set capacity to type(uint64).max — effectively unlimited.
+        bytes32 mintId = eETHInstance.EETH_MINT_LIMIT_ID();
+
+        vm.startPrank(admin);
+        rateLimiterInstance.setCapacity(mintId, 0);
+        rateLimiterInstance.setRemaining(mintId, 0);
+        vm.stopPrank();
+
+        vm.deal(chad, 1 ether);
+        vm.prank(chad);
+        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
+        liquidityPoolInstance.deposit{value: 1 ether}();
+    }
+
     // =====================================================================
     // Wrap-aware global bucket: wrap/unwrap do NOT trip WEETH_{MINT,BURN}.
-    // Non-wrap paths DO. This is what makes the global bucket useful as a
-    // circuit breaker without exposing wrap/unwrap as a grief surface.
+    // Non-wrap supply changes DO. This is what makes the global bucket useful as
+    // a circuit breaker without exposing wrap/unwrap as a grief surface.
     // =====================================================================
 
     function test_wrap_does_NOT_consume_global_mint_bucket() public {
-        // Set MINT cap to 1 gwei — any consumption would revert. Wrap 100 ETH
+        // Set MINT cap to 1 gwei — any consumption would revert. Wrap 40 ETH
         // (massively over the cap) and assert it succeeds because the wrap
         // path is intentionally exempted from the global MINT bucket.
         vm.startPrank(admin);
@@ -650,160 +248,20 @@ contract TokenRateLimitTest is TestSetup {
         assertEq(burnRem, 1, "BURN bucket undrained after 50 wrap/unwrap cycles");
     }
 
-    function test_direct_mint_outside_wrap_DOES_consume_global() public {
-        // Simulate a non-wrap mint path (e.g., a future bridge adapter calling
-        // an internal mint reach). We can't reach `_mint` directly from outside
-        // since it's internal — but we can prove the global is wired by setting
-        // _WRAP_CTX_SLOT=0 explicitly (its default) and observing that the
-        // global IS NOT exempted on the per-address consumption path.
-        //
-        // The most faithful surrogate: drive a wrap, then INSPECT that the
-        // wrap-flag is cleared by tx end. We do this in the complementary
-        // tests below; here we just confirm the cap is set low and a wrap
-        // doesn't accidentally pass via the global being misconfigured.
+    function test_global_mint_bucket_is_wired_for_non_wrap_paths() public {
+        // A non-wrap mint path (e.g., a future bridge adapter) would NOT set the
+        // transient wrap flag and so WOULD consume the global bucket. We can't
+        // reach `_mint` directly from outside (it's internal), but we can confirm
+        // the bucket exists and weETH is whitelisted — i.e. the circuit breaker is
+        // armed for any non-wrap supply change.
         vm.startPrank(admin);
         rateLimiterInstance.setCapacity(weEthInstance.WEETH_MINT_LIMIT_ID(), ONE_ETHER_GWEI);
         rateLimiterInstance.setRefillRate(weEthInstance.WEETH_MINT_LIMIT_ID(), 0);
         rateLimiterInstance.setRemaining(weEthInstance.WEETH_MINT_LIMIT_ID(), ONE_ETHER_GWEI);
         vm.stopPrank();
 
-        // Bucket exists and is consumer-whitelisted for weETH → ready to catch
-        // any non-wrap mint. (Full coverage of an actual non-wrap mint path
-        // requires deploying a mock bridge with an internal _mint reach, which
-        // isn't part of the current contract surface — track in a follow-up if
-        // a real second mint path is added.)
         assertTrue(rateLimiterInstance.limitExists(weEthInstance.WEETH_MINT_LIMIT_ID()));
         assertTrue(rateLimiterInstance.isConsumerAllowed(weEthInstance.WEETH_MINT_LIMIT_ID(), address(weEthInstance)));
-    }
-
-    function test_wrap_flag_clears_after_revert_inside_wrap() public {
-        // If wrap reverts mid-call, the tstore write must be reverted too —
-        // otherwise a subsequent (genuinely separate) mint path in the same
-        // tx could observe a stuck flag. Force wrap to revert at the eETH
-        // transferFrom leg (no eETH approval), then attempt a regular weETH
-        // transfer in the same tx and assert it consumes the per-address
-        // bucket normally (i.e., the rate-limit path is unbroken).
-        //
-        // We can't easily orchestrate a single-tx multi-step in a foundry
-        // test without a harness contract, so this test serves as a guard
-        // for the well-defined behavior of `tstore` under revert: the spec
-        // requires that any state changes (including transient) in a
-        // reverted call frame are reverted. The wrap call MUST revert in
-        // its entirety here, and a brand-new wrap in the next tx MUST be
-        // observed as wrap-context (flag set anew).
-        vm.startPrank(alice);
-        // No approve; safeTransferFrom inside wrap will revert.
-        vm.expectRevert();
-        weEthInstance.wrap(1 ether);
-
-        // Now actually approve and wrap — must succeed and not see a stuck flag
-        // (would manifest as wrap-skipped global passing when it shouldn't).
-        eETHInstance.approve(address(weEthInstance), type(uint256).max);
-        weEthInstance.wrap(1 ether);
-        vm.stopPrank();
-    }
-
-    function test_wrap_flag_does_NOT_leak_across_txs() public {
-        // tstore is per-transaction (EIP-1153). Wrap in one tx; in the next
-        // tx, any mint that ISN'T a wrap must trip the global if the cap is
-        // set low. We approximate "non-wrap mint" by leaning on the per-address
-        // bucket check (per-address consumption is also rate-limit gated, and
-        // the wrap-flag does NOT exempt per-address — so we can prove the
-        // flag is gone by observing the per-address bucket consumes again
-        // on the wrap's recipient leg).
-        vm.prank(guardianOnly);
-        _tightenWeeth(alice, 2 * ONE_ETHER_GWEI, 0);
-
-        vm.startPrank(alice);
-        eETHInstance.approve(address(weEthInstance), type(uint256).max);
-        weEthInstance.wrap(1 ether);  // tx N: per-address recipient bucket consumed
-        vm.stopPrank();
-
-        // New tx: tstore cleared. Try another wrap that would overflow per-address.
-        vm.prank(alice);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        weEthInstance.wrap(2 ether);
-    }
-
-    function test_global_eETH_mint_and_burn_buckets_are_independent() public {
-        // Tighten only MINT to a tiny non-zero cap. NOTE: capacity == 0 on a
-        // global bucket means "disabled (no-op)" per consumeToken —
-        // NOT frozen. Use 1 gwei as the smallest non-zero cap to actually
-        // throttle. (Per-address buckets behave differently — capacity=0
-        // there reverts on consume.)
-        vm.startPrank(admin);
-        rateLimiterInstance.setCapacity(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
-        rateLimiterInstance.setRefillRate(eETHInstance.EETH_MINT_LIMIT_ID(), 0);
-        rateLimiterInstance.setRemaining(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
-        vm.stopPrank();
-
-        vm.deal(dan, 1 ether);
-        vm.prank(dan);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        liquidityPoolInstance.deposit{value: 1 ether}();
-
-        // Burn path unaffected (BURN bucket still at type(uint64).max).
-        uint256 oneEthShare = liquidityPoolInstance.sharesForAmount(1 ether);
-        vm.prank(address(liquidityPoolInstance));
-        eETHInstance.burnShares(alice, oneEthShare);
-    }
-
-    function test_global_transfers_are_NOT_globally_limited() public {
-        // Tighten both eETH global IDs to 1 gwei each; transfers must still go
-        // through because transfer path does not consume MINT/BURN.
-        vm.startPrank(admin);
-        rateLimiterInstance.setCapacity(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
-        rateLimiterInstance.setRemaining(eETHInstance.EETH_MINT_LIMIT_ID(), 1);
-        rateLimiterInstance.setCapacity(eETHInstance.EETH_BURN_LIMIT_ID(), 1);
-        rateLimiterInstance.setRemaining(eETHInstance.EETH_BURN_LIMIT_ID(), 1);
-        vm.stopPrank();
-
-        vm.prank(alice);
-        eETHInstance.transfer(bob, 1 ether);
-    }
-
-    function test_global_mint_bucket_composes_with_per_address() public {
-        // Per-address bucket on chad: 5 ether. Global mint bucket: 1 ether.
-        // First deposit (1 ETH) fits both. Second deposit fits per-address but
-        // exceeds global → revert on the global side.
-        vm.startPrank(admin);
-        rateLimiterInstance.setCapacity(eETHInstance.EETH_MINT_LIMIT_ID(), ONE_ETHER_GWEI);
-        rateLimiterInstance.setRefillRate(eETHInstance.EETH_MINT_LIMIT_ID(), 0);
-        rateLimiterInstance.setRemaining(eETHInstance.EETH_MINT_LIMIT_ID(), ONE_ETHER_GWEI);
-        vm.stopPrank();
-
-        vm.prank(guardianOnly);
-        _tightenEth(chad, 5 * ONE_ETHER_GWEI, 0);
-
-        vm.deal(chad, 100 ether);
-        vm.prank(chad);
-        liquidityPoolInstance.deposit{value: 1 ether}();
-
-        // Per-address remaining = 4 ETH. Global remaining = 0. → revert.
-        vm.prank(chad);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        liquidityPoolInstance.deposit{value: 1 gwei}();
-    }
-
-    // =====================================================================
-    // Batch entry points (continued)
-    // =====================================================================
-
-    function test_eETH_batch_delete() public {
-        // Pre-create buckets for both via Multisig.
-        vm.startPrank(multisigOnly);
-        _setEth(alice, 1, 1);
-        _setEth(bob,   1, 1);
-        vm.stopPrank();
-
-        address[] memory users = new address[](2);
-        users[0] = alice; users[1] = bob;
-
-        vm.prank(multisigOnly);
-        eETHInstance.deleteAddressRateLimits(users);
-
-        assertFalse(rateLimiterInstance.addressLimitExists(address(eETHInstance), alice));
-        assertFalse(rateLimiterInstance.addressLimitExists(address(eETHInstance), bob));
     }
 
     // =====================================================================
@@ -816,10 +274,6 @@ contract TokenRateLimitTest is TestSetup {
     // BEFORE the new eETH/weETH impls are activated. `_setupGlobalMintBurnBuckets`
     // in TestSetup is the reference bootstrap.
     //
-    // The tests below tabulate, in code, every distinct global-bucket state and
-    // the exact revert selector each one produces. If a future agent is debugging
-    // an eETH/weETH upgrade revert, this is the lookup table:
-    //
     //   Global-bucket state                                    | consumeToken behavior
     //   -------------------------------------------------------|-----------------------------
     //   1. Bucket never created (no createNewLimiter)          | revert UnknownLimit
@@ -828,24 +282,16 @@ contract TokenRateLimitTest is TestSetup {
     //   4. Bucket created, consumer whitelisted, sufficient    | succeed, decrement remaining
     //   5. Bucket created, consumer whitelisted, insufficient  | revert LimitExceeded
     //
-    // Per-address `consumeForAddressIfConfigured` uses the SAME `capacity == 0`
-    // semantic on an existing bucket (reverts LimitExceeded) — see
-    // `test_addressLimit_lastRefill_sentinel_distinguishes_not_created_from_frozen`
-    // and `test_cap0_reverts_symmetric_on_global_and_perAddress` below. The only
-    // per-address-specific state is `lastRefill == 0` ("never created" →
-    // no-op / unrestricted user), which the global path doesn't need because
-    // missing globals revert UnknownLimit instead.
-    //
     // To soft-disable a global rate limit without un-whitelisting the consumer,
     // set capacity to type(uint64).max (effectively unlimited, never trips).
     //
     // Why this matters operationally: if a 3CP upgrade bundle swaps the eETH/weETH
     // impls WITHOUT including the four createNewLimiter + updateConsumers calls in
     // the same bundle, the failure mode is total — every LP deposit and every
-    // burnShares reverts UnknownLimit. Wrap/unwrap on weETH continues to work
-    // (transient-storage flag bypasses the global on those paths), which can
-    // make the incident look partial and confusing. These tests pin down each
-    // signal so the diagnosis is unambiguous.
+    // burnShares reverts. Wrap/unwrap on weETH continues to work (transient-storage
+    // flag bypasses the global on those paths), which can make the incident look
+    // partial and confusing. These tests pin down each signal so the diagnosis is
+    // unambiguous.
 
     function test_bootstrap_state1_uncreated_bucket_reverts_UnknownLimit() public {
         // The four real IDs are already created by TestSetup and there's no API
@@ -857,21 +303,13 @@ contract TokenRateLimitTest is TestSetup {
         vm.prank(address(eETHInstance));
         vm.expectRevert(IEtherFiRateLimiter.UnknownLimit.selector);
         rateLimiterInstance.consumeToken(neverCreatedId, 1);
-
-        // Implication: a 3CP that upgrades eETH/weETH impls WITHOUT first calling
-        // createNewLimiter for EETH_MINT_LIMIT_ID / EETH_BURN_LIMIT_ID /
-        // WEETH_MINT_LIMIT_ID / WEETH_BURN_LIMIT_ID will revert every LP deposit
-        // and every burnShares with this exact selector. Include the four
-        // createNewLimiter calls in the same bundle as the impl upgrade.
     }
 
     function test_bootstrap_state2_LP_deposit_reverts_InvalidConsumer_when_consumer_not_whitelisted() public {
         // Bucket exists (TestSetup created it at uint64.max) but if eETH is
         // removed from the consumer whitelist, the consume call reverts
         // InvalidConsumer BEFORE any capacity check.
-        // NOTE: resolve the bucket ID into a local BEFORE `vm.prank` — calling
-        // `eETHInstance.EETH_MINT_LIMIT_ID()` is itself an external call and
-        // would consume the single-call prank intended for `updateConsumers`.
+        // NOTE: resolve the bucket ID into a local BEFORE `vm.prank`.
         bytes32 mintId = eETHInstance.EETH_MINT_LIMIT_ID();
         vm.prank(admin);
         rateLimiterInstance.updateConsumers(mintId, address(eETHInstance), false);
@@ -880,11 +318,6 @@ contract TokenRateLimitTest is TestSetup {
         vm.prank(chad);
         vm.expectRevert(IEtherFiRateLimiter.InvalidConsumer.selector);
         liquidityPoolInstance.deposit{value: 1 ether}();
-
-        // Implication: a 3CP that calls createNewLimiter but forgets the matching
-        // updateConsumers(id, eETH, true) reverts every deposit with this selector.
-        // Recovery is a single tx from OPERATION_TIMELOCK, but the failure is
-        // total until that tx lands. Keep both calls in the same bundle.
     }
 
     function test_bootstrap_state2_LP_burn_reverts_InvalidConsumer_when_consumer_not_whitelisted() public {
@@ -905,12 +338,6 @@ contract TokenRateLimitTest is TestSetup {
         // the transient-storage wrap-context flag short-circuits the global consume
         // BEFORE we ever reach the rate limiter. This is by design — wrap/unwrap
         // is value-neutral and must never be DOSable via global-bucket state.
-        //
-        // Any NON-wrap mint reach (a future bridge adapter, a new mint authority,
-        // an exploit) would NOT set the transient flag and WOULD hit the consumer
-        // check, reverting InvalidConsumer. The safety property still holds: the
-        // global bucket remains an enforced circuit breaker for unauthorized
-        // supply changes even if wrap/unwrap continues to function.
         bytes32 wMintId = weEthInstance.WEETH_MINT_LIMIT_ID();
         vm.prank(admin);
         rateLimiterInstance.updateConsumers(wMintId, address(weEthInstance), false);
@@ -919,54 +346,6 @@ contract TokenRateLimitTest is TestSetup {
         eETHInstance.approve(address(weEthInstance), type(uint256).max);
         weEthInstance.wrap(1 ether);
         vm.stopPrank();
-
-        // Implication: during a half-bootstrapped upgrade, wrap/unwrap will look
-        // healthy in monitoring while LP deposits and burns are all reverting.
-        // Don't be fooled into thinking the rate limiter is "mostly working" —
-        // the wrap-skip is intentional and doesn't tell you anything about
-        // whether the rest of the wiring is correct.
-    }
-
-    function test_cap0_reverts_symmetric_on_global_and_perAddress() public {
-        // Symmetry invariant: `cap == 0` on an existing bucket reverts
-        // LimitExceeded on BOTH the global and per-address paths. The only
-        // path-specific "soft no-op" state is the per-address `lastRefill == 0`
-        // (never created → unrestricted user); there is no equivalent soft state
-        // on the global side (missing globals revert UnknownLimit).
-        //
-        // To soft-disable a global rate limit without un-whitelisting the
-        // consumer, set capacity to type(uint64).max — effectively unlimited,
-        // any consume succeeds.
-
-        bytes32 mintId = eETHInstance.EETH_MINT_LIMIT_ID();
-
-        // GLOBAL leg: setCapacity(id, 0) reverts on every consume.
-        vm.startPrank(admin);
-        rateLimiterInstance.setCapacity(mintId, 0);
-        rateLimiterInstance.setRemaining(mintId, 0);
-        vm.stopPrank();
-
-        vm.deal(chad, 1 ether);
-        vm.prank(chad);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        liquidityPoolInstance.deposit{value: 1 ether}();
-
-        // Restore the global so the per-address leg below isn't shadowed by the
-        // still-zeroed global. Use uint64.max as the documented soft-disable
-        // idiom (effectively unlimited).
-        vm.startPrank(admin);
-        rateLimiterInstance.setCapacity(mintId, type(uint64).max);
-        rateLimiterInstance.setRemaining(mintId, type(uint64).max);
-        vm.stopPrank();
-
-        // PER-ADDRESS leg: tighten to (0, 0) freezes; consume reverts the same way.
-        vm.prank(guardianOnly);
-        _tightenEth(dan, 0, 0);
-
-        vm.deal(dan, 1 ether);
-        vm.prank(dan);
-        vm.expectRevert(IEtherFiRateLimiter.LimitExceeded.selector);
-        liquidityPoolInstance.deposit{value: 1 ether}();
     }
 
     function test_bootstrap_sentinel_matrix_via_rateLimiter_direct() public {
@@ -992,7 +371,7 @@ contract TokenRateLimitTest is TestSetup {
         vm.prank(admin);
         rateLimiterInstance.updateConsumers(realId, address(eETHInstance), true);
 
-        // State 3: cap == 0 → revert LimitExceeded (symmetric with per-address freeze).
+        // State 3: cap == 0 → revert LimitExceeded.
         vm.startPrank(admin);
         rateLimiterInstance.setCapacity(realId, 0);
         rateLimiterInstance.setRemaining(realId, 0);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Removes Guardian/Multisig per-user throttling and freeze paths on token movement while leaving supply changes gated only by global buckets—broader blast radius if mint/burn paths are abused and no per-wallet brake on large transfers.
> 
> **Overview**
> Removes **per-address** rate limiting across `eETH`, `weETH`, `EtherFiRateLimiter`, and `RateLimitedToken`. Mint and burn still consume only the **global** `EETH_*` / `WEETH_*` buckets via `consumeToken`; **transfers** (including `eETH` `_transfer` and `weETH` peer-to-peer moves) no longer touch any bucket.
> 
> Deleted Guardian/Multisig entry points (`tightenAddressRateLimits`, `setAddressRateLimits`, `deleteAddressRateLimits`) and all limiter storage/API for per-user buckets (`addressLimits`, `consumeForAddressIfConfigured`, tighten/set/delete, views/events, `NotTightening`). **Wrap/unwrap** behavior on `weETH` is unchanged: transient wrap context still skips global mint/burn on value-neutral paths.
> 
> `test/TokenRateLimit.t.sol` is narrowed to global-bucket, unrestricted-transfer, `consumeToken` access control, wrap-exemption, and bootstrap-matrix cases; prior per-address, batch, refill, and composition tests are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2122018aef7f954999049ffb12a2e8652b127c82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->