### PR TITLE
chore: explicit NoEigenPod revert + fix stale role docstrings [re-review LOW 3 + INFO]

### DIFF
--- a/src/staking/EtherFiNode.sol
+++ b/src/staking/EtherFiNode.sol
@@ -298,7 +298,12 @@ contract EtherFiNode is IEtherFiNode {
      * @return balance The amount forwarded to the liquidity pool
      */
     function withdrawDisabledPodETH() external onlyEtherFiNodesManager returns (uint256 balance) {
-        getEigenPod().withdrawDisabledPodETH(address(this));
+        // A pod-less node has nothing to withdraw. The call already reverts (a void call to the
+        // zero address), but assert explicitly so the failure is a clear NoEigenPod rather than an
+        // opaque low-level revert.
+        IEigenPod pod = getEigenPod();
+        if (address(pod) == address(0)) revert NoEigenPod();
+        pod.withdrawDisabledPodETH(address(this));
         return _sweepToLiquidityPool();
     }
 

--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -229,7 +229,7 @@ contract EtherFiNodesManager is
      * @notice Triggers EIP-7002 withdrawal requests, grouping by EigenPod automatically.
      * @dev associated etherFiNode is derived from pubkey in the request. Caller should ensure
      *      all provided validators share the same eigenpod
-     * @dev Access: only ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE, pausable, nonReentrant.
+     * @dev Access: only EXECUTOR_OPERATIONS_ROLE, pausable, nonReentrant.
      * @param requests Array of WithdrawalRequest:
      *        - pubkey: 48-byte BLS pubkey
      *        - amountGwei: 0 for full exit, >0 for partial to pod
@@ -291,7 +291,7 @@ contract EtherFiNodesManager is
 
     /**
      * @notice Triggers EIP-7251 consolidation requests for validators in the same EigenPod.
-     * @dev Access: only ETHERFI_NODES_MANAGER_EL_CONSOLIDATION_ROLE, pausable, nonReentrant.
+     * @dev Access: only EXECUTOR_OPERATIONS_ROLE, pausable, nonReentrant.
      * @param requests Array of ConsolidationRequest:
      *        - srcPubkey: 48-byte BLS pubkey of source validator
      *        - targetPubkey: 48-byte BLS pubkey of target validator

--- a/src/staking/interfaces/IEtherFiNode.sol
+++ b/src/staking/interfaces/IEtherFiNode.sol
@@ -100,5 +100,6 @@ interface IEtherFiNode {
     error NoCompleteableWithdrawals();
     error FeeQueryFailed();
     error PredeployFailed();
+    error NoEigenPod();
 
 }

--- a/test/behaviour-tests/non-eigenpod-credentials.t.sol
+++ b/test/behaviour-tests/non-eigenpod-credentials.t.sol
@@ -724,7 +724,7 @@ contract NonEigenPodCredentialsTest is PreludeTest {
     function test_withdrawDisabledPodETH_revertsForAPodLessNode() public {
         address node = _newPodLessNode();
 
-        vm.expectRevert();
+        vm.expectRevert(IEtherFiNode.NoEigenPod.selector);
         vm.prank(address(etherFiNodesManager));
         IEtherFiNode(node).withdrawDisabledPodETH();
     }


### PR DESCRIPTION
Two small cleanups from the re-review.

## LOW 3 — `withdrawDisabledPodETH` on a pod-less node (clarity, **not a live bug**)
The re-review suspected a silent no-op (void call to `address(0)`). **Verified false:** the call already reverts today, and an existing test (`test_withdrawDisabledPodETH_revertsForAPodLessNode`) asserts it. This PR only makes the failure *explicit* — revert `NoEigenPod` instead of an opaque low-level revert — and tightens the test to assert the specific selector. No behavior change for the pod-present path (sweep tests still green).

## INFO — stale role docstrings
`requestExecutionLayerTriggeredWithdrawal` and `requestConsolidation` documented `ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE` / `ETHERFI_NODES_MANAGER_EL_CONSOLIDATION_ROLE`, neither of which exists. Both are gated by `EXECUTOR_OPERATIONS_ROLE`; corrected the docs. (Note: this also documents that exit-trigger and consolidation share one role — no separation of duties — which auditors should be aware of.)

Tests: credentials suite 79 green.

Base: `pankaj/feat/non-eigenpod-withdrawal-credentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and explicit revert/error typing only; no change to successful sweep or role-gated behavior on live paths.
> 
> **Overview**
> **`withdrawDisabledPodETH`** on pod-less nodes now reverts with **`NoEigenPod`** after resolving the pod, instead of failing via an opaque call to `address(0)`. The happy path (pod present, sweep to liquidity pool) is unchanged.
> 
> Adds **`NoEigenPod`** to **`IEtherFiNode`** and updates **`test_withdrawDisabledPodETH_revertsForAPodLessNode`** to assert that selector.
> 
> **`EtherFiNodesManager`** NatSpec for **`requestExecutionLayerTriggeredWithdrawal`** and **`requestConsolidation`** now documents **`EXECUTOR_OPERATIONS_ROLE`** (replacing non-existent role names); runtime access control was already **`onlyExecutorOperations`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0815da63f92e15a14273e501f6085e542c52c242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789229990&installation_model_id=18424&pr_number=494&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F494&signature=dd7ed76ae0ba281786669f343ec3f1c49087138b23fd695c2efa632d612c4272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->