### PR TITLE
Grant guardian Safe CANCELLER_ROLE on both timelocks

### DIFF
--- a/script/upgrades/security-upgrades/Constants.s.sol
+++ b/script/upgrades/security-upgrades/Constants.s.sol
@@ -125,7 +125,7 @@ abstract contract SecurityUpgradesConstants is Deployed {
     uint256 internal constant ADMIN_DAILY_FINALIZED_WITHDRAWAL_LIMIT = 20_000 ether;
 
     // ─────────────────────────────────────────────────────────────────────
-    // ROLE HOLDERS - 3 fixed + 6 user-set.
+    // ROLE HOLDERS - 3 fixed + 7 user-set.
     // ─────────────────────────────────────────────────────────────────────
     address internal constant HOLDER_UPGRADE_TIMELOCK_ROLE   = 0x9f26d4C958fD811A1F59B01B86Be7dFFc9d20761; // UPGRADE_TIMELOCK
     address internal constant HOLDER_OPERATION_TIMELOCK_ROLE = 0xcD425f44758a08BaAB3C4908f3e3dE5776e45d7a; // OPERATING_TIMELOCK
@@ -139,6 +139,11 @@ abstract contract SecurityUpgradesConstants is Deployed {
     address internal constant HOLDER_HOUSEKEEPING_OPERATIONS_ROLE = address(0);
     address internal constant HOLDER_EXECUTOR_OPERATIONS_ROLE     = address(0);
     address internal constant HOLDER_EIGENPOD_OPERATIONS_ROLE     = address(0);
+
+    // Guardian Safe granted TimelockController CANCELLER_ROLE on BOTH timelocks, so it can
+    // veto a scheduled-but-not-yet-executed op during its delay window. Set to the chosen
+    // guardian Safe before broadcast; _preflight reverts while it is address(0).
+    address internal constant HOLDER_CANCELLER_GUARDIAN           = address(0);
 
     // ─────────────────────────────────────────────────────────────────────
     // ROLE IDs — hardcoded keccak256 of the role name. Mirror the constants in
@@ -279,6 +284,11 @@ abstract contract SecurityUpgradesConstants is Deployed {
     EtherFiTimelock internal constant upgradeTimelock   = EtherFiTimelock(payable(UPGRADE_TIMELOCK));
     EtherFiTimelock internal constant operatingTimelock = EtherFiTimelock(payable(OPERATING_TIMELOCK));
     RoleRegistry    internal constant roleRegistry      = RoleRegistry(ROLE_REGISTRY);
+
+    // OZ TimelockController CANCELLER_ROLE — held on each EtherFiTimelock, NOT the RoleRegistry.
+    // Mirrors TimelockController.CANCELLER_ROLE = keccak256("CANCELLER_ROLE"). The timelock is
+    // its own role admin, so a grant must ride inside that timelock's own scheduled batch.
+    bytes32 internal constant TIMELOCK_CANCELLER_ROLE = keccak256("CANCELLER_ROLE"); // 0xfd643c72710c63c0180259aba6b2d05451e3591a24e58b62239378085726f783
 
     uint256 internal constant UPGRADE_TIMELOCK_DELAY   = 10 days;
     uint256 internal constant OPERATING_TIMELOCK_DELAY = 2 days;

--- a/script/upgrades/security-upgrades/transactions.s.sol
+++ b/script/upgrades/security-upgrades/transactions.s.sol
@@ -314,6 +314,7 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         require(HOLDER_HOUSEKEEPING_OPERATIONS_ROLE != address(0), "preflight: HOLDER_HOUSEKEEPING_OPERATIONS_ROLE unset");
         require(HOLDER_EXECUTOR_OPERATIONS_ROLE     != address(0), "preflight: HOLDER_EXECUTOR_OPERATIONS_ROLE unset");
         require(HOLDER_EIGENPOD_OPERATIONS_ROLE     != address(0), "preflight: HOLDER_EIGENPOD_OPERATIONS_ROLE unset");
+        require(HOLDER_CANCELLER_GUARDIAN           != address(0), "preflight: HOLDER_CANCELLER_GUARDIAN unset");
     }
 
     /// @dev Cross-check every hardcoded keccak256 role-ID string against a freshly-built
@@ -1018,9 +1019,9 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
 
         uint256 revokeCount = _countLegacyRoleHolders();
 
-        // 17 grants (9 HOLDER_* + 6 operating-multisig RevokeAdmin roles + 2 exec guardian safe)
-        // + (21 proxy upgrades + 1 beacon + 1 RR swap + 2 initializers + 2 Liquifier token
-        // unwhitelists) = 44, <=50 headroom + N legacy revokes.
+        // 18 grants (9 HOLDER_* + 6 operating-multisig RevokeAdmin roles + 2 exec guardian safe
+        // + 1 UPGRADE_TIMELOCK CANCELLER_ROLE) + (21 proxy upgrades + 1 beacon + 1 RR swap +
+        // 2 initializers + 2 Liquifier token unwhitelists) = 45, <=50 headroom + N legacy revokes.
         address[] memory targets = new address[](50 + revokeCount);
         bytes[]   memory data    = new bytes[](50 + revokeCount);
         uint256[] memory values  = new uint256[](50 + revokeCount);
@@ -1546,10 +1547,14 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
     //
     // Appends the 9 RolesLibrary role grants (one HOLDER_* each), PLUS 6 extra grants that
     // give the operating multisig every RevokeAdmin-governed role, PLUS 2 that give the
-    // executor guardian safe both guardian-tier roles — 17 grantRole calls total.
-    // grantRole is owner-gated (Solady
+    // executor guardian safe both guardian-tier roles, PLUS 1 that grants
+    // HOLDER_CANCELLER_GUARDIAN the TimelockController CANCELLER_ROLE on the UPGRADE_TIMELOCK
+    // itself — 18 grantRole calls total.
+    // The first 17 grantRole calls are owner-gated (Solady
     // setRole -> contract owner) and the RoleRegistry owner IS the UPGRADE_TIMELOCK
-    // executing this batch, so it can grant. These run before the proxy upgrades, so
+    // executing this batch, so it can grant. The 18th targets the UPGRADE_TIMELOCK, which is
+    // its own OZ AccessControl admin, so the same executing timelock can self-grant.
+    // These run before the proxy upgrades, so
     // the calldata hits the pre-upgrade registry impl — fine, it shares Solady's role
     // storage, and the grants are visible to the new impl after the swap. They MUST
     // precede the onlyUpgradeTimelock initializers in _appendUpgradeCalls, which need
@@ -1632,6 +1637,14 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         i++;
         targets[i] = ROLE_REGISTRY;
         data[i]    = abi.encodeWithSelector(RoleRegistry.grantRole.selector, GUARDIAN_ROLE, HOLDER_EXEC_GUARDIAN_SAFE);
+        i++;
+
+        // Grant the guardian Safe CANCELLER_ROLE on the UPGRADE_TIMELOCK so it can cancel a
+        // scheduled-but-pending op during the 10-day delay. Target is the timelock itself
+        // (NOT the RoleRegistry): TimelockController is its own AccessControl admin, and the
+        // UPGRADE_TIMELOCK is the account executing this batch, so it can self-grant.
+        targets[i] = UPGRADE_TIMELOCK;
+        data[i]    = abi.encodeWithSelector(upgradeTimelock.grantRole.selector, TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN);
         i++;
 
         return i;
@@ -1784,6 +1797,14 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         (targets[i], data[i]) = (WEETH_WITHDRAW_ADAPTER,                _pauseDur(PAUSE_UNTIL_WEETH_WITHDRAW_ADAPTER));                i++;
         (targets[i], data[i]) = (WITHDRAW_REQUEST_NFT,       _pauseDur(PAUSE_UNTIL_WITHDRAW_REQUEST_NFT));   i++;
 
+        // governance — grant the guardian Safe CANCELLER_ROLE on the OPERATING_TIMELOCK so it
+        // can cancel a scheduled-but-pending op during the 2-day delay. Target is the timelock
+        // itself: TimelockController is its own AccessControl admin and the OPERATING_TIMELOCK
+        // is the account executing this batch, so it self-grants. This rides the operating
+        // batch (not the upgrade batch) because only the OPERATING_TIMELOCK can grant its own role.
+        (targets[i], data[i]) = (OPERATING_TIMELOCK,
+            abi.encodeWithSelector(operatingTimelock.grantRole.selector, TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN)); i++;
+
         return _shrink(targets, values, data, i);
     }
 
@@ -1910,6 +1931,12 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         // The executor guardian safe must hold both guardian-tier roles.
         require(roleRegistry.hasRole(SUPER_GUARDIAN_ROLE, HOLDER_EXEC_GUARDIAN_SAFE), "SUPER_GUARDIAN_ROLE not granted to exec guardian safe");
         require(roleRegistry.hasRole(GUARDIAN_ROLE,       HOLDER_EXEC_GUARDIAN_SAFE), "GUARDIAN_ROLE not granted to exec guardian safe");
+
+        // The guardian Safe must hold CANCELLER_ROLE on BOTH timelocks. Both batches have been
+        // dry-run on the fork by the time this verifier runs (executeUpgrade then
+        // executeOperatingConfig in run()), so the grants are live on the forked timelocks.
+        require(upgradeTimelock.hasRole(TIMELOCK_CANCELLER_ROLE,   HOLDER_CANCELLER_GUARDIAN), "CANCELLER_ROLE not granted on upgrade timelock");
+        require(operatingTimelock.hasRole(TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN), "CANCELLER_ROLE not granted on operating timelock");
 
         require(LiquidityPool(payable(LIQUIDITY_POOL)).maxWithdrawAmount() == LP_MAX_WITHDRAW_AMOUNT, "LP.maxWithdrawAmount mismatch");
         require(LiquidityPool(payable(LIQUIDITY_POOL)).minWithdrawAmount() == LP_MIN_WITHDRAW_AMOUNT, "LP.minWithdrawAmount mismatch");

--- a/script/upgrades/security-upgrades/transactions.s.sol
+++ b/script/upgrades/security-upgrades/transactions.s.sol
@@ -1019,10 +1019,9 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
 
         uint256 revokeCount = _countLegacyRoleHolders();
 
-        // 19 role ops (9 HOLDER_* + 6 operating-multisig RevokeAdmin roles + 2 exec guardian safe
-        // + 2 UPGRADE_TIMELOCK CANCELLER reassign [grant guardian, revoke proposer]) + (21 proxy
-        // upgrades + 1 beacon + 1 RR swap + 2 initializers + 2 Liquifier token unwhitelists) = 46,
-        // <=50 headroom + N legacy revokes.
+        // 18 grants (9 HOLDER_* + 6 operating-multisig RevokeAdmin roles + 2 exec guardian safe
+        // + 1 UPGRADE_TIMELOCK CANCELLER_ROLE) + (21 proxy upgrades + 1 beacon + 1 RR swap +
+        // 2 initializers + 2 Liquifier token unwhitelists) = 45, <=50 headroom + N legacy revokes.
         address[] memory targets = new address[](50 + revokeCount);
         bytes[]   memory data    = new bytes[](50 + revokeCount);
         uint256[] memory values  = new uint256[](50 + revokeCount);
@@ -1548,14 +1547,13 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
     //
     // Appends the 9 RolesLibrary role grants (one HOLDER_* each), PLUS 6 extra grants that
     // give the operating multisig every RevokeAdmin-governed role, PLUS 2 that give the
-    // executor guardian safe both guardian-tier roles — 17 grantRole calls total — PLUS a
-    // 2-call CANCELLER_ROLE reassignment on the UPGRADE_TIMELOCK itself (grant the guardian
-    // Safe, revoke the construction-time proposer canceller ETHERFI_UPGRADE_ADMIN): 19 role
-    // ops total.
-    // The 17 grantRole calls are owner-gated (Solady
+    // executor guardian safe both guardian-tier roles, PLUS 1 that grants
+    // HOLDER_CANCELLER_GUARDIAN the TimelockController CANCELLER_ROLE on the UPGRADE_TIMELOCK
+    // itself — 18 grantRole calls total.
+    // The first 17 grantRole calls are owner-gated (Solady
     // setRole -> contract owner) and the RoleRegistry owner IS the UPGRADE_TIMELOCK
-    // executing this batch, so it can grant. The 2 CANCELLER ops target the UPGRADE_TIMELOCK,
-    // which is its own OZ AccessControl admin, so the same executing timelock self-administers.
+    // executing this batch, so it can grant. The 18th targets the UPGRADE_TIMELOCK, which is
+    // its own OZ AccessControl admin, so the same executing timelock can self-grant.
     // These run before the proxy upgrades, so
     // the calldata hits the pre-upgrade registry impl — fine, it shares Solady's role
     // storage, and the grants are visible to the new impl after the swap. They MUST
@@ -1641,20 +1639,12 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         data[i]    = abi.encodeWithSelector(RoleRegistry.grantRole.selector, GUARDIAN_ROLE, HOLDER_EXEC_GUARDIAN_SAFE);
         i++;
 
-        // Reassign CANCELLER_ROLE on the UPGRADE_TIMELOCK to the guardian Safe alone. Target is
-        // the timelock itself (NOT the RoleRegistry): TimelockController is its own AccessControl
-        // admin and the UPGRADE_TIMELOCK is the account executing this batch, so it self-administers.
-        //   (a) grant the guardian Safe CANCELLER_ROLE so it can cancel a scheduled-but-pending
-        //       op during the 10-day delay;
-        //   (b) revoke CANCELLER_ROLE from ETHERFI_UPGRADE_ADMIN, the proposer Safe that received
-        //       it at construction (verified the sole current canceller on-chain). Only its
-        //       CANCELLER_ROLE is removed — PROPOSER_ROLE and EXECUTOR_ROLE are untouched.
-        // After this the guardian Safe is the sole canceller of the upgrade timelock.
+        // Grant the guardian Safe CANCELLER_ROLE on the UPGRADE_TIMELOCK so it can cancel a
+        // scheduled-but-pending op during the 10-day delay. Target is the timelock itself
+        // (NOT the RoleRegistry): TimelockController is its own AccessControl admin, and the
+        // UPGRADE_TIMELOCK is the account executing this batch, so it can self-grant.
         targets[i] = UPGRADE_TIMELOCK;
         data[i]    = abi.encodeWithSelector(upgradeTimelock.grantRole.selector, TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN);
-        i++;
-        targets[i] = UPGRADE_TIMELOCK;
-        data[i]    = abi.encodeWithSelector(upgradeTimelock.revokeRole.selector, TIMELOCK_CANCELLER_ROLE, ETHERFI_UPGRADE_ADMIN);
         i++;
 
         return i;
@@ -1807,20 +1797,13 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         (targets[i], data[i]) = (WEETH_WITHDRAW_ADAPTER,                _pauseDur(PAUSE_UNTIL_WEETH_WITHDRAW_ADAPTER));                i++;
         (targets[i], data[i]) = (WITHDRAW_REQUEST_NFT,       _pauseDur(PAUSE_UNTIL_WITHDRAW_REQUEST_NFT));   i++;
 
-        // governance — reassign CANCELLER_ROLE on the OPERATING_TIMELOCK to the guardian Safe
-        // alone. Target is the timelock itself: TimelockController is its own AccessControl admin
-        // and the OPERATING_TIMELOCK is the account executing this batch, so it self-administers.
-        // This rides the operating batch (not the upgrade batch) because only the
-        // OPERATING_TIMELOCK can administer its own role.
-        //   (a) grant the guardian Safe CANCELLER_ROLE (veto a pending op during the 2-day delay);
-        //   (b) revoke CANCELLER_ROLE from ETHERFI_OPERATING_ADMIN, the proposer Safe that
-        //       received it at construction (verified the sole current canceller on-chain). Only
-        //       its CANCELLER_ROLE is removed — PROPOSER_ROLE / EXECUTOR_ROLE are untouched, so it
-        //       still proposes and executes this very batch.
+        // governance — grant the guardian Safe CANCELLER_ROLE on the OPERATING_TIMELOCK so it
+        // can cancel a scheduled-but-pending op during the 2-day delay. Target is the timelock
+        // itself: TimelockController is its own AccessControl admin and the OPERATING_TIMELOCK
+        // is the account executing this batch, so it self-grants. This rides the operating
+        // batch (not the upgrade batch) because only the OPERATING_TIMELOCK can grant its own role.
         (targets[i], data[i]) = (OPERATING_TIMELOCK,
             abi.encodeWithSelector(operatingTimelock.grantRole.selector, TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN)); i++;
-        (targets[i], data[i]) = (OPERATING_TIMELOCK,
-            abi.encodeWithSelector(operatingTimelock.revokeRole.selector, TIMELOCK_CANCELLER_ROLE, ETHERFI_OPERATING_ADMIN)); i++;
 
         return _shrink(targets, values, data, i);
     }
@@ -1949,14 +1932,11 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         require(roleRegistry.hasRole(SUPER_GUARDIAN_ROLE, HOLDER_EXEC_GUARDIAN_SAFE), "SUPER_GUARDIAN_ROLE not granted to exec guardian safe");
         require(roleRegistry.hasRole(GUARDIAN_ROLE,       HOLDER_EXEC_GUARDIAN_SAFE), "GUARDIAN_ROLE not granted to exec guardian safe");
 
-        // The guardian Safe must be the SOLE CANCELLER on BOTH timelocks. Both batches have been
+        // The guardian Safe must hold CANCELLER_ROLE on BOTH timelocks. Both batches have been
         // dry-run on the fork by the time this verifier runs (executeUpgrade then
-        // executeOperatingConfig in run()), so the grant + proposer revoke are live on the
-        // forked timelocks.
+        // executeOperatingConfig in run()), so the grants are live on the forked timelocks.
         require(upgradeTimelock.hasRole(TIMELOCK_CANCELLER_ROLE,   HOLDER_CANCELLER_GUARDIAN), "CANCELLER_ROLE not granted on upgrade timelock");
         require(operatingTimelock.hasRole(TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN), "CANCELLER_ROLE not granted on operating timelock");
-        require(!upgradeTimelock.hasRole(TIMELOCK_CANCELLER_ROLE,   ETHERFI_UPGRADE_ADMIN),   "upgrade proposer still holds CANCELLER_ROLE");
-        require(!operatingTimelock.hasRole(TIMELOCK_CANCELLER_ROLE, ETHERFI_OPERATING_ADMIN), "operating proposer still holds CANCELLER_ROLE");
 
         require(LiquidityPool(payable(LIQUIDITY_POOL)).maxWithdrawAmount() == LP_MAX_WITHDRAW_AMOUNT, "LP.maxWithdrawAmount mismatch");
         require(LiquidityPool(payable(LIQUIDITY_POOL)).minWithdrawAmount() == LP_MIN_WITHDRAW_AMOUNT, "LP.minWithdrawAmount mismatch");

--- a/script/upgrades/security-upgrades/transactions.s.sol
+++ b/script/upgrades/security-upgrades/transactions.s.sol
@@ -1019,9 +1019,10 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
 
         uint256 revokeCount = _countLegacyRoleHolders();
 
-        // 18 grants (9 HOLDER_* + 6 operating-multisig RevokeAdmin roles + 2 exec guardian safe
-        // + 1 UPGRADE_TIMELOCK CANCELLER_ROLE) + (21 proxy upgrades + 1 beacon + 1 RR swap +
-        // 2 initializers + 2 Liquifier token unwhitelists) = 45, <=50 headroom + N legacy revokes.
+        // 19 role ops (9 HOLDER_* + 6 operating-multisig RevokeAdmin roles + 2 exec guardian safe
+        // + 2 UPGRADE_TIMELOCK CANCELLER reassign [grant guardian, revoke proposer]) + (21 proxy
+        // upgrades + 1 beacon + 1 RR swap + 2 initializers + 2 Liquifier token unwhitelists) = 46,
+        // <=50 headroom + N legacy revokes.
         address[] memory targets = new address[](50 + revokeCount);
         bytes[]   memory data    = new bytes[](50 + revokeCount);
         uint256[] memory values  = new uint256[](50 + revokeCount);
@@ -1547,13 +1548,14 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
     //
     // Appends the 9 RolesLibrary role grants (one HOLDER_* each), PLUS 6 extra grants that
     // give the operating multisig every RevokeAdmin-governed role, PLUS 2 that give the
-    // executor guardian safe both guardian-tier roles, PLUS 1 that grants
-    // HOLDER_CANCELLER_GUARDIAN the TimelockController CANCELLER_ROLE on the UPGRADE_TIMELOCK
-    // itself — 18 grantRole calls total.
-    // The first 17 grantRole calls are owner-gated (Solady
+    // executor guardian safe both guardian-tier roles — 17 grantRole calls total — PLUS a
+    // 2-call CANCELLER_ROLE reassignment on the UPGRADE_TIMELOCK itself (grant the guardian
+    // Safe, revoke the construction-time proposer canceller ETHERFI_UPGRADE_ADMIN): 19 role
+    // ops total.
+    // The 17 grantRole calls are owner-gated (Solady
     // setRole -> contract owner) and the RoleRegistry owner IS the UPGRADE_TIMELOCK
-    // executing this batch, so it can grant. The 18th targets the UPGRADE_TIMELOCK, which is
-    // its own OZ AccessControl admin, so the same executing timelock can self-grant.
+    // executing this batch, so it can grant. The 2 CANCELLER ops target the UPGRADE_TIMELOCK,
+    // which is its own OZ AccessControl admin, so the same executing timelock self-administers.
     // These run before the proxy upgrades, so
     // the calldata hits the pre-upgrade registry impl — fine, it shares Solady's role
     // storage, and the grants are visible to the new impl after the swap. They MUST
@@ -1639,12 +1641,20 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         data[i]    = abi.encodeWithSelector(RoleRegistry.grantRole.selector, GUARDIAN_ROLE, HOLDER_EXEC_GUARDIAN_SAFE);
         i++;
 
-        // Grant the guardian Safe CANCELLER_ROLE on the UPGRADE_TIMELOCK so it can cancel a
-        // scheduled-but-pending op during the 10-day delay. Target is the timelock itself
-        // (NOT the RoleRegistry): TimelockController is its own AccessControl admin, and the
-        // UPGRADE_TIMELOCK is the account executing this batch, so it can self-grant.
+        // Reassign CANCELLER_ROLE on the UPGRADE_TIMELOCK to the guardian Safe alone. Target is
+        // the timelock itself (NOT the RoleRegistry): TimelockController is its own AccessControl
+        // admin and the UPGRADE_TIMELOCK is the account executing this batch, so it self-administers.
+        //   (a) grant the guardian Safe CANCELLER_ROLE so it can cancel a scheduled-but-pending
+        //       op during the 10-day delay;
+        //   (b) revoke CANCELLER_ROLE from ETHERFI_UPGRADE_ADMIN, the proposer Safe that received
+        //       it at construction (verified the sole current canceller on-chain). Only its
+        //       CANCELLER_ROLE is removed — PROPOSER_ROLE and EXECUTOR_ROLE are untouched.
+        // After this the guardian Safe is the sole canceller of the upgrade timelock.
         targets[i] = UPGRADE_TIMELOCK;
         data[i]    = abi.encodeWithSelector(upgradeTimelock.grantRole.selector, TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN);
+        i++;
+        targets[i] = UPGRADE_TIMELOCK;
+        data[i]    = abi.encodeWithSelector(upgradeTimelock.revokeRole.selector, TIMELOCK_CANCELLER_ROLE, ETHERFI_UPGRADE_ADMIN);
         i++;
 
         return i;
@@ -1797,13 +1807,20 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         (targets[i], data[i]) = (WEETH_WITHDRAW_ADAPTER,                _pauseDur(PAUSE_UNTIL_WEETH_WITHDRAW_ADAPTER));                i++;
         (targets[i], data[i]) = (WITHDRAW_REQUEST_NFT,       _pauseDur(PAUSE_UNTIL_WITHDRAW_REQUEST_NFT));   i++;
 
-        // governance — grant the guardian Safe CANCELLER_ROLE on the OPERATING_TIMELOCK so it
-        // can cancel a scheduled-but-pending op during the 2-day delay. Target is the timelock
-        // itself: TimelockController is its own AccessControl admin and the OPERATING_TIMELOCK
-        // is the account executing this batch, so it self-grants. This rides the operating
-        // batch (not the upgrade batch) because only the OPERATING_TIMELOCK can grant its own role.
+        // governance — reassign CANCELLER_ROLE on the OPERATING_TIMELOCK to the guardian Safe
+        // alone. Target is the timelock itself: TimelockController is its own AccessControl admin
+        // and the OPERATING_TIMELOCK is the account executing this batch, so it self-administers.
+        // This rides the operating batch (not the upgrade batch) because only the
+        // OPERATING_TIMELOCK can administer its own role.
+        //   (a) grant the guardian Safe CANCELLER_ROLE (veto a pending op during the 2-day delay);
+        //   (b) revoke CANCELLER_ROLE from ETHERFI_OPERATING_ADMIN, the proposer Safe that
+        //       received it at construction (verified the sole current canceller on-chain). Only
+        //       its CANCELLER_ROLE is removed — PROPOSER_ROLE / EXECUTOR_ROLE are untouched, so it
+        //       still proposes and executes this very batch.
         (targets[i], data[i]) = (OPERATING_TIMELOCK,
             abi.encodeWithSelector(operatingTimelock.grantRole.selector, TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN)); i++;
+        (targets[i], data[i]) = (OPERATING_TIMELOCK,
+            abi.encodeWithSelector(operatingTimelock.revokeRole.selector, TIMELOCK_CANCELLER_ROLE, ETHERFI_OPERATING_ADMIN)); i++;
 
         return _shrink(targets, values, data, i);
     }
@@ -1932,11 +1949,14 @@ contract SecurityUpgradesScript is Script, SecurityUpgradesConstants, Utils {
         require(roleRegistry.hasRole(SUPER_GUARDIAN_ROLE, HOLDER_EXEC_GUARDIAN_SAFE), "SUPER_GUARDIAN_ROLE not granted to exec guardian safe");
         require(roleRegistry.hasRole(GUARDIAN_ROLE,       HOLDER_EXEC_GUARDIAN_SAFE), "GUARDIAN_ROLE not granted to exec guardian safe");
 
-        // The guardian Safe must hold CANCELLER_ROLE on BOTH timelocks. Both batches have been
+        // The guardian Safe must be the SOLE CANCELLER on BOTH timelocks. Both batches have been
         // dry-run on the fork by the time this verifier runs (executeUpgrade then
-        // executeOperatingConfig in run()), so the grants are live on the forked timelocks.
+        // executeOperatingConfig in run()), so the grant + proposer revoke are live on the
+        // forked timelocks.
         require(upgradeTimelock.hasRole(TIMELOCK_CANCELLER_ROLE,   HOLDER_CANCELLER_GUARDIAN), "CANCELLER_ROLE not granted on upgrade timelock");
         require(operatingTimelock.hasRole(TIMELOCK_CANCELLER_ROLE, HOLDER_CANCELLER_GUARDIAN), "CANCELLER_ROLE not granted on operating timelock");
+        require(!upgradeTimelock.hasRole(TIMELOCK_CANCELLER_ROLE,   ETHERFI_UPGRADE_ADMIN),   "upgrade proposer still holds CANCELLER_ROLE");
+        require(!operatingTimelock.hasRole(TIMELOCK_CANCELLER_ROLE, ETHERFI_OPERATING_ADMIN), "operating proposer still holds CANCELLER_ROLE");
 
         require(LiquidityPool(payable(LIQUIDITY_POOL)).maxWithdrawAmount() == LP_MAX_WITHDRAW_AMOUNT, "LP.maxWithdrawAmount mismatch");
         require(LiquidityPool(payable(LIQUIDITY_POOL)).minWithdrawAmount() == LP_MIN_WITHDRAW_AMOUNT, "LP.minWithdrawAmount mismatch");


### PR DESCRIPTION
## What this does
Grants the OZ `TimelockController` `CANCELLER_ROLE` to a guardian Safe on both the `UPGRADE_TIMELOCK` (10d) and `OPERATING_TIMELOCK` (2d), baked into the 26Q2 security-upgrade scripts. The guardian becomes an **additional** canceller that can `cancel(bytes32)` a scheduled-but-pending op during its delay window.

`CANCELLER_ROLE` is self-administered: each `EtherFiTimelock` holds `TIMELOCK_ADMIN_ROLE` over itself (verified on-chain; no external admin), so the role can only be granted from inside that timelock's own scheduled batch:
- **UPGRADE_TIMELOCK** → Batch 1 (`_appendGrantCalls`).
- **OPERATING_TIMELOCK** → Batch 2 (`_buildOperatingConfigBatch`).

## Additive — proposers keep their canceller
At construction OZ grants `CANCELLER_ROLE` to every proposer, so each timelock's proposer Safe (`ETHERFI_UPGRADE_ADMIN`, `ETHERFI_OPERATING_ADMIN`) already holds it. These are **left intact**: per EARN-1253 (D-7) the upgrade/operating admins must retain the ability to cancel stale timelock proposals. The guardian is added alongside them.

## Changes
- `Constants.s.sol`
  - `HOLDER_CANCELLER_GUARDIAN` — the guardian Safe, left `address(0)` (TBD; fill before broadcast).
  - `TIMELOCK_CANCELLER_ROLE = keccak256("CANCELLER_ROLE")`.
- `transactions.s.sol`
  - `_preflight()` reverts while `HOLDER_CANCELLER_GUARDIAN` is unset.
  - One `grantRole(CANCELLER_ROLE, guardian)` appended to each timelock batch.
  - `verifyOperatingConfig()` asserts the guardian holds `CANCELLER_ROLE` on both timelocks after the on-fork dry-run.

## Verification
- `forge build` passes.
- On mainnet: both timelocks self-administer (`TIMELOCK_ADMIN_ROLE` over themselves), no external admin; both proposer Safes currently hold `CANCELLER_ROLE`.
- OZ v4 `TimelockController` source confirms self-administration and that `cancel` is `onlyRole(CANCELLER_ROLE)`.
- The script's own `_dryRunOnFork` exercises both grants end-to-end once the TBD constants are filled and run with `MAINNET_RPC_URL`.

## Before broadcast
- Set `HOLDER_CANCELLER_GUARDIAN` to the chosen guardian Safe (prefer a signer set disjoint from the proposers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can veto scheduled timelock batches during upgrade execution; mistakes in `HOLDER_CANCELLER_GUARDIAN` or batch ordering could leave wrong cancellers, though impact is limited to script-generated governance txs rather than live protocol contracts until broadcast.
> 
> **Overview**
> Wires the 26Q2 security-upgrade scripts so a dedicated guardian Safe can **cancel** pending timelock operations on both `UPGRADE_TIMELOCK` (10d) and `OPERATING_TIMELOCK` (2d) during their delay windows.
> 
> **Constants:** Adds `HOLDER_CANCELLER_GUARDIAN` (must be set before broadcast; `address(0)` until then) and `TIMELOCK_CANCELLER_ROLE` (`keccak256("CANCELLER_ROLE")` on the OZ `TimelockController`, not `RoleRegistry`).
> 
> **Batch calldata:** The upgrade-timelock batch gains an 18th op that **self-grants** `CANCELLER_ROLE` on `UPGRADE_TIMELOCK` to the guardian (each timelock administers its own AccessControl roles). The operating-timelock batch adds the same grant on `OPERATING_TIMELOCK`, since only that timelock can grant its own role. Documented batch size moves from 17→18 grants and 44→45 fixed ops.
> 
> **Safety checks:** `_preflight()` reverts if `HOLDER_CANCELLER_GUARDIAN` is unset. `verifyOperatingConfig()` asserts the guardian holds `CANCELLER_ROLE` on both timelocks after fork dry-runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a11508341fdfceeaca443d71301890423834bd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->