### PR TITLE
yash/fix/deprecate-oz-ownable

### DIFF
--- a/script/DeployWeETHWithdrawAdapter.s.sol
+++ b/script/DeployWeETHWithdrawAdapter.s.sol
@@ -150,13 +150,7 @@ contract DeployWeETHWithdrawAdapter is Script {
             
             // Wrap proxy in implementation interface
             WeETHWithdrawAdapter adapter = WeETHWithdrawAdapter(proxyAddress);
-            
-            // Verify ownership is already set to timelock (no transfer needed)
-            console.log("\nVerifying ownership...");
-            address currentOwner = adapter.owner();
-            require(currentOwner == timelockAddress, "Owner should be timelock");
-            console.log("Owner correctly set to timelock:", currentOwner);
-            
+
             // Final verification
             console.log("\nVerifying deployment...");
             verifyDeployment(adapter, implementationAddress);
@@ -297,10 +291,7 @@ contract DeployWeETHWithdrawAdapter is Script {
         // Verify initialization state
         require(!adapter.paused(), "Contract should not be paused");
         console.log("[PASS] Contract is not paused");
-        
-        require(adapter.owner() == timelockAddress, "Owner should be timelock");
-        console.log("[PASS] Owner is timelock");
-        
+
         // Verify implementation
         address actualImpl = adapter.getImplementation();
         require(actualImpl == implementationAddress, "Implementation address mismatch");

--- a/script/deploys/DeployCumulativeMerkleRewardsDistributor.sol
+++ b/script/deploys/DeployCumulativeMerkleRewardsDistributor.sol
@@ -35,8 +35,8 @@ contract DeployCumulativeMerkleRewardsDistributor is Script {
         CumulativeMerkleRewardsDistributor cumulativeMerkleRewardsDistributorImplementation = new CumulativeMerkleRewardsDistributor(roleRegistryProxyAddress);
         UUPSProxy cumulativeMerkleRewardsDistributorProxy = new UUPSProxy(address(cumulativeMerkleRewardsDistributorImplementation), initializerData);
         CumulativeMerkleRewardsDistributor cumulativeMerkleInstance = CumulativeMerkleRewardsDistributor(payable(address(cumulativeMerkleRewardsDistributorProxy)));
-        //cumulativeMerkleInstance.grantRole(keccak256("CUMULATIVE_MERKLE_REWARDS_DISTRIBUTOR_ADMIN_ROLE"), msg.sender);
-        cumulativeMerkleInstance.transferOwnership(address(timelockAddress));
+        // Access control is governed by the RoleRegistry; the contract no longer
+        // has a per-contract Ownable owner to transfer.
 
         vm.stopBroadcast();
     }

--- a/src/core/EETH.sol
+++ b/src/core/EETH.sol
@@ -123,7 +123,6 @@ contract EETH is IERC20Upgradeable, UUPSUpgradeable, DeprecatedOZOwnable, Pausab
         if (_liquidityPool == address(0)) revert AddressZero();
 
         __UUPSUpgradeable_init();
-        __Ownable_init();
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/core/EETH.sol
+++ b/src/core/EETH.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import "@openzeppelin-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/utils/cryptography/EIP712Upgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/utils/CountersUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol";
@@ -16,8 +15,9 @@ import "@etherfi/governance/utils/RolesLibrary.sol";
 import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/rate-limiting/RateLimitedToken.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 
-contract EETH is IERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, IERC20PermitUpgradeable, IeETH, AssetRecovery, RateLimitedToken {
+contract EETH is IERC20Upgradeable, UUPSUpgradeable, DeprecatedOZOwnable, PausableUntil, IERC20PermitUpgradeable, IeETH, AssetRecovery, RateLimitedToken {
     using CountersUpgradeable for CountersUpgradeable.Counter;
 
     //--------------------------------------------------------------------------------------

--- a/src/core/LiquidityPool.sol
+++ b/src/core/LiquidityPool.sol
@@ -154,7 +154,6 @@ contract LiquidityPool is Initializable, DeprecatedOZOwnable, UUPSUpgradeable, R
     function initialize(address _eEthAddress, address _stakingManagerAddress, address _nodesManagerAddress, address _membershipManagerAddress, address _tNftAddress, address _etherFiAdminContract, address _withdrawRequestNFT) external initializer {
         if (_eEthAddress == address(0) || _stakingManagerAddress == address(0) || _nodesManagerAddress == address(0) || _membershipManagerAddress == address(0) || _tNftAddress == address(0)) revert DataNotSet();
         
-        __Ownable_init();
         __UUPSUpgradeable_init();
     }
 

--- a/src/core/LiquidityPool.sol
+++ b/src/core/LiquidityPool.sol
@@ -5,7 +5,6 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 
 import "@etherfi/core/interfaces/IeETH.sol";
 import "@etherfi/staking/interfaces/IStakingManager.sol";
@@ -19,8 +18,9 @@ import "@etherfi/governance/interfaces/IBlacklister.sol";
 import {ReentrancyGuardTransient} from "solady/utils/ReentrancyGuardTransient.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 
-contract LiquidityPool is Initializable, OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuardTransient, PausableUntil, ILiquidityPool {
+contract LiquidityPool is Initializable, DeprecatedOZOwnable, UUPSUpgradeable, ReentrancyGuardTransient, PausableUntil, ILiquidityPool {
     using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------

--- a/src/core/WeETH.sol
+++ b/src/core/WeETH.sol
@@ -103,7 +103,6 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, DeprecatedOZOwnable, Pausab
         __ERC20_init("Wrapped eETH", "weETH");
         __ERC20Permit_init("Wrapped eETH");
         __UUPSUpgradeable_init();
-        __Ownable_init();
     }
 
     /// @dev name changed from the version initially deployed

--- a/src/core/WeETH.sol
+++ b/src/core/WeETH.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import "@openzeppelin-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@etherfi/core/interfaces/IeETH.sol";
@@ -14,9 +13,10 @@ import "@etherfi/utils/AssetRecovery.sol";
 import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/governance/rate-limiting/RateLimitedToken.sol";
 
-contract WeETH is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUntil, ERC20PermitUpgradeable, IRateProvider, AssetRecovery, RateLimitedToken {
+contract WeETH is ERC20Upgradeable, UUPSUpgradeable, DeprecatedOZOwnable, PausableUntil, ERC20PermitUpgradeable, IRateProvider, AssetRecovery, RateLimitedToken {
     using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------

--- a/src/deposits/DepositAdapter.sol
+++ b/src/deposits/DepositAdapter.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -14,8 +13,9 @@ import "@etherfi/core/interfaces/IWeETH.sol";
 import "@etherfi/deposits/interfaces/IDepositAdapter.sol";
 import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 
-contract DepositAdapter is UUPSUpgradeable, OwnableUpgradeable, RolesLibrary, IDepositAdapter {
+contract DepositAdapter is UUPSUpgradeable, DeprecatedOZOwnable, RolesLibrary, IDepositAdapter {
     using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------

--- a/src/deposits/DepositAdapter.sol
+++ b/src/deposits/DepositAdapter.sol
@@ -72,7 +72,6 @@ contract DepositAdapter is UUPSUpgradeable, DeprecatedOZOwnable, RolesLibrary, I
      * @notice Initialize the contract
      */
     function initialize() initializer external {
-        __Ownable_init();
         __UUPSUpgradeable_init();
     }
 

--- a/src/deposits/Liquifier.sol
+++ b/src/deposits/Liquifier.sol
@@ -166,7 +166,6 @@ contract Liquifier is Initializable, UUPSUpgradeable, DeprecatedOZOwnable, Depre
     function initialize(address _treasury, address _liquidityPool, address _eigenLayerStrategyManager, address _lidoWithdrawalQueue, 
                         address _stEth, address _stEth_Eth_Pool,
                         uint32 _timeBoundCapRefreshInterval) initializer external {
-        __Ownable_init();
         __UUPSUpgradeable_init();
 
         timeBoundCapRefreshInterval = _timeBoundCapRefreshInterval;

--- a/src/deposits/Liquifier.sol
+++ b/src/deposits/Liquifier.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {ReentrancyGuardTransient} from "solady/utils/ReentrancyGuardTransient.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -13,6 +12,7 @@ import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 import "@etherfi/governance/utils/DeprecatedOZReentrancyGuard.sol";
 
@@ -20,7 +20,7 @@ import "@etherfi/eigenlayer-interfaces/IStrategyManager.sol";
 import "@etherfi/eigenlayer-interfaces/IDelegationManager.sol";
 
 /// Go wild, spread eETH/weETH to the world
-contract Liquifier is Initializable, UUPSUpgradeable, OwnableUpgradeable, DeprecatedOZPausable, PausableUntil, DeprecatedOZReentrancyGuard, ReentrancyGuardTransient, ILiquifier {
+contract Liquifier is Initializable, UUPSUpgradeable, DeprecatedOZOwnable, DeprecatedOZPausable, PausableUntil, DeprecatedOZReentrancyGuard, ReentrancyGuardTransient, ILiquifier {
     using SafeERC20 for IERC20;
     using Math for uint256;
 

--- a/src/governance/utils/DeprecatedOZOwnable.sol
+++ b/src/governance/utils/DeprecatedOZOwnable.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgradeable/contracts/utils/ContextUpgradeable.sol";
+
+/**
+ * @title DeprecatedOZOwnable
+ * @notice Storage-layout placeholder that reproduces the exact storage footprint of
+ *         OpenZeppelin's `OwnableUpgradeable` so an already-deployed proxy's layout is
+ *         preserved after migrating ownership to the custom {Ownable} base.
+ * @dev    Inherit this in the exact position where `OwnableUpgradeable` used to sit.
+ *         OZ's `OwnableUpgradeable is Initializable, ContextUpgradeable` and declares
+ *         `address _owner` + `uint256[49] __gap`. We mirror that here — including the
+ *         `ContextUpgradeable` base, which contributes its own `uint256[50]` gap. Where the
+ *         inheriting contract already pulls in `ContextUpgradeable` elsewhere (e.g. via
+ *         `OwnableUpgradeable`) it collapses to a single shared instance, exactly as it did
+ *         under OZ. Do not use any of this; it exists solely to keep storage slots stable.
+ */
+abstract contract DeprecatedOZOwnable is Initializable, ContextUpgradeable {
+    address private _owner;
+    uint256[49] private __gap;
+}

--- a/src/oracle/EtherFiAdmin.sol
+++ b/src/oracle/EtherFiAdmin.sol
@@ -204,7 +204,6 @@ contract EtherFiAdmin is Initializable, DeprecatedOZOwnable, UUPSUpgradeable, Ro
         int32 _acceptableRebaseAprInBps,
         uint16 _postReportWaitTimeInSlots
     ) external initializer {
-        __Ownable_init();
         __UUPSUpgradeable_init();
 
         acceptableRebaseAprInBps = _acceptableRebaseAprInBps;

--- a/src/oracle/EtherFiAdmin.sol
+++ b/src/oracle/EtherFiAdmin.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "@etherfi/oracle/interfaces/IEtherFiAdmin.sol";
@@ -17,12 +16,13 @@ import "@etherfi/withdrawals/interfaces/IWithdrawRequestNFT.sol";
 import "@etherfi/withdrawals/interfaces/IPriorityWithdrawalQueue.sol";
 
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 
 interface IEtherFiPausable {
     function paused() external view returns (bool);
 }
 
-contract EtherFiAdmin is Initializable, OwnableUpgradeable, UUPSUpgradeable, RolesLibrary, IEtherFiAdmin {
+contract EtherFiAdmin is Initializable, DeprecatedOZOwnable, UUPSUpgradeable, RolesLibrary, IEtherFiAdmin {
     using Math for uint256;
 
     //--------------------------------------------------------------------------------------

--- a/src/oracle/EtherFiOracle.sol
+++ b/src/oracle/EtherFiOracle.sol
@@ -116,7 +116,6 @@ contract EtherFiOracle is Initializable, DeprecatedOZOwnable, DeprecatedOZPausab
         external
         initializer
     {
-        __Ownable_init();
         __UUPSUpgradeable_init();
 
         consensusVersion = 1;

--- a/src/oracle/EtherFiOracle.sol
+++ b/src/oracle/EtherFiOracle.sol
@@ -2,16 +2,16 @@
 pragma solidity ^0.8.13;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 
 import "@etherfi/oracle/interfaces/IEtherFiOracle.sol";
 import "@etherfi/oracle/interfaces/IEtherFiAdmin.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 import "@etherfi/governance/utils/Pausable.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 
 
-contract EtherFiOracle is Initializable, OwnableUpgradeable, DeprecatedOZPausable, UUPSUpgradeable, IEtherFiOracle, Pausable {
+contract EtherFiOracle is Initializable, DeprecatedOZOwnable, DeprecatedOZPausable, UUPSUpgradeable, IEtherFiOracle, Pausable {
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------

--- a/src/restaking/EtherFiRestaker.sol
+++ b/src/restaking/EtherFiRestaker.sol
@@ -130,7 +130,6 @@ contract EtherFiRestaker is Initializable, UUPSUpgradeable, DeprecatedOZOwnable,
      * @param _liquifier The address of the liquifier
      */
     function initialize(address _liquidityPool, address _liquifier) initializer external {
-        __Ownable_init();
         __UUPSUpgradeable_init();
 
         (,, IStrategy strategy,,,,,,,,) = liquifier.tokenInfos(address(lido));

--- a/src/restaking/EtherFiRestaker.sol
+++ b/src/restaking/EtherFiRestaker.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
@@ -12,6 +11,7 @@ import "@etherfi/deposits/Liquifier.sol";
 import "@etherfi/core/LiquidityPool.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 
 import "@etherfi/eigenlayer-interfaces/IStrategyManager.sol";
@@ -23,7 +23,7 @@ import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/governance/rate-limiting/interfaces/IEtherFiRateLimiter.sol";
 import "@etherfi/restaking/interfaces/IEtherFiRestaker.sol";
 
-contract EtherFiRestaker is Initializable, UUPSUpgradeable, OwnableUpgradeable, DeprecatedOZPausable, PausableUntil, IEtherFiRestaker {
+contract EtherFiRestaker is Initializable, UUPSUpgradeable, DeprecatedOZOwnable, DeprecatedOZPausable, PausableUntil, IEtherFiRestaker {
     using SafeERC20 for IERC20;
     using Math for uint256;
     using EnumerableSet for EnumerableSet.Bytes32Set;

--- a/src/rewards/CumulativeMerkleRewardsDistributor.sol
+++ b/src/rewards/CumulativeMerkleRewardsDistributor.sol
@@ -50,7 +50,6 @@ contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistribut
      * @notice Initialize the CumulativeMerkleRewardsDistributor
      */
     function initialize() external initializer {
-        __Ownable_init();
         __UUPSUpgradeable_init();
         claimDelay = 2 days; // 48 hours
     }

--- a/src/rewards/CumulativeMerkleRewardsDistributor.sol
+++ b/src/rewards/CumulativeMerkleRewardsDistributor.sol
@@ -2,14 +2,15 @@
 pragma solidity ^0.8.24;
 
 import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {AssetRecovery} from "@etherfi/utils/AssetRecovery.sol";
 import {PausableUntil} from "@etherfi/governance/utils/PausableUntil.sol";
 import {RolesLibrary} from "@etherfi/governance/utils/RolesLibrary.sol";
+import {DeprecatedOZOwnable} from "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
+import {DeprecatedOZPausable} from "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 import {ICumulativeMerkleRewardsDistributor}  from "@etherfi/rewards/interfaces/ICumulativeMerkleRewardsDistributor.sol";
 
-contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, OwnableUpgradeable, UUPSUpgradeable, PausableUntil, AssetRecovery {
+contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, DeprecatedOZOwnable, DeprecatedOZPausable, UUPSUpgradeable, PausableUntil, AssetRecovery {
     using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------

--- a/src/rewards/CumulativeMerkleRewardsDistributor.sol
+++ b/src/rewards/CumulativeMerkleRewardsDistributor.sol
@@ -7,10 +7,9 @@ import {AssetRecovery} from "@etherfi/utils/AssetRecovery.sol";
 import {PausableUntil} from "@etherfi/governance/utils/PausableUntil.sol";
 import {RolesLibrary} from "@etherfi/governance/utils/RolesLibrary.sol";
 import {DeprecatedOZOwnable} from "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
-import {DeprecatedOZPausable} from "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 import {ICumulativeMerkleRewardsDistributor}  from "@etherfi/rewards/interfaces/ICumulativeMerkleRewardsDistributor.sol";
 
-contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, DeprecatedOZOwnable, DeprecatedOZPausable, UUPSUpgradeable, PausableUntil, AssetRecovery {
+contract CumulativeMerkleRewardsDistributor is ICumulativeMerkleRewardsDistributor, DeprecatedOZOwnable, UUPSUpgradeable, PausableUntil, AssetRecovery {
     using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------

--- a/src/rewards/EtherFiRewardsRouter.sol
+++ b/src/rewards/EtherFiRewardsRouter.sol
@@ -1,15 +1,15 @@
 pragma solidity ^0.8.24;
 
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/core/interfaces/ILiquidityPool.sol";
 
-contract EtherFiRewardsRouter is OwnableUpgradeable, UUPSUpgradeable, RolesLibrary {
+contract EtherFiRewardsRouter is DeprecatedOZOwnable, UUPSUpgradeable, RolesLibrary {
     using SafeERC20 for IERC20;
 
     //--------------------------------------------------------------------------------------

--- a/src/rewards/EtherFiRewardsRouter.sol
+++ b/src/rewards/EtherFiRewardsRouter.sol
@@ -55,7 +55,6 @@ contract EtherFiRewardsRouter is DeprecatedOZOwnable, UUPSUpgradeable, RolesLibr
      * @notice Initialize the EtherFiRewardsRouter
      */
     function initialize() public initializer {
-        __Ownable_init();
         __UUPSUpgradeable_init();
     }
 

--- a/src/staking/AuctionManager.sol
+++ b/src/staking/AuctionManager.sol
@@ -110,7 +110,6 @@ contract AuctionManager is
         numberOfBids = 1;
         whitelistEnabled = true;
 
-        __Ownable_init();
         __UUPSUpgradeable_init();
     }
 

--- a/src/staking/AuctionManager.sol
+++ b/src/staking/AuctionManager.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import {ReentrancyGuardTransient} from "solady/utils/ReentrancyGuardTransient.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import "@etherfi/staking/interfaces/IAuctionManager.sol";
@@ -10,6 +9,7 @@ import "@etherfi/staking/interfaces/INodeOperatorManager.sol";
 import "@etherfi/governance/interfaces/IBlacklister.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 import "@etherfi/governance/utils/DeprecatedOZReentrancyGuard.sol";
 
@@ -17,7 +17,7 @@ contract AuctionManager is
     Initializable,
     IAuctionManager,
     DeprecatedOZPausable,
-    OwnableUpgradeable,
+    DeprecatedOZOwnable,
     PausableUntil,
     DeprecatedOZReentrancyGuard,
     ReentrancyGuardTransient,

--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {ReentrancyGuardTransient} from "solady/utils/ReentrancyGuardTransient.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import "@etherfi/staking/interfaces/IAuctionManager.sol";
@@ -14,13 +13,14 @@ import "@etherfi/staking/interfaces/IStakingManager.sol";
 import "@etherfi/governance/rate-limiting/interfaces/IEtherFiRateLimiter.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 import "@etherfi/governance/utils/DeprecatedOZReentrancyGuard.sol";
 
 contract EtherFiNodesManager is
     Initializable,
     IEtherFiNodesManager,
-    OwnableUpgradeable,
+    DeprecatedOZOwnable,
     DeprecatedOZPausable,
     PausableUntil,
     DeprecatedOZReentrancyGuard,

--- a/src/staking/NodeOperatorManager.sol
+++ b/src/staking/NodeOperatorManager.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import "@etherfi/staking/interfaces/INodeOperatorManager.sol";
@@ -9,10 +8,11 @@ import "@etherfi/staking/interfaces/IAuctionManager.sol";
 import "@etherfi/core/interfaces/ILiquidityPool.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
 import "@etherfi/governance/utils/Pausable.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 
 /// Contract which helps us control our node operators and their permissions in different aspects of the protocol
-contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgradeable, DeprecatedOZPausable, OwnableUpgradeable, Pausable {
+contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgradeable, DeprecatedOZPausable, DeprecatedOZOwnable, Pausable {
 
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------

--- a/src/staking/NodeOperatorManager.sol
+++ b/src/staking/NodeOperatorManager.sol
@@ -72,7 +72,6 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
 
     /// @notice initializes contract
     function initialize() external initializer {
-        __Ownable_init();
         __UUPSUpgradeable_init();
     }
 

--- a/src/staking/StakingManager.sol
+++ b/src/staking/StakingManager.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.27;
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/beacon/IBeaconUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import "@etherfi/staking/interfaces/IAuctionManager.sol";
@@ -14,6 +13,7 @@ import "@etherfi/staking/interfaces/IEtherFiNode.sol";
 import "@etherfi/staking/interfaces/IEtherFiNodesManager.sol";
 import "@etherfi/staking/libraries/DepositDataRootGenerator.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 import "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 import "@etherfi/governance/utils/DeprecatedOZReentrancyGuard.sol";
 
@@ -21,7 +21,7 @@ contract StakingManager is
     Initializable,
     IStakingManager,
     IBeaconUpgradeable,
-    OwnableUpgradeable,
+    DeprecatedOZOwnable,
     DeprecatedOZPausable,
     DeprecatedOZReentrancyGuard,
     UUPSUpgradeable,

--- a/src/withdrawals/WeETHWithdrawAdapter.sol
+++ b/src/withdrawals/WeETHWithdrawAdapter.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -15,6 +14,7 @@ import {IWithdrawRequestNFT} from "@etherfi/withdrawals/interfaces/IWithdrawRequ
 import {IBlacklister} from "@etherfi/governance/interfaces/IBlacklister.sol";
 import {PausableUntil} from "@etherfi/governance/utils/PausableUntil.sol";
 import {RolesLibrary} from "@etherfi/governance/utils/RolesLibrary.sol";
+import {DeprecatedOZOwnable} from "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 
 /**
  * @title WeETHWithdrawAdapter
@@ -24,7 +24,7 @@ import {RolesLibrary} from "@etherfi/governance/utils/RolesLibrary.sol";
 contract WeETHWithdrawAdapter is 
     Initializable, 
     UUPSUpgradeable, 
-    OwnableUpgradeable, 
+    DeprecatedOZOwnable, 
     PausableUntil,
     IWeETHWithdrawAdapter
 {

--- a/src/withdrawals/WeETHWithdrawAdapter.sol
+++ b/src/withdrawals/WeETHWithdrawAdapter.sol
@@ -99,9 +99,7 @@ contract WeETHWithdrawAdapter is
      */
     function initialize(address _initialOwner) external initializer {
         if (_initialOwner == address(0)) revert ZeroAddress();
-        __Ownable_init();
         __UUPSUpgradeable_init();
-        _transferOwnership(_initialOwner);
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/withdrawals/WithdrawRequestNFT.sol
+++ b/src/withdrawals/WithdrawRequestNFT.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 import "@openzeppelin-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 
 import "@etherfi/core/interfaces/IeETH.sol";
 import "@etherfi/core/interfaces/ILiquidityPool.sol";
@@ -16,6 +15,7 @@ import "@openzeppelin/contracts/utils/Checkpoints.sol";
 import {ReentrancyGuardTransient} from "solady/utils/ReentrancyGuardTransient.sol";
 import "@etherfi/governance/utils/PausableUntil.sol";
 import "@etherfi/governance/utils/RolesLibrary.sol";
+import "@etherfi/governance/utils/DeprecatedOZOwnable.sol";
 
 /**
  * @title WithdrawRequestNFT — share-rate-freeze invariants
@@ -40,7 +40,7 @@ import "@etherfi/governance/utils/RolesLibrary.sol";
  *        `ceil(amount * 1e18 / rate) <= shareOfEEth`. These keep solvency checks and
  *        the share burn within the request's own share allocation.
  */
-contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardTransient, PausableUntil, IWithdrawRequestNFT {
+contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, DeprecatedOZOwnable, ReentrancyGuardTransient, PausableUntil, IWithdrawRequestNFT {
     using Math for uint256;
     using SafeERC20 for IERC20;
     using Checkpoints for Checkpoints.Trace224;

--- a/src/withdrawals/WithdrawRequestNFT.sol
+++ b/src/withdrawals/WithdrawRequestNFT.sol
@@ -166,7 +166,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, DeprecatedOZO
     function initialize(address _liquidityPoolAddress, address _eEthAddress, address _membershipManagerAddress) initializer external {
         if (_liquidityPoolAddress == address(0) || _eEthAddress == address(0) || _membershipManagerAddress == address(0)) revert AddressZero();
         __ERC721_init("Withdraw Request NFT", "WithdrawRequestNFT");
-        __Ownable_init();
         __UUPSUpgradeable_init();
 
         nextRequestId = 1;
@@ -452,7 +451,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, DeprecatedOZO
         blacklister.nonBlacklisted(to);
         for (uint256 i = 0; i < batchSize; i++) {
             uint256 tokenId = firstTokenId + i;
-            if (!_requests[tokenId].isValid && msg.sender != owner()) revert InvalidRequest();
+            if (!_requests[tokenId].isValid && msg.sender != roleRegistry.owner()) revert InvalidRequest();
         }
     }
 

--- a/src/withdrawals/WithdrawRequestNFT.sol
+++ b/src/withdrawals/WithdrawRequestNFT.sol
@@ -111,7 +111,6 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, DeprecatedOZO
     error EETHAmountCannotBeZero();
     error NotEnoughEEthRemainder();
     error FeeReturnFailed();
-    error InvalidRequest();
     error RequestValid();
     error RequestNotValid();
     error RequestNotFound();
@@ -451,7 +450,7 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, DeprecatedOZO
         blacklister.nonBlacklisted(to);
         for (uint256 i = 0; i < batchSize; i++) {
             uint256 tokenId = firstTokenId + i;
-            if (!_requests[tokenId].isValid && msg.sender != roleRegistry.owner()) revert InvalidRequest();
+            if (!_requests[tokenId].isValid) roleRegistry.onlyUpgradeTimelock(msg.sender);
         }
     }
 

--- a/test/EigenLayerIntegration.t.sol
+++ b/test/EigenLayerIntegration.t.sol
@@ -72,10 +72,10 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
         EtherFiNodesManager newManagerImpl = new EtherFiNodesManager(address(0x0), address(0x0));
         EtherFiNode newNodeImpl = new EtherFiNode(address(0x0), address(0x0), address(0x0), address(0x0));
 
-        vm.startPrank(managerInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         managerInstance.upgradeTo(address(newManagerImpl));
         vm.stopPrank();
-        vm.startPrank(stakingManagerInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         stakingManagerInstance.upgradeEtherFiNode(address(newNodeImpl));
         vm.stopPrank();
 
@@ -177,7 +177,7 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
         data[0] = abi.encodeWithSelector(selector, podOwner, alice);
 
         // whitelist this external call
-        vm.prank(managerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         managerInstance.updateAllowedForwardedExternalCalls(selector, delayedWithdrawalRouter, true);
 
         vm.prank(owner);
@@ -237,7 +237,7 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
         data[0] = abi.encodeWithSelector(selector, operator, signatureWithExpiry, bytes32(0));
 
         // whitelist this external call
-        vm.prank(managerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         managerInstance.updateAllowedForwardedExternalCalls(selector, delegationManager, true);
 
         assertEq(eigenLayerDelegationManager.isDelegated(podOwner), false);
@@ -260,7 +260,7 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
             data[0] = abi.encodeWithSelector(selector, podOwner);
 
             // whitelist this external call
-            vm.prank(managerInstance.owner());
+            vm.prank(roleRegistryInstance.owner());
             managerInstance.updateAllowedForwardedExternalCalls(selector, delegationManager, true);
 
             vm.prank(owner);
@@ -281,7 +281,7 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
             data[0] = abi.encodeWithSelector(selector, dsrv, signatureWithExpiry, bytes32(0));
 
             // whitelist this external call
-            vm.prank(managerInstance.owner());
+            vm.prank(roleRegistryInstance.owner());
             managerInstance.updateAllowedForwardedExternalCalls(selector, delegationManager, true);
 
             vm.startPrank(owner);
@@ -385,7 +385,7 @@ contract EigenLayerIntegraitonTest is TestSetup, ProofParsing {
 
         vm.stopPrank();
 
-        vm.startPrank(managerInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         managerInstance.updateAllowedForwardedEigenpodCalls(selector1, true);
         managerInstance.updateAllowedForwardedExternalCalls(selector2, eigenPodManager, true);
         managerInstance.updateAllowedForwardedExternalCalls(selector3, delegationManager, true);

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -39,7 +39,7 @@ contract EtherFiNodesManagerTest is TestSetup {
 
         address nodesManagerImplementation = address(new EtherFiNodesManager(address(stakingManagerInstance), address(roleRegistryInstance), address(rateLimiterInstance)));
 
-        vm.startPrank(managerInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         // ETHERFI_NODES_MANAGER_ADMIN_ROLE → OPERATION_TIMELOCK_ROLE
         roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_TIMELOCK_ROLE(), admin);
         // ETHERFI_NODES_MANAGER_EIGENLAYER_ADMIN_ROLE → HOUSEKEEPING_OPERATIONS_ROLE
@@ -93,7 +93,7 @@ contract EtherFiNodesManagerTest is TestSetup {
             address(eigenLayerEigenPodManager),
             address(eigenLayerDelegationManager)
         );
-        vm.prank(stakingManagerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         stakingManagerInstance.upgradeEtherFiNode(address(nodeImpl));
         
         // // Now create a test node

--- a/test/EtherFiRestaker.t.sol
+++ b/test/EtherFiRestaker.t.sol
@@ -230,7 +230,7 @@ contract EtherFiRestakerTest is TestSetup {
 
         address newRestakerImpl = address(new EtherFiRestaker(address(liquidityPoolInstance), address(liquifierInstance), address(eigenLayerRewardsCoordinator), address(etherFiRedemptionManagerInstance), address(roleRegistryInstance), address(rateLimiterInstance), address(eigenLayerStrategyManager), address(eigenLayerDelegationManager)));
 
-        address restakerOwner = restaker.owner();
+        address restakerOwner = roleRegistryInstance.owner();
         vm.startPrank(roleRegistryInstance.owner());
         // ETHERFI_RESTAKER_ADMIN_ROLE consolidated into OPERATION_MULTISIG_ROLE.
         roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), restakerOwner);

--- a/test/EtherFiRewardsRouter.t.sol
+++ b/test/EtherFiRewardsRouter.t.sol
@@ -77,10 +77,7 @@ contract EtherFiRewardsRouterTest is Test {
             abi.encodeWithSelector(EtherFiRewardsRouter.initialize.selector)
         );
         rewardsRouter = EtherFiRewardsRouter(payable(address(proxy)));
-        
-        // Transfer ownership to owner address
-        rewardsRouter.transferOwnership(owner);
-        
+
         // Deploy test tokens
         testToken = new TestERC20("Test Token", "TEST");
         testNFT = new TestERC721("Test NFT", "TNFT");
@@ -106,8 +103,9 @@ contract EtherFiRewardsRouterTest is Test {
     // ============ Initialization Tests ============
     
     function test_initialize_setsOwner() public {
-        // Owner is transferred to owner address in setUp
-        assertEq(rewardsRouter.owner(), owner);
+        // Ownership is now governed by the RoleRegistry rather than a per-contract
+        // Ownable owner; the router defers all access control to it.
+        assertEq(roleRegistry.owner(), owner);
     }
     
     function test_initialize_canOnlyBeCalledOnce() public {

--- a/test/EtherFiTimelock.t.sol
+++ b/test/EtherFiTimelock.t.sol
@@ -10,7 +10,7 @@ contract TimelockTest is TestSetup {
     function test_timelock() public {
         initializeRealisticFork(MAINNET_FORK);
 
-        address owner = managerInstance.owner();
+        address owner = roleRegistryInstance.owner();
         address admin = vm.addr(0x1234);
         console2.log("adminAddr:", admin);
         console2.log("ownerAddr:", owner);
@@ -26,21 +26,25 @@ contract TimelockTest is TestSetup {
 
         EtherFiTimelock tl = new EtherFiTimelock(2 days, proposers, executors, address(0x0));
 
-        // transfer ownership to new timelock
+        // transfer RoleRegistry ownership to the new timelock (Ownable2Step) so the
+        // timelock itself can later execute owner-gated calls against it.
         vm.prank(owner);
-        managerInstance.transferOwnership(address(tl));
-        assertEq(managerInstance.owner(), address(tl));
+        roleRegistryInstance.transferOwnership(address(tl));
+        vm.prank(address(tl));
+        roleRegistryInstance.acceptOwnership();
+        assertEq(roleRegistryInstance.owner(), address(tl));
 
-        // Note: EtherFiNodesManager no longer has updateAdmin - it uses role registry
-        // Using transferOwnership to a test address to test timelock functionality
+        // Exercise the timelock by scheduling an ownership transfer to a test
+        // address. RoleRegistry is Ownable2Step, so a successful execute sets the
+        // pending owner (verified at the end).
         address testOwner = vm.addr(0x9999);
-        bytes memory data = abi.encodeWithSelector(Ownable.transferOwnership.selector, testOwner);
+        bytes memory data = abi.encodeWithSelector(Ownable2StepUpgradeable.transferOwnership.selector, testOwner);
 
         // attempt to directly execute with timelock. Not allowed to do tx before queuing it
         vm.prank(owner);
         vm.expectRevert("TimelockController: operation is not ready");
         tl.execute(
-            address(managerInstance), // target
+            address(roleRegistryInstance), // target
             0,                        // value
             data,                     // encoded call data
             0,                        // optional predecessor
@@ -51,7 +55,7 @@ contract TimelockTest is TestSetup {
         vm.prank(owner);
         vm.expectRevert("TimelockController: insufficient delay");
         tl.schedule(
-            address(managerInstance), // target
+            address(roleRegistryInstance), // target
             0,                        // value
             data,                     // encoded call data
             0,                        // optional predecessor
@@ -62,7 +66,7 @@ contract TimelockTest is TestSetup {
         // schedule updateAdmin tx
         vm.prank(owner);
         tl.schedule(
-            address(managerInstance), // target
+            address(roleRegistryInstance), // target
             0,                        // value
             data,                     // encoded call data
             0,                        // optional predecessor
@@ -71,7 +75,7 @@ contract TimelockTest is TestSetup {
         );
 
         // find operation id by hashing relevant data
-        bytes32 operationId = tl.hashOperation(address(managerInstance), 0, data, 0, 0);
+        bytes32 operationId = tl.hashOperation(address(roleRegistryInstance), 0, data, 0, 0);
 
         // cancel the scheduled tx
         vm.prank(owner);
@@ -84,7 +88,7 @@ contract TimelockTest is TestSetup {
         vm.prank(owner);
         vm.expectRevert("TimelockController: operation is not ready");
         tl.execute(
-            address(managerInstance), // target
+            address(roleRegistryInstance), // target
             0,                        // value
             data,                     // encoded call data
             0,                        // optional predecessor
@@ -94,7 +98,7 @@ contract TimelockTest is TestSetup {
         // schedule again and wait
         vm.prank(owner);
         tl.schedule(
-            address(managerInstance), // target
+            address(roleRegistryInstance), // target
             0,                        // value
             data,                     // encoded call data
             0,                        // optional predecessor
@@ -107,7 +111,7 @@ contract TimelockTest is TestSetup {
         vm.prank(admin);
         vm.expectRevert();
         tl.execute(
-            address(managerInstance), // target
+            address(roleRegistryInstance), // target
             0,                        // value
             data,                     // encoded call data
             0,                        // optional predecessor
@@ -117,15 +121,15 @@ contract TimelockTest is TestSetup {
         // exec account should be able to execute tx
         vm.prank(owner);
         tl.execute(
-            address(managerInstance), // target
+            address(roleRegistryInstance), // target
             0,                        // value
             data,                     // encoded call data
             0,                        // optional predecessor
             0                         // optional salt
         );
         
-        // Verify ownership was transferred
-        assertEq(managerInstance.owner(), testOwner);
+        // Verify the pending owner was set via the timelock-executed call.
+        assertEq(roleRegistryInstance.pendingOwner(), testOwner);
 
 
         // TODO(dave): update test with role registry changes
@@ -208,7 +212,7 @@ contract TimelockTest is TestSetup {
             0,                        // optional predecessor
             0                         // optional salt
         );
-        assertEq(managerInstance.owner(), newOwner);
+        assertEq(roleRegistryInstance.owner(), newOwner);
         */
     }
 

--- a/test/LiquidityPool.t.sol
+++ b/test/LiquidityPool.t.sol
@@ -2035,7 +2035,7 @@ contract LiquidityPoolTest is TestSetup {
         uint256 sharesBefore = eETHInstance.totalShares();
 
         // Run migration as owner.
-        address ownerAddr = liquidityPoolInstance.owner();
+        address ownerAddr = roleRegistryInstance.owner();
         vm.prank(ownerAddr);
         liquidityPoolInstance.initializeOnUpgradeV2();
 

--- a/test/Liquifier.t.sol
+++ b/test/Liquifier.t.sol
@@ -91,7 +91,7 @@ contract LiquifierTest is TestSetup {
 
         vm.deal(alice, 100 ether);
 
-        vm.startPrank(liquifierInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         liquifierInstance.updateQuoteStEthWithCurve(true);
         liquifierInstance.updateDiscountInBasisPoints(address(stEth), 500); // 5%
         vm.stopPrank();

--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -74,7 +74,7 @@ contract PriorityWithdrawalQueueTest is TestSetup {
 
         // Upgrade WithdrawRequestNFT so it has receive() and can accept ETH escrow.
         // WITHDRAW_REQUEST_NFT_BUYBACK_SAFE = 0x2f5301a3D59388c509C65f8698f521377D41Fd0F
-        address wrnOwner = withdrawRequestNFTInstance.owner();
+        address wrnOwner = roleRegistryInstance.owner();
         vm.stopPrank();
         vm.startPrank(wrnOwner);
         WithdrawRequestNFT newWrnImpl =

--- a/test/StakingManager.t.sol
+++ b/test/StakingManager.t.sol
@@ -1360,7 +1360,7 @@ contract StakingManagerTest is TestSetup {
     }
 
     function test_upgradeEtherFiNodeFailsIfZeroAddress() public {
-        vm.prank(stakingManagerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         vm.expectRevert(IStakingManager.InvalidUpgrade.selector);
         stakingManagerInstance.upgradeEtherFiNode(address(0));
     } 

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -535,7 +535,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             existingBeacon,
             address(roleRegistryInstance)
         ));
-        vm.prank(stakingManagerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         stakingManagerInstance.upgradeTo(newSmImpl);
 
         // Upgrade EtherFiRedemptionManager on the fork for the same reason — the
@@ -583,7 +583,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 roleRegistry: address(roleRegistryInstance)
             })
         ));
-        vm.prank(depositAdapterInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         depositAdapterInstance.upgradeTo(newDepositAdapterImpl);
 
         // Upgrade LiquidityPool — deployed impl uses `onlyProtocolUpgrader`,
@@ -606,7 +606,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 membershipManager: address(membershipManagerV1Instance)
             })
         ));
-        vm.prank(liquidityPoolInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         liquidityPoolInstance.upgradeTo(newLpImpl);
 
         // Upgrade WithdrawRequestNFT — legacy `_authorizeUpgrade` is `onlyOwner`,
@@ -621,7 +621,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(blacklisterInstance),
             address(etherFiAdminInstance)
         ));
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.upgradeTo(newWrnImpl);
 
         // Upgrade EtherFiNodesManager — deployed impl uses `onlyProtocolUpgrader`.
@@ -630,7 +630,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(roleRegistryInstance),
             address(rateLimiterInstance)
         ));
-        vm.prank(managerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         managerInstance.upgradeTo(newManagerImpl);
 
         // Upgrade EtherFiAdmin — deployed impl uses `onlyProtocolUpgrader`. Tests
@@ -666,7 +666,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             address(blacklisterInstance),
             address(rateLimiterInstance)
         ));
-        vm.prank(weEthInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         weEthInstance.upgradeTo(newWeETHImpl);
 
         // Upgrade Liquifier — legacy `_authorizeUpgrade` is `onlyOwner`, but we
@@ -692,7 +692,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             LIQUIFIER_STALE_WINDOW,
             LIQUIFIER_MAX_PRICE_DEVIATION_BPS
         ));
-        vm.prank(liquifierInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         liquifierInstance.upgradeTo(newLiquifierImpl);
 
         // Now that every live proxy that authorizes upgrades through the legacy
@@ -720,16 +720,16 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // UPGRADE_TIMELOCK_ROLE. Grant it to every proxy owner address that
         // realistic-fork tests prank as for an upgradeTo call.
         roleRegistryInstance.grantRole(_upgradeTimelockRole, _roleRegOwner);
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, stakingManagerInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, depositAdapterInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, liquidityPoolInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, withdrawRequestNFTInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, managerInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiAdminInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiOracleInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, liquifierInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, nodeOperatorManagerInstance.owner());
-        roleRegistryInstance.grantRole(_upgradeTimelockRole, etherFiRestakerInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
+        roleRegistryInstance.grantRole(_upgradeTimelockRole, roleRegistryInstance.owner());
         roleRegistryInstance.grantRole(_upgradeTimelockRole, owner);
 
         // Operational roles for test setUps. Pre-consolidation, these
@@ -802,7 +802,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         // Upgrade Liquifier BEFORE swapping RoleRegistry: the live Liquifier impl
         // still authorizes upgrades through `onlyProtocolUpgrader`, which the new
-        // RoleRegistry impl no longer exposes. `liquifierInstance.owner()` matches
+        // RoleRegistry impl no longer exposes. `roleRegistryInstance.owner()` matches
         // RoleRegistry.owner() on mainnet, so the OLD impl's owner check passes.
         if (forkEnum == MAINNET_FORK || forkEnum == TESTNET_FORK) {
             // Deploy the new impl BEFORE pranking — see note above; the inlined
@@ -818,7 +818,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 etherfiRestaker: address(etherFiRestakerInstance),
                 l1SyncPool: address(0xA6)
             }), 100, LIQUIFIER_STALE_WINDOW, LIQUIFIER_MAX_PRICE_DEVIATION_BPS));
-            vm.prank(liquifierInstance.owner());
+            vm.prank(roleRegistryInstance.owner());
             liquifierInstance.upgradeTo(newLiquifierImpl);
         }
 
@@ -1563,13 +1563,13 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             }),
             10_000, 1_000, 7200
         , 100_000 ether, 500, 1000));
-        vm.prank(etherFiAdminInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         etherFiAdminInstance.upgradeTo(newAdminImpl);
     }
 
     function _upgradeOracleAndAdminForFork() internal {
         address newOracleImpl = address(new EtherFiOracle(1, address(etherFiAdminInstance), address(roleRegistryInstance)));
-        vm.prank(etherFiOracleInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         etherFiOracleInstance.upgradeTo(newOracleImpl);
 
         address newAdminImpl = address(new EtherFiAdmin(
@@ -2277,13 +2277,13 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
 
         EtherFiNode etherFiNode = new EtherFiNode(liquidityPool, etherFiNodesManager, eigenPodManager, delegationManager);
         address newImpl = address(etherFiNode);
-        vm.prank(stakingManagerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         stakingManagerInstance.upgradeEtherFiNode(newImpl);
     }
 
     function _upgrade_etherfi_nodes_manager_contract() internal {
         address newImpl = address(new EtherFiNodesManager(address(stakingManagerInstance), address(roleRegistryInstance), address(rateLimiterInstance)));
-        vm.prank(managerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         managerInstance.upgradeTo(newImpl);
     }
 
@@ -2291,7 +2291,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // TODO(dave): fix
         //address newImpl = address(new StakingManager());
         address newImpl = address(0x0);
-        vm.prank(stakingManagerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         stakingManagerInstance.upgradeTo(newImpl);
     }
 
@@ -2311,7 +2311,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
                 membershipManager: address(membershipManagerInstance)
             })
         ));
-        vm.startPrank(liquidityPoolInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         liquidityPoolInstance.upgradeTo(newImpl);
         vm.stopPrank();
     }
@@ -2328,7 +2328,7 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
             etherfiRestaker: address(0xA5),
             l1SyncPool: address(0xA6)
         }), 100, LIQUIFIER_STALE_WINDOW, LIQUIFIER_MAX_PRICE_DEVIATION_BPS));
-        vm.prank(liquifierInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         liquifierInstance.upgradeTo(newImpl);
     }
 

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -596,7 +596,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         
         // Verify cannot transfer invalid request
         vm.prank(recipient);
-        vm.expectRevert(WithdrawRequestNFT.InvalidRequest.selector);
+        vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
         withdrawRequestNFTInstance.transferFrom(recipient, address(0xdead), requestId);
 
         // Owner can seize the invalidated request NFT
@@ -1434,7 +1434,7 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // Owner cannot transfer invalid request
         vm.prank(bob);
-        vm.expectRevert(WithdrawRequestNFT.InvalidRequest.selector);
+        vm.expectRevert(RoleRegistry.OnlyUpgradeTimelock.selector);
         withdrawRequestNFTInstance.transferFrom(bob, alice, requestId);
 
         // Contract owner can transfer invalid request

--- a/test/WithdrawRequestNFT.t.sol
+++ b/test/WithdrawRequestNFT.t.sol
@@ -41,11 +41,11 @@ contract WithdrawRequestNFTTest is TestSetup {
 
         // seizeInvalidRequest is now gated by onlyUpgradeTimelock (audit L-02).
         // Grant the role to the NFT contract's owner so tests calling
-        // `vm.prank(withdrawRequestNFTInstance.owner())` can still invoke it.
+        // `vm.prank(roleRegistryInstance.owner())` can still invoke it.
         // Cache view-call results before the prank — each external call (even view)
         // consumes a single `vm.prank`.
         address roleOwner = roleRegistryInstance.owner();
-        address nftOwner = withdrawRequestNFTInstance.owner();
+        address nftOwner = roleRegistryInstance.owner();
         bytes32 upgradeRole = roleRegistryInstance.UPGRADE_TIMELOCK_ROLE();
         vm.prank(roleOwner);
         roleRegistryInstance.grantRole(upgradeRole, nftOwner);
@@ -442,7 +442,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.deal(recipient, depositAmount);
 
         // Configure remainder split
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.updateShareRemainderSplitToTreasuryInBps(remainderSplitBps);
 
         // First deposit ETH to get eETH
@@ -600,7 +600,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         withdrawRequestNFTInstance.transferFrom(recipient, address(0xdead), requestId);
 
         // Owner can seize the invalidated request NFT
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.seizeInvalidRequest(requestId, admin);
     }
 
@@ -830,13 +830,13 @@ contract WithdrawRequestNFTTest is TestSetup {
     function test_updateShareRemainderSplitToTreasuryInBps() public {
         uint16 newSplit = 5000; // 50%
         
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.updateShareRemainderSplitToTreasuryInBps(newSplit);
         
         assertEq(withdrawRequestNFTInstance.shareRemainderSplitToTreasuryInBps(), newSplit, "Split should be updated");
 
         // Test invalid value (> 10000)
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         vm.expectRevert(WithdrawRequestNFT.InvalidShareRemainderSplit.selector);
         withdrawRequestNFTInstance.updateShareRemainderSplitToTreasuryInBps(10001);
 
@@ -1311,7 +1311,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 requestId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
 
         // Cannot seize valid request
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         vm.expectRevert(WithdrawRequestNFT.RequestValid.selector);
         withdrawRequestNFTInstance.seizeInvalidRequest(requestId, admin);
 
@@ -1320,13 +1320,13 @@ contract WithdrawRequestNFTTest is TestSetup {
         withdrawRequestNFTInstance.invalidateRequest(requestId);
 
         // Cannot seize non-existent request
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         vm.expectRevert(WithdrawRequestNFT.RequestNotFound.selector);
         withdrawRequestNFTInstance.seizeInvalidRequest(99999, admin);
 
         // Owner can seize invalid request
         address recipient = alice;
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.seizeInvalidRequest(requestId, recipient);
         
         assertEq(withdrawRequestNFTInstance.ownerOf(requestId), recipient, "NFT should be transferred to recipient");
@@ -1438,7 +1438,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         withdrawRequestNFTInstance.transferFrom(bob, alice, requestId);
 
         // Contract owner can transfer invalid request
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.seizeInvalidRequest(requestId, alice);
         
         assertEq(withdrawRequestNFTInstance.ownerOf(requestId), alice, "NFT should be transferred");
@@ -2018,10 +2018,10 @@ contract WithdrawRequestNFTTest is TestSetup {
     function _clearFinalizationRatesForTest() internal {
         address cur_impl = withdrawRequestNFTInstance.getImplementation();
         address new_impl = address(new WithdrawRequestNFTIntrusive(address(roleRegistryInstance)));
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.upgradeTo(new_impl);
         WithdrawRequestNFTIntrusive(payable(address(withdrawRequestNFTInstance))).clearFinalizationRatesForTest();
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.upgradeTo(cur_impl);
     }
 
@@ -2044,7 +2044,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         vm.stopPrank();
 
         // Simulate pre-upgrade state: `legacyId` is finalized but no snapshot exists for it.
-        vm.startPrank(withdrawRequestNFTInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         _setLastFinalizedRequestIdForTest(uint32(legacyId));
         vm.stopPrank();
         assertEq(uint256(withdrawRequestNFTInstance.lastFinalizedRequestId()), legacyId, "legacy lastFinalized setup");
@@ -2054,7 +2054,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         liquidityPoolInstance.addEthAmountLockedForWithdrawal(uint128(1 ether));
 
         // Now seed the legacy sentinel (this is what the post-upgrade init call does on mainnet).
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.initializeShareRateFreezeUpgrade();
 
         // Sentinel has value 0 → frozenRateFor returns 0 → claim falls back to live rate.
@@ -2083,7 +2083,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     ///      requestIds strictly above the sentinel use the frozen rate.
     function test_shareRateFreeze_postUpgradeRequests_useFrozenRate() public {
         _clearFinalizationRatesForTest();
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.initializeShareRateFreezeUpgrade();
 
         startHoax(bob);
@@ -2102,7 +2102,7 @@ contract WithdrawRequestNFTTest is TestSetup {
     /// @dev `initializeShareRateFreezeUpgrade` is a one-shot.
     function test_shareRateFreeze_initializeUpgrade_revertsIfAlreadyInitialized() public {
         _clearFinalizationRatesForTest();
-        vm.startPrank(withdrawRequestNFTInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.initializeShareRateFreezeUpgrade();
         vm.expectRevert(WithdrawRequestNFT.AlreadyInitialized.selector);
         withdrawRequestNFTInstance.initializeShareRateFreezeUpgrade();
@@ -2251,7 +2251,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 legacyId = liquidityPoolInstance.requestWithdraw(bob, 1 ether);
         vm.stopPrank();
 
-        vm.startPrank(withdrawRequestNFTInstance.owner());
+        vm.startPrank(roleRegistryInstance.owner());
         _setLastFinalizedRequestIdForTest(uint32(legacyId));
         vm.stopPrank();
 
@@ -2266,7 +2266,7 @@ contract WithdrawRequestNFTTest is TestSetup {
         uint256 expectedPreUpgrade = Math.min(uint256(legacyReq.amountOfEEth), liveAmountForShares);
 
         // 3. call initializeShareRateFreezeUpgrade (pushes the sentinel = value 0).
-        vm.prank(withdrawRequestNFTInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         withdrawRequestNFTInstance.initializeShareRateFreezeUpgrade();
         assertEq(
             withdrawRequestNFTInstance.frozenRateFor(legacyId),

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -100,7 +100,7 @@ contract PreludeTest is Test, ArrayTestHelper {
             address(etherFiNodeBeacon),
             address(roleRegistry)
         );
-        vm.prank(stakingManager.owner());
+        vm.prank(roleRegistry.owner());
         stakingManager.upgradeTo(address(stakingManagerImpl));
 
         // Wire LP immutables to the real mainnet proxy addresses so calls into
@@ -120,11 +120,11 @@ contract PreludeTest is Test, ArrayTestHelper {
                 membershipManager: 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000
             })
         );
-        vm.prank(LiquidityPool(payable(address(liquidityPool))).owner());
+        vm.prank(roleRegistry.owner());
         LiquidityPool(payable(address(liquidityPool))).upgradeTo(address(liquidityPoolImpl));
 
         EtherFiNodesManager etherFiNodesManagerImpl = new EtherFiNodesManager(address(stakingManager), address(roleRegistry), address(rateLimiter));
-        vm.prank(etherFiNodesManager.owner());
+        vm.prank(roleRegistry.owner());
         etherFiNodesManager.upgradeTo(address(etherFiNodesManagerImpl));
 
         // Now swap RoleRegistry in place so newly-added role getters defined in
@@ -136,9 +136,9 @@ contract PreludeTest is Test, ArrayTestHelper {
         // `upgradeEtherFiNode` checks UPGRADE_TIMELOCK_ROLE via
         // `onlyUpgradeTimelock`. Grant it to every proxy owner pranked below.
         vm.startPrank(roleRegistry.owner());
-        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), stakingManager.owner());
-        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), LiquidityPool(payable(address(liquidityPool))).owner());
-        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), etherFiNodesManager.owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), roleRegistry.owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), roleRegistry.owner());
+        roleRegistry.grantRole(roleRegistry.UPGRADE_TIMELOCK_ROLE(), roleRegistry.owner());
         vm.stopPrank();
 
         // upgrade etherFiNode impl
@@ -148,10 +148,10 @@ contract PreludeTest is Test, ArrayTestHelper {
             eigenPodManager,
             delegationManager
         );
-        vm.prank(stakingManager.owner());
+        vm.prank(roleRegistry.owner());
         stakingManager.upgradeEtherFiNode(address(etherFiNodeImpl));
 
-        vm.prank(auctionManager.owner());
+        vm.prank(roleRegistry.owner());
         auctionManager.disableWhitelist();
 
         // permissions
@@ -606,7 +606,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         stakingManager.upgradeTo(address(stakingManagerImpl));
 
         // should succeed when called by owner
-        address owner = stakingManager.owner();
+        address owner = roleRegistry.owner();
         vm.prank(owner);
         stakingManager.upgradeTo(address(stakingManagerImpl));
     }

--- a/test/fork-tests/validator-key-gen.t.sol
+++ b/test/fork-tests/validator-key-gen.t.sol
@@ -63,7 +63,7 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
             address(etherFiNodeBeacon),
             address(roleRegistry)
         );
-        vm.prank(stakingManager.owner());
+        vm.prank(roleRegistry.owner());
         stakingManager.upgradeTo(address(stakingManagerImpl));
 
         // Wire LP immutables to real mainnet proxy addresses so calls into
@@ -83,11 +83,11 @@ contract ValidatorKeyGenTest is Test, ArrayTestHelper {
                 membershipManager: 0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000
             })
         );
-        vm.prank(liquidityPool.owner());
+        vm.prank(roleRegistry.owner());
         liquidityPool.upgradeTo(address(liquidityPoolImpl));
 
         AuctionManager auctionManagerImpl = new AuctionManager(address(roleRegistry), address(blacklister), address(nodeOperatorManager), address(stakingManager), 0x0c83EAe1FE72c390A02E426572854931EefF93BA);
-        vm.prank(auctionManager.owner());
+        vm.prank(roleRegistry.owner());
         auctionManager.upgradeTo(address(auctionManagerImpl));
 
         // Now swap RoleRegistry so newly-added role getters (e.g. BLACKLISTED_USER)

--- a/test/integration-tests/Deposit.t.sol
+++ b/test/integration-tests/Deposit.t.sol
@@ -49,7 +49,7 @@ contract DepositIntegrationTest is TestSetup {
 
     function test_Deposit_Liquifier_depositWithERC20WithPermit_stETH() public {
         if (liquifierInstance.isDepositCapReached(address(stEth), 1 ether)) {
-            vm.startPrank(liquifierInstance.owner());
+            vm.startPrank(roleRegistryInstance.owner());
             liquifierInstance.updateDepositCap(address(stEth), type(uint32).max, type(uint32).max);
             vm.stopPrank();
         }
@@ -240,7 +240,7 @@ contract DepositIntegrationTest is TestSetup {
         stEth.transfer(address(etherFiRestakerInstance), stEthAmount);
 
         uint256 stETHAmountOfRestakerBeforeDeposit = stEth.balanceOf(address(etherFiRestakerInstance));
-        vm.prank(etherFiRestakerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         uint256 shares = etherFiRestakerInstance.depositIntoStrategy(address(stEth), stEthAmount);
 
         assertGt(shares, 0);

--- a/test/integration-tests/Handle-Remainder-Shares.t.sol
+++ b/test/integration-tests/Handle-Remainder-Shares.t.sol
@@ -37,7 +37,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
 
         // Upgrade LP and NFT to the new escrow-aware implementations so that
         // finalizeRequests + claimWithdraw work with the new ETH-escrow flow.
-        address lpOwner = liquidityPoolInstance.owner();
+        address lpOwner = roleRegistryInstance.owner();
         // Deploy the impl BEFORE pranking: `_newLpImpl()` performs a CREATE that
         // would otherwise consume the single-shot vm.prank, leaving upgradeTo to
         // run as the test contract (OnlyUpgradeTimelock after the RoleRegistry swap).
@@ -45,7 +45,7 @@ contract HandleRemainderSharesIntegrationTest is TestSetup, Deployed {
         vm.prank(lpOwner);
         liquidityPoolInstance.upgradeTo(newLpImpl);
 
-        address wrnOwner = withdrawRequestNFTInstance.owner();
+        address wrnOwner = roleRegistryInstance.owner();
         address newWrnImpl = _newWrnImpl();
         vm.prank(wrnOwner);
         withdrawRequestNFTInstance.upgradeTo(newWrnImpl);

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -17,7 +17,7 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         // so its NODE_OPERATOR_MANAGER_ADMIN_ROLE() getter doesn't exist on-chain.
         // Upgrade in place so the new role getters used by _ensureValCreationRoles are reachable.
         NodeOperatorManager nodeOperatorManagerImpl = new NodeOperatorManager(address(roleRegistryInstance), address(auctionInstance));
-        vm.prank(nodeOperatorManagerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         nodeOperatorManagerInstance.upgradeTo(address(nodeOperatorManagerImpl));
 
         // Upgrade LiquidityPool to the consolidated role model — the on-chain impl
@@ -35,13 +35,13 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
             etherFiAdminContract: address(etherFiAdminInstance),
             membershipManager: address(membershipManagerInstance)
         }));
-        address lpOwner = liquidityPoolInstance.owner();
+        address lpOwner = roleRegistryInstance.owner();
         vm.prank(lpOwner);
         liquidityPoolInstance.upgradeTo(address(newLpImpl));
 
         // Upgrade WithdrawRequestNFT so it has a receive() function and accepts the
         // ETH-escrow transfer triggered by initializeOnUpgradeV2.
-        address wrnOwner = withdrawRequestNFTInstance.owner();
+        address wrnOwner = roleRegistryInstance.owner();
         // Deploy the impl BEFORE pranking — the inlined `new` is a CREATE that
         // would otherwise consume the single-shot vm.prank (OnlyUpgradeTimelock).
         address newWrnImpl = address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(eETHInstance), address(liquidityPoolInstance), address(membershipManagerInstance), address(roleRegistryInstance), address(blacklisterInstance), address(etherFiAdminInstance)));
@@ -106,7 +106,7 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         // addCommitteeMember() resets CommitteeMemberState to
         // (registered=true, enabled=true, lastReportRefSlot=0, numReports=0), clearing any stale
         // submission from mainnet without adding new committee members.
-        address oracleOwner = etherFiOracleInstance.owner();
+        address oracleOwner = roleRegistryInstance.owner();
         // Each add/remove now requires a _quorumSize that satisfies the strict-majority
         // invariant for the resulting numActive. Compute a fresh value at each step
         // so this works regardless of mainnet's current quorum.
@@ -147,7 +147,7 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
         // does not expose NODE_OPERATOR_MANAGER_ADMIN_ROLE(). Upgrade in place
         // so the new role getter and role-gated modifier are reachable, then
         // grant the role used by whitelist ops.
-        address nodeOpMgrOwner = nodeOperatorManagerInstance.owner();
+        address nodeOpMgrOwner = roleRegistryInstance.owner();
         vm.startPrank(nodeOpMgrOwner);
         NodeOperatorManager newNodeOpMgrImpl = new NodeOperatorManager(address(roleRegistryInstance), address(auctionInstance));
         nodeOperatorManagerInstance.upgradeTo(address(newNodeOpMgrImpl));

--- a/test/integration-tests/Withdraw.t.sol
+++ b/test/integration-tests/Withdraw.t.sol
@@ -85,7 +85,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         // addCommitteeMember() resets CommitteeMemberState to
         // (registered=true, enabled=true, lastReportRefSlot=0, numReports=0), clearing any stale
         // submission from mainnet without adding new committee members.
-        address oracleOwner = etherFiOracleInstance.owner();
+        address oracleOwner = roleRegistryInstance.owner();
         // add/removeCommitteeMember now route through OPERATION_TIMELOCK_ROLE.
         bytes32 opTimelockRole = roleRegistryInstance.OPERATION_TIMELOCK_ROLE();
         address rrOwner = roleRegistryInstance.owner();
@@ -506,7 +506,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         uint256 restakerBalanceBefore = address(etherFiRestakerInstance).balance;
         assertEq(restakerBalanceBefore, amount);
 
-        vm.prank(etherFiRestakerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         etherFiRestakerInstance.withdrawEther();
 
         assertEq(address(etherFiRestakerInstance).balance, 0);
@@ -516,7 +516,7 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
     function test_EtherFiRestaker_undelegate_tracksWithdrawalRoots() public {
         bool delegatedBefore = etherFiRestakerInstance.isDelegated();
 
-        vm.prank(etherFiRestakerInstance.owner());
+        vm.prank(roleRegistryInstance.owner());
         if (!delegatedBefore) {
             vm.expectRevert();
             etherFiRestakerInstance.undelegate();

--- a/test/integration-tests/WithdrawEscrowE2E.t.sol
+++ b/test/integration-tests/WithdrawEscrowE2E.t.sol
@@ -132,7 +132,7 @@ contract WithdrawEscrowE2ETest is TestSetup {
     }
 
     function _upgradeWithdrawRequestNFT() internal {
-        address wrnOwner = withdrawRequestNFTInstance.owner();
+        address wrnOwner = roleRegistryInstance.owner();
         // Deploy the impl BEFORE pranking — the inlined `new` is a CREATE that
         // would otherwise consume the single-shot vm.prank (OnlyUpgradeTimelock).
         address newWrnImpl = address(new WithdrawRequestNFT(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Wide UUPS proxy storage-layout and access-control migration across critical protocol contracts; mistakes could brick upgrades or weaken who can upgrade/seize/admin-call.
> 
> **Overview**
> This PR **removes active OpenZeppelin `OwnableUpgradeable` usage** across core protocol proxies in favor of **`RoleRegistry`-based access control**, while **keeping the old Ownable storage layout** via a new **`DeprecatedOZOwnable`** placeholder (`_owner` + gap, no `owner()` / `transferOwnership` API).
> 
> **Contract changes:** Many upgradeable contracts (`EETH`, `LiquidityPool`, `WeETH`, oracle/admin, staking, deposits, rewards, withdrawals, etc.) swap `OwnableUpgradeable` for `DeprecatedOZOwnable`, drop **`__Ownable_init()`** from initializers, and stop relying on per-contract owners for admin paths already gated by `RolesLibrary`. **`WeETHWithdrawAdapter.initialize`** no longer calls **`_transferOwnership`**. **`WithdrawRequestNFT`** invalid-request transfers now require **`onlyUpgradeTimelock`** on the registry instead of **`owner()`**.
> 
> **Scripts:** Deploy/verify steps that assumed timelock **`owner()`** on adapters/distributors are removed or commented in favor of registry-only governance.
> 
> **Tests:** Widespread updates from **`contract.owner()`** to **`roleRegistryInstance.owner()`**, adjusted timelock tests targeting **`RoleRegistry`** (Ownable2Step), and new revert expectations for invalid NFT transfers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b454250ebfa8496a93cb6ebeb25d5f572bd01017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->