### PR TITLE
yash/refactor/staking-natspec

### DIFF
--- a/src/staking/AuctionManager.sol
+++ b/src/staking/AuctionManager.sol
@@ -54,7 +54,6 @@ contract AuctionManager is
     //--------------------------------------------------------------------------------------
     //-------------------------------------  EVENTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     event BidCreated(address indexed bidder, uint256 amountPerBid, uint256[] bidIdArray, uint64[] ipfsIndexArray);
     event BidCancelled(uint256 indexed bidId);
     event BidReEnteredAuction(uint256 indexed bidId);
@@ -65,7 +64,6 @@ contract AuctionManager is
     //--------------------------------------------------------------------------------------
     //-------------------------------------  ERRORS  ---------------------------------------
     //--------------------------------------------------------------------------------------
-
     error AddressZero();
     error InvalidBidSize();
     error NotWhitelisted();
@@ -84,8 +82,14 @@ contract AuctionManager is
     //--------------------------------------------------------------------------------------
     //-------------------------------------  CONSTRUCTOR  ----------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _roleRegistry The address of the role registry
+     * @param _blacklister The address of the blacklister
+     * @param _nodeOperatorManagerContract The address of the node operator manager contract
+     * @param _stakingManagerContractAddress The address of the staking manager contract
+     * @param _treasury The address of the treasury
+     */
     constructor(address _roleRegistry, address _blacklister, address _nodeOperatorManagerContract, address _stakingManagerContractAddress, address _treasury) RolesLibrary(_roleRegistry) {
         blacklister = IBlacklister(_blacklister);
         nodeOperatorManager = INodeOperatorManager(_nodeOperatorManagerContract);
@@ -95,10 +99,12 @@ contract AuctionManager is
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //---------------------------------  INITIALIZERS  -------------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @notice Initialize to set variables on deployment
+    /**
+     * @notice Initialize to set variables on deployment
+     * @param _nodeOperatorManagerContract The address of the node operator manager contract
+     */
     function initialize(
         address _nodeOperatorManagerContract
     ) external initializer {
@@ -113,10 +119,15 @@ contract AuctionManager is
         __UUPSUpgradeable_init();
     }
 
-    /// @notice Creates bid(s) for the right to run a validator node when ETH is deposited
-    /// @param _bidSize the number of bids that the node operator would like to create
-    /// @param _bidAmountPerBid the ether value of each bid that is created
-    /// @return bidIdArray array of the bidIDs that were created
+    //--------------------------------------------------------------------------------------
+    //------------------------------- AUCTION FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Creates bid(s) for the right to run a validator node when ETH is deposited
+     * @param _bidSize the number of bids that the node operator would like to create
+     * @param _bidAmountPerBid the ether value of each bid that is created
+     * @return bidIdArray array of the bidIDs that were created
+     */
     function createBid(
         uint256 _bidSize,
         uint256 _bidAmountPerBid
@@ -173,27 +184,36 @@ contract AuctionManager is
         return bidIdArray;
     }
 
-    /// @notice Cancels bids in a batch by calling the 'cancelBid' function multiple times
-    /// @dev Calls an internal function to perform the cancel
-    /// @param _bidIds the ID's of the bids to cancel
+    /**
+     * @notice Cancels bids in a batch by calling the 'cancelBid' function multiple times
+     * @param _bidIds the ID's of the bids to cancel
+     * @dev Calls an internal function to perform the cancel
+     */
     function cancelBidBatch(uint256[] calldata _bidIds) external whenNotPaused nonBlacklisted {
         for (uint256 i = 0; i < _bidIds.length; i++) {
             _cancelBid(_bidIds[i]);
         }
     }
 
-    /// @notice Cancels a specified bid by de-activating it
-    /// @dev Calls an internal function to perform the cancel
-    /// @param _bidId the ID of the bid to cancel
+    /**
+     * @notice Cancels a specified bid by de-activating it
+     * @param _bidId the ID of the bid to cancel
+     * @dev Calls an internal function to perform the cancel
+     */
     function cancelBid(uint256 _bidId) public whenNotPaused nonBlacklisted {
         _cancelBid(_bidId);
     }
 
-    /// @notice Updates the details of the bid which has been used in a stake match
-    /// @dev Called by batchDepositWithBidIds() in StakingManager.sol. Forwards the
-    ///      consumed bid's ETH to `treasury` so protocol-side bid revenue is not
-    ///      stranded in this contract.
-    /// @param _bidId the ID of the bid being removed from the auction (since it has been selected)
+    //--------------------------------------------------------------------------------------
+    //------------------------------- STAKING FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Updates the details of the bid which has been used in a stake match
+     * @param _bidId the ID of the bid being removed from the auction (since it has been selected)
+     * @dev Called by batchDepositWithBidIds() in StakingManager.sol. Forwards the
+     *      consumed bid's ETH to `treasury` so protocol-side bid revenue is not
+     *      stranded in this contract.
+     */
     function updateSelectedBidInformation(
         uint256 _bidId
     ) external onlyStakingManagerContract {
@@ -211,8 +231,10 @@ contract AuctionManager is
         }
     }
 
-    /// @notice Lets a bid that was matched to a cancelled stake re-enter the auction
-    /// @param _bidId the ID of the bid which was matched to the cancelled stake.
+    /**
+     * @notice Lets a bid that was matched to a cancelled stake re-enter the auction
+     * @param _bidId the ID of the bid which was matched to the cancelled stake.
+     */
     function reEnterAuction(
         uint256 _bidId
     ) external onlyStakingManagerContract {
@@ -224,24 +246,69 @@ contract AuctionManager is
         emit BidReEnteredAuction(_bidId);
     }
 
-    /// @notice Disables the whitelisting phase of the bidding
-    /// @dev Allows both regular users and whitelisted users to bid
+    //--------------------------------------------------------------------------------------
+    //------------------------------- ADMIN FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+
+    /**
+     * @notice Updates the minimum bid price for a non-whitelisted bidder
+     * @param _newMinBidAmount the new amount to set the minimum bid price as
+     * @dev Only the operating multisig can update the minimum bid price
+     */
+    function setMinBidPrice(uint64 _newMinBidAmount) external onlyOperatingMultisig {
+        if (_newMinBidAmount >= maxBidAmount) revert InvalidMinBid();
+        if (_newMinBidAmount < whitelistBidAmount) revert InvalidMinBid();
+        minBidAmount = _newMinBidAmount;
+    }
+
+    /**
+     * @notice Updates the maximum bid price for both whitelisted and non-whitelisted bidders
+     * @param _newMaxBidAmount the new amount to set the maximum bid price as
+     * @dev Only the operating multisig can update the maximum bid price
+     */
+    function setMaxBidPrice(uint64 _newMaxBidAmount) external onlyOperatingMultisig {
+        if (_newMaxBidAmount <= minBidAmount) revert InvalidMaxBid();
+        maxBidAmount = _newMaxBidAmount;
+    }
+
+    /**
+     * @notice Disables the whitelisting phase of the bidding
+     * @dev Allows both regular users and whitelisted users to bid
+     */
     function disableWhitelist() public onlyOperatingMultisig {
         whitelistEnabled = false;
         emit WhitelistDisabled(whitelistEnabled);
     }
 
-    /// @notice Enables the whitelisting phase of the bidding
-    /// @dev Only users who are on a whitelist can bid
+    /**
+     * @notice Enables the whitelisting phase of the bidding
+     * @dev Only users who are on a whitelist can bid
+     */
     function enableWhitelist() public onlyOperatingMultisig {
         whitelistEnabled = true;
         emit WhitelistEnabled(whitelistEnabled);
     }
 
+    /**
+     * @notice Updates the minimum bid price for a whitelisted address
+     * @param _newAmount the new amount to set the minimum bid price as
+     * @dev Only the operating multisig can update the minimum bid price for a whitelisted address
+     */
+    function updateWhitelistMinBidAmount(
+        uint128 _newAmount
+    ) external onlyOperatingMultisig {
+        if (_newAmount >= minBidAmount || _newAmount == 0) revert InvalidWhitelistAmount();
+        whitelistBidAmount = _newAmount;
+    }
+
     //--------------------------------------------------------------------------------------
     //-------------------------------  INTERNAL FUNCTIONS   --------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Cancels a bid by de-activating it and refunding the user with their bid amount
+     * @param _bidId the ID of the bid to cancel
+     * @dev Called by cancelBid() and cancelBidBatch()
+     */
     function _cancelBid(uint256 _bidId) internal {
         Bid storage bid = bids[_bidId];
         if (bid.bidderAddress != msg.sender) revert InvalidBid();
@@ -258,69 +325,62 @@ contract AuctionManager is
         emit BidCancelled(_bidId);
     }
 
+    /**
+     * @notice Authorizes the upgrade of the implementation contract
+     * @param newImplementation the address of the new implementation contract
+     * @dev Only the upgrade timelock can authorize the upgrade
+     */
     function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //--------------------------------------  GETTER  --------------------------------------
     //--------------------------------------------------------------------------------------
 
-    /// @notice Fetches the address of the user who placed a bid for a specific bid ID
-    /// @dev Needed for registerValidator() function in Staking Contract as well as function in the EtherFiNodeManager.sol
-    /// @return the address of the user who placed (owns) the bid
+    /**
+     * @notice Fetches the address of the user who placed a bid for a specific bid ID
+     * @param _bidId the ID of the bid to fetch the owner of
+     * @dev Needed for registerValidator() function in Staking Contract as well as function in the EtherFiNodeManager.sol
+     * @return the address of the user who placed (owns) the bid
+     */
     function getBidOwner(uint256 _bidId) external view returns (address) {
         return bids[_bidId].bidderAddress;
     }
 
-    /// @notice Fetches if a selected bid is currently active
-    /// @dev Needed for batchDepositWithBidIds() function in Staking Contract
-    /// @return the boolean value of the active flag in bids
+    /**
+     * @notice Fetches if a selected bid is currently active
+     * @param _bidId the ID of the bid to fetch the active status of
+     * @dev Needed for batchDepositWithBidIds() function in Staking Contract
+     * @return the boolean value of the active flag in bids
+     */
     function isBidActive(uint256 _bidId) external view returns (bool) {
         return bids[_bidId].isActive;
     }
 
-    /// @notice Fetches the address of the implementation contract currently being used by the proxy
-    /// @return the address of the currently used implementation contract
+    /**
+     * @notice Fetches the address of the implementation contract currently being used by the proxy
+     * @dev Needed for the getImplementation() function in the UUPSUpgradeable contract
+     * @return the address of the currently used implementation contract
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
 
     //--------------------------------------------------------------------------------------
-    //--------------------------------------  SETTER  --------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    /// @notice Updates the minimum bid price for a non-whitelisted bidder
-    /// @param _newMinBidAmount the new amount to set the minimum bid price as
-    function setMinBidPrice(uint64 _newMinBidAmount) external onlyOperatingMultisig {
-        if (_newMinBidAmount >= maxBidAmount) revert InvalidMinBid();
-        if (_newMinBidAmount < whitelistBidAmount) revert InvalidMinBid();
-        minBidAmount = _newMinBidAmount;
-    }
-
-    /// @notice Updates the maximum bid price for both whitelisted and non-whitelisted bidders
-    /// @param _newMaxBidAmount the new amount to set the maximum bid price as
-    function setMaxBidPrice(uint64 _newMaxBidAmount) external onlyOperatingMultisig {
-        if (_newMaxBidAmount <= minBidAmount) revert InvalidMaxBid();
-        maxBidAmount = _newMaxBidAmount;
-    }
-
-    /// @notice Updates the minimum bid price for a whitelisted address
-    /// @param _newAmount the new amount to set the minimum bid price as
-    function updateWhitelistMinBidAmount(
-        uint128 _newAmount
-    ) external onlyOperatingMultisig {
-        if (_newAmount >= minBidAmount || _newAmount == 0) revert InvalidWhitelistAmount();
-        whitelistBidAmount = _newAmount;
-    }
-
-    //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Modifier to only allow the staking manager contract to call a function
+     * @dev Only the staking manager contract can call this function
+     */
     modifier onlyStakingManagerContract() {
         if (msg.sender != stakingManagerContractAddress) revert IncorrectCaller();
         _;
     }
 
+    /**
+     * @notice Modifier to only allow non-blacklisted addresses to call a function
+     * @dev Only non-blacklisted addresses can call this function
+     */
     modifier nonBlacklisted() {
         blacklister.nonBlacklisted(msg.sender);
         _;

--- a/src/staking/EtherFiNode.sol
+++ b/src/staking/EtherFiNode.sol
@@ -16,30 +16,38 @@ import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {LibCall} from "solady/utils/LibCall.sol";
 
 contract EtherFiNode is IEtherFiNode {
+    //---------------------------------------------------------------------------
+    //-----------------------------  Storage  -----------------------------------
+    //---------------------------------------------------------------------------
+    LegacyNodeState legacyState; // all legacy state in this contract has been deprecated
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  IMMUTABLES  --------------------------------------------
+    //--------------------------------------------------------------------------------------
     ILiquidityPool public immutable liquidityPool;
     IEtherFiNodesManager public immutable etherFiNodesManager;
-
-    // eigenlayer core contracts
     IEigenPodManager public immutable eigenPodManager;
     IDelegationManager public immutable delegationManager;
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  CONSTANTS  --------------------------------------------
+    //--------------------------------------------------------------------------------------
     uint32 public constant EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS = 100800;
     address public constant BEACON_ETH_STRATEGY_ADDRESS = address(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
-
     /// @dev Suggested gas stipend for contract receiving ETH to perform a few
     /// storage reads and writes, but low enough to prevent griefing.
     uint256 internal constant GAS_STIPEND_NO_GRIEF = 100_000;
 
-    //---------------------------------------------------------------------------
-    //-----------------------------  Storage  -----------------------------------
-    //---------------------------------------------------------------------------
-
-    LegacyNodeState legacyState; // all legacy state in this contract has been deprecated
-
-    //-------------------------------------------------------------------------
-    //-----------------------------  Admin  -----------------------------------
-    //-------------------------------------------------------------------------
-
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  CONSTRUCTOR  --------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _liquidityPool The address of the liquidity pool
+     * @param _etherFiNodesManager The address of the etherFi nodes manager
+     * @param _eigenPodManager The address of the eigenpod manager
+     * @param _delegationManager The address of the delegation manager
+     */
     constructor(address _liquidityPool, address _etherFiNodesManager, address _eigenPodManager, address _delegationManager) {
         liquidityPool = ILiquidityPool(_liquidityPool);
         etherFiNodesManager = IEtherFiNodesManager(_etherFiNodesManager);
@@ -47,42 +55,94 @@ contract EtherFiNode is IEtherFiNode {
         delegationManager = IDelegationManager(_delegationManager);
     }
 
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  FALLBACK  --------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Fallback function to receive ETH
+     * @dev using fallback instead of receive here as nodes are expected to receive ETH from flows with non-empty calldata
+     */
     fallback() external payable {}
 
     //--------------------------------------------------------------------------------------
-    //---------------------------- Eigenlayer Interactions  --------------------------------
+    //---------------------------- OPERATIONAL FUNCTIONS  ----------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @dev returns the associated eigenpod or the zero address if it is not created yet.
-    ///      `EigenPodManager.getPod()` is not used because it returns the deterministic address regardless of if it exists
-    function getEigenPod() public view returns (IEigenPod) {
-        return eigenPodManager.ownerToPod(address(this));
-    }
-
-    /// @dev creates a new eigenpod and returns its address. Reverts if a pod already exists for this node.
-    ///      This address is deterministic and you can pre-compute it if necessary.
+    /**
+     * @notice Creates a new eigenpod and returns its address. Reverts if a pod already exists for this node.
+     * @dev This address is deterministic and you can pre-compute it if necessary.
+     * @dev Only the etherFi nodes manager can call this function
+     * @return The address of the new eigenpod
+     */
     function createEigenPod() external onlyEtherFiNodesManager returns (address) {
         return eigenPodManager.createPod();
     }
 
-    /// @dev specify another address with permissions to submit checkpoint and withdrawal credential proofs
+    /**
+     * @notice Specifies another address with permissions to submit checkpoint and withdrawal credential proofs
+     * @param _newProofSubmitter The address of the new proof submitter
+     * @dev Only the etherFi nodes manager can call this function
+     */
     function setProofSubmitter(address _newProofSubmitter) external onlyEtherFiNodesManager {
         getEigenPod().setProofSubmitter(_newProofSubmitter);
     }
 
-    /// @dev start an eigenlayer checkpoint proof. Once a checkpoint is started, it must be completed
+    /**
+     * @notice Starts an eigenlayer checkpoint proof. Once a checkpoint is started, it must be completed
+     * @dev Only the etherFi nodes manager can call this function
+     */
     function startCheckpoint() external onlyEtherFiNodesManager {
         bool revertIfNoBalance = true; // protect from wasting gas if checkpoint will not increase shares
         getEigenPod().startCheckpoint(revertIfNoBalance);
     }
 
-    /// @dev submit a subset of proofs for the currently active checkpoint
+    /**
+     * @notice Submits a subset of proofs for the currently active checkpoint
+     * @param balanceContainerProof The balance container proof
+     * @param proofs The proofs to submit
+     * @dev Only the etherFi nodes manager can call this function
+     */
     function verifyCheckpointProofs(BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyEtherFiNodesManager {
         getEigenPod().verifyCheckpointProofs(balanceContainerProof, proofs);
     }
 
-    /// @dev convenience function to queue a beaconETH withdrawal from eigenlayer. You must wait EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS before claiming.
-    ///   It is fine to queue a withdrawal before validators have finished exiting on the beacon chain.
+    /**
+     * @notice Transfers any funds held by the node to the liquidity pool.
+     * @dev Under normal operations it is not expected for eth to accumulate in the nodes,
+     *      this is just to handle any exceptional cases such as someone sending directly to the node.
+     * @return The balance of the node
+     */
+    function sweepFunds() external onlyEtherFiNodesManager returns (uint256 balance) {
+        return _sweepToLiquidityPool();
+    }
+
+    /**
+     * @notice Requests an execution layer triggered withdrawal from eigenlayer.
+     * @param requests The requests to request the withdrawal with
+     * @dev Only the etherFi nodes manager can call this function
+     */
+    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable onlyEtherFiNodesManager {
+        getEigenPod().requestWithdrawal{value: msg.value}(requests);
+    }
+
+    /**
+     * @notice Requests an execution layer triggered consolidation from eigenlayer.
+     * @param requests The requests to request the consolidation with
+     * @dev Only the etherFi nodes manager can call this function
+     */
+    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable onlyEtherFiNodesManager {
+        getEigenPod().requestConsolidation{value: msg.value}(requests);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //------------------------------- WITHDRAWAL FUNCTIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Convenience function to queue a beaconETH withdrawal from eigenlayer.
+     * @param amount The amount of beaconETH to withdraw
+     * @dev You must wait EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS before claiming.
+     *      It is fine to queue a withdrawal before validators have finished exiting on the beacon chain.
+     * @return The withdrawal root
+     */
     function queueETHWithdrawal(uint256 amount) external onlyEtherFiNodesManager returns (bytes32 withdrawalRoot) {
 
         // beacon eth is always 1 to 1 with deposit shares
@@ -102,10 +162,14 @@ contract EtherFiNode is IEtherFiNode {
     }
 
 
-    /// @dev completes all queued beaconETH withdrawals that are currently claimable.
-    ///   Note that since the node is usually delegated to an operator,
-    ///   most of the time this should be called with "receiveAsTokens" = true because
-    ///   receiving shares while delegated will simply redelegate the shares.
+    /**
+     * @notice Completes all queued beaconETH withdrawals that are currently claimable.
+     * @param receiveAsTokens Whether to receive the withdrawals as tokens
+     * @dev Note that since the node is usually delegated to an operator,
+     *      most of the time this should be called with "receiveAsTokens" = true because
+     *      receiving shares while delegated will simply redelegate the shares.
+     * @return The balance of the node
+     */
     function completeQueuedETHWithdrawals(bool receiveAsTokens) external onlyEtherFiNodesManager returns (uint256 balance) {
 
         // because we are just dealing with beacon eth we don't need to populate the tokens[] array
@@ -129,16 +193,27 @@ contract EtherFiNode is IEtherFiNode {
         return _sweepToLiquidityPool();
     }
 
-    /// @dev queue a withdrawal from eigenlayer. You must wait EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS before claiming.
-    ///   For the general case of queuing a beaconETH withdrawal you can use queueETHWithdrawal instead.
+    /**
+     * @notice Queues a withdrawal from eigenlayer.
+     * @param params The parameters to queue the withdrawal with
+     * @dev You must wait EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS before claiming.
+     *      For the general case of queuing a beaconETH withdrawal you can use queueETHWithdrawal instead.
+     * @return The withdrawal roots
+     */
     function queueWithdrawals(IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyEtherFiNodesManager returns (bytes32[] memory withdrawalRoots) {
         return delegationManager.queueWithdrawals(params);
     }
 
-    /// @dev complete an arbitrary withdrawal from eigenlayer.
-    ///   For the general case of claiming beaconETH withdrawals you can use completeQueuedETHWithdrawals instead.
-    ///   Any ETH that lands on this node as a result of the completion is auto-swept to the liquidity pool;
-    ///   the swept amount is returned so the manager can emit FundsTransferred at the wrapper level too.
+    /**
+     * @notice Completes an arbitrary withdrawal from eigenlayer.
+     * @param withdrawals The withdrawals to complete
+     * @param tokens The tokens to complete the withdrawals with
+     * @param receiveAsTokens Whether to receive the withdrawals as tokens
+     * @dev For the general case of claiming beaconETH withdrawals you can use completeQueuedETHWithdrawals instead.
+     *      Any ETH that lands on this node as a result of the completion is auto-swept to the liquidity pool;
+     *      the swept amount is returned so the manager can emit FundsTransferred at the wrapper level too.
+     * @return The balance of the node
+     */
     function completeQueuedWithdrawals(
         IDelegationManager.Withdrawal[] calldata withdrawals,
         IERC20[][] calldata tokens,
@@ -148,15 +223,39 @@ contract EtherFiNode is IEtherFiNode {
         return _sweepToLiquidityPool();
     }
 
-    // @notice transfers any funds held by the node to the liquidity pool.
-    // @dev under normal operations it is not expected for eth to accumulate in the nodes,
-    //    this is just to handle any exceptional cases such as someone sending directly to the node.
-    function sweepFunds() external onlyEtherFiNodesManager returns (uint256 balance) {
-        return _sweepToLiquidityPool();
+    //--------------------------------------------------------------------------------------
+    //-------------------------------- CALL FORWARDING  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Forwards a call to the eigenpod
+     * @param data The data to forward
+     * @dev Only the etherFi nodes manager can call this function
+     * @return The result of the call
+     */
+    function forwardEigenPodCall(bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
+        // callContract will revert if targeting an EOA so it is safe if getEigenPod() returns the zero address
+        return LibCall.callContract(address(getEigenPod()), 0, data);
     }
 
-    /// @dev forwards the lesser of (node balance, liquidityPool.totalValueOutOfLp()) to the
-    ///   liquidity pool. Shared by sweepFunds and completeQueued*Withdrawals.
+    /**
+     * @notice Forwards a call to an external contract
+     * @param to The address of the external contract
+     * @param data The data to forward
+     * @dev Only the etherFi nodes manager can call this function
+     * @return The result of the call
+     */
+    function forwardExternalCall(address to, bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
+        return LibCall.callContract(to, 0, data);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  INTERNAL FUNCTIONS  -----------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Forwards the lesser of (node balance, liquidityPool.totalValueOutOfLp()) to the liquidity pool.
+     * @dev Shared by sweepFunds and completeQueued*Withdrawals.
+     * @return The balance of the node
+     */
     function _sweepToLiquidityPool() private returns (uint256 balance) {
         uint256 contractBalance = address(this).balance;
         uint256 totalValueOutOfLp = liquidityPool.totalValueOutOfLp();
@@ -168,37 +267,25 @@ contract EtherFiNode is IEtherFiNode {
         }
     }
 
-    //-------------------------------------------------------------------
-    //-------------  Execution-Layer Triggered Withdrawals  -------------
-    //-------------------------------------------------------------------
-    function requestExecutionLayerTriggeredWithdrawal(IEigenPod.WithdrawalRequest[] calldata requests) external payable onlyEtherFiNodesManager {
-        getEigenPod().requestWithdrawal{value: msg.value}(requests);
-    }
-
-    //-------------------------------------------------------------------
-    //-------------  Execution-Layer Triggered Consolidations  ----------
-    //-------------------------------------------------------------------
-    function requestConsolidation(IEigenPod.ConsolidationRequest[] calldata requests) external payable onlyEtherFiNodesManager {
-        getEigenPod().requestConsolidation{value: msg.value}(requests);
-    }
-
     //--------------------------------------------------------------------------------------
-    //-------------------------------- CALL FORWARDING  ------------------------------------
+    //-----------------------------  GETTERS  --------------------------------------------
     //--------------------------------------------------------------------------------------
-
-    function forwardEigenPodCall(bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
-        // callContract will revert if targeting an EOA so it is safe if getEigenPod() returns the zero address
-        return LibCall.callContract(address(getEigenPod()), 0, data);
-    }
-
-    function forwardExternalCall(address to, bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
-        return LibCall.callContract(to, 0, data);
+    /**
+     * @notice Returns the associated eigenpod or the zero address if it is not created yet.
+     * @dev `EigenPodManager.getPod()` is not used because it returns the deterministic address regardless of if it exists
+     * @return The associated eigenpod
+     */
+    function getEigenPod() public view returns (IEigenPod) {
+        return eigenPodManager.ownerToPod(address(this));
     }
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Modifier to only allow the etherFi nodes manager to call a function
+     * @dev Only the etherFi nodes manager can call this function
+     */
     modifier onlyEtherFiNodesManager() {
         if (msg.sender != address(etherFiNodesManager)) revert InvalidCaller();
         _;

--- a/src/staking/EtherFiNode.sol
+++ b/src/staking/EtherFiNode.sol
@@ -109,7 +109,7 @@ contract EtherFiNode is IEtherFiNode {
      * @notice Transfers any funds held by the node to the liquidity pool.
      * @dev Under normal operations it is not expected for eth to accumulate in the nodes,
      *      this is just to handle any exceptional cases such as someone sending directly to the node.
-     * @return The balance of the node
+     * @return balance The balance of the node
      */
     function sweepFunds() external onlyEtherFiNodesManager returns (uint256 balance) {
         return _sweepToLiquidityPool();
@@ -141,7 +141,7 @@ contract EtherFiNode is IEtherFiNode {
      * @param amount The amount of beaconETH to withdraw
      * @dev You must wait EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS before claiming.
      *      It is fine to queue a withdrawal before validators have finished exiting on the beacon chain.
-     * @return The withdrawal root
+     * @return withdrawalRoot The withdrawal root
      */
     function queueETHWithdrawal(uint256 amount) external onlyEtherFiNodesManager returns (bytes32 withdrawalRoot) {
 
@@ -168,7 +168,7 @@ contract EtherFiNode is IEtherFiNode {
      * @dev Note that since the node is usually delegated to an operator,
      *      most of the time this should be called with "receiveAsTokens" = true because
      *      receiving shares while delegated will simply redelegate the shares.
-     * @return The balance of the node
+     * @return balance The balance of the node
      */
     function completeQueuedETHWithdrawals(bool receiveAsTokens) external onlyEtherFiNodesManager returns (uint256 balance) {
 
@@ -198,7 +198,7 @@ contract EtherFiNode is IEtherFiNode {
      * @param params The parameters to queue the withdrawal with
      * @dev You must wait EIGENLAYER_WITHDRAWAL_DELAY_BLOCKS before claiming.
      *      For the general case of queuing a beaconETH withdrawal you can use queueETHWithdrawal instead.
-     * @return The withdrawal roots
+     * @return withdrawalRoots The withdrawal roots
      */
     function queueWithdrawals(IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyEtherFiNodesManager returns (bytes32[] memory withdrawalRoots) {
         return delegationManager.queueWithdrawals(params);
@@ -212,7 +212,7 @@ contract EtherFiNode is IEtherFiNode {
      * @dev For the general case of claiming beaconETH withdrawals you can use completeQueuedETHWithdrawals instead.
      *      Any ETH that lands on this node as a result of the completion is auto-swept to the liquidity pool;
      *      the swept amount is returned so the manager can emit FundsTransferred at the wrapper level too.
-     * @return The balance of the node
+     * @return balance The balance of the node
      */
     function completeQueuedWithdrawals(
         IDelegationManager.Withdrawal[] calldata withdrawals,
@@ -254,7 +254,7 @@ contract EtherFiNode is IEtherFiNode {
     /**
      * @notice Forwards the lesser of (node balance, liquidityPool.totalValueOutOfLp()) to the liquidity pool.
      * @dev Shared by sweepFunds and completeQueued*Withdrawals.
-     * @return The balance of the node
+     * @return balance The balance of the node
      */
     function _sweepToLiquidityPool() private returns (uint256 balance) {
         uint256 contractBalance = address(this).balance;

--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -27,22 +27,25 @@ contract EtherFiNodesManager is
     ReentrancyGuardTransient,
     UUPSUpgradeable
 {
-
-    IStakingManager public immutable stakingManager;
-    IEtherFiRateLimiter public immutable rateLimiter;
-    address public constant BEACON_ETH_STRATEGY_ADDRESS = address(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
-
     //---------------------------------------------------------------------------
-    //-----------------------------  Storage  -----------------------------------
+    //-----------------------------  STATE-VARIABLES  ---------------------------
     //---------------------------------------------------------------------------
     LegacyNodesManagerState private legacyState;
     mapping(address => mapping(bytes4 => bool)) public allowedForwardedEigenpodCalls; // Call Forwarding: user -> functionSelector -> allowed
     mapping(address => mapping(bytes4 => mapping(address => bool))) public allowedForwardedExternalCalls; // Call Forwarding: user -> functionSelector -> targetAddress -> allowed
     mapping(bytes32 => IEtherFiNode) public etherFiNodeFromPubkeyHash;
 
-    //-------------------------------------------------------------------------
-    //-----------------------------  Rate Limiter Buckets ---------------------
-    //-------------------------------------------------------------------------
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  IMMUTABLES  --------------------------------------------
+    //--------------------------------------------------------------------------------------
+    IStakingManager public immutable stakingManager;
+    IEtherFiRateLimiter public immutable rateLimiter;
+
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  CONSTANTS  --------------------------------------------
+    //--------------------------------------------------------------------------------------
+    address public constant BEACON_ETH_STRATEGY_ADDRESS = address(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
+    // rate limiting constants
     bytes32 public constant UNRESTAKING_LIMIT_ID = keccak256("UNRESTAKING_LIMIT_ID");
     bytes32 public constant EXIT_REQUEST_LIMIT_ID = keccak256("EXIT_REQUEST_LIMIT_ID");
     bytes32 public constant CONSOLIDATION_REQUEST_LIMIT_ID = keccak256("CONSOLIDATION_REQUEST_LIMIT_ID");
@@ -50,19 +53,22 @@ contract EtherFiNodesManager is
     uint256 public constant FULL_EXIT_GWEI = 2_048_000_000_000;
     uint256 public constant VALIDATOR_PUBKEY_LENGTH = 48;
 
-    //-------------------------------------------------------------------------
-    //-----------------------------  Admin  -----------------------------------
-    //-------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    //--------------------------------------------------------------------------------------
+    //-----------------------------  CONSTRUCTOR  --------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Constructor
+     * @param _stakingManager The address of the staking manager
+     * @param _roleRegistry The address of the role registry
+     * @param _rateLimiter The address of the rate limiter
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
     constructor(address _stakingManager, address _roleRegistry, address _rateLimiter) RolesLibrary(_roleRegistry) {
         stakingManager = IStakingManager(_stakingManager);
         rateLimiter = IEtherFiRateLimiter(_rateLimiter);
 
         _disableInitializers();
     }
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     /// @dev under normal conditions ETH should not accumulate in the EtherFiNode. This will forward
     ///   the eth to the liquidity pool in the event of ETH being accidentally sent there
@@ -75,66 +81,113 @@ contract EtherFiNodesManager is
     }
 
     //--------------------------------------------------------------------------------------
-    //---------------------------- Eigenlayer Interactions  --------------------------------
+    //---------------------------- OPERATIONAL FUNCTIONS  --------------------------------
     //--------------------------------------------------------------------------------------
-
     // Note that most of these calls are pod-level actions and it is a little awkward to always
     // provide a specific validator ID. This is to maintain compatibility with much of our existing
     // tooling which used to operate on a per-validator level instead of per-pod/per-node.
     // Over time we will migrate to directly calling the associated method on the EtherFiNode contract where applicable.
 
+    /**
+     * @notice Creates a new eigenpod for a given node
+     * @param node The node to create the eigenpod for
+     * @return The address of the new eigenpod
+     */
     function createEigenPod(address node) external whenNotPaused returns (address) {
         if (msg.sender != address(stakingManager)) revert InvalidCaller();
         if (!stakingManager.deployedEtherFiNodes(node)) revert UnknownNode();
         return IEtherFiNode(node).createEigenPod();
     }
 
-    function getEigenPod(address node) public view returns (address) {
-        _validateNode(node);
-        return address(IEtherFiNode(node).getEigenPod());
-    }
-    
-    function getEigenPod(uint256 id) public view returns (address) {
-        return getEigenPod(etherfiNodeAddress(id));
-    }
-
+    /**
+     * @notice Starts a checkpoint for a given node
+     * @param node The node to start the checkpoint for
+     */
     function startCheckpoint(address node) public onlyEigenpodOperations whenNotPaused {
         _validateNode(node);
         IEtherFiNode(node).startCheckpoint();
     }
     
+    /**
+     * @notice Starts a checkpoint for a given node
+     * @param id The id of the node to start the checkpoint for
+     */
     function startCheckpoint(uint256 id) external onlyEigenpodOperations whenNotPaused {
         startCheckpoint(etherfiNodeAddress(id));
     }
 
+    /**
+     * @notice Verifies checkpoint proofs for a given node
+     * @param node The node to verify the checkpoint proofs for
+     * @param balanceContainerProof The balance container proof
+     * @param proofs The proofs to verify
+     */
     function verifyCheckpointProofs(address node, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) public onlyEigenpodOperations whenNotPaused {
         _validateNode(node);
         IEtherFiNode(node).verifyCheckpointProofs(balanceContainerProof, proofs);
     }
     
+    /**
+     * @notice Verifies checkpoint proofs for a given node
+     * @param id The id of the node to verify the checkpoint proofs for
+     * @param balanceContainerProof The balance container proof
+     * @param proofs The proofs to verify
+     */
     function verifyCheckpointProofs(uint256 id, BeaconChainProofs.BalanceContainerProof calldata balanceContainerProof, BeaconChainProofs.BalanceProof[] calldata proofs) external onlyEigenpodOperations whenNotPaused {
         verifyCheckpointProofs(etherfiNodeAddress(id), balanceContainerProof, proofs);
     }
 
-    function setProofSubmitter(address node, address proofSubmitter) public onlyOperatingMultisig whenNotPaused {
-        _validateNode(node);
-        IEtherFiNode(node).setProofSubmitter(proofSubmitter);
-    }
-    
-    function setProofSubmitter(uint256 id, address proofSubmitter) external onlyOperatingMultisig whenNotPaused {
-        setProofSubmitter(etherfiNodeAddress(id), proofSubmitter);
-    }
-
+    //--------------------------------------------------------------------------------------
+    //---------------------------- WITHDRAWAL OPERATIONS  --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Queues a beaconETH withdrawal for a given node
+     * @param node The node to queue the beaconETH withdrawal for
+     * @param amount The amount of beaconETH to withdraw
+     * @return The withdrawal root
+     */
     function queueETHWithdrawal(address node, uint256 amount) public onlyExecutorOperations whenNotPaused returns (bytes32 withdrawalRoot) {
         _validateNode(node);
         rateLimiter.consume(UNRESTAKING_LIMIT_ID, SafeCast.toUint64(amount / 1 gwei));
         return IEtherFiNode(node).queueETHWithdrawal(amount);
     }
     
+    /**
+     * @notice Queues a beaconETH withdrawal for a given node
+     * @param id The id of the node to queue the beaconETH withdrawal for
+     * @param amount The amount of beaconETH to withdraw
+     * @return The withdrawal root
+     */
     function queueETHWithdrawal(uint256 id, uint256 amount) external onlyExecutorOperations whenNotPaused returns (bytes32 withdrawalRoot) {
         return queueETHWithdrawal(etherfiNodeAddress(id), amount);
     }
 
+    /**
+     * @notice Queues a withdrawal for a given node
+     * @param node The node to queue the withdrawal for
+     * @param params The parameters to queue the withdrawal with
+     */
+    function queueWithdrawals(address node, IDelegationManager.QueuedWithdrawalParams[] calldata params) public onlyExecutorOperations whenNotPaused {
+        _validateNode(node);
+        // need to rate limit any beacon eth being withdrawn
+        rateLimiter.consume(UNRESTAKING_LIMIT_ID, SafeCast.toUint64(_sumRestakingETHWithdrawals(params) / 1 gwei));
+        IEtherFiNode(node).queueWithdrawals(params);
+    }
+    
+    /**
+     * @notice Queues a withdrawal for a given node
+     * @param id The id of the node to queue the withdrawal for
+     * @param params The parameters to queue the withdrawal with
+     */
+    function queueWithdrawals(uint256 id, IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyExecutorOperations whenNotPaused {
+        queueWithdrawals(etherfiNodeAddress(id), params);
+    }
+
+    /**
+     * @notice Completes all queued beaconETH withdrawals for a given node
+     * @param node The node to complete the queued beaconETH withdrawals for
+     * @param receiveAsTokens Whether to receive the withdrawals as tokens
+     */
     function completeQueuedETHWithdrawals(address node, bool receiveAsTokens) public onlyHousekeepingOperations whenNotPaused {
         _validateNode(node);
         uint256 balance = IEtherFiNode(node).completeQueuedETHWithdrawals(receiveAsTokens);
@@ -143,21 +196,22 @@ contract EtherFiNodesManager is
         }
     }
     
+    /**
+     * @notice Completes all queued beaconETH withdrawals for a given node
+     * @param id The id of the node to complete the queued beaconETH withdrawals for
+     * @param receiveAsTokens Whether to receive the withdrawals as tokens
+     */
     function completeQueuedETHWithdrawals(uint256 id, bool receiveAsTokens) external onlyHousekeepingOperations whenNotPaused {
         completeQueuedETHWithdrawals(etherfiNodeAddress(id), receiveAsTokens);
     }
 
-    function queueWithdrawals(address node, IDelegationManager.QueuedWithdrawalParams[] calldata params) public onlyExecutorOperations whenNotPaused {
-        _validateNode(node);
-        // need to rate limit any beacon eth being withdrawn
-        rateLimiter.consume(UNRESTAKING_LIMIT_ID, SafeCast.toUint64(sumRestakingETHWithdrawals(params) / 1 gwei));
-        IEtherFiNode(node).queueWithdrawals(params);
-    }
-    
-    function queueWithdrawals(uint256 id, IDelegationManager.QueuedWithdrawalParams[] calldata params) external onlyExecutorOperations whenNotPaused {
-        queueWithdrawals(etherfiNodeAddress(id), params);
-    }
-
+    /**
+     * @notice Completes all queued withdrawals for a given node
+     * @param node The node to complete the queued withdrawals for
+     * @param withdrawals The withdrawals to complete
+     * @param tokens The tokens to complete the withdrawals with
+     * @param receiveAsTokens Whether to receive the withdrawals as tokens
+     */
     function completeQueuedWithdrawals(address node, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) public onlyHousekeepingOperations whenNotPaused {
         _validateNode(node);
         uint256 balance = IEtherFiNode(node).completeQueuedWithdrawals(withdrawals, tokens, receiveAsTokens);
@@ -166,25 +220,19 @@ contract EtherFiNodesManager is
         }
     }
     
+    /**
+     * @notice Completes all queued withdrawals for a given node
+     * @param id The id of the node to complete the queued withdrawals for
+     * @param withdrawals The withdrawals to complete
+     * @param tokens The tokens to complete the withdrawals with
+     * @param receiveAsTokens Whether to receive the withdrawals as tokens
+     */
     function completeQueuedWithdrawals(uint256 id, IDelegationManager.Withdrawal[] calldata withdrawals, IERC20[][] calldata tokens, bool[] calldata receiveAsTokens) external onlyHousekeepingOperations whenNotPaused {
         completeQueuedWithdrawals(etherfiNodeAddress(id), withdrawals, tokens, receiveAsTokens);
     }
 
-    function sumRestakingETHWithdrawals(IDelegationManager.QueuedWithdrawalParams[] calldata params) internal pure returns (uint256) {
-        // Calculate total beaconETH amount for rate limiting - only rate limit beaconETH strategy withdrawals
-        uint256 totalBeaconEth = 0;
-        for (uint256 i = 0; i < params.length; i++) {
-            for (uint256 j = 0; j < params[i].strategies.length; j++) {
-                if (params[i].strategies[j] == IStrategy(BEACON_ETH_STRATEGY_ADDRESS)) {
-                    totalBeaconEth += params[i].depositShares[j];
-                }
-            }
-        }
-        return totalBeaconEth;
-    }
-
     //-------------------------------------------------------------------
-    //-------------  Execution-Layer Triggered Withdrawals  -------------
+    //--------------------  EL TRIGGER FUNCTIONS  -----------------------
     //-------------------------------------------------------------------
     /**
      * @notice Triggers EIP-7002 withdrawal requests, grouping by EigenPod automatically.
@@ -200,7 +248,7 @@ contract EtherFiNodesManager is
         if (requests.length == 0) revert EmptyWithdrawalsRequest();
 
         // rate limit the amount of the that can be withdrawn from beacon chain
-        uint256 totalExitGwei = getTotalEthRequested(requests);
+        uint256 totalExitGwei = _getTotalEthRequested(requests);
         rateLimiter.consume(EXIT_REQUEST_LIMIT_ID, SafeCast.toUint64(totalExitGwei));
 
         bytes32 pubKeyHash = calculateValidatorPubkeyHash(requests[0].pubkey);
@@ -217,19 +265,6 @@ contract EtherFiNodesManager is
         }
     }
 
-    function getTotalEthRequested (IEigenPod.WithdrawalRequest[] calldata requests) internal pure returns (uint256) {
-        uint256 totalGwei;
-        for (uint256 i = 0; i < requests.length; ++i) {
-            uint256 gweiAmount = requests[i].amountGwei == 0
-                ? FULL_EXIT_GWEI
-                : uint256(requests[i].amountGwei);
-
-            totalGwei += gweiAmount;
-        }
-        return totalGwei;
-    }
-
-
     /**
      * @notice Triggers EIP-7251 consolidation requests for validators in the same EigenPod.
      * @dev Access: only ETHERFI_NODES_MANAGER_EL_CONSOLIDATION_ROLE, pausable, nonReentrant.
@@ -244,7 +279,7 @@ contract EtherFiNodesManager is
         if (requests.length == 0) revert EmptyConsolidationRequest();
 
         // rate limit consolidation requests - each request could affect up to FULL_EXIT_GWEI
-        uint256 totalConsolidationGwei = getTotalConsolidationGwei(requests);
+        uint256 totalConsolidationGwei = _getTotalConsolidationGwei(requests);
         rateLimiter.consume(CONSOLIDATION_REQUEST_LIMIT_ID, SafeCast.toUint64(totalConsolidationGwei));
 
         // eigenlayer will revert if all validators don't belong to the same pod
@@ -270,53 +305,15 @@ contract EtherFiNodesManager is
         }
     }
 
-    /// @notice Calculates the total Gwei affected by consolidation requests for rate limiting
-    /// @dev For true consolidations (src != target), the source validator's full balance is merged
-    ///      For credential switches (src == target), we count 0 as no ETH movement occurs
-    /// @param requests The consolidation requests to process
-    /// @return totalGwei The total Gwei to rate limit
-    function getTotalConsolidationGwei(IEigenPod.ConsolidationRequest[] calldata requests) internal pure returns (uint256 totalGwei) {
-        for (uint256 i = 0; i < requests.length; ) {
-            // Only count true consolidations where source validator balance is moved
-            // Credential switches (src == target) don't move ETH
-            if (calculateValidatorPubkeyHash(requests[i].srcPubkey) != calculateValidatorPubkeyHash(requests[i].targetPubkey)) {
-                totalGwei += FULL_EXIT_GWEI;
-            }
-            unchecked { ++i; }
-        }
-    }
-
-    // returns withdrawal fee per each request
-    function getWithdrawalRequestFee(address pod) public view returns (uint256) {
-        return IEigenPod(pod).getWithdrawalRequestFee();
-    }
-
-    // returns consolidation fee per each request
-    function getConsolidationRequestFee(address pod) public view returns (uint256) {
-        return IEigenPod(pod).getConsolidationRequestFee();
-    }
-
     //-------------------------------------------------------------------
-    //---------------------  Key Management  ----------------------------
+    //---------------------  VALIDATOR LINKING FUNCTIONS ---------------
     //-------------------------------------------------------------------
-
-    ///@notice Calculates the pubkey hash of a validator's pubkey as per SSZ spec
-    function calculateValidatorPubkeyHash(bytes memory pubkey) public pure returns (bytes32) {
-        if (pubkey.length != VALIDATOR_PUBKEY_LENGTH) revert InvalidPubKeyLength();
-        return sha256(abi.encodePacked(pubkey, bytes16(0)));
-    }
-
-    /// @notice converts a target address to 0x01 withdrawal credential format for a traditional 32eth validator
-    function addressToWithdrawalCredentials(address addr) public pure returns (bytes memory) {
-        return abi.encodePacked(bytes1(0x01), bytes11(0x0), addr);
-    }
-
-    /// @notice converts a target address to 0x02 withdrawal credential format for a post Pectra compounding validator
-    function addressToCompoundingWithdrawalCredentials(address addr) public pure returns (bytes memory) {
-        return abi.encodePacked(bytes1(0x02), bytes11(0x0), addr);
-    }
-
-    /// @dev associate the provided pubkey with particular EtherFiNode instance.
+    /**
+     * @notice Associate the provided pubkey with particular EtherFiNode instance.
+     * @param pubkey The pubkey to associate with the node
+     * @param nodeAddress The address of the node to associate the pubkey with
+     * @param legacyId The legacy id of the node to associate the pubkey with
+     */
     function linkPubkeyToNode(bytes calldata pubkey, address nodeAddress, uint256 legacyId) external whenNotPaused {
         if (msg.sender != address(stakingManager)) revert InvalidCaller();
         bytes32 pubkeyHash = calculateValidatorPubkeyHash(pubkey);
@@ -330,27 +327,12 @@ contract EtherFiNodesManager is
         emit PubkeyLinked(pubkeyHash, nodeAddress, legacyId, pubkey);
     }
 
-    /// @notice get the etherFiNode instance associated with the provided ID. (Legacy validatorId or pubkeyHash)
-    /// @dev Note that this ID can either be a a traditional etherfi validatorID or
-    //       a validatorPubkeyHash cast as a uint256. This was done maintaint compatibility
-    //       with minimal changes as we migrate from our id system to using pubkey hash instead
-    function etherfiNodeAddress(uint256 id) public view returns (address) {
-        // if the ID is a legacy validatorID use the old storage array
-        // otherwise assume it is a pubkey hash.
-        // In a future upgrade we can fully remove the legacy path
-
-        // heuristic that if a pubkey hash, at least 1 bit of higher order bits must be 1
-        // all of the legacy id's were incrementing integers that will not have those bits set
-        uint256 mask = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000;
-        if (mask & id > 0) {
-            return address(etherFiNodeFromPubkeyHash[bytes32(id)]);
-        } else {
-            return legacyState.DEPRECATED_etherfiNodeAddress[id];
-        }
-    }
-
-    /// @dev this method is for linking our old legacy validator ids that were created before
-    ///    we started tracking the pubkeys onchain. We can delete this method once we have linked all of our legacy validators
+    /**
+     * @notice Link legacy validator ids that were created before we started tracking pubkeys onchain
+     * @param validatorIds The legacy validator ids to link
+     * @param pubkeys The pubkeys to link the validator ids to
+     * @dev We can delete this method once we have linked all of our legacy validators
+     */
     function linkLegacyValidatorIds(uint256[] calldata validatorIds, bytes[] calldata pubkeys) external onlyExecutorOperations {
         if (validatorIds.length != pubkeys.length) revert LengthMismatch();
         for (uint256 i = 0; i < validatorIds.length; i++) {
@@ -368,31 +350,61 @@ contract EtherFiNodesManager is
         }
     }
 
-
     //--------------------------------------------------------------------------------------
-    //-------------------------------- CALL FORWARDING  ------------------------------------
+    //-------------------------------  ADMIN FUNCTIONS  ------------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @notice Update the whitelist for external calls that can be executed by an EtherfiNode
-    /// @param user The address to grant/revoke permission for
-    /// @param selector method selector
-    /// @param target call target for forwarded call
-    /// @param allowed enable or disable the call
+    /**
+     * @notice Update the whitelist for external calls that can be executed by an EtherfiNode
+     * @param user The address to grant/revoke permission for
+     * @param selector method selector
+     * @param target call target for forwarded call
+     * @param allowed enable or disable the call
+     */
     function updateAllowedForwardedExternalCalls(address user, bytes4 selector, address target, bool allowed) external onlyAdmin {
         allowedForwardedExternalCalls[user][selector][target] = allowed;
         emit UserAllowedForwardedExternalCallsUpdated(user, selector, target, allowed);
     }
 
-    /// @notice Update the whitelist for external calls that can be executed against the corresponding eigenpod
-    /// @param user The address to grant/revoke permission for
-    /// @param selector method selector
-    /// @param allowed enable or disable the call
+    /**
+     * @notice Update the whitelist for external calls that can be executed against the corresponding eigenpod
+     * @param user The address to grant/revoke permission for
+     * @param selector method selector
+     * @param allowed enable or disable the call
+     */
     function updateAllowedForwardedEigenpodCalls(address user, bytes4 selector, bool allowed) external onlyAdmin {
         allowedForwardedEigenpodCalls[user][selector] = allowed;
         emit UserAllowedForwardedEigenpodCallsUpdated(user, selector, allowed);
     }
 
-    /// @notice forward a whitelisted call to a whitelisted external contract with the EtherFiNode as the caller
+    /**
+     * @notice Set the proof submitter for a specific node
+     * @param node The node address to set the proof submitter for
+     * @param proofSubmitter The address of the proof submitter
+     */
+    function setProofSubmitter(address node, address proofSubmitter) public onlyOperatingMultisig whenNotPaused {
+        _validateNode(node);
+        IEtherFiNode(node).setProofSubmitter(proofSubmitter);
+    }
+    
+    /**
+     * @notice Set the proof submitter for a specific node
+     * @param id The id of the node to set the proof submitter for
+     * @param proofSubmitter The address of the proof submitter
+     */
+    function setProofSubmitter(uint256 id, address proofSubmitter) external onlyOperatingMultisig whenNotPaused {
+        setProofSubmitter(etherfiNodeAddress(id), proofSubmitter);
+    }
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------- CALL FORWARDING  ------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice forward a whitelisted call to a whitelisted external contract with the EtherFiNode as the caller
+     * @param nodes The nodes to forward the call to
+     * @param data The data to forward the call with
+     * @param target The target to forward the call to
+     * @return returnData The return data from the call
+     */
     function forwardExternalCall(address[] calldata nodes, bytes[] calldata data, address target) external onlyEigenpodOperations whenNotPaused returns (bytes[] memory returnData) {
         if (nodes.length != data.length) revert InvalidForwardedCall();
 
@@ -411,8 +423,14 @@ contract EtherFiNodesManager is
         }
     }
 
-    /// @notice forward a whitelisted call to the associated eigenPod of the EtherFiNode with the EtherFiNode as the caller.
-    ///   This serves to allow us to support minor eigenlayer upgrades without needing to immediately upgrade our contracts.
+    /**
+     * @notice forward a whitelisted call to the associated eigenPod of the EtherFiNode with the EtherFiNode as the caller.
+     * @param nodes The nodes to forward the call to
+     * @param data The data to forward the call with
+     * @return returnData The return data from the call
+     * @dev This serves to allow us to support minor eigenlayer upgrades without needing to immediately upgrade our contracts.
+     * @return The return data from the call
+     */
     function forwardEigenPodCall(address[] calldata nodes, bytes[] calldata data) external onlyEigenpodOperations whenNotPaused returns (bytes[] memory returnData) {
         if (nodes.length != data.length) revert InvalidForwardedCall();
 
@@ -431,11 +449,162 @@ contract EtherFiNodesManager is
     }
 
     //--------------------------------------------------------------------------------------
-    //-----------------------------------  HELPERS  ----------------------------------------
+    //-------------------------------  INTERNAL FUNCTIONS  ----------------------------------
     //--------------------------------------------------------------------------------------
-    
-    /// @dev Internal helper to validate node exists and revert if not
+    /**
+     * @notice Calculates the total Gwei requested for withdrawal requests
+     * @param requests The withdrawal requests to process
+     * @return totalGwei The total Gwei to rate limit
+     */
+    function _getTotalEthRequested (IEigenPod.WithdrawalRequest[] calldata requests) internal pure returns (uint256) {
+        uint256 totalGwei;
+        for (uint256 i = 0; i < requests.length; ++i) {
+            uint256 gweiAmount = requests[i].amountGwei == 0
+                ? FULL_EXIT_GWEI
+                : uint256(requests[i].amountGwei);
+
+            totalGwei += gweiAmount;
+        }
+        return totalGwei;
+    }
+
+    /**
+     * @notice Calculates the total Gwei affected by consolidation requests for rate limiting
+     * @dev For true consolidations (src != target), the source validator's full balance is merged
+     *      For credential switches (src == target), we count 0 as no ETH movement occurs
+     * @param requests The consolidation requests to process
+     * @return totalGwei The total Gwei to rate limit
+     */
+    function _getTotalConsolidationGwei(IEigenPod.ConsolidationRequest[] calldata requests) internal pure returns (uint256 totalGwei) {
+        for (uint256 i = 0; i < requests.length; ) {
+            // Only count true consolidations where source validator balance is moved
+            // Credential switches (src == target) don't move ETH
+            if (calculateValidatorPubkeyHash(requests[i].srcPubkey) != calculateValidatorPubkeyHash(requests[i].targetPubkey)) {
+                totalGwei += FULL_EXIT_GWEI;
+            }
+            unchecked { ++i; }
+        }
+    }
+
+    /**
+     * @notice Calculates the total beaconETH amount for rate limiting - only rate limit beaconETH strategy withdrawals
+     * @param params The withdrawal parameters to process
+     * @return totalBeaconEth The total beaconETH amount
+     */
+    function _sumRestakingETHWithdrawals(IDelegationManager.QueuedWithdrawalParams[] calldata params) internal pure returns (uint256) {
+        // Calculate total beaconETH amount for rate limiting - only rate limit beaconETH strategy withdrawals
+        uint256 totalBeaconEth = 0;
+        for (uint256 i = 0; i < params.length; i++) {
+            for (uint256 j = 0; j < params[i].strategies.length; j++) {
+                if (params[i].strategies[j] == IStrategy(BEACON_ETH_STRATEGY_ADDRESS)) {
+                    totalBeaconEth += params[i].depositShares[j];
+                }
+            }
+        }
+        return totalBeaconEth;
+    }
+
+    /**
+     * @notice Validate that the node exists and revert if not
+     * @param node The node address to validate
+     */
     function _validateNode(address node) internal view {
         if (!stakingManager.deployedEtherFiNodes(node)) revert UnknownNode();
+    }
+
+    /**
+     * @notice Authorize the upgrade of the EtherFiNodesManager contract
+     * @param newImplementation The new implementation address
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //--------------------------------------------------------------------------------------
+    //--------------------------------  GETTERS  -------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Returns the associated eigenpod for a given node
+     * @param node The node to get the eigenpod for
+     * @return The associated eigenpod
+     */
+    function getEigenPod(address node) public view returns (address) {
+        _validateNode(node);
+        return address(IEtherFiNode(node).getEigenPod());
+    }
+    
+    /**
+     * @notice Returns the associated eigenpod for a given node
+     * @param id The id of the node to get the eigenpod for
+     * @return The associated eigenpod
+     */
+    function getEigenPod(uint256 id) public view returns (address) {
+        return getEigenPod(etherfiNodeAddress(id));
+    }
+
+    /**
+     * @notice Returns the withdrawal fee per each request
+     * @param pod The pod to get the withdrawal fee for
+     * @return The withdrawal fee
+     */
+    function getWithdrawalRequestFee(address pod) public view returns (uint256) {
+        return IEigenPod(pod).getWithdrawalRequestFee();
+    }
+
+    /**
+     * @notice Returns the consolidation fee per each request
+     * @param pod The pod to get the consolidation fee for
+     * @return The consolidation fee
+     */
+    function getConsolidationRequestFee(address pod) public view returns (uint256) {
+        return IEigenPod(pod).getConsolidationRequestFee();
+    }
+    /**
+     * @notice Calculates the pubkey hash of a validator's pubkey as per SSZ spec
+     * @param pubkey The pubkey to calculate the hash of
+     * @return The hash of the pubkey
+     */
+    function calculateValidatorPubkeyHash(bytes memory pubkey) public pure returns (bytes32) {
+        if (pubkey.length != VALIDATOR_PUBKEY_LENGTH) revert InvalidPubKeyLength();
+        return sha256(abi.encodePacked(pubkey, bytes16(0)));
+    }
+
+    /**
+     * @notice Converts a target address to 0x01 withdrawal credential format for a traditional 32eth validator
+     * @param addr The address to convert
+     * @return The withdrawal credential format
+     */
+    function addressToWithdrawalCredentials(address addr) public pure returns (bytes memory) {
+        return abi.encodePacked(bytes1(0x01), bytes11(0x0), addr);
+    }
+
+    /**
+     * @notice Converts a target address to 0x02 withdrawal credential format for a post Pectra compounding validator
+     * @param addr The address to convert
+     * @return The withdrawal credential format
+     */
+    function addressToCompoundingWithdrawalCredentials(address addr) public pure returns (bytes memory) {
+        return abi.encodePacked(bytes1(0x02), bytes11(0x0), addr);
+    }
+
+    /**
+     * @notice Get the etherFiNode instance associated with the provided ID. (Legacy validatorId or pubkeyHash)
+     * @param id The ID to get the etherFiNode instance for
+     * @dev Note that this ID can either be a a traditional etherfi validatorID or
+     *      a validatorPubkeyHash cast as a uint256. This was done maintaint compatibility
+     *      with minimal changes as we migrate from our id system to using pubkey hash instead
+     * @return The etherFiNode instance
+     */
+    function etherfiNodeAddress(uint256 id) public view returns (address) {
+        // if the ID is a legacy validatorID use the old storage array
+        // otherwise assume it is a pubkey hash.
+        // In a future upgrade we can fully remove the legacy path
+
+        // heuristic that if a pubkey hash, at least 1 bit of higher order bits must be 1
+        // all of the legacy id's were incrementing integers that will not have those bits set
+        uint256 mask = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000;
+        if (mask & id > 0) {
+            return address(etherFiNodeFromPubkeyHash[bytes32(id)]);
+        } else {
+            return legacyState.DEPRECATED_etherfiNodeAddress[id];
+        }
     }
 }

--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -144,7 +144,7 @@ contract EtherFiNodesManager is
      * @notice Queues a beaconETH withdrawal for a given node
      * @param node The node to queue the beaconETH withdrawal for
      * @param amount The amount of beaconETH to withdraw
-     * @return The withdrawal root
+     * @return withdrawalRoot The withdrawal root
      */
     function queueETHWithdrawal(address node, uint256 amount) public onlyExecutorOperations whenNotPaused returns (bytes32 withdrawalRoot) {
         _validateNode(node);
@@ -156,7 +156,7 @@ contract EtherFiNodesManager is
      * @notice Queues a beaconETH withdrawal for a given node
      * @param id The id of the node to queue the beaconETH withdrawal for
      * @param amount The amount of beaconETH to withdraw
-     * @return The withdrawal root
+     * @return withdrawalRoot The withdrawal root
      */
     function queueETHWithdrawal(uint256 id, uint256 amount) external onlyExecutorOperations whenNotPaused returns (bytes32 withdrawalRoot) {
         return queueETHWithdrawal(etherfiNodeAddress(id), amount);
@@ -429,7 +429,6 @@ contract EtherFiNodesManager is
      * @param data The data to forward the call with
      * @return returnData The return data from the call
      * @dev This serves to allow us to support minor eigenlayer upgrades without needing to immediately upgrade our contracts.
-     * @return The return data from the call
      */
     function forwardEigenPodCall(address[] calldata nodes, bytes[] calldata data) external onlyEigenpodOperations whenNotPaused returns (bytes[] memory returnData) {
         if (nodes.length != data.length) revert InvalidForwardedCall();

--- a/src/staking/NodeOperatorManager.sol
+++ b/src/staking/NodeOperatorManager.sol
@@ -13,30 +13,9 @@ import "@etherfi/governance/utils/DeprecatedOZPausable.sol";
 
 /// Contract which helps us control our node operators and their permissions in different aspects of the protocol
 contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgradeable, DeprecatedOZPausable, DeprecatedOZOwnable, Pausable {
-
-    //--------------------------------------------------------------------------------------
-    //-------------------------------------  EVENTS  ---------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    event OperatorRegistered(address operator, uint64 totalKeys, uint64 keysUsed, bytes ipfsHash);
-    event AddedToWhitelist(address userAddress);
-    event RemovedFromWhitelist(address userAddress);
-    event UpdatedOperatorApprovals(address operator, LiquidityPool.SourceOfFunds source, bool approved);
-
-    //--------------------------------------------------------------------------------------
-    //-------------------------------------  ERRORS  ---------------------------------------
-    //--------------------------------------------------------------------------------------
-
-    error IncorrectCaller();
-    error InvalidLengths();
-    error AlreadyRegistered();
-    error InsufficientPublicKeys();
-    error InvalidArrayLengths();
-
     //--------------------------------------------------------------------------------------
     //---------------------------------  STATE-VARIABLES  ----------------------------------
     //--------------------------------------------------------------------------------------
-
     // deprecated storage slots
     uint160 private __gap_0;
 
@@ -53,31 +32,59 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
     //--------------------------------------------------------------------------------------
     //---------------------------------  IMMUTABLES  --------------------------------------
     //--------------------------------------------------------------------------------------
-
     address public immutable auctionManagerContractAddress;
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  EVENTS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    event OperatorRegistered(address operator, uint64 totalKeys, uint64 keysUsed, bytes ipfsHash);
+    event AddedToWhitelist(address userAddress);
+    event RemovedFromWhitelist(address userAddress);
+    event UpdatedOperatorApprovals(address operator, LiquidityPool.SourceOfFunds source, bool approved);
+
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ERRORS  ---------------------------------------
+    //--------------------------------------------------------------------------------------
+    error IncorrectCaller();
+    error InvalidLengths();
+    error AlreadyRegistered();
+    error InsufficientPublicKeys();
+    error InvalidArrayLengths();
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTRUCTOR  -------------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Constructor
+     * @param _roleRegistry The address of the role registry
+     * @param _auctionManagerContractAddress The address of the auction manager contract
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
     constructor(address _roleRegistry, address _auctionManagerContractAddress) RolesLibrary(_roleRegistry) {
         auctionManagerContractAddress = _auctionManagerContractAddress;
         _disableInitializers();
     }
 
     //--------------------------------------------------------------------------------------
-    //----------------------------  STATE-CHANGING FUNCTIONS  ------------------------------
+    //----------------------------  INITIALIZERS  ------------------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @notice initializes contract
+    /**
+     * @notice Initialize the NodeOperatorManager
+     * @dev This function is called by the constructor to initialize the contract
+     *      and is only called once.
+     */
     function initialize() external initializer {
         __UUPSUpgradeable_init();
     }
 
-    /// @notice Registers a user as a operator to allow them to bid
-    /// @param _ipfsHash location of all IPFS data stored for operator
-    /// @param _totalKeys The number of keys they have available, relates to how many validators they can run
+    //--------------------------------------------------------------------------------------
+    //----------------------------  REGISTER FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Registers a user as a operator to allow them to bid
+     * @param _ipfsHash location of all IPFS data stored for operator
+     * @param _totalKeys The number of keys they have available, relates to how many validators they can run
+     */
     function registerNodeOperator(
         bytes memory _ipfsHash,
         uint64 _totalKeys
@@ -101,9 +108,11 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
         );
     }
 
-    /// @notice Fetches the next key they have available to use
-    /// @param _user the user to fetch the key for
-    /// @return The ipfs index available for the validator
+    /**
+     * @notice Fetches the next key they have available to use
+     * @param _user the user to fetch the key for
+     * @return The ipfs index available for the validator
+     */
     function fetchNextKeyIndex(
         address _user
     ) external onlyAuctionManagerContract returns (uint64) {
@@ -116,14 +125,19 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
         return ipfsIndex;
     }
 
-    /// @notice Approves or un approves an operator to run validators from a specific source of funds
-    /// @dev To allow a permissioned system, we will approve node operators to run validators only for a specific source of funds (EETH / ETHER_FAN)
-    ///         Some operators can be approved for both sources and some for only one. Being approved means that when a BNFT player deposits,
-    ///         we allocate a source of funds to be used for the deposit. And only operators approved for that source can run the validators
-    ///         being created.
-    /// @param _users the operator addresses to perform an approval or denial on
-    /// @param _approvedTags the source of funds we will be updating operator permissions for
-    /// @param _approvals whether we are approving or un approving the operator
+    //--------------------------------------------------------------------------------------
+    //----------------------------  ADMIN FUNCTIONS  -------------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Approves or un approves an operator to run validators from a specific source of funds
+     * @dev To allow a permissioned system, we will approve node operators to run validators only for a specific source of funds (EETH / ETHER_FAN)
+     *         Some operators can be approved for both sources and some for only one. Being approved means that when a BNFT player deposits,
+     *         we allocate a source of funds to be used for the deposit. And only operators approved for that source can run the validators
+     *         being created.
+     * @param _users the operator addresses to perform an approval or denial on
+     * @param _approvedTags the source of funds we will be updating operator permissions for
+     * @param _approvals whether we are approving or un approving the operator
+     */
     function batchUpdateOperatorsApprovedTags(
         address[] memory _users, 
         LiquidityPool.SourceOfFunds[] memory _approvedTags, 
@@ -137,46 +151,54 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
         }
     }
 
-    /// @notice Adds an address to the whitelist
-    /// @param _address Address of the user to add
+    /**
+     * @notice Adds an address to the whitelist
+     * @param _address Address of the user to add
+     */
     function addToWhitelist(address _address) external onlyOperatingMultisig {
         whitelistedAddresses[_address] = true;
 
         emit AddedToWhitelist(_address);
     }
 
-    /// @notice Removed an address from the whitelist
-    /// @param _address Address of the user to remove
+    /**
+     * @notice Removed an address from the whitelist
+     * @param _address Address of the user to remove
+     */
     function removeFromWhitelist(address _address) external onlyOperatingMultisig {
         whitelistedAddresses[_address] = false;
 
         emit RemovedFromWhitelist(_address);
     }
 
-    /// @notice Function to check whether an operator is approved for a specified source of funds
-    /// @param _operator the operator we are checking permissions for
-    /// @param _source the source of funds we are checking the operator against
-    /// @return approved whether the operator is approved or not
-    function isEligibleToRunValidatorsForSourceOfFund(address _operator, ILiquidityPool.SourceOfFunds _source) external view returns (bool approved) {
-        approved = operatorApprovedTags[_operator][_source];
-    }
+    //--------------------------------------------------------------------------------------
+    //-------------------------------  INTERNAL FUNCTIONS   --------------------------------
+    //--------------------------------------------------------------------------------------
+    /**
+     * @notice Authorizes the upgrade of the implementation contract
+     * @param newImplementation the address of the new implementation contract
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
 
     //--------------------------------------------------------------------------------------
     //-----------------------------------  GETTERS   ---------------------------------------
     //--------------------------------------------------------------------------------------
-
-    /// @notice Fetches the number of keys the user has, used or un-used
-    /// @param _user the user to fetch the data for
-    /// @return totalKeys The number of keys the user has
+    /**
+     * @notice Fetches the number of keys the user has, used or un-used
+     * @param _user the user to fetch the data for
+     * @return totalKeys The number of keys the user has
+     */
     function getUserTotalKeys(
         address _user
     ) external view returns (uint64 totalKeys) {
         totalKeys = addressToOperatorData[_user].totalKeys;
     }
 
-    /// @notice Fetches the number of keys the user has left to use
-    /// @param _user the user to fetch the data for
-    /// @return numKeysRemaining the number of keys the user has remaining
+    /**
+     * @notice Fetches the number of keys the user has left to use
+     * @param _user the user to fetch the data for
+     * @return numKeysRemaining the number of keys the user has remaining
+     */
     function getNumKeysRemaining(
         address _user
     ) external view returns (uint64 numKeysRemaining) {
@@ -186,30 +208,44 @@ contract NodeOperatorManager is INodeOperatorManager, Initializable, UUPSUpgrade
             keyData.totalKeys - keyData.keysUsed;
     }
 
-    /// @notice Fetches if the user is whitelisted
-    /// @dev Used in the auction contract to verify when a user bids that they are indeed whitelisted
-    /// @param _user the user to fetch the data for
-    /// @return whitelisted Bool value if they are whitelisted or not
+    /**
+     * @notice Fetches if the user is whitelisted
+     * @dev Used in the auction contract to verify when a user bids that they are indeed whitelisted
+     * @param _user the user to fetch the data for
+     * @return whitelisted Bool value if they are whitelisted or not
+     */
     function isWhitelisted(
         address _user
     ) public view returns (bool whitelisted) {
         whitelisted = whitelistedAddresses[_user];
     }
 
+    /**
+     * @notice Function to check whether an operator is approved for a specified source of funds
+     * @param _operator the operator we are checking permissions for
+     * @param _source the source of funds we are checking the operator against
+     * @return approved whether the operator is approved or not
+     */
+    function isEligibleToRunValidatorsForSourceOfFund(address _operator, ILiquidityPool.SourceOfFunds _source) external view returns (bool approved) {
+        approved = operatorApprovedTags[_operator][_source];
+    }
+
+    /**
+     * @notice Fetches the address of the implementation contract currently being used by the proxy
+     * @dev Needed for the getImplementation() function in the UUPSUpgradeable contract
+     * @return the address of the currently used implementation contract
+     */
     function getImplementation() external view returns (address) {
         return _getImplementation();
     }
 
     //--------------------------------------------------------------------------------------
-    //-------------------------------  INTERNAL FUNCTIONS   --------------------------------
-    //--------------------------------------------------------------------------------------
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
-    //--------------------------------------------------------------------------------------
     //-----------------------------------  MODIFIERS  --------------------------------------
     //--------------------------------------------------------------------------------------
-
+    /**
+     * @notice Modifier to only allow the auction manager contract to call a function
+     * @dev Only the auction manager contract can call this function
+     */
     modifier onlyAuctionManagerContract() {
         if (msg.sender != auctionManagerContractAddress) revert IncorrectCaller();
         _;

--- a/src/staking/StakingManager.sol
+++ b/src/staking/StakingManager.sol
@@ -27,29 +27,42 @@ contract StakingManager is
     UUPSUpgradeable,
     RolesLibrary
 {
+    //---------------------------------------------------------------------------
+    //-----------------------------  Storage  -----------------------------------
+    //---------------------------------------------------------------------------
+    LegacyStakingManagerState legacyState; // all legacy state in this contract has been deprecated
+    mapping(address => bool) public deployedEtherFiNodes;
+    mapping(bytes32 => ValidatorCreationStatus) public validatorCreationStatus;
 
+    //---------------------------------------------------------------------------
+    //-----------------------------  IMMUTABLES  ---------------------------------
+    //---------------------------------------------------------------------------
     address public immutable liquidityPool;
-    uint256 public constant INITIAL_DEPOSIT_AMOUNT = 1 ether;
-    uint256 public constant MIN_VALIDATOR_SIZE_WEI = 32 ether;
-    uint256 public constant MAX_VALIDATOR_SIZE_WEI = 2048 ether;
-    uint256 public constant VALIDATOR_PUBKEY_LENGTH = 48;
     IEtherFiNodesManager public immutable etherFiNodesManager;
     IDepositContract public immutable depositContractEth2;
     IAuctionManager public immutable auctionManager;
     UpgradeableBeacon public immutable etherFiNodeBeacon;
 
     //---------------------------------------------------------------------------
-    //-----------------------------  Storage  -----------------------------------
+    //-----------------------------  CONSTANTS  ---------------------------------
     //---------------------------------------------------------------------------
-
-    LegacyStakingManagerState legacyState; // all legacy state in this contract has been deprecated
-    mapping(address => bool) public deployedEtherFiNodes;
-    mapping(bytes32 => ValidatorCreationStatus) public validatorCreationStatus;
+    uint256 public constant INITIAL_DEPOSIT_AMOUNT = 1 ether;
+    uint256 public constant MIN_VALIDATOR_SIZE_WEI = 32 ether;
+    uint256 public constant MAX_VALIDATOR_SIZE_WEI = 2048 ether;
+    uint256 public constant VALIDATOR_PUBKEY_LENGTH = 48;
 
     //-------------------------------------------------------------------------
-    //-----------------------------  Admin  -----------------------------------
+    //-----------------------------  CONSTRUCTOR  ----------------------------
     //-------------------------------------------------------------------------
-
+    /**
+     * @notice Constructor
+     * @param _liquidityPool The address of the liquidity pool
+     * @param _etherFiNodesManager The address of the etherfi nodes manager
+     * @param _ethDepositContract The address of the eth deposit contract
+     * @param _auctionManager The address of the auction manager
+     * @param _etherFiNodeBeacon The address of the etherfi node beacon
+     * @param _roleRegistry The address of the role registry
+     */
     constructor(
         address _liquidityPool,
         address _etherFiNodesManager,
@@ -67,12 +80,15 @@ contract StakingManager is
         _disableInitializers();
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
-
     //---------------------------------------------------------------------------
-    //------------------------- Deposit Flow ------------------------------------
+    //------------------------- OPERATIONAL FUNCTIONS  ----------------------------
     //---------------------------------------------------------------------------
-    
+    /**
+     * @notice Invalidates a registered beacon validator
+     * @param depositData The deposit data of the validator to invalidate
+     * @param bidId The bid id of the validator to invalidate
+     * @param etherFiNode The address of the etherfi node to invalidate the validator for
+     */
     function invalidateRegisteredBeaconValidator(DepositData calldata depositData, uint256 bidId, address etherFiNode) external onlyOracleOperations {
         bytes32 validatorCreationDataHash = keccak256(abi.encode(depositData.publicKey, depositData.signature, depositData.depositDataRoot, depositData.ipfsHashForEncryptedValidatorKey, bidId, etherFiNode));
         if (validatorCreationStatus[validatorCreationDataHash] != ValidatorCreationStatus.REGISTERED) revert InvalidValidatorCreationStatus();
@@ -80,8 +96,31 @@ contract StakingManager is
         emit ValidatorCreationStatusUpdated(depositData, bidId, etherFiNode, validatorCreationDataHash, ValidatorCreationStatus.INVALIDATED);
     }
 
-   /// @notice send 1 eth to deposit contract to create the validator.
-    ///    The rest of the eth will not be sent until the oracle confirms the withdrawal credentials
+    /**
+     * @notice Creates a new proxy instance of the etherFiNode withdrawal safe contract.
+     * @param _createEigenPod Whether to create an associated eigenPod contract.
+     * @return The address of the new etherFiNode
+     */
+    function instantiateEtherFiNode(bool _createEigenPod) external onlyExecutorOperations returns (address) {
+        BeaconProxy proxy = new BeaconProxy(address(etherFiNodeBeacon), "");
+        address node = address(proxy);
+
+        deployedEtherFiNodes[node] = true;
+        emit EtherFiNodeDeployed(node);
+
+        if (_createEigenPod) {
+            etherFiNodesManager.createEigenPod(node);
+        }
+
+        return node;
+    }
+
+    /**
+     * @notice Sends 1 eth to deposit contract to create the validator.
+     * @param depositData The deposit data of the validator to create
+     * @param bidIds The bid ids of the validator to create
+     * @param etherFiNode The address of the etherfi node to create the validator for
+     */
     function createBeaconValidators(DepositData[] calldata depositData, uint256[] calldata bidIds, address etherFiNode) external payable {
         if (msg.sender != liquidityPool) revert InvalidCaller();
         if (depositData.length != bidIds.length) revert InvalidDepositData();
@@ -114,8 +153,12 @@ contract StakingManager is
         }
     }
 
-    /// @notice register the beacon validators data for later confirmation from the oracle before the 1eth deposit
-    /// @dev provided deposit data must be for a 0x02 compounding validator
+    /**
+     * @notice Registers the beacon validators data for later confirmation from the oracle before the 1eth deposit
+     * @param depositData The deposit data of the validator to register
+     * @param bidIds The bid ids of the validator to register
+     * @param etherFiNode The address of the etherfi node to register the validator for
+     */
     function registerBeaconValidators(DepositData[] calldata depositData, uint256[] calldata bidIds, address etherFiNode) external {
         if (msg.sender != liquidityPool) revert InvalidCaller();
         if (depositData.length != bidIds.length) revert InvalidDepositData();
@@ -139,12 +182,16 @@ contract StakingManager is
         }
     }
 
-    /// @notice send remaining eth to activate validators created by "createBeaconValidators"
-    ///    The oracle is expected to have confirmed the withdrawal credentials
-    /// @dev note that since this is considered a "validator top up" by the beacon chain,
-    ///   The signatures are not actually verified by the beacon chain, as key ownership was
-    ///   already proved during the previous deposit. The "deposit data root" i.e. (checksum) however must be valid.
-    ///   The caller can use generateDepositDataRoot() to generate a valid root.
+    /**
+     * @notice Sends remaining eth to activate validators created by "createBeaconValidators"
+     * @param depositData The deposit data of the validator to confirm and fund
+     * @param validatorSizeWei The size of the validator to confirm and fund
+     * @dev The oracle is expected to have confirmed the withdrawal credentials
+     *      note that since this is considered a "validator top up" by the beacon chain,
+     *      the signatures are not actually verified by the beacon chain, as key ownership was
+     *      already proved during the previous deposit. The "deposit data root" i.e. (checksum) however must be valid.
+     *      The caller can use generateDepositDataRoot() to generate a valid root.
+     */
     function confirmAndFundBeaconValidators(DepositData[] calldata depositData, uint256 validatorSizeWei) external payable {
         if (msg.sender != liquidityPool) revert InvalidCaller();
         if (validatorSizeWei < MIN_VALIDATOR_SIZE_WEI || validatorSizeWei > MAX_VALIDATOR_SIZE_WEI) revert InvalidValidatorSize();
@@ -172,61 +219,23 @@ contract StakingManager is
         }
     }
 
-    /// @notice Calculates the pubkey hash of a validator's pubkey as per SSZ spec
-    function calculateValidatorPubkeyHash(bytes memory pubkey) public pure returns (bytes32) {
-        if (pubkey.length != VALIDATOR_PUBKEY_LENGTH) revert InvalidPubKeyLength();
-        return sha256(abi.encodePacked(pubkey, bytes16(0)));
-    }
-
-    /// @notice compute deposit_data_root for the provide deposit data
-    //    The deposit_data_root is essentially a checksum of the provided deposit over the (pubkey, signature, withdrawalCreds, amount)
-    //    and represents the "node" that will be inserted into the beacon deposit merkle tree.
-    //    Note that this is separate from the from the top level beacon deposit_root
-    function generateDepositDataRoot(bytes memory pubkey, bytes memory signature, bytes memory withdrawalCredentials, uint256 amount) public pure returns (bytes32) {
-        return depositDataRootGenerator.generateDepositDataRoot(pubkey, signature, withdrawalCredentials, amount);
-    }
-
     //---------------------------------------------------------------------------
-    //--------------------- EtherFiNode Beacon Proxy ----------------------------
+    //--------------------- ADMIN FUNCTIONS  ------------------------------------
     //---------------------------------------------------------------------------
-
-    /// @notice Upgrades the etherfi node
-    /// @param _newImplementation The new address of the etherfi node
+    /**
+     * @notice Upgrades the etherfi node
+     * @param _newImplementation The new address of the etherfi node
+     */
     function upgradeEtherFiNode(address _newImplementation) external onlyUpgradeTimelock {
         if (_newImplementation == address(0)) revert InvalidUpgrade();
 
         etherFiNodeBeacon.upgradeTo(_newImplementation);
     }
 
-    /// @notice Fetches the address of the beacon contract for future EtherFiNodes (withdrawal safes)
-    function getEtherFiNodeBeacon() external view returns (address) {
-        return address(etherFiNodeBeacon);
-    }
-
-    /// @notice Fetches the address of the implementation contract currently being used by the beacon proxy
-    /// @return the address of the currently used implementation contract
-    function implementation() public view override returns (address) {
-        return etherFiNodeBeacon.implementation();
-    }
-
-    /// @dev create a new proxy instance of the etherFiNode withdrawal safe contract.
-    /// @param _createEigenPod whether or not to create an associated eigenPod contract.
-    function instantiateEtherFiNode(bool _createEigenPod) external onlyExecutorOperations returns (address) {
-        BeaconProxy proxy = new BeaconProxy(address(etherFiNodeBeacon), "");
-        address node = address(proxy);
-
-        deployedEtherFiNodes[node] = true;
-        emit EtherFiNodeDeployed(node);
-
-        if (_createEigenPod) {
-            etherFiNodesManager.createEigenPod(node);
-        }
-
-        return node;
-    }
-
-    /// @dev this method is for backfilling the addresses of etherFiNodes the protocol has previously deployed
-    ///    Once this data has been backfilled we can delete this method
+    /**
+     * @notice Backfills the addresses of etherFiNodes the protocol has previously deployed
+     * @param nodes The addresses of the etherFiNodes to backfill
+     */
     function backfillExistingEtherFiNodes(address[] calldata nodes) external onlyOperatingMultisig {
         for (uint256 i = 0; i < nodes.length; i++) {
             address node = nodes[i];
@@ -235,5 +244,55 @@ contract StakingManager is
             deployedEtherFiNodes[node] = true;
             emit EtherFiNodeDeployed(node);
         }
+    }
+
+    //---------------------------------------------------------------------------
+    //-----------------------------  INTERNAL FUNCTIONS  -------------------------
+    //---------------------------------------------------------------------------
+    /**
+     * @notice Authorizes the upgrade of the implementation contract
+     * @param newImplementation the address of the new implementation contract
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyUpgradeTimelock {}
+
+    //---------------------------------------------------------------------------
+    //-----------------------------  GETTERS  ------------------------------------
+    //---------------------------------------------------------------------------
+    /**
+     * @notice Fetches the address of the beacon contract for future EtherFiNodes (withdrawal safes)
+     * @return the address of the beacon contract
+     */
+    function getEtherFiNodeBeacon() external view returns (address) {
+        return address(etherFiNodeBeacon);
+    }
+
+    /**
+     * @notice Fetches the address of the implementation contract currently being used by the beacon proxy
+     * @return the address of the currently used implementation contract
+     */
+    function implementation() public view override returns (address) {
+        return etherFiNodeBeacon.implementation();
+    }
+
+    /**
+     * @notice Calculates the pubkey hash of a validator's pubkey as per SSZ spec
+     * @param pubkey The pubkey to calculate the hash of
+     * @return The hash of the pubkey
+     */
+    function calculateValidatorPubkeyHash(bytes memory pubkey) public pure returns (bytes32) {
+        if (pubkey.length != VALIDATOR_PUBKEY_LENGTH) revert InvalidPubKeyLength();
+        return sha256(abi.encodePacked(pubkey, bytes16(0)));
+    }
+
+    /**
+     * @notice compute deposit_data_root for the provide deposit data
+     * @param pubkey The pubkey to generate the deposit data root for
+     * @param signature The signature to generate the deposit data root for
+     * @param withdrawalCredentials The withdrawal credentials to generate the deposit data root for
+     * @param amount The amount to generate the deposit data root for
+     * @return The deposit data root
+     */
+    function generateDepositDataRoot(bytes memory pubkey, bytes memory signature, bytes memory withdrawalCredentials, uint256 amount) public pure returns (bytes32) {
+        return depositDataRootGenerator.generateDepositDataRoot(pubkey, signature, withdrawalCredentials, amount);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are comment and code organization only; no intentional logic or access-control modifications, though any large reorder diff warrants a quick compile/test pass before upgrade.
> 
> **Overview**
> This PR **standardizes NatSpec and file layout** across five staking contracts (`AuctionManager`, `EtherFiNode`, `EtherFiNodesManager`, `NodeOperatorManager`, `StakingManager`) without changing on-chain behavior.
> 
> Comments move from terse `///` lines to structured `/** @notice … @param … @dev … */` blocks, with clearer section banners (e.g. initializers, auction/staking/admin, operational vs withdrawal, getters, modifiers). **AuctionManager** groups bid admin setters under **ADMIN FUNCTIONS** instead of a separate setter section. **EtherFiNodesManager** reorders code (immutables/constants, withdrawal vs EL-trigger vs validator linking), moves `setProofSubmitter` into admin, clusters view/helpers at the bottom, and renames internal rate-limit helpers to `_getTotalEthRequested`, `_getTotalConsolidationGwei`, and `_sumRestakingETHWithdrawals` (same logic). **EtherFiNode** and **StakingManager** similarly reorder storage/immutables and regroup functions (e.g. `getEigenPod` under getters; `instantiateEtherFiNode` with operational deposit flow). **NodeOperatorManager** mainly reorders events/errors and section headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac2e91fac0e9935fc04dd8373022c99a439a43c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->