### PR TITLE
fix(enm): revert disablePod on stale-beacon silent no-op [audit finding 1, HIGH]

### DIFF
--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -108,7 +108,14 @@ contract EtherFiNodesManager is
     function disablePod(address node) external onlyOperatingTimelock whenNotPaused {
         _validateNode(node);
         IEtherFiNode(node).disablePod();
-        emit PodDisabled(node, address(IEtherFiNode(node).getEigenPod()));
+        // Guard against a silent no-op. `disablePod()` returns nothing, so if the EtherFiNode beacon
+        // has not been upgraded yet the node's empty fallback swallows the call and returns success
+        // without ever reaching the pod. Assert the pod actually reports retirement, so a stale-beacon
+        // deployment reverts loudly here instead of emitting a false PodDisabled that would let us
+        // consolidate out of a still-live pod and cut its beacon-chain slashing factor.
+        IEigenPod pod = IEtherFiNode(node).getEigenPod();
+        if (address(pod) == address(0) || !pod.restakingDisabled()) revert PodNotDisabled();
+        emit PodDisabled(node, address(pod));
     }
 
     /**

--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -108,11 +108,6 @@ contract EtherFiNodesManager is
     function disablePod(address node) external onlyOperatingTimelock whenNotPaused {
         _validateNode(node);
         IEtherFiNode(node).disablePod();
-        // Guard against a silent no-op. `disablePod()` returns nothing, so if the EtherFiNode beacon
-        // has not been upgraded yet the node's empty fallback swallows the call and returns success
-        // without ever reaching the pod. Assert the pod actually reports retirement, so a stale-beacon
-        // deployment reverts loudly here instead of emitting a false PodDisabled that would let us
-        // consolidate out of a still-live pod and cut its beacon-chain slashing factor.
         IEigenPod pod = IEtherFiNode(node).getEigenPod();
         if (address(pod) == address(0) || !pod.restakingDisabled()) revert PodNotDisabled();
         emit PodDisabled(node, address(pod));

--- a/src/staking/interfaces/IEtherFiNodesManager.sol
+++ b/src/staking/interfaces/IEtherFiNodesManager.sol
@@ -141,4 +141,5 @@ interface IEtherFiNodesManager {
     error InsufficientWithdrawalFees();
     error InsufficientConsolidationFees();
     error MixedNodeRequest();
+    error PodNotDisabled();
 }

--- a/test/behaviour-tests/non-eigenpod-credentials.t.sol
+++ b/test/behaviour-tests/non-eigenpod-credentials.t.sol
@@ -651,10 +651,32 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         address pod = address(IEtherFiNode(node).getEigenPod());
 
         vm.mockCall(eigenPodManager, abi.encodeWithSignature("disablePod()"), "");
+        // The manager now asserts the pod actually reports retirement before emitting PodDisabled,
+        // so the pod must report restakingDisabled() == true for the happy path.
+        vm.mockCall(pod, abi.encodeWithSignature("restakingDisabled()"), abi.encode(true));
 
         vm.expectEmit(true, true, false, true, address(etherFiNodesManager));
         emit IEtherFiNodesManager.PodDisabled(node, pod);
 
+        vm.prank(admin); // OPERATION_TIMELOCK_ROLE
+        etherFiNodesManager.disablePod(node);
+
+        vm.clearMockedCalls();
+    }
+
+    /// @dev Regression for the silent no-op: if the EtherFiNode beacon is stale, node.disablePod()
+    ///      is swallowed by the empty fallback and returns success. The manager must not emit a
+    ///      false PodDisabled — it reverts PodNotDisabled because the pod still reports restaking on.
+    function test_disablePod_revertsWhenPodNotActuallyDisabled() public {
+        vm.prank(admin);
+        address node = stakingManager.instantiateEtherFiNode(true);
+        address pod = address(IEtherFiNode(node).getEigenPod());
+
+        // Simulate a node/pod that accepts disablePod() (or swallows it) yet stays enabled.
+        vm.mockCall(eigenPodManager, abi.encodeWithSignature("disablePod()"), "");
+        vm.mockCall(pod, abi.encodeWithSignature("restakingDisabled()"), abi.encode(false));
+
+        vm.expectRevert(IEtherFiNodesManager.PodNotDisabled.selector);
         vm.prank(admin); // OPERATION_TIMELOCK_ROLE
         etherFiNodesManager.disablePod(node);
 


### PR DESCRIPTION
## Finding 1 (HIGH) — `disablePod` silent no-op

`EtherFiNodesManager.disablePod` calls `IEtherFiNode(node).disablePod()`, which returns nothing. If the **EtherFiNode beacon has not been upgraded yet**, the old implementation's empty `fallback()` swallows the call and returns success — so the manager emits a false `PodDisabled` while the pod is still live. The runbook's next step (consolidating validators out) would then cut the pod's beacon-chain slashing factor and devalue our claim on the ETH still in it.

### Fix
After calling `disablePod()`, assert the pod actually reports `restakingDisabled()`; otherwise revert `PodNotDisabled`. A stale-beacon deployment now fails loudly instead of silently succeeding.

### Tests
- New regression test `test_disablePod_revertsWhenPodNotActuallyDisabled` (pod stays enabled → reverts `PodNotDisabled`).
- Updated `test_disabledPod_retirementRoutesThroughTheNodeAsPodOwner` to mock `restakingDisabled() == true` for the happy path.
- `non-eigenpod-credentials` suite: 77 passing on mainnet fork.

### Evidence
Empirically reproduced on a Tenderly fork carrying real EigenLayer v1.14.0 (rehearsal test T2): pre-fix, `disablePod` silently succeeds + emits `PodDisabled` while `restakingDisabled` stays 0.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials` (fix targets code introduced by PR #485).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches irreversible EigenPod retirement on the restaking path; a wrong check could block legitimate retirements or still allow a false success that devalues ETH claims via the beacon slashing factor.
> 
> **Overview**
> **Fixes a HIGH audit finding** where `disablePod` could silently succeed and emit `PodDisabled` even though the EigenPod was still live.
> 
> If the EtherFiNode beacon is stale, the empty `fallback` swallows `disablePod()` and returns success. The manager now asserts the pod exists and reports `restakingDisabled()` before emitting, otherwise reverts `PodNotDisabled`. That stops the runbook from consolidating validators out of a still-active pod and cutting the beacon-chain slashing factor.
> 
> Adds a regression test for the silent no-op path and updates the happy-path test to mock `restakingDisabled() == true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7fa6419b87c7ee62cb298c34aecdd6176869b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789060499&installation_model_id=18424&pr_number=486&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F486&signature=bc568005ff4e9e3954a9d0da29288334df0f6fd635f641bb25bb41c853a2c92a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->