### PR TITLE
Follow-up to #461: protocol-fee cap cast (M1) + WRN escrow guard (L1)

### DIFF
--- a/src/oracle/EtherFiAdmin.sol
+++ b/src/oracle/EtherFiAdmin.sol
@@ -545,9 +545,14 @@ contract EtherFiAdmin is Initializable, DeprecatedOZOwnable, UUPSUpgradeable, Ro
      * @return _error The error message
      */
     function _validateProtocolFees(IEtherFiOracle.OracleReport calldata _report) internal pure returns (bool, string memory) {
-        int128 totalRewards = int128(_report.protocolFees) + _report.accruedRewards;
+        // protocolFees is uint128, but the cap arithmetic below is signed. A value above int128 max would
+        // wrap negative on an int128 cast and silently bypass the 20% cap, so reject it up front and run the
+        // comparison in int256 to avoid any truncation.
+        if (_report.protocolFees > uint128(type(int128).max)) return (false, "EtherFiAdmin: protocol fees exceed int128 max");
+        int256 protocolFees = int256(uint256(_report.protocolFees));
+        int256 totalRewards = protocolFees + int256(_report.accruedRewards);
         // protocol fees are less than 20% of total rewards
-        if (_report.protocolFees > 0 && int128(_report.protocolFees) * int256(uint256(MAX_PROTOCOL_FEE_INV_RATIO)) > totalRewards) return (false, "EtherFiAdmin: protocol fees exceed 20% total rewards");
+        if (protocolFees > 0 && protocolFees * int256(uint256(MAX_PROTOCOL_FEE_INV_RATIO)) > totalRewards) return (false, "EtherFiAdmin: protocol fees exceed 20% total rewards");
         return (true, "");
     }
 

--- a/src/withdrawals/WithdrawRequestNFT.sol
+++ b/src/withdrawals/WithdrawRequestNFT.sol
@@ -350,7 +350,9 @@ contract WithdrawRequestNFT is ERC721Upgradeable, UUPSUpgradeable, DeprecatedOZO
         _burn(tokenId);
         delete _requests[tokenId];
 
-        if (ethAmountLockedForWithdrawal < amountToWithdraw) revert InsufficientEscrow();
+        // Guard against the value actually subtracted (the full escrowed amount), not the (possibly smaller)
+        // payout, so the check protects its own subtraction instead of letting it underflow.
+        if (ethAmountLockedForWithdrawal < request.amountOfEEth) revert InsufficientEscrow();
         ethAmountLockedForWithdrawal -= uint128(request.amountOfEEth);
 
         liquidityPool.withdraw(amountToWithdraw, request.shareOfEEth);

--- a/test/EtherFiOracle.t.sol
+++ b/test/EtherFiOracle.t.sol
@@ -1771,6 +1771,22 @@ contract EtherFiOracleTest is TestSetup {
         etherFiAdminInstance.executeTasks(report);
     }
 
+    // Regression pin: protocolFees is uint128, but the 20% cap arithmetic is signed. A value above
+    // int128 max must be rejected outright. Before the fix, the cap math cast it to int128, wrapping
+    // it negative so `5*pf > totalRewards` was false and the cap was silently bypassed.
+    function test_canExecuteTasks_falseWhenFeesExceedInt128Max() public {
+        IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
+        report.accruedRewards = 0;
+        report.protocolFees = uint128(type(int128).max) + 1; // wraps negative on an int128 cast
+        _moveClock(1 days / 12);
+        _submitForConsensus(report);
+
+        assertEq(etherFiAdminInstance.canExecuteTasks(report), false);
+
+        vm.expectRevert(abi.encodeWithSelector(EtherFiAdmin.ReportValidationFailed.selector, "EtherFiAdmin: protocol fees exceed int128 max"));
+        etherFiAdminInstance.executeTasks(report);
+    }
+
     function test_canExecuteTasks_falseWhenValidatorRateAboveCap() public {
         IEtherFiOracle.OracleReport memory report = _emptyOracleReport();
         report.validatorsToApprove = new uint256[](400); // > 200/day cap


### PR DESCRIPTION
Follow-up fixes from the multi-lens review of #461. Two code fixes plus two posture/process notes (H1, H2) for sign-off.

## M1 — protocolFees cap can be bypassed by an oversized fee (Medium, oracle-gated)

`OracleReport.protocolFees` changed from `int128` to `uint128` in #461, but `EtherFiAdmin._validateProtocolFees` still casts `int128(_report.protocolFees)`. A value above `int128` max wraps negative on the cast, so the cap check `5 * protocolFees > totalRewards` is false (LHS negative) and the 20%-of-rewards cap is bypassed. The raw `uint128` then flows to `LiquidityPool.rebase` and mints fee shares to the fee recipient.

Reachable only via a malicious or buggy oracle report that reaches consensus (not directly attacker-triggerable), and the value required is ~1.7e20 ETH, so it is a latent footgun introduced by the type change rather than a live exploit.

Fix: reject `protocolFees > uint128(type(int128).max)` up front and run the cap comparison in `int256` so no truncation is possible. Adds `test_canExecuteTasks_falseWhenFeesExceedInt128Max` (fails on the pre-fix code, which let the report validate).

## L1 — WRN escrow guard does not protect its own subtraction (Low)

`WithdrawRequestNFT._claimWithdraw` checked `ethAmountLockedForWithdrawal < amountToWithdraw` but then subtracted the larger `request.amountOfEEth`. In correct operation `ethAmountLockedForWithdrawal >= request.amountOfEEth` always holds (finalize escrows the full amount), so the guard never triggers; if state were ever inconsistent the prior code would revert via arithmetic underflow instead of the intended `InsufficientEscrow`. Fix guards against `request.amountOfEEth` so the check matches the subtraction. PriorityWithdrawalQueue already follows the correct pattern.

## Tests

- `test/EtherFiOracle.t.sol`: 116 pass (incl. new M1 regression).
- `test/WithdrawRequestNFT.t.sol`: 75 pass.
- `test/LiquidityPool.t.sol`: 119 pass.

## Notes carried over from the #461 review (no code change here)

**H1 — posture sign-off (accepted):** removing per-address transfer rate limits is a deliberate circuit-breaker reduction. Global mint/burn buckets, the LP positive-TVL cap, and the negative-APR cap remain. Global pause + Hypernative auto-pause are accepted as the compensating control for the per-address lever. This makes token-level pause the only remaining surgical lever.

**H2 — coordinated upgrade ordering:** `LiquidityPool.rebase` now gates on `etherFiAdminContract` (was `membershipManager`) with a new 2-arg signature, and `EtherFiAdmin` dropped the `membershipManager` immutable. `EtherFiAdmin` must be upgraded/rewired in the same coordinated upgrade as `LiquidityPool`, or rebases revert with `IncorrectCaller` and oracle reports stall. Sequence the EETH/WeETH/EtherFiAdmin/EtherFiRateLimiter redeploys (new constructor immutables) alongside the WRN/LP/PWQ impls.

Runbook/Hypernative-wiring audit and indexer/integrator notice for the removed selectors and changed event fields are being handled separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches oracle report validation on protocol fees (consensus-gated) and withdrawal claim escrow math; changes are defensive but affect critical fee and redemption paths.
> 
> **Overview**
> Closes two validation gaps from the #461 follow-up: **oracle protocol-fee caps** and **withdraw NFT escrow accounting**.
> 
> **`EtherFiAdmin._validateProtocolFees`** now rejects `protocolFees` above `int128` max before any signed math, and runs the 20%-of-rewards check in **`int256`** so a `uint128`→`int128` cast can’t wrap negative and skip the cap. A regression test pins consensus reports with oversized fees.
> 
> **`WithdrawRequestNFT._claimWithdraw`** compares **`ethAmountLockedForWithdrawal`** against **`request.amountOfEEth`** (the amount subtracted from escrow), not the smaller claim payout, so **`InsufficientEscrow`** fires instead of an underflow if state is inconsistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c8f1c47394c301833f1a922bfb63631e13fe40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->