### PR TITLE
fix(oracle): resolve top-up credentials through pod-or-node + regression test [re-review finding 1]

### DIFF
--- a/src/oracle/EtherFiAdmin.sol
+++ b/src/oracle/EtherFiAdmin.sol
@@ -367,8 +367,17 @@ contract EtherFiAdmin is Initializable, DeprecatedOZOwnable, UUPSUpgradeable, Ro
         IStakingManager.DepositData[] memory depositData = new IStakingManager.DepositData[](_validatorIds.length);
 
         for (uint256 i = 0; i < _validatorIds.length; i++) {
-            address eigenPod = address(IEtherFiNode(etherFiNodesManager.etherfiNodeAddress(_validatorIds[i])).getEigenPod());
-            bytes memory withdrawalCredentials = etherFiNodesManager.addressToCompoundingWithdrawalCredentials(eigenPod);
+            // Resolve the credential target through the same pod-or-node rule StakingManager uses,
+            // instead of hardcoding getEigenPod(). For a pod-less node getEigenPod() is address(0),
+            // so the old code baked 0x02+address(0) credentials whose deposit root never matches the
+            // node credentials fixed at creation, reverting IncorrectBeaconRoot and stranding the
+            // validator at 1 ETH. Resolve raw (not via withdrawalCredentialTarget) so a top-up is not
+            // blocked if the pod was retired between creation and approval — matching
+            // StakingManager.confirmAndFundBeaconValidators.
+            address node = etherFiNodesManager.etherfiNodeAddress(_validatorIds[i]);
+            address credentialTarget = address(IEtherFiNode(node).getEigenPod());
+            if (credentialTarget == address(0)) credentialTarget = node;
+            bytes memory withdrawalCredentials = etherFiNodesManager.addressToCompoundingWithdrawalCredentials(credentialTarget);
             bytes32 depositDataRoot = stakingManager.generateDepositDataRoot(_pubKeys[i], _signatures[i], withdrawalCredentials, remainingEthPerValidator);
 
             depositData[i] = IStakingManager.DepositData({

--- a/test/behaviour-tests/oracle-podless-funding.t.sol
+++ b/test/behaviour-tests/oracle-podless-funding.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "@tests/behaviour-tests/prelude.t.sol";
+import "@etherfi/oracle/EtherFiAdmin.sol";
+import {IEtherFiAdmin} from "@etherfi/oracle/interfaces/IEtherFiAdmin.sol";
+import {IEtherFiOracle} from "@etherfi/oracle/interfaces/IEtherFiOracle.sol";
+
+/// @notice Funds a pod-less validator through the REAL production top-up path:
+///         EtherFiAdmin.executeValidatorApprovalTask -> _approveValidators ->
+///         LiquidityPool.confirmAndFundBeaconValidators.
+/// @dev The existing pod-less tests hand-build the top-up DepositData and prank the admin, which
+///      skips EtherFiAdmin._approveValidators -- the only component that builds this data in
+///      production. This test lets _approveValidators build it. Pre-fix, _approveValidators
+///      hardcoded getEigenPod() (== address(0) for a pod-less node) and the top-up reverted
+///      IncorrectBeaconRoot; post-fix it resolves pod-or-node and the validator funds to full size.
+contract OraclePodlessFundingTest is PreludeTest {
+    // EIP-1967 implementation slot.
+    bytes32 constant IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+    // validatorApprovalTaskStatus mapping base slot (forge inspect EtherFiAdmin storageLayout).
+    uint256 constant TASK_STATUS_SLOT = 211;
+
+    address podLessNode;
+    bytes valPubkey;
+    bytes valSignature;
+
+    function _newPodLessNode() internal returns (address) {
+        vm.prank(admin);
+        return stakingManager.instantiateEtherFiNode(/*createEigenPod=*/ false);
+    }
+
+    /// @dev Redeploy EtherFiAdmin with the proxy's own immutables and point the proxy at it, so the
+    ///      fork runs the fixed _approveValidators (PreludeTest does not upgrade EtherFiAdmin).
+    function _upgradeEtherFiAdminInPlace(address proxy) internal {
+        EtherFiAdmin cur = EtherFiAdmin(proxy);
+        IEtherFiAdmin.ConstructorAddresses memory addrs = IEtherFiAdmin.ConstructorAddresses({
+            etherFiOracle: address(cur.etherFiOracle()),
+            stakingManager: address(cur.stakingManager()),
+            auctionManager: address(cur.auctionManager()),
+            etherFiNodesManager: address(cur.etherFiNodesManager()),
+            liquidityPool: address(cur.liquidityPool()),
+            withdrawRequestNft: address(cur.withdrawRequestNft()),
+            roleRegistry: 0x62247D29B4B9BECf4BB73E0c722cf6445cfC7cE9,
+            priorityWithdrawalQueue: address(cur.priorityWithdrawalQueue())
+        });
+        EtherFiAdmin newImpl = new EtherFiAdmin(
+            addrs,
+            cur.maxAcceptableRebaseAprInBps(),
+            cur.maxValidatorTaskBatchSize(),
+            cur.staleOracleReportBlockWindow(),
+            cur.maxAcceptableFinalizedWithdrawalAmountPerDay(),
+            cur.maxAcceptableNumValidatorsToApprovePerDay(),
+            cur.maxNumberOfRequestsToFinalizePerReport()
+        );
+        vm.store(proxy, IMPL_SLOT, bytes32(uint256(uint160(address(newImpl)))));
+    }
+
+    /// @dev Phase 1: create a pod-less validator (1 ETH) with node-based 0x02 credentials.
+    ///      Returns the out-of-LP value captured before the 1 ETH deposit.
+    function _createPodLessValidatorPhase1() internal returns (uint256 outStart) {
+        podLessNode = _newPodLessNode();
+        bytes memory creds = abi.encodePacked(bytes1(0x02), bytes11(0x0), podLessNode);
+
+        address nodeOperator = vm.addr(0x123456);
+        if (!nodeOperatorManager.registered(nodeOperator)) {
+            vm.prank(nodeOperator);
+            nodeOperatorManager.registerNodeOperator("test_ipfs_hash", 1000);
+        }
+        vm.deal(nodeOperator, 1 ether);
+        vm.prank(nodeOperator);
+        uint256 bidId = auctionManager.createBid{value: 0.1 ether}(1, 0.1 ether)[0];
+
+        valPubkey = vm.randomBytes(48);
+        valSignature = vm.randomBytes(96);
+        fundContract(address(liquidityPool), 10000 ether);
+
+        IStakingManager.DepositData memory createData = IStakingManager.DepositData({
+            publicKey: valPubkey,
+            signature: valSignature,
+            depositDataRoot: depositDataRootGenerator.generateDepositDataRoot(valPubkey, valSignature, creds, 1 ether),
+            ipfsHashForEncryptedValidatorKey: "test_ipfs_hash"
+        });
+
+        outStart = liquidityPool.totalValueOutOfLp();
+        vm.prank(admin);
+        liquidityPool.batchRegister(toArray(createData), toArray_u256(bidId), podLessNode);
+        vm.prank(admin);
+        liquidityPool.batchCreateBeaconValidators(toArray(createData), toArray_u256(bidId), podLessNode);
+        assertEq(liquidityPool.totalValueOutOfLp(), outStart + 1 ether, "phase 1 deposited 1 ETH");
+    }
+
+    /// @dev Seed the two executeValidatorApprovalTask gates (orthogonal to the builder under test).
+    function _seedApprovalTask(address proxy, bytes32 reportHash, uint256[] memory validatorIds) internal {
+        vm.mockCall(
+            address(EtherFiAdmin(proxy).etherFiOracle()),
+            abi.encodeWithSelector(IEtherFiOracle.isConsensusReached.selector, reportHash),
+            abi.encode(true)
+        );
+        bytes32 taskHash = keccak256(abi.encode(reportHash, validatorIds));
+        // TaskStatus { bool completed; bool exists; } packed in one slot: exists at byte offset 1.
+        bytes32 taskSlot = keccak256(abi.encode(taskHash, TASK_STATUS_SLOT));
+        vm.store(proxy, taskSlot, bytes32(uint256(1) << 8));
+        (bool completed, bool exists) = EtherFiAdmin(proxy).validatorApprovalTaskStatus(taskHash);
+        assertTrue(exists && !completed, "seeded approval task exists, not completed");
+    }
+
+    function test_oracleApprovalPath_fundsPodLessValidator() public {
+        address proxy = LiquidityPool(payable(address(liquidityPool))).etherFiAdminContract();
+        _upgradeEtherFiAdminInPlace(proxy);
+
+        uint256 outStart = _createPodLessValidatorPhase1();
+
+        bytes32 pubkeyHash = etherFiNodesManager.calculateValidatorPubkeyHash(valPubkey);
+        assertEq(etherFiNodesManager.etherfiNodeAddress(uint256(pubkeyHash)), podLessNode, "oracle resolves node by pubkeyHash id");
+
+        uint256[] memory validatorIds = new uint256[](1);
+        validatorIds[0] = uint256(pubkeyHash);
+        bytes[] memory pubKeys = new bytes[](1);
+        pubKeys[0] = valPubkey;
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = valSignature;
+
+        bytes32 reportHash = keccak256("podless-funding-report");
+        _seedApprovalTask(proxy, reportHash, validatorIds);
+
+        uint256 validatorSizeWei = liquidityPool.validatorSizeWei();
+
+        // The whole point: let EtherFiAdmin._approveValidators BUILD the top-up deposit data.
+        vm.prank(admin); // ORACLE_OPERATIONS_ROLE
+        EtherFiAdmin(proxy).executeValidatorApprovalTask(reportHash, validatorIds, pubKeys, signatures);
+
+        assertEq(liquidityPool.totalValueOutOfLp(), outStart + validatorSizeWei, "funded to full validator size via oracle path");
+        assertEq(address(etherFiNodesManager.etherFiNodeFromPubkeyHash(pubkeyHash)), podLessNode, "still linked to the pod-less node");
+        assertEq(address(IEtherFiNode(podLessNode).getEigenPod()), address(0), "node remained pod-less");
+
+        vm.clearMockedCalls();
+    }
+}


### PR DESCRIPTION
## Finding 1 (BLOCKER) — the production top-up builder stranded pod-less validators

The independent re-review at head `0101757` found that `EtherFiAdmin._approveValidators` — the production builder of the 31 ETH top-up deposit data, reached via `executeValidatorApprovalTask` — hardcoded `getEigenPod()`. For a **pod-less** node that is `address(0)`, so it baked `0x02 + address(0)` credentials whose deposit root can never match the node credentials fixed at creation. `confirmAndFundBeaconValidators` then reverts `IncorrectBeaconRoot`, and the validator is **stranded at 1 ETH forever**.

This is the *only* production path that funds a validator past 1 ETH, so the pod-less feature could not work as merged. `EtherFiAdmin.sol` was outside the original 15-file diff, which is why it was missed.

### Fix (`src/oracle/EtherFiAdmin.sol`)
Resolve the credential target as **pod-or-node** — `IEtherFiNode(node).getEigenPod()`, else the node — mirroring `StakingManager.confirmAndFundBeaconValidators`. Resolved raw (not via `withdrawalCredentialTarget`) so a top-up is **not** blocked if the pod was retired between creation and approval (consistent with the earlier finding-4 scoping). Pod-backed nodes are unaffected: `getEigenPod()` returns the pod, the `else` branch is never taken, and the built root is byte-identical to before.

### Test (`test/behaviour-tests/oracle-podless-funding.t.sol`)
Drives the **real** path — `executeValidatorApprovalTask → _approveValidators → confirmAndFundBeaconValidators` — for a pod-less validator and asserts it funds to full validator size, stays linked, and stays pod-less. The existing pod-less tests hand-build the top-up `DepositData` and prank the admin, skipping `_approveValidators`; this one lets the builder build it.

**Non-vacuous, verified both directions:**
- Passes against the fixed builder.
- **Fails `IncorrectBeaconRoot()`** when the fix is reverted (confirmed with `forge build --force` to defeat the incremental-build cache).

### Notes
- Existing suites unaffected: lifecycle 54, prelude 42 green.
- **Out of scope / follow-up (oracle repo):** the off-chain daemon has a second, independent gate — `validator_scanner.py` computes expected credentials through `getEigenPod` and rejects pod-less validators with "Withdrawal credentials mismatch." That must be fixed in the oracle repo before pod-less validators can be approved in production. This PR only fixes the on-chain builder.
- Release ordering: oracle + `EtherFiAdmin` must land before/with the contract upgrade, never after.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials` (the #485 branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789221592&installation_model_id=18424&pr_number=491&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F491&signature=c9b8ebf019f7b93c73fa9658a347e531395d5be3fde53e4e57eb74a96ab6e49b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the only on-chain path that builds validator top-up deposit data after oracle approval; incorrect credential logic would strand funds, but the change mirrors existing StakingManager behavior and is covered by a targeted regression test.
> 
> **Overview**
> Fixes a **blocker** where pod-less validators could never complete oracle-driven funding past the initial 1 ETH deposit.
> 
> **`EtherFiAdmin._approveValidators`** no longer builds top-up deposit roots using **`getEigenPod()` alone**. It now uses the same **pod-or-node** rule as **`StakingManager.confirmAndFundBeaconValidators`**: EigenPod when present, otherwise the EtherFi node address. That keeps compounding withdrawal credentials aligned with what was fixed at validator creation, so **`confirmAndFundBeaconValidators`** no longer reverts **`IncorrectBeaconRoot`**. Pod-backed validators behave as before; the fallback only applies when the pod is **`address(0)`**.
> 
> Adds **`oracle-podless-funding.t.sol`**, which runs the production path **`executeValidatorApprovalTask` → `_approveValidators` → `confirmAndFundBeaconValidators`** for a pod-less validator (including an in-place **`EtherFiAdmin`** impl swap on the fork) and asserts full-size funding without requiring hand-built deposit data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c355f43116e35e22d5accfbbabdd7c199bc4fcd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->