### PR TITLE
test: fix fork test post upgrade

### DIFF
--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -715,6 +715,8 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         bytes32 _operatingMultisigRole = roleRegistryInstance.OPERATION_MULTISIG_ROLE();
         bytes32 _operatingTimelockRole = roleRegistryInstance.OPERATION_TIMELOCK_ROLE();
         bytes32 _upgradeTimelockRole = roleRegistryInstance.UPGRADE_TIMELOCK_ROLE();
+        bytes32 _housekeepingRole = roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE();
+        bytes32 _guardianRole = roleRegistryInstance.GUARDIAN_ROLE();
         address _roleRegOwner = roleRegistryInstance.owner();
         address _operatingTimelockAddr = deployed.OPERATING_TIMELOCK();
         vm.startPrank(_roleRegOwner);
@@ -741,7 +743,11 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         // routes them through OPERATION_TIMELOCK / OPERATION_MULTISIG, so we
         // mirror that historical access for the addresses tests prank as.
         // Note: HOUSEKEEPING / GUARDIAN are intentionally NOT granted here —
-        // tests for sweepFunds & friends rely on `admin` lacking them.
+        // tests for sweepFunds & friends rely on `admin` lacking them. The 26Q2
+        // upgrade (mainnet block 25533308) granted both to the operating multisig,
+        // which is `admin` on this fork, so revoke them to restore that assumption.
+        roleRegistryInstance.revokeRole(_housekeepingRole, admin);
+        roleRegistryInstance.revokeRole(_guardianRole, admin);
         roleRegistryInstance.grantRole(_operatingTimelockRole, owner);
         roleRegistryInstance.grantRole(_operatingTimelockRole, alice);
         roleRegistryInstance.grantRole(_operatingTimelockRole, admin);
@@ -1497,6 +1503,10 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         for (uint256 i = 0; i < eethIds.length; i++) {
             if (!rateLimiterInstance.limitExists(eethIds[i])) {
                 rateLimiterInstance.createNewLimiter(eethIds[i], maxUint64, maxUint64);
+            } else {
+                rateLimiterInstance.setCapacity(eethIds[i], maxUint64);
+                rateLimiterInstance.setRefillRate(eethIds[i], maxUint64);
+                rateLimiterInstance.setRemaining(eethIds[i], maxUint64);
             }
             rateLimiterInstance.updateConsumers(eethIds[i], address(eETHInstance), true);
         }

--- a/test/V0MigrationFork.t.sol
+++ b/test/V0MigrationFork.t.sol
@@ -41,11 +41,14 @@ contract V0MigrationForkTest is Test {
 
     MembershipManager mm;
 
+    /// @dev Last mainnet state before the 26Q2 security upgrade executed
+    ///      (block 25533308, 2026-07-14). The V0 migration has since run on
+    ///      mainnet, so this test must fork pre-upgrade state to keep
+    ///      exercising the migration path it was written to validate.
+    uint256 constant PRE_UPGRADE_BLOCK = 25_526_000;
+
     function setUp() public {
-        // Use the latest fork — these are pure read/migrate flows so block
-        // pinning is unnecessary. If a tester wants a specific block they can
-        // override via cheatcodes before calling test_*.
-        vm.selectFork(vm.createFork(vm.envString("MAINNET_RPC_URL")));
+        vm.selectFork(vm.createFork(vm.envString("MAINNET_RPC_URL"), PRE_UPGRADE_BLOCK));
         mm = MembershipManager(payable(MEMBERSHIP_MANAGER));
     }
 

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -151,7 +151,8 @@ contract PreludeTest is Test, ArrayTestHelper {
         vm.prank(roleRegistry.owner());
         stakingManager.upgradeEtherFiNode(address(etherFiNodeImpl));
 
-        vm.prank(roleRegistry.owner());
+        address operatingMultisig = roleRegistry.roleHolders(roleRegistry.OPERATION_MULTISIG_ROLE())[0];
+        vm.prank(operatingMultisig);
         auctionManager.disableWhitelist();
 
         // permissions

--- a/test/fork-tests/RevertEscrowDrain.t.sol
+++ b/test/fork-tests/RevertEscrowDrain.t.sol
@@ -35,8 +35,16 @@ interface IOwnableRead { function owner() external view returns (address); }
 contract RevertEscrowDrainTest is Test, Deployed {
     Blacklister internal blacklister;
 
+    /// @dev Last mainnet state before the 26Q2 security upgrade + escrow-drain
+    ///      claim flush executed (2026-07-14, upgrade at block 25533308). These
+    ///      tests validate the upgrade/migration path from live PRE-upgrade
+    ///      state — the deployed post-upgrade impls dropped `owner()` and
+    ///      already ran `initializeOnUpgradeV2`, so a latest-block fork can no
+    ///      longer exercise them.
+    uint256 constant PRE_UPGRADE_BLOCK = 25_526_000;
+
     function setUp() public {
-        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"));
+        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), PRE_UPGRADE_BLOCK);
         // The new impls wire a Blacklister as an immutable; deploy a fresh one for the harness.
         Blacklister bImpl = new Blacklister(ROLE_REGISTRY);
         blacklister = Blacklister(address(new UUPSProxy(address(bImpl), abi.encodeWithSelector(Blacklister.initialize.selector))));

--- a/test/fork-tests/UpgradeStorageIntegrity.t.sol
+++ b/test/fork-tests/UpgradeStorageIntegrity.t.sol
@@ -135,9 +135,16 @@ contract UpgradeStorageIntegrityTest is Test, SecurityUpgradesConstants {
         assertEq(a.paused,     b.paused,     "WRN.paused");
     }
 
+    /// @dev Last mainnet state before the 26Q2 security upgrade executed
+    ///      (block 25533308, 2026-07-14). These tests validate the upgrade path
+    ///      from live PRE-upgrade state — the deployed post-upgrade impls
+    ///      dropped `owner()` and already ran `initializeOnUpgradeV2`, so a
+    ///      latest-block fork can no longer exercise them.
+    uint256 constant PRE_UPGRADE_BLOCK = 25_526_000;
+
     function setUp() public {
-        // Latest-block fork; realistic mainnet state.
-        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"));
+        // Pinned pre-upgrade fork; realistic mainnet state.
+        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), PRE_UPGRADE_BLOCK);
 
         // NOTE: RoleRegistry is intentionally NOT upgraded here. The currently
         // deployed LP/WRN/PQ impls authorize upgrades via the legacy

--- a/test/integration-tests/Deposit.t.sol
+++ b/test/integration-tests/Deposit.t.sol
@@ -240,7 +240,13 @@ contract DepositIntegrationTest is TestSetup {
         stEth.transfer(address(etherFiRestakerInstance), stEthAmount);
 
         uint256 stETHAmountOfRestakerBeforeDeposit = stEth.balanceOf(address(etherFiRestakerInstance));
-        vm.prank(roleRegistryInstance.owner());
+
+        address roleRegOwner = roleRegistryInstance.owner();
+        bytes32 executorRole = roleRegistryInstance.EXECUTOR_OPERATIONS_ROLE();
+        vm.prank(roleRegOwner);
+        roleRegistryInstance.grantRole(executorRole, roleRegOwner);
+
+        vm.prank(roleRegOwner);
         uint256 shares = etherFiRestakerInstance.depositIntoStrategy(address(stEth), stEthAmount);
 
         assertGt(shares, 0);

--- a/test/integration-tests/Withdraw.t.sol
+++ b/test/integration-tests/Withdraw.t.sol
@@ -506,7 +506,12 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
         uint256 restakerBalanceBefore = address(etherFiRestakerInstance).balance;
         assertEq(restakerBalanceBefore, amount);
 
-        vm.prank(roleRegistryInstance.owner());
+        address roleRegOwner = roleRegistryInstance.owner();
+        bytes32 housekeepingRole = roleRegistryInstance.HOUSEKEEPING_OPERATIONS_ROLE();
+        vm.prank(roleRegOwner);
+        roleRegistryInstance.grantRole(housekeepingRole, roleRegOwner);
+
+        vm.prank(roleRegOwner);
         etherFiRestakerInstance.withdrawEther();
 
         assertEq(address(etherFiRestakerInstance).balance, 0);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes with no production contract modifications; risk is limited to CI correctness and fork assumptions.
> 
> **Overview**
> Keeps **mainnet fork tests** valid after the 26Q2 security upgrade (block 25533308) by pinning forks to **`PRE_UPGRADE_BLOCK` (25_526_000)** in `V0MigrationFork`, `RevertEscrowDrain`, and `UpgradeStorageIntegrity`, so upgrade/migration and V0 migration paths can still run from pre-upgrade chain state.
> 
> In **`initializeRealisticForkWithBlock`**, revokes **`HOUSEKEEPING_OPERATIONS_ROLE`** and **`GUARDIAN_ROLE`** from fork `admin` when the upgrade granted them to the operating multisig, preserving tests that expect `admin` cannot call sweep-style paths. **`_setupGlobalMintBurnBuckets`** now resets capacity/refill/remaining when eETH MINT/BURN limiters already exist on fork.
> 
> Integration/behaviour fixes: **`prelude.t.sol`** pranks the **operating multisig** (not RoleRegistry owner) for `disableWhitelist`; **`Deposit.t.sol`** grants **`EXECUTOR_OPERATIONS_ROLE`** before `depositIntoStrategy`; **`Withdraw.t.sol`** grants **`HOUSEKEEPING_OPERATIONS_ROLE`** before `withdrawEther`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3eba9fe43799e62ad6a491a105f734a85a7a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->