### PR TITLE
fix(enm): apply MixedNodeRequest guard to disabled pods [audit finding 3, MED]

### DIFF
--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -248,7 +248,7 @@ contract EtherFiNodesManager is
         // pod, EigenLayer already enforces pod membership and reverts, and it does so against the
         // pod's own validator set rather than our pubkey mapping, which may not have every
         // legacy validator linked.
-        if (target == address(node)) {
+        if (_requiresBatchMembershipCheck(address(node), target)) {
             for (uint256 i = 1; i < requests.length; i++) {
                 if (address(etherFiNodeFromPubkeyHash[calculateValidatorPubkeyHash(requests[i].pubkey)]) != address(node)) revert MixedNodeRequest();
             }
@@ -295,7 +295,7 @@ contract EtherFiNodesManager is
 
         // Pod-less only, for the reason given in requestExecutionLayerTriggeredWithdrawal. The
         // target is deliberately not constrained; it may live outside this node.
-        if (target == address(node)) {
+        if (_requiresBatchMembershipCheck(address(node), target)) {
             for (uint256 i = 1; i < requests.length; i++) {
                 if (address(etherFiNodeFromPubkeyHash[calculateValidatorPubkeyHash(requests[i].srcPubkey)]) != address(node)) revert MixedNodeRequest();
             }
@@ -620,6 +620,21 @@ contract EtherFiNodesManager is
     function _credentialTarget(address node) internal view returns (address) {
         address pod = address(IEtherFiNode(node).getEigenPod());
         return pod == address(0) ? node : pod;
+    }
+
+    /// @dev Whether a request batch must be checked for same-node membership. True for pod-less nodes
+    ///   (the node itself is the target) and for nodes whose pod has been retired: EigenLayer v1.14
+    ///   stops enforcing pod membership once restaking is disabled, so without this a mixed batch
+    ///   through a disabled pod would burn fees and emit phantom exit/consolidation events. The
+    ///   try/catch keeps pre-v1.14 pods, which have no `restakingDisabled()` selector, on the
+    ///   original pod-backed path where EigenLayer still enforces membership itself.
+    function _requiresBatchMembershipCheck(address node, address target) internal view returns (bool) {
+        if (target == node) return true;
+        try IEigenPod(target).restakingDisabled() returns (bool disabled) {
+            return disabled;
+        } catch {
+            return false;
+        }
     }
 
     function addressToWithdrawalCredentials(address addr) public pure returns (bytes memory) {


### PR DESCRIPTION
## Finding 3 (MED) — mixed-node batch guard bypassed on disabled pods

The `MixedNodeRequest` batch-membership check in `requestExecutionLayerTriggeredWithdrawal` / `requestConsolidation` runs only when `target == address(node)` (the pod-less case). The comment justifies skipping it for pod-backed nodes because *"EigenLayer already enforces pod membership and reverts."* That is false once a pod is **disabled**: EL v1.14 skips its own `ValidatorNotActiveInPod` check when `restakingDisabled`. So during migration, a batch routed through a disabled pod that mixes pubkeys from a different node is validated by nobody — the CL silently drops the mismatched requests, the fee is burned, and phantom exit/consolidation events are emitted.

### Fix
Extend the guard to also fire when the target pod reports `restakingDisabled()`, via a new `_requiresBatchMembershipCheck` helper. A `try/catch` keeps pre-v1.14 pods (no `restakingDisabled()` selector) on the original pod-backed path, so existing pod requests are unaffected — this is important: a naive call would revert every pod-backed request until EL upgrades.

### Tests
- `non-eigenpod-credentials`: 76 passing; `Request-consolidation` pectra fork: 3 passing.

### Evidence
Reproduced on a Tenderly fork carrying real EL v1.14.0 (rehearsal test T4): a mixed-node consolidation batch through a disabled pod was accepted with no `MixedNodeRequest` revert.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 89e59808c5d7285ea6112cae7f9f7a96aee53eba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789060725&installation_model_id=18424&pr_number=487&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F487&signature=1c779a422546066baf7b352bdde4c2a68072261f4504d50e1393854a60867359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->