### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 etherfi-protocol
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ certoraRun certora/conf/<contract-name>.conf # Formal verification
 
 ether.fi is open-source and licensed under the [MIT License](LICENSE).
 
+Third-party interfaces vendored under `src/interfaces/` keep the licenses of the projects they came from, as marked by the SPDX header in each file. That covers the EigenLayer interfaces (BUSL-1.1) and the deposit contract interfaces.
+
 ---
 
 <p align="center">Built with ❤️ by the ether.fi team</p>


### PR DESCRIPTION
## Description

The README links to `[MIT License](LICENSE)` but the file has never existed, so the link 404s and GitHub reports no license for this repo. This adds it.

The text is verbatim MIT and matches `etherfi-protocol/.github`, including the `Copyright (c) 2023 etherfi-protocol` line, so GitHub picks it up automatically.

## Licensing check

I checked every `.sol` file under `src/` before adding a blanket license. Of the 54 contracts that are ether.fi's own code, 52 declare `SPDX-License-Identifier: MIT` and none declare anything else.

The non-MIT files under `src/` are all vendored third-party interfaces that keep their upstream licenses:

| License | Files |
| --- | --- |
| BUSL-1.1 | 26 EigenLayer interfaces |
| CC0-1.0 | `IETHPOSDeposit.sol` |
| AGPL-3.0-only | `IDepositContract.sol` |
| BSD-3-Clause | `ITimelock.sol` |
| GPL-3.0-or-later | `IRateProvider.sol` |
| UNLICENSED | `ILayerZeroTellerWithRateLimiting.sol` |

Per-file SPDX headers govern those files, so a root MIT LICENSE does not reach them. I added a line to the README saying as much, rather than editing the LICENSE text, which would break GitHub's license detection.

## Worth a follow-up

Three files under `src/` carry no SPDX header at all:

- `src/rewards/EtherFiRewardsRouter.sol`
- `src/interfaces/IWETH.sol`
- `src/archive/BucketRateLimiter.sol`

`EtherFiRewardsRouter.sol` is deployed, so it's the one worth labelling. I left them alone here to keep this PR to licensing metadata.

## Context

ether.fi is being added to the pooled staking page on ethereum.org (ethereum/ethereum-org-website#19097). Their listing policy asks whether the project is open source, and the entry claims `isFoss: true`. A LICENSE file makes that checkable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and licensing metadata only; no contract or runtime behavior changes.
> 
> **Overview**
> Adds a root **MIT LICENSE** so the README’s `[MIT License](LICENSE)` link resolves and GitHub can detect the project license (text aligned with `etherfi-protocol/.github`, including `Copyright (c) 2023 etherfi-protocol`).
> 
> Updates the **License** section in the README to note that vendored interfaces under `src/interfaces/` remain under their per-file SPDX headers (e.g. EigenLayer BUSL-1.1, deposit contract interfaces), and are not relicensed by the root MIT file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e06df623d9207c3a4420651e3dbb64ea5e1cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789640020&installation_model_id=18424&pr_number=496&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F496&signature=00691bb43ff4be9423196661e3a9b9b45fb530e10ecb24c99a33ff6895ce390a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->