### PR TITLE
test(invariant): fix Cursor Bugbot findings (I10 membership mgr + I12/I13 non-vacuity)

### DIFF
--- a/test/invariant/RewardsDistributor.invariant.t.sol
+++ b/test/invariant/RewardsDistributor.invariant.t.sol
@@ -39,6 +39,21 @@ contract RewardsDistributorInvariantTest is TestSetup {
         // Fund the distributor with ETH so ETH-token claims can pay out.
         vm.deal(address(cumulativeMerkleRewardsDistributorInstance), 1_000_000 ether);
 
+        // Restrict fuzzing to the handler's ACTION functions. Without an explicit
+        // selector list the engine also targets the handler's public view getters
+        // (numClaimants / claimants / callCounts / ghost*), wasting the call budget
+        // on no-ops so the lifecycle (setPending -> finalize -> claim) is never
+        // driven and the run is vacuous (all counters 0). Curate the selectors so
+        // every call advances the state machine.
+        bytes4[] memory selectors = new bytes4[](7);
+        selectors[0] = handler.doSetPendingRoot.selector;
+        selectors[1] = handler.doFinalize.selector;
+        selectors[2] = handler.doClaim.selector;
+        selectors[3] = handler.doReplayClaim.selector;
+        selectors[4] = handler.doSetClaimDelay.selector;
+        selectors[5] = handler.doWarp.selector;
+        selectors[6] = handler.doRoll.selector;
+        targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }
 
@@ -77,6 +92,30 @@ contract RewardsDistributorInvariantTest is TestSetup {
             handler.ghost_finalizeRootMismatch(),
             "I13: claimable root != root that was pending for >= claimDelay"
         );
+    }
+
+    // =====================================================================
+    // Non-vacuity: the run MUST have actually exercised the merkle-delay and
+    // payout logic this suite defends. Without this, the I12/I13 ghost flags
+    // stay false and balances stay zero if those paths are never hit, so the
+    // invariants could pass without proving anything. Asserted once at the end.
+    // =====================================================================
+    function afterInvariant() public {
+        // I13 path: at least one root must have been finalized after its delay.
+        assertGt(handler.callCounts("finalize_ok"), 0, "non-vacuity: no merkle root was ever finalized (I13 unexercised)");
+        // I12 path: at least one successful claim must have paid out.
+        assertGt(handler.callCounts("claim_ok"), 0, "non-vacuity: no claim ever succeeded (I12 payout unexercised)");
+        // Double-pay defense: at least one replay must have been attempted AND rejected.
+        assertGt(handler.callCounts("replay_revert"), 0, "non-vacuity: replay/double-pay path never exercised");
+
+        // And the run must have actually moved ETH: total ghost-paid across all
+        // claimants > 0 (independent of the counters above).
+        uint256 totalPaid;
+        uint256 n = handler.numClaimants();
+        for (uint256 i = 0; i < n; i++) {
+            totalPaid += handler.ghostPaid(handler.claimants(i));
+        }
+        assertGt(totalPaid, 0, "non-vacuity: zero ETH paid across the whole run (claims never settled)");
     }
 
     // =====================================================================

--- a/test/invariant/ValidatorStateMachine.invariant.t.sol
+++ b/test/invariant/ValidatorStateMachine.invariant.t.sol
@@ -49,7 +49,12 @@ contract ValidatorStateMachineInvariantTest is TestSetup, Deployed {
             priorityWithdrawalQueue: address(priorityQueueInstance),
             blacklister: address(blacklisterInstance),
             etherFiAdminContract: address(etherFiAdminInstance),
-            membershipManager: address(membershipManagerInstance)
+            // Use the REAL deployed membership manager, not the V0-typed
+            // `membershipManagerInstance` which is never populated on a realistic
+            // fork (only `membershipManagerV1Instance` is, from deployed.MEMBERSHIP_MANAGER()).
+            // Passing address(0) here would diverge the immutable from the production
+            // bootstrap and mis-auth any membership-routed LP path.
+            membershipManager: MEMBERSHIP_MANAGER
         }), 0);
         address lpOwner = liquidityPoolInstance.owner();
         vm.prank(lpOwner);
@@ -60,7 +65,7 @@ contract ValidatorStateMachineInvariantTest is TestSetup, Deployed {
         address wrnOwner = withdrawRequestNFTInstance.owner();
         vm.prank(wrnOwner);
         withdrawRequestNFTInstance.upgradeTo(
-            address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(eETHInstance), address(liquidityPoolInstance), address(membershipManagerInstance), address(roleRegistryInstance), address(blacklisterInstance), address(etherFiAdminInstance), 1, 4e18))
+            address(new WithdrawRequestNFT(WITHDRAW_REQUEST_NFT_BUYBACK_SAFE, address(eETHInstance), address(liquidityPoolInstance), MEMBERSHIP_MANAGER, address(roleRegistryInstance), address(blacklisterInstance), address(etherFiAdminInstance), 1, 4e18))
         );
 
         // The production queue proxy on mainnet still runs the master impl which

--- a/test/invariant/handlers/RewardsDistributorHandler.sol
+++ b/test/invariant/handlers/RewardsDistributorHandler.sol
@@ -97,6 +97,7 @@ contract RewardsDistributorHandler is StdUtils {
 
         vm.prank(admin);
         dist.finalizeMerkleRoot(token, block.number);
+        callCounts["finalize_ok"]++;
         // Post-finalize: claimable root must equal what we set pending.
         if (dist.claimableMerkleRoots(token) != root) ghost_finalizeRootMismatch = true;
         ghost_hasPending = false;
@@ -154,7 +155,13 @@ contract RewardsDistributorHandler is StdUtils {
 
     /// @notice Full deterministic claim: establish a single-leaf root for the
     ///         chosen claimant at a strictly higher cumulative amount, then
-    ///         claim. Proves I12 monotonicity + exact payout.
+    ///         claim. Proves I12 monotonicity + exact payout. Self-contained: a
+    ///         SINGLE call drives the entire lifecycle (setPending -> finalize
+    ///         after delay -> claim -> replay-rejected), so the suite is
+    ///         non-vacuous even on a 1-call sequence (Foundry shrinks a failing
+    ///         run to its minimal subsequence and re-evaluates afterInvariant on
+    ///         that replay; a self-contained action keeps the non-vacuity gates
+    ///         satisfiable there).
     function doClaim(uint256 acctSeed, uint128 amt) external {
         address account = _claimant(acctSeed);
         uint256 preCum = dist.cumulativeClaimed(token, account);
@@ -182,6 +189,20 @@ contract RewardsDistributorHandler is StdUtils {
             ghostPaid[account] += (postCum - preCum);
             lastSeenCumulative[account] = postCum;
             callCounts["claim_ok"]++;
+
+            // Inline replay against the SAME (already-claimed) cumulative: must
+            // revert (NothingToClaim). Doing it here makes a single doClaim call
+            // exercise finalize + claim + replay-rejection together, so the
+            // non-vacuity gates hold even under sequence shrinking.
+            uint256 preBalReplay = account.balance;
+            try dist.claim(token, account, newCum, leaf, proof) {
+                // A successful replay at an equal cumulative is a double-pay.
+                ghost_doublePayViolated = true;
+                if (account.balance != preBalReplay) ghost_doublePayViolated = true;
+                callCounts["replay_unexpected_ok"]++;
+            } catch {
+                callCounts["replay_revert"]++;
+            }
         } catch {
             callCounts["claim_revert"]++;
         }


### PR DESCRIPTION
## Address Cursor Bugbot findings on #470

Cursor Bugbot flagged 2 Medium issues on the merged invariant suites. Both are real; both fixed here. **`src/` untouched** — test-only.

### 1. I10 `ValidatorStateMachine` — unset membership manager on fork
The fork suite re-deployed `LiquidityPool` and `WithdrawRequestNFT` passing `address(membershipManagerInstance)` as the membership-manager immutable. On a realistic mainnet fork that **V0-typed** var is never populated — only `membershipManagerV1Instance` is (from `deployed.MEMBERSHIP_MANAGER()`). So the new impls got `address(0)`, diverging from the production bootstrap and mis-authing any membership-routed path.

**Fix:** use the real deployed `MEMBERSHIP_MANAGER` constant for both the LP and WRN constructors. (The contract already inherits `Deployed`.)

### 2. I12/I13 `RewardsDistributor` — invariants lacked non-vacuity
The suite logged coverage counters but never **hard-asserted** that finalize/claim actually happened, so the ghost flags could stay false and the invariants pass without exercising the merkle-delay or payout logic. Worse, I found the run was **actually vacuous**: with no `targetSelector`, the engine also fuzzed the handler's public view getters and wasted the call budget — `setPending`/`finalize`/`claim` never fired.

**Fixes:**
- **`targetSelector`** added — restrict fuzzing to the 7 action functions so every call advances the state machine.
- **`afterInvariant()` non-vacuity gate** — assert `finalize_ok`, `claim_ok`, `replay_revert` all `> 0` and total ETH paid `> 0`.
- **Self-contained `doClaim`** — it already finalizes via `_establishRoot` (now counted) and runs an inline replay-rejection, so a single call exercises finalize + claim + replay. This keeps the non-vacuity gate satisfiable even when Foundry shrinks a failing run to a 1-call subsequence (the shrink-masking trap).

### Verification
- Rewards suite: **256 runs × 16,384 calls, 0 reverts**, genuinely non-vacuous (`finalize_ok=23, claim_ok=9, replay_revert=16`), stable across 3 seeds.
- I10 fork suite: still passes with the membership-manager fix (`16×384 calls, 0 reverts`).

Base: `seongyun/fuzz/security-upgrades` (the release line these suites were merged into via #468).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to invariant/fork tests and handlers; production `src/` is untouched.
> 
> **Overview**
> Test-only fixes for two invariant suites flagged after merge: fork setup now matches production membership wiring, and the rewards fuzz run is forced to exercise the paths I12/I13 actually defend.
> 
> **I10 `ValidatorStateMachine`:** When re-deploying `LiquidityPool` and `WithdrawRequestNFT` on a mainnet fork, the suite now passes the real **`MEMBERSHIP_MANAGER`** from `Deployed` instead of `membershipManagerInstance`, which stays unset on a realistic fork and had been wiring **`address(0)`** into the new impls.
> 
> **I12/I13 `RewardsDistributor`:** Fuzzing is limited with **`targetSelector`** to the seven handler actions so calls are not wasted on view getters. **`afterInvariant()`** hard-requires at least one successful finalize, claim, and replay-revert plus **non-zero total ETH paid**. The handler increments **`finalize_ok`** inside **`_establishRoot`**, and **`doClaim`** performs an inline replay attempt so a single shrunk call sequence can still satisfy the non-vacuity gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1174666a91e344251dcb12e1f3034f9170469187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->