### PR TITLE
fix(enm): validate node in sweepFunds(address) [audit finding 6, LOW]

### DIFF
--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -73,6 +73,10 @@ contract EtherFiNodesManager is
     /// @dev Sweeps a node directly. Validators in the new credential regime pay out to the node
     ///   itself, so the node address is the natural handle.
     function sweepFunds(address node) external onlyHousekeepingOperations whenNotPaused {
+        // Validate like every other node-taking entrypoint. Without this, a housekeeping caller
+        // could pass an arbitrary contract, making the manager call into it and emit a forged
+        // FundsTransferred event that poisons off-chain accounting.
+        _validateNode(node);
         uint256 balance = IEtherFiNode(node).sweepFunds();
         if (balance > 0) {
             emit FundsTransferred(node, balance);

--- a/test/behaviour-tests/non-eigenpod-credentials.t.sol
+++ b/test/behaviour-tests/non-eigenpod-credentials.t.sol
@@ -682,4 +682,12 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         vm.prank(address(etherFiNodesManager));
         IEtherFiNode(node).withdrawDisabledPodETH();
     }
+
+    /// @dev sweepFunds(address) must validate the node like every other node-taking entrypoint, so a
+    ///      housekeeping caller cannot point it at an arbitrary contract and forge FundsTransferred.
+    function test_sweepFunds_revertsForUnknownNode() public {
+        vm.expectRevert(IEtherFiNodesManager.UnknownNode.selector);
+        vm.prank(eigenlayerAdmin); // HOUSEKEEPING_OPERATIONS_ROLE
+        etherFiNodesManager.sweepFunds(address(0xdeadbeef));
+    }
 }


### PR DESCRIPTION
## Finding 6 (LOW) — `sweepFunds(address)` missing `_validateNode`

`sweepFunds(address)` was the only node-taking entrypoint that skipped `_validateNode`, while every sibling (`disablePod`, `withdrawDisabledPodETH`, `queueETHWithdrawal`, `startCheckpoint`, …) validates. A housekeeping-role caller (or a compromised cron key) could pass an arbitrary contract, make the real manager call into it, and emit a forged `FundsTransferred(node, balance)` event that poisons any off-chain sweep/TVL accounting keyed on manager events.

### Fix
Add `_validateNode(node)` so only `deployedEtherFiNodes` are accepted.

### Tests
- New regression test `test_sweepFunds_revertsForUnknownNode`.
- `non-eigenpod-credentials`: 77 passing.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789061151&installation_model_id=18424&pr_number=489&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F489&signature=35a7956e18cc1c0dae4eec04299fd5734de92d9c0d0f8e65890c65bf93db5744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c51b07c675a2261f7c59bd14d47301aa9af5ff90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->