### PR TITLE
temp

### DIFF
--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -317,6 +317,23 @@ contract EtherFiNodesManager is
             }
         }
 
+        // The target decides where the source's balance ends up, and neither layer below us checks
+        // it: EIP-7251 only requires the target to hold 0x02 credentials, and a pod only vets the
+        // target when the pod is the caller. Without this, one key could move every pod-less
+        // validator's stake to a validator it owns. Runs unconditionally, on every request.
+        for (uint256 i = 0; i < requests.length; i++) {
+            bytes32 srcHash = calculateValidatorPubkeyHash(requests[i].srcPubkey);
+            bytes32 tgtHash = calculateValidatorPubkeyHash(requests[i].targetPubkey);
+            if (tgtHash == srcHash) continue; // switch to compounding: moves no value
+            if (address(etherFiNodeFromPubkeyHash[tgtHash]) != address(0)) continue; // one of ours
+            // Proven into the source's own pod, so EigenLayer merkle-verified its credentials.
+            // ACTIVE, not != INACTIVE: a WITHDRAWN target is dropped by the consensus layer, which
+            // would burn the fee and log a consolidation that never happens.
+            if (target != address(node)
+                && IEigenPod(target).validatorStatus(tgtHash) == IEigenPodTypes.VALIDATOR_STATUS.ACTIVE) continue;
+            revert UnknownConsolidationTarget();
+        }
+
         // pod-backed reads the pod directly, as before; see requestExecutionLayerTriggeredWithdrawal
         uint256 feePerRequest = target == address(node)
             ? node.getConsolidationRequestFee()

--- a/src/staking/EtherFiNodesManager.sol
+++ b/src/staking/EtherFiNodesManager.sol
@@ -382,8 +382,12 @@ contract EtherFiNodesManager is
      * @param validatorIds The legacy validator ids to link
      * @param pubkeys The pubkeys to link the validator ids to
      * @dev We can delete this method once we have linked all of our legacy validators
+     * @dev Multisig, not executor: this writes the map that requestConsolidation trusts to decide a
+     *      target is ours, and it cannot verify the pubkey belongs to the id. Sharing a role with
+     *      requestConsolidation would let one key add its own validator and then consolidate into
+     *      it, so the power to grow the trusted set is kept apart from the power to use it.
      */
-    function linkLegacyValidatorIds(uint256[] calldata validatorIds, bytes[] calldata pubkeys) external onlyExecutorOperations {
+    function linkLegacyValidatorIds(uint256[] calldata validatorIds, bytes[] calldata pubkeys) external onlyOperatingMultisig {
         if (validatorIds.length != pubkeys.length) revert LengthMismatch();
         for (uint256 i = 0; i < validatorIds.length; i++) {
 

--- a/src/staking/interfaces/IEtherFiNodesManager.sol
+++ b/src/staking/interfaces/IEtherFiNodesManager.sol
@@ -140,6 +140,7 @@ interface IEtherFiNodesManager {
     error InsufficientWithdrawalFees();
     error InsufficientConsolidationFees();
     error MixedNodeRequest();
+    error UnknownConsolidationTarget();
     error PodNotDisabled();
     error PodRetired();
 }

--- a/test/EtherFiNodesManager.t.sol
+++ b/test/EtherFiNodesManager.t.sol
@@ -50,11 +50,15 @@ contract EtherFiNodesManagerTest is TestSetup {
         roleRegistryInstance.grantRole(roleRegistryInstance.EIGENPOD_OPERATIONS_ROLE(), callForwarder);
         // ETHERFI_NODES_MANAGER_EL_TRIGGER_EXIT_ROLE → EXECUTOR_OPERATIONS_ROLE
         roleRegistryInstance.grantRole(roleRegistryInstance.EXECUTOR_OPERATIONS_ROLE(), elTriggerExit);
+        // linkLegacyValidatorIds moved to OPERATION_MULTISIG_ROLE; linking is fixture setup here.
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), elTriggerExit);
         // STAKING_MANAGER_NODE_CREATOR_ROLE → EXECUTOR_OPERATIONS_ROLE
         roleRegistryInstance.grantRole(roleRegistryInstance.EXECUTOR_OPERATIONS_ROLE(), address(liquidityPoolInstance));
         // Existing tests prank the mainnet OPERATING_TIMELOCK to call
-        // instantiateEtherFiNode / linkLegacyValidatorIds (both EXECUTOR_OPERATIONS_ROLE-gated now).
+        // instantiateEtherFiNode (EXECUTOR_OPERATIONS_ROLE) and linkLegacyValidatorIds
+        // (OPERATION_MULTISIG_ROLE), so it needs both.
         roleRegistryInstance.grantRole(roleRegistryInstance.EXECUTOR_OPERATIONS_ROLE(), deployed.OPERATING_TIMELOCK());
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), deployed.OPERATING_TIMELOCK());
         // requestConsolidation is EXECUTOR_OPERATIONS_ROLE-gated and tests still prank admin.
         roleRegistryInstance.grantRole(roleRegistryInstance.EXECUTOR_OPERATIONS_ROLE(), admin);
         // PROTOCOL_PAUSER / PROTOCOL_UNPAUSER → OPERATION_MULTISIG_ROLE (onlyOperations)

--- a/test/behaviour-tests/non-eigenpod-credentials.t.sol
+++ b/test/behaviour-tests/non-eigenpod-credentials.t.sol
@@ -415,14 +415,48 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         assertEq(CONSOLIDATION_REQUEST_PREDEPLOY.balance, before + fee);
     }
 
-    /// @dev The target is intentionally unconstrained, which is what lets a retiring pod's
-    ///      validators consolidate into a node-credentialled target.
-    function test_podLess_consolidationTargetMayBeOutsideTheNode() public {
+    /// @dev The target may live on a different node, which is what lets a retiring pod's validators
+    ///      consolidate into a node-credentialled target. It must still be one of ours.
+    function test_podLess_consolidationTargetMayBeOnAnotherNode() public {
         address node = _newPodLessNode();
         TestValidator memory src = _validatorOn(node, 8);
-        bytes memory foreignTarget = abi.encodePacked(bytes32(keccak256("foreign")), bytes16(uint128(9)));
+        TestValidator memory target = _validatorOn(_newPodLessNode(), 9);
+        assertTrue(src.etherFiNode != target.etherFiNode);
 
-        IEigenPodTypes.ConsolidationRequest[] memory requests = _consolidation(src.pubkey, foreignTarget);
+        IEigenPodTypes.ConsolidationRequest[] memory requests = _consolidation(src.pubkey, target.pubkey);
+        uint256 fee = IEtherFiNode(node).getConsolidationRequestFee();
+        uint256 before = CONSOLIDATION_REQUEST_PREDEPLOY.balance;
+
+        vm.deal(elExiter, fee);
+        vm.prank(elExiter);
+        etherFiNodesManager.requestConsolidation{value: fee}(requests);
+
+        assertEq(CONSOLIDATION_REQUEST_PREDEPLOY.balance, before + fee);
+    }
+
+    /// @dev The theft path: the consensus layer only requires a 0x02 target, and a pod-less node
+    ///      calls the predeploy itself, so nothing below us checks who owns the target.
+    function test_podLess_consolidationRejectsTargetWeDoNotOwn() public {
+        address node = _newPodLessNode();
+        TestValidator memory src = _validatorOn(node, 20);
+        bytes memory attackerTarget = abi.encodePacked(bytes32(keccak256("attacker")), bytes16(uint128(21)));
+
+        IEigenPodTypes.ConsolidationRequest[] memory requests = _consolidation(src.pubkey, attackerTarget);
+        uint256 fee = IEtherFiNode(node).getConsolidationRequestFee();
+        vm.deal(elExiter, fee);
+
+        vm.expectRevert(IEtherFiNodesManager.UnknownConsolidationTarget.selector);
+        vm.prank(elExiter);
+        etherFiNodesManager.requestConsolidation{value: fee}(requests);
+    }
+
+    /// @dev A switch is exempt because it moves no value, so an unlinked legacy validator can still
+    ///      convert its own credentials to 0x02.
+    function test_podLess_switchIsExemptFromTheTargetCheck() public {
+        address node = _newPodLessNode();
+        TestValidator memory val = _validatorOn(node, 22);
+
+        IEigenPodTypes.ConsolidationRequest[] memory requests = _consolidation(val.pubkey, val.pubkey);
         uint256 fee = IEtherFiNode(node).getConsolidationRequestFee();
         uint256 before = CONSOLIDATION_REQUEST_PREDEPLOY.balance;
 
@@ -498,8 +532,9 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: fee}(requests);
     }
 
-    /// @dev A live pod constrains the consolidation TARGET to one it has proven, so a pod-backed node
-    ///      cannot consolidate into an outside validator. The pod-less path has no such constraint.
+    /// @dev A foreign target is rejected on the pod-backed path too. The manager's guard fires first
+    ///      now; before it existed the pod itself reverted ValidatorNotActiveInPod here, which is why
+    ///      only pod-less nodes were exposed.
     function test_livePod_rejectsAForeignConsolidationTarget() public {
         bytes[] memory pubkeys = new bytes[](1);
         uint256[] memory legacyIds = new uint256[](1);
@@ -517,7 +552,7 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         uint256 fee = pod.getConsolidationRequestFee();
         vm.deal(elExiter, fee);
 
-        vm.expectRevert(IEigenPodErrors.ValidatorNotActiveInPod.selector);
+        vm.expectRevert(IEtherFiNodesManager.UnknownConsolidationTarget.selector);
         vm.prank(elExiter);
         etherFiNodesManager.requestConsolidation{value: fee}(requests);
     }

--- a/test/behaviour-tests/non-eigenpod-credentials.t.sol
+++ b/test/behaviour-tests/non-eigenpod-credentials.t.sol
@@ -498,6 +498,30 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: fee}(requests);
     }
 
+    /// @dev A live pod constrains the consolidation TARGET to one it has proven, so a pod-backed node
+    ///      cannot consolidate into an outside validator. The pod-less path has no such constraint.
+    function test_livePod_rejectsAForeignConsolidationTarget() public {
+        bytes[] memory pubkeys = new bytes[](1);
+        uint256[] memory legacyIds = new uint256[](1);
+        pubkeys[0] = PK_16171;
+        legacyIds[0] = 51715;
+        vm.prank(elExiter);
+        etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
+
+        (, IEigenPod pod) = _resolvePod(pubkeys[0]);
+
+        // Stands in for an attacker-owned validator: never proven into this pod
+        bytes memory foreignTarget = abi.encodePacked(bytes32(keccak256("attacker")), bytes16(uint128(1)));
+
+        IEigenPodTypes.ConsolidationRequest[] memory requests = _consolidation(pubkeys[0], foreignTarget);
+        uint256 fee = pod.getConsolidationRequestFee();
+        vm.deal(elExiter, fee);
+
+        vm.expectRevert(IEigenPodErrors.ValidatorNotActiveInPod.selector);
+        vm.prank(elExiter);
+        etherFiNodesManager.requestConsolidation{value: fee}(requests);
+    }
+
     /// @dev Guards the ABI parity indexers rely on: a rename or type change on either side
     ///      diverges the selectors and fails here.
     function test_requestEvents_topicsMatchEigenPod() public pure {

--- a/test/behaviour-tests/non-eigenpod-credentials.t.sol
+++ b/test/behaviour-tests/non-eigenpod-credentials.t.sol
@@ -510,7 +510,7 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         uint256[] memory legacyIds = new uint256[](1);
         pubkeys[0] = PK_16171;
         legacyIds[0] = 51715;
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         (, IEigenPod pod) = _resolvePod(pubkeys[0]);
@@ -540,7 +540,7 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         uint256[] memory legacyIds = new uint256[](1);
         pubkeys[0] = PK_16171;
         legacyIds[0] = 51715;
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         (, IEigenPod pod) = _resolvePod(pubkeys[0]);
@@ -574,7 +574,7 @@ contract NonEigenPodCredentialsTest is PreludeTest {
         pubkeys[0] = PK_16171;
         legacyIds[0] = 51715;
 
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         (IEtherFiNode node, IEigenPod pod) = _resolvePod(pubkeys[0]);

--- a/test/behaviour-tests/pectra-fork-tests/Request-consolidation.t.sol
+++ b/test/behaviour-tests/pectra-fork-tests/Request-consolidation.t.sol
@@ -57,6 +57,9 @@ contract RequestConsolidationTest is TestSetup, Deployed {
         // RateLimiter mutators (createNewLimiter, updateConsumers) are now onlyAdmin → OPERATION_TIMELOCK_ROLE.
         roleRegistry.grantRole(roleRegistry.OPERATION_TIMELOCK_ROLE(), roleRegistry.owner());
         roleRegistry.grantRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), realElExiter);
+        // linkLegacyValidatorIds moved to OPERATION_MULTISIG_ROLE. Linking is only fixture setup in
+        // this file; PreludeTest.test_linkLegacyValidatorIds covers the role separation itself.
+        roleRegistry.grantRole(roleRegistry.OPERATION_MULTISIG_ROLE(), realElExiter);
         // ETHERFI_NODES_MANAGER_EL_CONSOLIDATION_ROLE consolidated into EXECUTOR_OPERATIONS_ROLE.
         roleRegistry.grantRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), ETHERFI_OPERATING_ADMIN);
         vm.stopPrank();

--- a/test/behaviour-tests/prelude.t.sol
+++ b/test/behaviour-tests/prelude.t.sol
@@ -374,7 +374,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         bytes memory signature = hex"877bee8d83cac8bf46c89ce50215da0b5e370d282bb6c8599aabdbc780c33833687df5e1f5b5c2de8a6cd20b6572c8b0130b1744310a998e1079e3286ff03e18e4f94de8cdebecf3aaac3277b742adb8b0eea074e619c20d13a1dda6cba6e3df";
 
         // need to link because this validator is already past this step from the old flow
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(toArray_u256(bidId), toArray_bytes(pubkey));
 
         vm.prank(admin);
@@ -411,7 +411,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         // link it to an arbitrary id
         uint256 legacyID = 10885;
         bytes memory pubkey = hex"8f9c0aab19ee7586d3d470f132842396af606947a0589382483308fdffdaf544078c3be24210677a9c471ce70b3b4c2c";
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(toArray_u256(legacyID), toArray_bytes(pubkey));
 
         // user with no role should not be able to forward calls
@@ -475,7 +475,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         // Setup: link to legacy ID
         uint256 legacyID = 10886;
         bytes memory pubkey = hex"8f9c0aab19ee7586d3d470f132842396af606947a0589382483308fdffdaf544078c3be24210677a9c471ce70b3b4c2c";
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(toArray_u256(legacyID), toArray_bytes(pubkey));
 
         // Setup: create two users with CALL_FORWARDER_ROLE
@@ -686,7 +686,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         uint256 legacyID = 10885;
 
         // force link this validator
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(toArray_u256(legacyID), toArray_bytes(validatorPubkey));
 
         // Set up rate limiter for the linked EtherFiNode proxy
@@ -760,7 +760,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         bytes32 pubkeyHash = etherFiNodesManager.calculateValidatorPubkeyHash(validatorPubkey);
         uint256 legacyID = 10885;
 
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(toArray_u256(legacyID), toArray_bytes(validatorPubkey));
 
         address nodeAddr = etherFiNodesManager.etherfiNodeAddress(uint256(pubkeyHash));
@@ -1094,23 +1094,42 @@ contract PreludeTest is Test, ArrayTestHelper {
         pubkeys[1] = vm.randomBytes(48);
         pubkeys[2] = vm.randomBytes(48);
 
-        // should fail if not admin
-        vm.expectRevert(RoleRegistry.OnlyExecutorOperations.selector);
+        // should fail if not the operating multisig
+        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
-        vm.prank(elExiter);
+        // Executor alone must NOT be able to link: it also holds
+        // requestConsolidation, and this map is what that guard trusts to decide
+        // a target is ours. A fresh address is used because the shared fixture
+        // actors hold several roles at once.
+        address executorOnly = address(0xE0E0);
+        // startPrank, not prank: the nested EXECUTOR_OPERATIONS_ROLE() read would
+        // consume a single-call prank and leave grantRole unauthorized.
+        vm.startPrank(roleRegistry.owner());
+        roleRegistry.grantRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), executorOnly);
+        vm.stopPrank();
+        assertFalse(
+            roleRegistry.hasRole(roleRegistry.OPERATION_MULTISIG_ROLE(), executorOnly),
+            "fixture: executorOnly must not hold the multisig role"
+        );
+
+        vm.expectRevert(RoleRegistry.OnlyOperatingMultisig.selector);
+        vm.prank(executorOnly);
+        etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
+
+        vm.prank(admin);
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         // should fail if attempt to re-link already linked ids
         vm.expectRevert(IEtherFiNodesManager.AlreadyLinked.selector);
-        vm.prank(elExiter);
+        vm.prank(admin);
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         // should fail if attempt to link unknown node
         uint256 badId = 9999999;
         bytes memory badPubkey = vm.randomBytes(48);
         vm.expectRevert(IEtherFiNodesManager.UnknownNode.selector);
-        vm.prank(elExiter);
+        vm.prank(admin);
         etherFiNodesManager.linkLegacyValidatorIds(toArray_u256(badId), toArray_bytes(badPubkey));
 
     }
@@ -1234,7 +1253,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[1] = 51716;
         legacyIds[2] = 51717;
 
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys); 
         vm.stopPrank();
         _setExitRateLimit(172800, 2);
@@ -1292,7 +1311,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[2] = 51717;
 
         // Link and init
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
         vm.stopPrank();
         _setExitRateLimit(172800, 2);
@@ -1367,7 +1386,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[1] = 51716;
         legacyIds[2] = 51717;
 
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
         vm.stopPrank();
 
@@ -1391,7 +1410,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[1] = 51716;
         legacyIds[2] = 51717;
 
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys); 
         vm.stopPrank();
         _setExitRateLimit(172800, 2);
@@ -1514,7 +1533,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[0] = 51715;
         amounts[0] = 1_000_000_000; // 1 ETH partial exit
 
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         // Grant role to the triggering EOA
@@ -1702,7 +1721,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[1] = 51716;
         legacyIds[2] = 51717;
 
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         (, IEigenPod pod0) = _resolvePod(pubkeys[0]);
@@ -1756,7 +1775,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         pubkeys[0] = PK_16171;
         legacyIds[0] = 51715;
 
-        vm.prank(elExiter);
+        vm.prank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
 
         (, IEigenPod pod0) = _resolvePod(pubkeys[0]);
@@ -1775,7 +1794,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[0] = 51715;
         legacyIds[1] = 51716;
 
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
         vm.stopPrank();
 
@@ -1828,7 +1847,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[1] = 51716;
         legacyIds[2] = 51717;
 
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
         vm.stopPrank();
 
@@ -1875,7 +1894,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         pubkeys[0] = PK_16171;
         legacyIds[0] = 51715;
 
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
         vm.stopPrank();
 
@@ -1912,7 +1931,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[0] = 51715;
         legacyIds[1] = 51716;
 
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
         vm.stopPrank();
 
@@ -1966,7 +1985,7 @@ contract PreludeTest is Test, ArrayTestHelper {
         legacyIds[1] = 51716;
         legacyIds[2] = 51717;
 
-        vm.startPrank(elExiter);
+        vm.startPrank(admin); // OPERATION_MULTISIG_ROLE for linkLegacyValidatorIds
         etherFiNodesManager.linkLegacyValidatorIds(legacyIds, pubkeys);
         vm.stopPrank();
 

--- a/test/fork-tests/pectra-fork-tests/Consolidation-through-EOA.sol
+++ b/test/fork-tests/pectra-fork-tests/Consolidation-through-EOA.sol
@@ -66,6 +66,8 @@ contract ConsolidationThroughEOATest is Test {
 
         vm.startPrank(roleRegistry.owner());
         roleRegistry.grantRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), realElExiter);
+        // linkLegacyValidatorIds moved to OPERATION_MULTISIG_ROLE; linking is fixture setup here.
+        roleRegistry.grantRole(roleRegistry.OPERATION_MULTISIG_ROLE(), realElExiter);
 
         // Setup consolidation rate limiter bucket (required for new rate limiting)
         roleRegistry.grantRole(roleRegistry.OPERATION_MULTISIG_ROLE(), roleRegistry.owner());

--- a/test/invariant/ValidatorLifecycle.invariant.t.sol
+++ b/test/invariant/ValidatorLifecycle.invariant.t.sol
@@ -37,12 +37,12 @@ contract ValidatorLifecycleInvariantTest is TestSetup {
     function setUp() public {
         setUpTests();
 
-        // linkLegacyValidatorIds is onlyExecutorOperations; grant the role to a
+        // linkLegacyValidatorIds is onlyOperatingMultisig; grant the role to a
         // dedicated address the handler pranks for the legacy-path re-link attack.
-        // startPrank (not prank) so the nested EXECUTOR_OPERATIONS_ROLE() read doesn't
+        // startPrank (not prank) so the nested OPERATION_MULTISIG_ROLE() read doesn't
         // consume the prank before grantRole runs.
         vm.startPrank(roleRegistryInstance.owner());
-        roleRegistryInstance.grantRole(roleRegistryInstance.EXECUTOR_OPERATIONS_ROLE(), executorOps);
+        roleRegistryInstance.grantRole(roleRegistryInstance.OPERATION_MULTISIG_ROLE(), executorOps);
         vm.stopPrank();
 
         handler = new ValidatorLifecycleHandler(managerInstance, address(stakingManagerInstance), executorOps);

--- a/test/invariant/handlers/ValidatorLifecycleHandler.sol
+++ b/test/invariant/handlers/ValidatorLifecycleHandler.sol
@@ -20,7 +20,7 @@ import "@etherfi/staking/EtherFiNodesManager.sol";
 contract ValidatorLifecycleHandler is Test {
     EtherFiNodesManager internal immutable manager;
     address internal immutable stakingManagerAddr;
-    address internal immutable executorOps;   // linkLegacyValidatorIds caller (EXECUTOR_OPERATIONS_ROLE)
+    address internal immutable executorOps;   // linkLegacyValidatorIds caller (OPERATION_MULTISIG_ROLE)
 
     // ---- ghost state ----
     // first node each pubkey hash was linked to (0 = never linked)
@@ -117,7 +117,7 @@ contract ValidatorLifecycleHandler is Test {
     }
 
     /// Actively attempt to repoint an already-linked pubkey via the SECOND writer
-    /// to etherFiNodeFromPubkeyHash — linkLegacyValidatorIds (EXECUTOR_OPERATIONS_ROLE).
+    /// to etherFiNodeFromPubkeyHash — linkLegacyValidatorIds (OPERATION_MULTISIG_ROLE).
     /// We feed it a legacyId that a prior link already populated in
     /// DEPRECATED_etherfiNodeAddress (so the UnknownNode guard passes) paired with an
     /// already-linked pubkey. The call MUST revert AlreadyLinked and leave the link


### PR DESCRIPTION
Scratch PR for reviewing a diff. **Not for merge.** Based on
`pankaj/feat/non-eigenpod-withdrawal-credentials` rather than `master`, so the
diff is only the three new commits instead of all of #485.

Addresses the review conclusion on #485: "link them all, gate that function via
multisig, and make the change to the consolidation function."

### Commits

| SHA | What |
| --- | --- |
| `6ffd3d1c` | test: pin that a live pod constrains the consolidation target |
| `5daa413f` | feat(enm): require consolidation targets to be EtherFi-owned |
| `80421985` | feat(enm): gate `linkLegacyValidatorIds` behind the operating multisig |

### Why the target guard exists

EIP-7251's `process_consolidation_request` requires only that the target hold
`0x02` credentials. There is no source/target same-address rule — the only
`withdrawal_credentials[12:]` check in the spec is against `source_address`.
A pod vets the target only when the pod is the caller, so a pod-less node
calling the predeploy directly had no target constraint at all.

`test_livePod_rejectsAForeignConsolidationTarget` records the pre-existing
control on the pod-backed path: mainnet's EigenPod reverts
`ValidatorNotActiveInPod` on an unproven target. That is what pod-less nodes
were missing.

### The guard

Three grounds to accept, deny otherwise:

- `src == target` — a switch to compounding, moves no value
- linked in `etherFiNodeFromPubkeyHash` — one of ours
- `ACTIVE` in the source's own pod — EigenLayer merkle-verified the credentials

Cross-credential consolidation still works, which is the point of the feature:
a target on another node passes the second branch. `ACTIVE` rather than
`!= INACTIVE` because `WITHDRAWN` passes the looser check and the consensus
layer drops a withdrawn target, burning the fee and logging a consolidation
that never happens.

### The role gate

The guard trusts `etherFiNodeFromPubkeyHash`, and `linkLegacyValidatorIds`
writes that map while verifying nothing about the pair. On the same role as
`requestConsolidation`, one key could link a validator it owned and then
consolidate into it. Now `onlyOperatingMultisig` (4-of-7), matching
`setProofSubmitter`. The power to grow the trusted set is separate from the
power to use it.

`test_linkLegacyValidatorIds` asserts that directly: an address holding only
`EXECUTOR_OPERATIONS_ROLE` is rejected.

### Deployment order

The ~23k legacy backfill must run **before** this ships, or every one of ~73
batches needs a 4-of-7 signature. Ops runbook and workflow live in
protocol-ops.

### Verification

Full suite 1679/1684. The 5 failures are pre-existing and environmental (a
`NotRegistered` setUp and 6 suites needing `OP_RPC_URL`), reproduced with these
changes reverted.

### Known limit

The registry branch is trusted bookkeeping, not proof. The backfill's beacon
verification closes that for the legacy set and the pod-`ACTIVE` branch is
cryptographic, but a future mislink by the Safe would still be accepted. A
Lido-style beacon proof of the target's credentials is the full fix, as a
follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790348711&installation_model_id=18424&pr_number=498&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F498&signature=3a1892287452b65459d6e257b2a37f6cb03588ae73e36350a479cbf154ccb1d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes staking consolidation authorization and who can populate the pubkey registry—both directly affect where validator ETH can be directed.
> 
> **Overview**
> Closes a **consolidation theft vector** on pod-less nodes: EIP-7251 only checks that the target has `0x02` credentials, so `requestConsolidation` now **always** validates each target before forwarding. Allowed targets are **switch-to-compounding** (`src == target`), any pubkey in `etherFiNodeFromPubkeyHash`, or an **`ACTIVE`** validator in the source pod (not merely non-`INACTIVE`, to avoid withdrawn targets). Anything else reverts with **`UnknownConsolidationTarget`**.
> 
> **`linkLegacyValidatorIds`** is moved from executor ops to **`onlyOperatingMultisig`**, so the role that can extend the trusted pubkey map cannot also submit consolidations that rely on it. Tests and fixtures are updated for the new role split and for rejecting foreign consolidation targets on both pod-less and live-pod paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804219856a09bd31913fd91abe37c12e667c5476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->