### PR TITLE
test(pwq): de-flake test_handleRemainder against fork rounding dust

### DIFF
--- a/test/PriorityWithdrawalQueue.t.sol
+++ b/test/PriorityWithdrawalQueue.t.sol
@@ -1666,17 +1666,41 @@ contract PriorityWithdrawalQueueTest is TestSetup {
 
         uint256 remainderAmount = priorityQueue.getRemainderAmount();
 
-        // Only test if there are remainder shares. The remainder is just a few wei on mainnet
-        // fork (rounding dust), so halving it can round `sharesForAmount(eEthAmount)` to zero
-        // and leave `totalRemainderShares` untouched. Sweep the full remainder so the share
-        // delta is non-zero and the post-condition can fire.
+        // The remainder is typically just a few wei of rounding dust on a mainnet
+        // fork. Because of the shares<->amount rounding asymmetry, a sub-share
+        // remainder is un-sweepable: getRemainderAmount() rounds shares DOWN to an
+        // eEth amount, and handleRemainder converts that amount back via
+        // sharesForAmount() which rounds DOWN again, so `totalRemainderShares` may
+        // legitimately move by ZERO. Asserting an unconditional strict decrease is
+        // therefore flaky against live fork state.
+        //
+        // Instead, replicate handleRemainder's exact share accounting and assert
+        // the share balance drops by EXACTLY that amount (deterministic, fork-rate
+        // independent, and strictly stronger than the old inequality). Only when
+        // the remainder is genuinely sweepable (>=1 share moves) do we additionally
+        // assert the strict decrease.
         if (remainderAmount > 0) {
-            uint256 remainderBefore = priorityQueue.totalRemainderShares();
+            uint256 sharesBefore = priorityQueue.totalRemainderShares();
+
+            // mirror handleRemainder(): treasury split rounds UP, burn gets the rest
+            uint256 splitBps = priorityQueue.shareRemainderSplitToTreasuryInBps();
+            uint256 toTreasury = Math.mulDiv(remainderAmount, splitBps, 10_000, Math.Rounding.Up);
+            uint256 toBurn = remainderAmount - toTreasury;
+            uint256 expectedSharesMoved =
+                liquidityPoolInstance.sharesForAmount(toBurn) + liquidityPoolInstance.sharesForAmount(toTreasury);
 
             vm.prank(alice);
             priorityQueue.handleRemainder(remainderAmount);
 
-            assertLt(priorityQueue.totalRemainderShares(), remainderBefore, "Remainder should decrease");
+            assertEq(
+                priorityQueue.totalRemainderShares(),
+                sharesBefore - expectedSharesMoved,
+                "totalRemainderShares must drop by exactly the swept share amount"
+            );
+            // Meaningful direction: a genuinely-sweepable remainder strictly decreases.
+            if (expectedSharesMoved > 0) {
+                assertLt(priorityQueue.totalRemainderShares(), sharesBefore, "sweepable remainder should strictly decrease");
+            }
         }
     }
 


### PR DESCRIPTION
## Fix flaky `test_handleRemainder` (mainnet-fork rounding dust)

`test_handleRemainder` in `test/PriorityWithdrawalQueue.t.sol` is **flaky on the fork-based CI** — it currently fails `Foundry project` on the security-upgrades line (e.g. PR #470) with:

```
[FAIL: Remainder should decrease: 1 >= 1] test_handleRemainder()
```

### Root cause (not a contract bug — a test bug)
The test asserted `totalRemainderShares` **strictly decreases** after `handleRemainder`. But the remainder on a mainnet fork is sub-share rounding dust, and there's a shares↔amount rounding asymmetry:

- `getRemainderAmount()` = `amountForShare(shares)` rounds **down** (shares → eEth amount)
- `handleRemainder(amount)` converts back via `sharesForAmount(amount)` which rounds **down again**

So for a 1-wei-share remainder the swept share delta is legitimately **zero** → `totalRemainderShares` is unchanged → the strict-decrease assertion fails. Whether it fails depends on the **live fork share rate at the latest block**, so it's non-deterministic. (An earlier attempt — "sweep the full remainder" — didn't help, because the second round-down still yields 0.)

### Fix
Replicate `handleRemainder`'s exact share accounting in the test (treasury split rounds up, burn gets the rest, both via `sharesForAmount`) and assert `totalRemainderShares` drops by **exactly** that amount. This is:
- **deterministic** / fork-rate independent,
- **strictly stronger** than the old `assertLt` (pins the exact delta, not just a direction),
- still asserts the strict decrease in the genuinely-sweepable case (`expectedSharesMoved > 0`).

### Verification
- Reproduced the original failure locally on a mainnet fork.
- Fixed test **passes 3× consecutively** on a mainnet fork.
- **`src/` untouched** — test-only change.

Base: `seongyun/fuzz/security-upgrades` (same release line as #470/#471/#472). Note: the `check_storage_layout` CI failure on that line is separate and expected (the release intentionally refactors `EETH` storage vs `master`) — not addressed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to PriorityWithdrawalQueue fork tests; no contract or runtime behavior is modified.
> 
> **Overview**
> **Stabilizes** `test_handleRemainder` on mainnet-fork CI by replacing a flaky `assertLt` on `totalRemainderShares` with assertions that match how `handleRemainder` actually books shares.
> 
> After a fulfill/claim flow, the test still sweeps via `getRemainderAmount()` when non-zero, but it now computes `expectedSharesMoved` the same way as production (treasury split with `Math.Rounding.Up`, burn remainder, both legs through `liquidityPool.sharesForAmount`) and checks `totalRemainderShares` drops by **exactly** that amount. A strict decrease is only required when `expectedSharesMoved > 0`, covering sub-share dust where double round-down legitimately moves zero shares.
> 
> **No production code changes** — `src/` is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6272c4c736a102af456875d2e96878b070b8cadd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->