### PR TITLE
fix(enm): block validator creation against a retired pod [audit finding 4, MED]

### DIFF
--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -611,7 +611,18 @@ contract EtherFiNodesManager is
      */
     function withdrawalCredentialTarget(address node) public view returns (address) {
         _validateNode(node);
-        return _credentialTarget(node);
+        address target = _credentialTarget(node);
+        // Refuse to bake credentials against a retired pod: a validator created here could never
+        // verify its credentials or checkpoint, so its 32 ETH would be stranded behind a dead pod.
+        // Only the creation paths call this validated resolver; the request paths use
+        // _credentialTarget directly, so validators already live on a since-retired pod are
+        // unaffected. try/catch leaves pre-v1.14 pods (no restakingDisabled() selector) as before.
+        if (target != node) {
+            try IEigenPod(target).restakingDisabled() returns (bool disabled) {
+                if (disabled) revert PodRetired();
+            } catch {}
+        }
+        return target;
     }
 
     /// @dev Unvalidated derivation, for callers that only need the target for an event. The

--- a/src/staking/interfaces/IEtherFiNodesManager.sol
+++ b/src/staking/interfaces/IEtherFiNodesManager.sol
@@ -141,4 +141,5 @@ interface IEtherFiNodesManager {
     error InsufficientWithdrawalFees();
     error InsufficientConsolidationFees();
     error MixedNodeRequest();
+    error PodRetired();
 }

--- a/test/behaviour-tests/non-eigenpod-credentials.t.sol
+++ b/test/behaviour-tests/non-eigenpod-credentials.t.sol
@@ -66,6 +66,23 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         etherFiNodesManager.withdrawalCredentialTarget(address(0xdeadbeef));
     }
 
+    /// @dev A retired pod is never a valid credential target: a new validator against it could never
+    ///      verify credentials or checkpoint, stranding its 32 ETH behind a dead pod. The validated
+    ///      resolver (used by all three creation paths) must reject it.
+    function test_credentialTarget_revertsForRetiredPod() public {
+        vm.prank(admin);
+        address node = stakingManager.instantiateEtherFiNode(true);
+        address pod = address(IEtherFiNode(node).getEigenPod());
+
+        // Simulate an EL v1.14 pod that has been retired.
+        vm.mockCall(pod, abi.encodeWithSignature("restakingDisabled()"), abi.encode(true));
+
+        vm.expectRevert(IEtherFiNodesManager.PodRetired.selector);
+        etherFiNodesManager.withdrawalCredentialTarget(node);
+
+        vm.clearMockedCalls();
+    }
+
     /// @dev The target is derived rather than stored, which is only safe because a node's pod is
     ///      fixed at instantiation. createEigenPod is callable solely by StakingManager, whose one
     ///      call site is inside instantiateEtherFiNode.


### PR DESCRIPTION
## Finding 4 (MED) — new validators can be created against a retired pod

`disablePod` never clears `ownerToPod`, so `_credentialTarget` keeps returning the (now disabled) pod for a retired node. All three StakingManager creation paths resolve credentials through `withdrawalCredentialTarget`, so they would bake `0x02` credentials pointing at the **dead pod** — and such a validator can never `verifyWithdrawalCredentials` or checkpoint, stranding its 32 ETH. PR #485 also removed the `getEigenPod() == 0` guard from `registerBeaconValidators`, so nothing else blocked it.

### Fix
`withdrawalCredentialTarget` (the **validated** resolver used only by the creation paths) reverts `PodRetired` when the target pod reports `restakingDisabled()`. The request paths use `_credentialTarget` directly and are intentionally untouched, so validators already live on a since-retired pod keep working. `try/catch` leaves pre-v1.14 pods working as before.

### Tests
- New regression test `test_credentialTarget_revertsForRetiredPod`.
- `non-eigenpod-credentials`: 77 passing; `non-eigenpod-validator-lifecycle`: 54 passing.

### Evidence
Reproduced on a Tenderly fork with real EL v1.14.0 (rehearsal test T3): after disabling a node's pod, the resolver returned the disabled pod and baked `0x02` creds pointing at it.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the credential resolver used by all validator creation paths and guards against stranded ETH, but the change is a small defensive check with a regression test and does not alter request/exit flows.
> 
> **Overview**
> Prevents new validators from being created against a **retired EigenPod**, which would strand 32 ETH behind a dead pod that can never verify credentials or checkpoint.
> 
> `withdrawalCredentialTarget` (used by all three StakingManager creation paths) now reverts `PodRetired` when the target pod reports `restakingDisabled()`. Request paths still use `_credentialTarget` directly, so existing validators on a since-retired pod keep working. A `try/catch` preserves pre-v1.14 pod behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f219f9b209f2838e4bb636ad6a20dd786d5393c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789060965&installation_model_id=18424&pr_number=488&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F488&signature=9847fc1a0b1ce2979625b5b1d3f346edd0a22c44bd8ad0e07b98ffc34d46ebcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->