### PR TITLE
ci: fix storage-layout check paths after src/ reorg

### DIFF
--- a/.github/workflows/foundry-storage-check.yml
+++ b/.github/workflows/foundry-storage-check.yml
@@ -31,142 +31,142 @@ jobs:
       - name: Check storage layout for EETH
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EETH.sol:EETH
+          contract: src/core/EETH.sol:EETH
 
       - name: Check storage layout for WeETH
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/WeETH.sol:WeETH
+          contract: src/core/WeETH.sol:WeETH
 
       - name: Check storage layout for LiquidityPool
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/LiquidityPool.sol:LiquidityPool
+          contract: src/core/LiquidityPool.sol:LiquidityPool
 
       - name: Check storage layout for StakingManager
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/StakingManager.sol:StakingManager
+          contract: src/staking/StakingManager.sol:StakingManager
 
       - name: Check storage layout for EtherFiNodesManager
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EtherFiNodesManager.sol:EtherFiNodesManager
+          contract: src/staking/EtherFiNodesManager.sol:EtherFiNodesManager
 
       - name: Check storage layout for EtherFiNode
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EtherFiNode.sol:EtherFiNode
+          contract: src/staking/EtherFiNode.sol:EtherFiNode
 
       # Management & Admin Contracts
       - name: Check storage layout for EtherFiAdmin
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EtherFiAdmin.sol:EtherFiAdmin
+          contract: src/oracle/EtherFiAdmin.sol:EtherFiAdmin
 
       - name: Check storage layout for NodeOperatorManager
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/NodeOperatorManager.sol:NodeOperatorManager
+          contract: src/staking/NodeOperatorManager.sol:NodeOperatorManager
 
       - name: Check storage layout for AuctionManager
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/AuctionManager.sol:AuctionManager
+          contract: src/staking/AuctionManager.sol:AuctionManager
 
       - name: Check storage layout for MembershipManager
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/MembershipManager.sol:MembershipManager
+          contract: src/archive/membership/MembershipManager.sol:MembershipManager
 
       - name: Check storage layout for MembershipNFT
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/MembershipNFT.sol:MembershipNFT
+          contract: src/archive/membership/MembershipNFT.sol:MembershipNFT
 
       - name: Check storage layout for RoleRegistry
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/RoleRegistry.sol:RoleRegistry
+          contract: src/governance/RoleRegistry.sol:RoleRegistry
 
       # Oracle & Rewards
       - name: Check storage layout for EtherFiOracle
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EtherFiOracle.sol:EtherFiOracle
+          contract: src/oracle/EtherFiOracle.sol:EtherFiOracle
 
       - name: Check storage layout for CumulativeMerkleRewardsDistributor
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/CumulativeMerkleRewardsDistributor.sol:CumulativeMerkleRewardsDistributor
+          contract: src/rewards/CumulativeMerkleRewardsDistributor.sol:CumulativeMerkleRewardsDistributor
 
       - name: Check storage layout for EtherFiRewardsRouter
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EtherFiRewardsRouter.sol:EtherFiRewardsRouter
+          contract: src/rewards/EtherFiRewardsRouter.sol:EtherFiRewardsRouter
 
       # NFT Contracts
       - name: Check storage layout for BNFT
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/BNFT.sol:BNFT
+          contract: src/archive/BNFT.sol:BNFT
 
       - name: Check storage layout for TNFT
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/TNFT.sol:TNFT
+          contract: src/archive/TNFT.sol:TNFT
 
       - name: Check storage layout for WithdrawRequestNFT
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/WithdrawRequestNFT.sol:WithdrawRequestNFT
+          contract: src/withdrawals/WithdrawRequestNFT.sol:WithdrawRequestNFT
 
       # Liquidity & Trading
       - name: Check storage layout for Liquifier
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/Liquifier.sol:Liquifier
+          contract: src/deposits/Liquifier.sol:Liquifier
 
       - name: Check storage layout for EtherFiRestaker
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EtherFiRestaker.sol:EtherFiRestaker
+          contract: src/restaking/EtherFiRestaker.sol:EtherFiRestaker
 
       - name: Check storage layout for EtherFiRedemptionManager
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EtherFiRedemptionManager.sol:EtherFiRedemptionManager
+          contract: src/withdrawals/EtherFiRedemptionManager.sol:EtherFiRedemptionManager
 
       - name: Check storage layout for DepositAdapter
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/DepositAdapter.sol:DepositAdapter
+          contract: src/deposits/DepositAdapter.sol:DepositAdapter
 
       # Rate Limiting & Utilities
       - name: Check storage layout for BucketRateLimiter
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/BucketRateLimiter.sol:BucketRateLimiter
+          contract: src/archive/BucketRateLimiter.sol:BucketRateLimiter
 
       - name: Check storage layout for TVLOracle
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/TVLOracle.sol:TVLOracle
+          contract: src/archive/TVLOracle.sol:TVLOracle
 
       - name: Check storage layout for EarlyAdopterPool
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EarlyAdopterPool.sol:EarlyAdopterPool
+          contract: src/archive/EarlyAdopterPool.sol:EarlyAdopterPool
 
       - name: Check storage layout for UUPSProxy
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/UUPSProxy.sol:UUPSProxy
+          contract: src/utils/UUPSProxy.sol:UUPSProxy
 
       - name: Check storage layout for EtherFiTimelock
         uses: Rubilmax/foundry-storage-check@main
         with:
-          contract: src/EtherFiTimelock.sol:EtherFiTimelock
+          contract: src/governance/EtherFiTimelock.sol:EtherFiTimelock
 
       # Helper Contracts
       - name: Check storage layout for AddressProvider


### PR DESCRIPTION
## Summary

The `Check storage layout` workflow has been failing on every run since the `src/` directory reorg: it still referenced the old flat paths (e.g. `src/EETH.sol`), so each step died with:

```
Error: Could not find source file for contract `EETH` at src/EETH.sol
```

This updates all 30 contract references in `.github/workflows/foundry-storage-check.yml` to their new locations (`src/core/`, `src/staking/`, `src/oracle/`, `src/archive/`, etc.). Contract names are unchanged — only file paths moved.

## Verification

- Every `path:ContractName` entry checked against the source tree (file exists and declares that contract)
- `forge inspect <entry> storage-layout` run locally for all 30 entries — all resolve and produce a layout

## Expected: the storage check is red on this PR itself

The [foundry-storage-check action](https://github.com/Rubilmax/foundry-storage-check) keys its baseline artifacts by contract path, so a PR run looks for `master.src_core_EETH.sol-EETH.json` — which can't exist until the new paths run on master once. This is the action's documented first-run behavior ("An error will appear at first run!" in its README) and there is no clean way around the bootstrap.

It self-heals on merge: on `push` events the action only generates and uploads baselines (it skips the comparison entirely — `if (context.eventName !== "pull_request") return`), so the merge push to master will go green and seed all 30 baseline artifacts. Every subsequent PR then compares normally. Note the check is already failing on master and is not a required check (#385 merged with it red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)