### PR TITLE
fix(node): enforce pod-immutability — block createPod/stake forwarding to EigenPodManager [re-review MED 2]

### DIFF
--- a/src/staking/EtherFiNode.sol
+++ b/src/staking/EtherFiNode.sol
@@ -271,6 +271,16 @@ contract EtherFiNode is IEtherFiNode {
      * @return The result of the call
      */
     function forwardExternalCall(address to, bytes calldata data) external onlyEtherFiNodesManager returns (bytes memory) {
+        // A node's pod is fixed at instantiation, and the credential resolver treats pod-or-no-pod as
+        // immutable. Block createPod()/stake() on the EigenPodManager from ever being forwarded here:
+        // otherwise a whitelisted forwarding entry could attach a pod to a funded pod-less node and
+        // silently flip its withdrawal-credential resolution from node to pod.
+        if (to == address(eigenPodManager) && data.length >= 4) {
+            bytes4 selector = bytes4(data[:4]);
+            if (selector == IEigenPodManager.createPod.selector || selector == IEigenPodManager.stake.selector) {
+                revert ForwardedCallNotAllowed();
+            }
+        }
         return LibCall.callContract(to, 0, data);
     }
 

--- a/test/behaviour-tests/forwarding-createpod-deny.t.sol
+++ b/test/behaviour-tests/forwarding-createpod-deny.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "@tests/behaviour-tests/prelude.t.sol";
+import {IEtherFiNode} from "@etherfi/staking/interfaces/IEtherFiNode.sol";
+import {IEigenPodManager} from "@etherfi/interfaces/eigenlayer-interfaces/IEigenPodManager.sol";
+
+/// @notice A node's pod-or-no-pod status is treated as immutable by the credential resolver. This
+///         pins that even a whitelisted forwarding entry cannot make a node create a pod on the
+///         EigenPodManager, which would attach a pod to a funded pod-less node and silently flip its
+///         withdrawal-credential resolution from node to pod.
+contract ForwardingCreatePodDenyTest is PreludeTest {
+    function _newPodLessNode() internal returns (address) {
+        vm.prank(admin);
+        return stakingManager.instantiateEtherFiNode(/*createEigenPod=*/ false);
+    }
+
+    function _forward(address node, bytes memory data) internal {
+        address[] memory nodes = new address[](1);
+        nodes[0] = node;
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = data;
+        vm.prank(callForwarder); // EIGENPOD_OPERATIONS_ROLE
+        etherFiNodesManager.forwardExternalCall(nodes, payloads, eigenPodManager);
+    }
+
+    function test_forwardExternalCall_cannotCreatePodOnEigenPodManager() public {
+        address node = _newPodLessNode();
+        bytes4 sel = IEigenPodManager.createPod.selector;
+
+        // Even with the operating timelock whitelisting createPod on the EigenPodManager...
+        vm.prank(admin); // OPERATION_TIMELOCK_ROLE
+        etherFiNodesManager.updateAllowedForwardedExternalCalls(callForwarder, sel, eigenPodManager, true);
+
+        vm.expectRevert(IEtherFiNode.ForwardedCallNotAllowed.selector);
+        _forward(node, abi.encodeWithSelector(sel));
+    }
+
+    function test_forwardExternalCall_cannotStakeOnEigenPodManager() public {
+        address node = _newPodLessNode();
+        bytes4 sel = IEigenPodManager.stake.selector;
+
+        vm.prank(admin);
+        etherFiNodesManager.updateAllowedForwardedExternalCalls(callForwarder, sel, eigenPodManager, true);
+
+        vm.expectRevert(IEtherFiNode.ForwardedCallNotAllowed.selector);
+        _forward(node, abi.encodeWithSelector(sel, bytes(""), bytes(""), bytes32(0)));
+    }
+}


### PR DESCRIPTION
## Re-review MED 2 — createPod-via-forwarding invariant was unenforced

The credential resolver treats a node's pod-or-no-pod status as immutable (the PR's stated safety invariant), but that was only **documented**, not enforced. `EtherFiNode.forwardExternalCall` applied no target/selector restriction, so if the operating timelock ever whitelisted `createPod` (or `stake`) on the EigenPodManager for a forwarding-capable caller, a funded **pod-less** node could be made to call `EigenPodManager.createPod()`, attaching a pod and silently flipping `withdrawalCredentialTarget` from node → pod. Consequences: EL-triggered exits for that node's validators route to the pod while their on-chain withdrawal address is the node (CL drops them, burned fees, phantom events), and new validators bake pod credentials — the mid-life target change the PR's own ⚠️ invariant warns about.

Two independent review agents flagged the doc's "createPod reachable only from instantiateEtherFiNode" claim as incomplete (it omits the forwarding vector).

### Fix
Reject `createPod()`/`stake()` targeting the EigenPodManager inside `EtherFiNode.forwardExternalCall` (reverts `ForwardedCallNotAllowed`). The invariant now holds in code even if such a selector is ever whitelisted.

### Tests
New `forwarding-createpod-deny.t.sol`: with the timelock whitelisting `createPod`/`stake` on the EigenPodManager, a forwarded call still reverts `ForwardedCallNotAllowed`. **Non-vacuous** — neutralizing the guard makes the createPod case succeed (creates the pod) instead of reverting. Existing forwarding-whitelist suite green.

Config-gated today (needs a timelock whitelist mistake to be exploitable), so no live exposure — this closes the class and makes the documented invariant real.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789229643&installation_model_id=18424&pr_number=493&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F493&signature=c24e8e0100bea8873646a1589ddc4e75f57ed9842f2380989abcfa3844ff3226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches staking withdrawal-credential invariants and external-call forwarding; the change is a narrow deny-list that reduces misconfiguration risk rather than broadening privileges.
> 
> **Overview**
> **`EtherFiNode.forwardExternalCall`** now rejects forwards to **`EigenPodManager`** whose selector is **`createPod`** or **`stake`**, reverting **`ForwardedCallNotAllowed`** before **`LibCall`**. That closes a path where a timelock-whitelisted forward could attach a pod to a pod-less node and change withdrawal-credential resolution.
> 
> **`forwarding-createpod-deny.t.sol`** asserts those calls still revert even when **`updateAllowedForwardedExternalCalls`** whitelists the selectors on the manager.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ae9abb167681c8ea20b5c807b1f3cbfa1af6aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->