### PR TITLE
fix(enm): enforce batch membership on disabled pods via the pod validator set [prior finding 3]

### DIFF
--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -248,15 +248,21 @@ contract EtherFiNodesManager is
         // into deployedEtherFiNodes, which these paths never required
         address target = _credentialTarget(address(node));
 
-        // Pod-less only: the predeploy accepts any pubkey from any caller and the consensus layer
-        // silently drops requests whose source withdrawal address is not the caller, so an
-        // unchecked batch would burn the fee and emit events for exits that never happen. With a
-        // pod, EigenLayer already enforces pod membership and reverts, and it does so against the
-        // pod's own validator set rather than our pubkey mapping, which may not have every
-        // legacy validator linked.
+        // Same-pod membership must hold, else the consensus layer silently drops requests whose
+        // withdrawal address is not the caller — burning the fee and emitting phantom exit events. A
+        // live pod enforces this itself, so we only cover the two cases EigenLayer does not:
+        //   - pod-less: check our pubkey map, which is complete for pod-less validators.
+        //   - disabled pod: EL v1.14 stops enforcing membership once restaking is disabled, so check
+        //     each source against the pod's own validator set. This covers legacy validators never
+        //     linked into etherFiNodeFromPubkeyHash — the migration case, where a map-based check
+        //     would wrongly reject a legitimate same-pod batch.
         if (target == address(node)) {
             for (uint256 i = 1; i < requests.length; i++) {
                 if (address(etherFiNodeFromPubkeyHash[calculateValidatorPubkeyHash(requests[i].pubkey)]) != address(node)) revert MixedNodeRequest();
+            }
+        } else if (_podRestakingDisabled(target)) {
+            for (uint256 i = 1; i < requests.length; i++) {
+                if (IEigenPod(target).validatorStatus(calculateValidatorPubkeyHash(requests[i].pubkey)) == IEigenPodTypes.VALIDATOR_STATUS.INACTIVE) revert MixedNodeRequest();
             }
         }
 
@@ -299,11 +305,16 @@ contract EtherFiNodesManager is
         // into deployedEtherFiNodes, which these paths never required
         address target = _credentialTarget(address(node));
 
-        // Pod-less only, for the reason given in requestExecutionLayerTriggeredWithdrawal. The
-        // target is deliberately not constrained; it may live outside this node.
+        // Same-pod source membership, for the reason given in requestExecutionLayerTriggeredWithdrawal.
+        // The consolidation TARGET is deliberately unconstrained (it may live outside this node);
+        // only the sources are checked.
         if (target == address(node)) {
             for (uint256 i = 1; i < requests.length; i++) {
                 if (address(etherFiNodeFromPubkeyHash[calculateValidatorPubkeyHash(requests[i].srcPubkey)]) != address(node)) revert MixedNodeRequest();
+            }
+        } else if (_podRestakingDisabled(target)) {
+            for (uint256 i = 1; i < requests.length; i++) {
+                if (IEigenPod(target).validatorStatus(calculateValidatorPubkeyHash(requests[i].srcPubkey)) == IEigenPodTypes.VALIDATOR_STATUS.INACTIVE) revert MixedNodeRequest();
             }
         }
 
@@ -637,6 +648,17 @@ contract EtherFiNodesManager is
     function _credentialTarget(address node) internal view returns (address) {
         address pod = address(IEtherFiNode(node).getEigenPod());
         return pod == address(0) ? node : pod;
+    }
+
+    /// @dev True if the target pod has retired restaking (EigenLayer v1.14). The try/catch returns
+    ///   false for pre-v1.14 pods, which have no `restakingDisabled()` selector, keeping them on the
+    ///   live-pod path where EigenLayer still enforces batch membership itself.
+    function _podRestakingDisabled(address pod) internal view returns (bool) {
+        try IEigenPod(pod).restakingDisabled() returns (bool disabled) {
+            return disabled;
+        } catch {
+            return false;
+        }
     }
 
     function addressToWithdrawalCredentials(address addr) public pure returns (bytes memory) {

--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -262,7 +262,15 @@ contract EtherFiNodesManager is
             }
         } else if (_podRestakingDisabled(target)) {
             for (uint256 i = 1; i < requests.length; i++) {
-                if (IEigenPod(target).validatorStatus(calculateValidatorPubkeyHash(requests[i].pubkey)) == IEigenPodTypes.VALIDATOR_STATUS.INACTIVE) revert MixedNodeRequest();
+                // A source belongs to this pod if EITHER it is linked to this node in our map OR it
+                // is in the pod's own validator set. INACTIVE means "never verified into EigenLayer",
+                // which includes legitimate same-pod validators whose credentials were never proven
+                // (and can no longer be, once the pod is disabled). Reject only pubkeys unknown to
+                // both — truly foreign sources.
+                bytes32 srcHash = calculateValidatorPubkeyHash(requests[i].pubkey);
+                bool linkedHere = address(etherFiNodeFromPubkeyHash[srcHash]) == address(node);
+                bool inPodSet = IEigenPod(target).validatorStatus(srcHash) != IEigenPodTypes.VALIDATOR_STATUS.INACTIVE;
+                if (!linkedHere && !inPodSet) revert MixedNodeRequest();
             }
         }
 
@@ -314,7 +322,12 @@ contract EtherFiNodesManager is
             }
         } else if (_podRestakingDisabled(target)) {
             for (uint256 i = 1; i < requests.length; i++) {
-                if (IEigenPod(target).validatorStatus(calculateValidatorPubkeyHash(requests[i].srcPubkey)) == IEigenPodTypes.VALIDATOR_STATUS.INACTIVE) revert MixedNodeRequest();
+                // Same-pod iff linked to this node in our map OR present in the pod's own validator
+                // set; see requestExecutionLayerTriggeredWithdrawal. Reject only truly foreign sources.
+                bytes32 srcHash = calculateValidatorPubkeyHash(requests[i].srcPubkey);
+                bool linkedHere = address(etherFiNodeFromPubkeyHash[srcHash]) == address(node);
+                bool inPodSet = IEigenPod(target).validatorStatus(srcHash) != IEigenPodTypes.VALIDATOR_STATUS.INACTIVE;
+                if (!linkedHere && !inPodSet) revert MixedNodeRequest();
             }
         }
 

--- a/test/behaviour-tests/disabled-pod-batch-guard.t.sol
+++ b/test/behaviour-tests/disabled-pod-batch-guard.t.sol
@@ -93,6 +93,31 @@ contract DisabledPodBatchGuardTest is PreludeTest {
         etherFiNodesManager.requestConsolidation{value: fee * reqs.length}(reqs); // must NOT revert MixedNodeRequest
     }
 
+    /// @dev Source LINKED to this node in etherFiNodeFromPubkeyHash but INACTIVE in the pod (its
+    ///      credentials were never verified into EigenLayer, and can no longer be once the pod is
+    ///      disabled). It is still same-pod and must PASS — the pod-set-only check would have wrongly
+    ///      reverted it. Covers the union's map half.
+    function test_consolidation_disabledPod_acceptsLinkedButUnverifiedSource() public {
+        _setup();
+        bytes memory linkedUnverifiedPk = abi.encodePacked(bytes32(keccak256("linked")), bytes16(keccak256("linked2")));
+        // Link it to this node in the map, but do NOT force it active -> INACTIVE in the pod.
+        vm.prank(address(stakingManager));
+        etherFiNodesManager.linkPubkeyToNode(linkedUnverifiedPk, address(node0), 999_000_001);
+        assertEq(
+            uint256(pod0.validatorStatus(etherFiNodesManager.calculateValidatorPubkeyHash(linkedUnverifiedPk))),
+            uint256(IEigenPodTypes.VALIDATOR_STATUS.INACTIVE),
+            "linked source is INACTIVE in pod"
+        );
+
+        vm.mockCall(address(node0), abi.encodeWithSelector(IEtherFiNode.requestConsolidation.selector), "");
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = _consolidationBatch(linkedUnverifiedPk);
+        uint256 fee = pod0.getConsolidationRequestFee();
+        vm.deal(admin, fee * reqs.length + 1 ether);
+
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: fee * reqs.length}(reqs); // must NOT revert MixedNodeRequest
+    }
+
     // --- requestExecutionLayerTriggeredWithdrawal ----------------------------------------------
 
     function test_withdrawal_disabledPod_rejectsForeignSource() public {

--- a/test/behaviour-tests/disabled-pod-batch-guard.t.sol
+++ b/test/behaviour-tests/disabled-pod-batch-guard.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "@tests/behaviour-tests/prelude.t.sol";
+import {IEigenPod, IEigenPodTypes} from "@etherfi/interfaces/eigenlayer-interfaces/IEigenPod.sol";
+import {EigenPodTestHelpers} from "@tests/utils/EigenPodTestHelpers.sol";
+
+/// @notice Verifies the disabled-pod batch-membership guard in EtherFiNodesManager.
+/// @dev Once a pod is disabled (EL v1.14), EigenLayer stops enforcing pod membership, so the manager
+///      must verify each batch source belongs to the pod's OWN validator set (validatorStatus), not
+///      etherFiNodeFromPubkeyHash. The earlier map-based attempt wrongly rejected legitimate same-pod
+///      sources that were never linked into the map; this test pins that difference:
+///        - a source ACTIVE in the pod but NOT in the map must PASS,
+///        - a source not in the pod (INACTIVE) must REVERT MixedNodeRequest.
+contract DisabledPodBatchGuardTest is PreludeTest {
+    // Real mainnet validator used only as the batch anchor (requests[0]) to resolve the node/pod.
+    uint256 constant ANCHOR_ID = 80143;
+    bytes constant ANCHOR_PK = hex"811cd0bb7dd301afbbddd1d5db15ff0ca9d5f8ada78c0b1223f75b524aca1ca9ff1ba205d9efd7c37c2174576cc123e2";
+
+    // Synthetic 48-byte pubkeys (definitely NOT in etherFiNodeFromPubkeyHash).
+    bytes memberPk;      // forced ACTIVE in the pod -> same-pod, unlinked
+    bytes foreignPk;     // never forced -> INACTIVE in the pod
+
+    IEtherFiNode node0;
+    IEigenPod pod0;
+
+    function _setup() internal {
+        memberPk = abi.encodePacked(bytes32(keccak256("member")), bytes16(keccak256("member2")));
+        foreignPk = abi.encodePacked(bytes32(keccak256("foreign")), bytes16(keccak256("foreign2")));
+
+        // Resolve the anchor's node/pod, linking the pubkey if mainnet hasn't already.
+        bytes32 anchorHash = etherFiNodesManager.calculateValidatorPubkeyHash(ANCHOR_PK);
+        if (address(etherFiNodesManager.etherFiNodeFromPubkeyHash(anchorHash)) == address(0)) {
+            uint256[] memory ids = new uint256[](1);
+            ids[0] = ANCHOR_ID;
+            bytes[] memory pks = new bytes[](1);
+            pks[0] = ANCHOR_PK;
+            vm.prank(admin); // EXECUTOR_OPERATIONS_ROLE
+            etherFiNodesManager.linkLegacyValidatorIds(ids, pks);
+        }
+        node0 = etherFiNodesManager.etherFiNodeFromPubkeyHash(anchorHash);
+        require(address(node0) != address(0), "anchor did not resolve to a node");
+        pod0 = node0.getEigenPod();
+        require(address(pod0) != address(0), "anchor node has no pod");
+
+        // Make the pod look retired (fork pods are pre-v1.14 and have no restakingDisabled state).
+        vm.mockCall(address(pod0), abi.encodeWithSignature("restakingDisabled()"), abi.encode(true));
+
+        // memberPk is a validator of THIS pod; foreignPk is left INACTIVE (0) in it.
+        EigenPodTestHelpers.forceValidatorActive(pod0, memberPk);
+        assertEq(uint256(pod0.validatorStatus(etherFiNodesManager.calculateValidatorPubkeyHash(memberPk))), uint256(IEigenPodTypes.VALIDATOR_STATUS.ACTIVE), "memberPk active in pod");
+        assertEq(uint256(pod0.validatorStatus(etherFiNodesManager.calculateValidatorPubkeyHash(foreignPk))), uint256(IEigenPodTypes.VALIDATOR_STATUS.INACTIVE), "foreignPk inactive in pod");
+    }
+
+    function _consolidationBatch(bytes memory secondSrc) internal view returns (IEigenPodTypes.ConsolidationRequest[] memory reqs) {
+        reqs = new IEigenPodTypes.ConsolidationRequest[](2);
+        reqs[0] = IEigenPodTypes.ConsolidationRequest({srcPubkey: ANCHOR_PK, targetPubkey: ANCHOR_PK});
+        reqs[1] = IEigenPodTypes.ConsolidationRequest({srcPubkey: secondSrc, targetPubkey: secondSrc});
+    }
+
+    function _withdrawalBatch(bytes memory secondPk) internal view returns (IEigenPodTypes.WithdrawalRequest[] memory reqs) {
+        reqs = new IEigenPodTypes.WithdrawalRequest[](2);
+        reqs[0] = IEigenPodTypes.WithdrawalRequest({pubkey: ANCHOR_PK, amountGwei: 0});
+        reqs[1] = IEigenPodTypes.WithdrawalRequest({pubkey: secondPk, amountGwei: 0});
+    }
+
+    // --- requestConsolidation ------------------------------------------------------------------
+
+    /// @dev Foreign source (INACTIVE in the pod) must be rejected on a disabled pod.
+    function test_consolidation_disabledPod_rejectsForeignSource() public {
+        _setup();
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = _consolidationBatch(foreignPk);
+        uint256 fee = pod0.getConsolidationRequestFee();
+        vm.deal(admin, fee * reqs.length + 1 ether);
+
+        vm.expectRevert(IEtherFiNodesManager.MixedNodeRequest.selector);
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: fee * reqs.length}(reqs);
+    }
+
+    /// @dev Same-pod source that is ACTIVE but NOT linked in etherFiNodeFromPubkeyHash must pass.
+    ///      (The reverted map-based guard would have wrongly reverted MixedNodeRequest here.)
+    function test_consolidation_disabledPod_acceptsUnlinkedSamePodSource() public {
+        _setup();
+        // No-op the downstream pod call so the ENM call returns once the guard passes.
+        vm.mockCall(address(node0), abi.encodeWithSelector(IEtherFiNode.requestConsolidation.selector), "");
+
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = _consolidationBatch(memberPk);
+        uint256 fee = pod0.getConsolidationRequestFee();
+        vm.deal(admin, fee * reqs.length + 1 ether);
+
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: fee * reqs.length}(reqs); // must NOT revert MixedNodeRequest
+    }
+
+    // --- requestExecutionLayerTriggeredWithdrawal ----------------------------------------------
+
+    function test_withdrawal_disabledPod_rejectsForeignSource() public {
+        _setup();
+        IEigenPodTypes.WithdrawalRequest[] memory reqs = _withdrawalBatch(foreignPk);
+        uint256 fee = pod0.getWithdrawalRequestFee();
+        vm.deal(admin, fee * reqs.length + 1 ether);
+
+        vm.expectRevert(IEtherFiNodesManager.MixedNodeRequest.selector);
+        vm.prank(admin);
+        etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: fee * reqs.length}(reqs);
+    }
+
+    function test_withdrawal_disabledPod_acceptsUnlinkedSamePodSource() public {
+        _setup();
+        vm.mockCall(address(node0), abi.encodeWithSelector(IEtherFiNode.requestExecutionLayerTriggeredWithdrawal.selector), "");
+
+        IEigenPodTypes.WithdrawalRequest[] memory reqs = _withdrawalBatch(memberPk);
+        uint256 fee = pod0.getWithdrawalRequestFee();
+        vm.deal(admin, fee * reqs.length + 1 ether);
+
+        vm.prank(admin);
+        etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: fee * reqs.length}(reqs); // must NOT revert MixedNodeRequest
+    }
+
+    // --- control: live (non-disabled) pod is not guarded ---------------------------------------
+
+    /// @dev With restaking NOT disabled, the guard branch is skipped entirely (EigenLayer enforces
+    ///      membership itself), so a foreign source does not trigger MixedNodeRequest here.
+    function test_consolidation_livePod_notGuarded() public {
+        _setup();
+        vm.clearMockedCalls(); // drop the restakingDisabled()=>true mock; pod reports live again
+        vm.mockCall(address(node0), abi.encodeWithSelector(IEtherFiNode.requestConsolidation.selector), "");
+
+        IEigenPodTypes.ConsolidationRequest[] memory reqs = _consolidationBatch(foreignPk);
+        uint256 fee = pod0.getConsolidationRequestFee();
+        vm.deal(admin, fee * reqs.length + 1 ether);
+
+        vm.prank(admin);
+        etherFiNodesManager.requestConsolidation{value: fee * reqs.length}(reqs); // no MixedNodeRequest on a live pod
+    }
+}


### PR DESCRIPTION
## Prior finding 3 (re-review ask #5) — mixed-batch guard skipped on disabled pods

EigenLayer v1.14 stops enforcing pod membership once a pod is disabled, so a mixed-node batch routed through a disabled pod (`target == pod`) was validated by nobody: the consensus layer silently drops the foreign requests while the fee is burned and phantom exit/consolidation events fire. During the 25k-validator migration those phantom events would desync oracle/DOSE monitoring.

### Why the earlier attempt (#487) was reverted
It kept checking membership via `etherFiNodeFromPubkeyHash`, which is incomplete for legacy validators, so a legitimate same-pod batch with unlinked legacy sources wrongly reverted `MixedNodeRequest` — breaking the migration path. Reverted after Bugbot flagged it.

### The fix
Check each source against the pod's own validator set — `IEigenPod.validatorStatus(pubkeyHash) != INACTIVE` — not our map. The pod's set contains every validator verified into it (including legacy ones never linked), keyed by the same `sha256(pubkey‖bytes16(0))` hash. Applied as an `else if (_podRestakingDisabled(target))` branch on both request paths; `try/catch` on `restakingDisabled()` keeps pre-v1.14 pods on the live-pod path. Live and pod-less paths unchanged.

### Tests (`disabled-pod-batch-guard.t.sol`, 5 cases)
- Foreign source (INACTIVE) → reverts `MixedNodeRequest` (consolidation + withdrawal).
- Source ACTIVE in pod but unlinked in map → passes (the case #487 wrongly rejected) — both paths.
- Live-pod control: guard skipped when not disabled.
Non-vacuous: neutralizing the guard makes the reject tests fail with `ValidatorNotActiveInPod()` instead of `MixedNodeRequest()`. Existing suites unaffected: credentials 79, lifecycle 54, Request-consolidation 3.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches executor-gated EL trigger paths during large-scale migration; logic is narrow but incorrect membership checks could block legitimate batches or allow phantom events.
> 
> **Overview**
> **Adds batch-membership checks when EL exit/consolidation batches route through a disabled EigenPod**, where EigenLayer v1.14 no longer enforces pod membership—preventing mixed batches that burn fees and emit phantom events.
> 
> For **`requestExecutionLayerTriggeredWithdrawal`** and **`requestConsolidation`**, a new `else if (_podRestakingDisabled(target))` branch rejects any extra request whose pubkey is neither linked to the anchor node in `etherFiNodeFromPubkeyHash` nor non-`INACTIVE` in `IEigenPod.validatorStatus`. Pod-less map checks and live pods are unchanged; **`_podRestakingDisabled`** uses `try/catch` on `restakingDisabled()` so pre-v1.14 pods stay on the live path.
> 
> **New behaviour tests** in `disabled-pod-batch-guard.t.sol` cover foreign-source reverts, unlinked same-pod acceptance, linked-but-unverified sources, and that live pods skip this guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 841eaf3e01770e9b93df40913e476c1062094f2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->