### PR TITLE
test(enm): remove vacuous-pass escape hatch in disablePod fork test [audit finding 12]

### DIFF
--- a/test/behaviour-tests/non-eigenpod-credentials.t.sol
+++ b/test/behaviour-tests/non-eigenpod-credentials.t.sol
@@ -574,14 +574,21 @@ contract NonEigenPodCredentialsTest is PreludeTest {
     function test_disablePod_revertsUntilEigenLayerV1_14_0() public {
         vm.prank(admin);
         address node = stakingManager.instantiateEtherFiNode(/*createEigenPod=*/ true);
+        IEigenPod pod = IEtherFiNode(node).getEigenPod();
 
-        (bool supported,) =
-            address(IEtherFiNode(node).getEigenPod()).staticcall(abi.encodeWithSignature("restakingDisabled()"));
+        (bool supported,) = address(pod).staticcall(abi.encodeWithSignature("restakingDisabled()"));
         if (supported) {
-            emit log("EigenLayer v1.14.0 is live: extend this test to cover the disablePod success path");
+            // EL v1.14.0 is live: a freshly created pod has no shares, checkpoints or queued
+            // withdrawals, so retirement through the manager succeeds and the pod reports it. Assert
+            // the real success path rather than returning green, so this test never passes vacuously.
+            vm.prank(admin); // OPERATION_TIMELOCK_ROLE
+            etherFiNodesManager.disablePod(node);
+            assertTrue(pod.restakingDisabled(), "pod should report retirement after disablePod");
             return;
         }
 
+        // Pre-v1.14: the EigenPodManager has no disablePod selector and no fallback, so the call
+        // reverts rather than silently succeeding.
         vm.expectRevert();
         vm.prank(address(etherFiNodesManager));
         IEtherFiNode(node).disablePod();


### PR DESCRIPTION
## Finding 12 (test quality) — vacuous-pass escape hatch

`test_disablePod_revertsUntilEigenLayerV1_14_0` emitted a log and `return`ed with **zero assertions** whenever the live pod supports `restakingDisabled()` (i.e. once EL v1.14.0 lands). So the moment mainnet upgrades, the only disablePod fork test silently stops testing anything and stays green.

### Fix
Replace the early return with a real assertion: on a v1.14 fork, drive retirement through the manager (`etherFiNodesManager.disablePod`) and assert the pod reports `restakingDisabled()`. A freshly created pod has no shares/checkpoints/queued withdrawals, so retirement succeeds cleanly. The pre-v1.14 revert branch is unchanged — **both branches now assert**.

### Tests
- `test_disablePod_revertsUntilEigenLayerV1_14_0` passes on the current (pre-v1.14) mainnet fork via the revert branch.

The rehearsal (see the Tenderly rehearsal doc) already proves the real disablePod success path against v1.14.0 code; this makes the in-repo suite exercise it too once v1.14 is live, instead of skipping.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in a behaviour fork test; no production contract or runtime logic is modified.
> 
> **Overview**
> Fixes a **test-quality gap** in `test_disablePod_revertsUntilEigenLayerV1_14_0`: when the forked pod exposes `restakingDisabled()` (EigenLayer v1.14+), the test no longer logs and exits without assertions.
> 
> On that branch it now drives retirement via **`etherFiNodesManager.disablePod(node)`** (admin / operating timelock) and asserts **`pod.restakingDisabled()`**, using a freshly created pod so retirement can succeed cleanly. The **pre-v1.14** path is unchanged: it still expects **`IEtherFiNode(node).disablePod()`** to revert when called from the manager.
> 
> Both fork eras now have real assertions, so the suite cannot stay green while silently skipping disablePod coverage after mainnet upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 954e492e1045ac922111cc851ed16cf00308f5a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789061278&installation_model_id=18424&pr_number=490&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F490&signature=e9ccae6cccea301c98555e25110852e37eb2ab6b10a1739dc256c1f3375c27e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->