### PR TITLE
feat(deposits): mint weETH directly on the ETH and WETH paths

### DIFF
--- a/src/core/LiquidityPool.sol
+++ b/src/core/LiquidityPool.sol
@@ -65,6 +65,11 @@ contract LiquidityPool is Initializable, DeprecatedOZOwnable, UUPSUpgradeable, R
     //--------------------------------------------------------------------------------------
     //---------------------------------  CONSTANTS  ---------------------------------------
     //--------------------------------------------------------------------------------------
+    /// @dev Authority for {depositETHToRecipient}. Held by the DepositAdapter. Lets that
+    ///      contract choose which address the freshly minted eETH shares are credited to,
+    ///      the same trust the Liquifier already has via {depositToRecipient}.
+    bytes32 public constant LIQUIDITY_POOL_DEPOSIT_ADAPTER_ROLE = keccak256("LIQUIDITY_POOL_DEPOSIT_ADAPTER_ROLE");
+
     uint256 public constant SHARE_UNIT = 1e18;
 
     // Hard cap on how far a single rebase may INCREASE TVL (rewards), in bps of TVL.
@@ -228,6 +233,31 @@ contract LiquidityPool is Initializable, DeprecatedOZOwnable, UUPSUpgradeable, R
         emit Deposit(_recipient, _amount, SourceOfFunds.EETH, _referral);
 
         return _deposit(_recipient, 0, _amount);
+    }
+
+    /**
+     * @notice Deposit ETH into the Liquidity Pool, crediting the eETH shares to `_recipient`
+     * @param _recipient The address the eETH shares are minted to
+     * @param _referral The address of the referral
+     * @return uint256 The number of eETH shares minted
+     * @dev Payable sibling of {depositToRecipient}, restricted to holders of
+     *      LIQUIDITY_POOL_DEPOSIT_ADAPTER_ROLE. Exists so the DepositAdapter can credit the
+     *      shares straight to the weETH contract and then mint the matching weETH, instead
+     *      of taking the shares itself and wrapping them. Accounting is identical to
+     *      {deposit}: same `_deposit` body, same `_sharesForDepositAmount`, same
+     *      `nonDecreasingRate` guard. The only difference is which address the shares land on.
+     */
+    function depositETHToRecipient(address _recipient, address _referral) external payable nonReentrant whenNotPaused returns (uint256) {
+        roleRegistry.checkRoles(msg.sender, abi.encode(LIQUIDITY_POOL_DEPOSIT_ADAPTER_ROLE));
+        blacklister.nonBlacklisted(_recipient);
+
+        // Emits the caller, not `_recipient`, so the event is byte-for-byte what the
+        // adapter's old `deposit(_referral)` call produced. Indexers keyed on the adapter
+        // keep working. Depositor attribution is carried by the adapter's own
+        // `AdapterDeposit` event, as it already was.
+        emit Deposit(msg.sender, msg.value, SourceOfFunds.EETH, _referral);
+
+        return _deposit(_recipient, msg.value, 0);
     }
 
     /**

--- a/src/core/WeETH.sol
+++ b/src/core/WeETH.sol
@@ -33,6 +33,16 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, DeprecatedOZOwnable, Pausab
     IBlacklister public immutable blacklister;
 
     //--------------------------------------------------------------------------------------
+    //---------------------------------  ROLES  --------------------------------------------
+    //--------------------------------------------------------------------------------------
+    /// @dev Authority for {mintFor}. Held by the DepositAdapter so ETH/WETH deposits can
+    ///      mint weETH in one step instead of round-tripping through {wrap}. The role is
+    ///      NOT a licence to inflate supply: {mintFor} routes through the same
+    ///      `_afterTokenTransfer` backing check as every other mint, so a holder can only
+    ///      mint against eETH shares that are already sitting in this contract.
+    bytes32 public constant WEETH_MINTER_ROLE = keccak256("WEETH_MINTER_ROLE");
+
+    //--------------------------------------------------------------------------------------
     //---------------------------------  ERRORS  ------------------------------------------
     //--------------------------------------------------------------------------------------
     error ZeroAmount();
@@ -115,6 +125,34 @@ contract WeETH is ERC20Upgradeable, UUPSUpgradeable, DeprecatedOZOwnable, Pausab
     {
         try eETH.permit(msg.sender, address(this), _permit.value, _permit.deadline, _permit.v, _permit.r, _permit.s) {} catch {}
         return wrap(_eETHAmount);
+    }
+
+    /**
+     * @notice Mints `_shares` weETH to `_to` against eETH shares already held by this contract
+     * @param _to the recipient of the newly minted weETH
+     * @param _shares the number of weETH to mint, denominated in eETH shares
+     * @return the amount of weETH minted, equal to `_shares`
+     * @dev Counterpart to {wrap} for callers that mint the backing eETH shares straight to
+     *      this contract rather than to themselves. {wrap} has to convert shares to an eETH
+     *      amount and back again, and both conversions floor, so it returns 1-2 wei fewer
+     *      weETH than the shares that were deposited. A caller that credits shares directly
+     *      has no such round trip and mints the exact share count.
+     *
+     *      Safety does not rest on the role alone. The mint runs through
+     *      `_afterTokenTransfer`, which reverts unless
+     *      `totalSupply <= eETH.shares(address(this))`. A role holder therefore cannot mint
+     *      weETH that is not already backed: calling this without having credited the shares
+     *      first reverts with {WeETHUnderbacked}. The role governs who may claim newly
+     *      credited backing, not how much weETH may exist.
+     */
+    function mintFor(address _to, uint256 _shares) external returns (uint256) {
+        roleRegistry.checkRoles(msg.sender, abi.encode(WEETH_MINTER_ROLE));
+        if (_shares == 0) revert ZeroAmount();
+        if (_to == address(0)) revert ZeroAddress();
+
+        _mint(_to, _shares);
+
+        return _shares;
     }
 
     /**

--- a/src/core/interfaces/ILiquidityPool.sol
+++ b/src/core/interfaces/ILiquidityPool.sol
@@ -71,6 +71,7 @@ interface ILiquidityPool {
     function deposit(address _referral) external payable returns (uint256);
     function deposit(address _user, address _referral) external payable returns (uint256);
     function depositToRecipient(address _recipient, uint256 _amount, address _referral) external returns (uint256);
+    function depositETHToRecipient(address _recipient, address _referral) external payable returns (uint256);
     function withdraw(address _recipient, uint256 _amount) external returns (uint256);
     function withdraw(uint256 _amount, uint256 _share) external;
     function burnEEthSharesForNonETHWithdrawal(uint256 _amountSharesToBurn, uint256 _withdrawalValueInETH) external;

--- a/src/core/interfaces/IWeETH.sol
+++ b/src/core/interfaces/IWeETH.sol
@@ -26,6 +26,7 @@ interface IWeETH is IERC20Upgradeable {
     function wrap(uint256 _eETHAmount) external returns (uint256);
     function wrapWithPermit(uint256 _eETHAmount, ILiquidityPool.PermitInput calldata _permit) external returns (uint256);
     function unwrap(uint256 _weETHAmount) external returns (uint256);
+    function mintFor(address _to, uint256 _shares) external returns (uint256);
     function permit(
         address owner,
         address spender,

--- a/src/deposits/DepositAdapter.sol
+++ b/src/deposits/DepositAdapter.sol
@@ -84,10 +84,10 @@ contract DepositAdapter is UUPSUpgradeable, DeprecatedOZOwnable, RolesLibrary, I
      * @return weEthAmount weETH received by the depositer
      */
     function depositETHForWeETH(address _referral) external payable nonBlacklisted returns (uint256) {
-        uint256 eETHShares = liquidityPool.deposit{value: msg.value}(_referral);
-        
+        uint256 eETHShares = liquidityPool.depositETHToRecipient{value: msg.value}(address(weETH), _referral);
+
         emit AdapterDeposit(msg.sender, msg.value, SourceOfFunds.ETH, _referral);
-        return _wrapAndReturn(eETHShares);
+        return weETH.mintFor(msg.sender, eETHShares);
     }
 
     /**
@@ -104,10 +104,10 @@ contract DepositAdapter is UUPSUpgradeable, DeprecatedOZOwnable, RolesLibrary, I
         IERC20(address(wETH)).safeTransferFrom(msg.sender, address(this), _amount);
         wETH.withdraw(_amount);
 
-        uint256 eETHShares = liquidityPool.deposit{value: _amount}(_referral);
-        
+        uint256 eETHShares = liquidityPool.depositETHToRecipient{value: _amount}(address(weETH), _referral);
+
         emit AdapterDeposit(msg.sender, _amount, SourceOfFunds.WETH, _referral);
-        return _wrapAndReturn(eETHShares);
+        return weETH.mintFor(msg.sender, eETHShares);
     }
 
     /**
@@ -173,9 +173,11 @@ contract DepositAdapter is UUPSUpgradeable, DeprecatedOZOwnable, RolesLibrary, I
      * @notice Sweep dust accumulated in the adapter to a recipient.
      * @param _token Address of the ERC20 to sweep
      * @param _to Recipient of the swept tokens
-     * @dev Each deposit strands 1-2 wei of eETH due to floor-rounding in both
-     *      amountForShare (shares -> ETH) and wrap (ETH -> shares). This function
-     *      lets operations recover the residual balance of any ERC20 left here.
+     * @dev stETH and wstETH deposits strand 1-2 wei of eETH each, from floor-rounding in
+     *      both amountForShare (shares -> ETH) and wrap (ETH -> shares). ETH and WETH
+     *      deposits no longer strand anything. This function lets operations recover the
+     *      residual balance of any ERC20 left here, including the balance accrued by ETH and
+     *      WETH deposits before that change.
      */
     function sweepDust(address _token, address _to) external onlyOperatingMultisig {
         if (_to == address(0)) revert InvalidRecipient();
@@ -200,6 +202,12 @@ contract DepositAdapter is UUPSUpgradeable, DeprecatedOZOwnable, RolesLibrary, I
      * @notice Wrap eETH shares and return weETH
      * @param _eEthShares Amount of eETH shares to wrap
      * @return weEthAmount weETH received by the depositer
+     * @dev Still used by the stETH and wstETH paths. Those route through
+     *      `Liquifier.depositWithERC20`, which hardcodes the Liquifier's caller as the eETH
+     *      recipient, so the adapter cannot redirect the shares to weETH without changing the
+     *      Liquifier as well. The ETH and WETH paths no longer come through here: they credit
+     *      the shares to weETH up front and mint against them, which avoids the
+     *      shares -> amount -> shares round trip and the 1-2 wei it strands.
      */
     function _wrapAndReturn(uint256 _eEthShares) internal returns (uint256) {
         uint256 eEthAmount = liquidityPool.amountForShare(_eEthShares);

--- a/test/DepositAdapterDirectMint.t.sol
+++ b/test/DepositAdapterDirectMint.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "@etherfi/deposits/DepositAdapter.sol";
+import "@tests/TestSetup.sol";
+
+/**
+ * @title DepositAdapterDirectMintTest
+ * @notice Differential tests for minting weETH directly on the ETH and WETH deposit paths.
+ * @dev The adapter used to take the eETH shares itself and wrap them, which converted
+ *      shares -> eETH amount -> shares and floored twice, leaving 1-2 wei stranded on the
+ *      adapter. It now credits the shares to weETH and mints against them.
+ *
+ *      What these tests are for is proving the swap changed nothing it was not meant to.
+ *      Pooled ETH, total eETH shares and therefore the exchange rate are all untouched, so
+ *      no existing holder moves by a single wei. The depositor gets the 1-2 wei that used
+ *      to be stranded.
+ */
+contract DepositAdapterDirectMintTest is TestSetup {
+    IWETH public wETH;
+
+    address internal depositor = makeAddr("directMintDepositor");
+    address internal bystander = makeAddr("directMintBystander");
+
+    function setUp() public {
+        initializeRealisticFork(MAINNET_FORK);
+        wETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
+        // Give the bystander an existing weETH position so we can prove it never moves.
+        vm.deal(bystander, 10 ether);
+        vm.prank(bystander);
+        depositAdapterInstance.depositETHForWeETH{value: 10 ether}(address(0));
+
+        vm.deal(depositor, 200_000 ether);
+    }
+
+    //---------------------------------------------------------------------------------
+    //  The protocol-wide numbers the swap must not touch
+    //---------------------------------------------------------------------------------
+
+    /// @dev The whole safety argument in one test: a deposit leaves the rate, the share
+    ///      ledger and every other holder exactly where they were.
+    function testFuzz_directMintLeavesRateAndOtherHoldersUntouched(uint256 _amount) public {
+        // Below ~1 gwei a deposit mints zero shares at the live rate and LiquidityPool
+        // rejects it with InvalidAmount. That floor predates this change.
+        uint256 amount = bound(_amount, 1 gwei, 100_000 ether);
+
+        uint256 rateBefore = liquidityPoolInstance.amountForShare(1 ether);
+        uint256 weEthRateBefore = weEthInstance.getRate();
+        uint256 pooledBefore = liquidityPoolInstance.getTotalPooledEther();
+        uint256 sharesBefore = eETHInstance.totalShares();
+        uint256 bystanderWeEth = weEthInstance.balanceOf(bystander);
+        uint256 bystanderEEth = eETHInstance.balanceOf(bystander);
+
+        vm.prank(depositor);
+        uint256 minted = depositAdapterInstance.depositETHForWeETH{value: amount}(address(0));
+
+        // Pooled ETH and the share ledger move by exactly the deposit and exactly the
+        // shares minted for it — the same as any other deposit.
+        assertEq(liquidityPoolInstance.getTotalPooledEther(), pooledBefore + amount, "pooled ETH");
+        assertEq(eETHInstance.totalShares(), sharesBefore + minted, "total shares");
+
+        // The rate is a pure function of those two, so it is unchanged.
+        assertEq(liquidityPoolInstance.amountForShare(1 ether), rateBefore, "eETH rate moved");
+        assertEq(weEthInstance.getRate(), weEthRateBefore, "weETH rate moved");
+
+        // Nobody else's position moves.
+        assertEq(weEthInstance.balanceOf(bystander), bystanderWeEth, "bystander weETH moved");
+        assertEq(eETHInstance.balanceOf(bystander), bystanderEEth, "bystander eETH moved");
+    }
+
+    /// @dev weETH supply stays fully backed by eETH shares held in the weETH contract.
+    function testFuzz_backingInvariantHoldsWithEquality(uint256 _amount) public {
+        uint256 amount = bound(_amount, 1 gwei, 100_000 ether);
+
+        uint256 supplyBefore = weEthInstance.totalSupply();
+        uint256 proxySharesBefore = eETHInstance.shares(address(weEthInstance));
+
+        vm.prank(depositor);
+        uint256 minted = depositAdapterInstance.depositETHForWeETH{value: amount}(address(0));
+
+        assertEq(weEthInstance.totalSupply(), supplyBefore + minted, "supply delta");
+        assertEq(eETHInstance.shares(address(weEthInstance)), proxySharesBefore + minted, "backing delta");
+        assertLe(weEthInstance.totalSupply(), eETHInstance.shares(address(weEthInstance)), "underbacked");
+    }
+
+    //---------------------------------------------------------------------------------
+    //  Old path vs new path, on identical state
+    //---------------------------------------------------------------------------------
+
+    /// @dev Runs the retired wrap path and the direct-mint path from the same snapshot and
+    ///      compares. The depositor is never worse off, and never better off by more than
+    ///      the 2 wei the double flooring used to discard.
+    function testFuzz_directMintMatchesWrapPathWithinTwoWei(uint256 _amount) public {
+        uint256 amount = bound(_amount, 1 gwei, 100_000 ether);
+
+        uint256 snap = vm.snapshotState();
+
+        // Old path, reproduced by hand: take the shares, convert to an eETH amount, wrap.
+        vm.startPrank(depositor);
+        uint256 shares = liquidityPoolInstance.deposit{value: amount}(address(0));
+        uint256 eEthAmount = liquidityPoolInstance.amountForShare(shares);
+        IERC20(address(eETHInstance)).approve(address(weEthInstance), eEthAmount);
+        uint256 viaWrap = weEthInstance.wrap(eEthAmount);
+        vm.stopPrank();
+
+        vm.revertToState(snap);
+
+        // New path.
+        vm.prank(depositor);
+        uint256 viaDirectMint = depositAdapterInstance.depositETHForWeETH{value: amount}(address(0));
+
+        assertGe(viaDirectMint, viaWrap, "direct mint pays less than wrap");
+        assertLe(viaDirectMint - viaWrap, 2, "direct mint pays more than the reclaimed dust");
+    }
+
+    /// @dev The reclaimed wei is the dust that used to pile up on the adapter, so the
+    ///      adapter no longer accrues an eETH balance on the ETH path.
+    function test_directMintStrandsNoDustOnAdapter() public {
+        uint256 adapterEEthBefore = eETHInstance.balanceOf(address(depositAdapterInstance));
+
+        vm.startPrank(depositor);
+        for (uint256 i = 0; i < 20; i++) {
+            depositAdapterInstance.depositETHForWeETH{value: 1 ether + i}(address(0));
+        }
+        vm.stopPrank();
+
+        assertLe(
+            eETHInstance.balanceOf(address(depositAdapterInstance)),
+            adapterEEthBefore + 1,
+            "adapter still accruing dust"
+        );
+    }
+
+    /// @dev Depositing and immediately unwrapping returns the deposit, minus only the
+    ///      rounding the eETH share math has always had.
+    function testFuzz_depositUnwrapRoundTrip(uint256 _amount) public {
+        uint256 amount = bound(_amount, 1 gwei, 100_000 ether);
+
+        vm.startPrank(depositor);
+        uint256 minted = depositAdapterInstance.depositETHForWeETH{value: amount}(address(0));
+        uint256 eEthBack = weEthInstance.unwrap(minted);
+        vm.stopPrank();
+
+        assertLe(eEthBack, amount, "round trip returned more than deposited");
+        assertApproxEqAbs(eEthBack, amount, 3, "round trip lost more than rounding");
+    }
+
+    //---------------------------------------------------------------------------------
+    //  The WETH path
+    //---------------------------------------------------------------------------------
+
+    function test_wethPathMintsDirectly() public {
+        uint256 rateBefore = weEthInstance.getRate();
+
+        vm.startPrank(depositor);
+        wETH.deposit{value: 50 ether}();
+        wETH.approve(address(depositAdapterInstance), 50 ether);
+        uint256 minted = depositAdapterInstance.depositWETHForWeETH(50 ether, address(0));
+        vm.stopPrank();
+
+        assertEq(weEthInstance.balanceOf(depositor), minted, "depositor balance");
+        assertEq(weEthInstance.getRate(), rateBefore, "weETH rate moved");
+        assertLe(weEthInstance.totalSupply(), eETHInstance.shares(address(weEthInstance)), "underbacked");
+    }
+
+    //---------------------------------------------------------------------------------
+    //  mintFor cannot inflate supply
+    //---------------------------------------------------------------------------------
+
+    /// @dev The backing check, not the role, is what bounds the mint. Even the authorised
+    ///      caller cannot mint weETH that no eETH share backs.
+    function test_mintForRevertsWhenNotBacked() public {
+        // Read these before pranking — a view call would consume the prank.
+        uint256 supplyAfterMint = weEthInstance.totalSupply() + 1 ether;
+        uint256 backing = eETHInstance.shares(address(weEthInstance));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(WeETH.WeETHUnderbacked.selector, supplyAfterMint, backing)
+        );
+        vm.prank(address(depositAdapterInstance));
+        weEthInstance.mintFor(depositor, 1 ether);
+    }
+
+    function test_mintForRevertsForUnauthorisedCaller() public {
+        vm.prank(depositor);
+        vm.expectRevert();
+        weEthInstance.mintFor(depositor, 1 ether);
+    }
+
+    function test_mintForRejectsZeroArguments() public {
+        vm.startPrank(address(depositAdapterInstance));
+        vm.expectRevert(WeETH.ZeroAmount.selector);
+        weEthInstance.mintFor(depositor, 0);
+
+        vm.expectRevert(WeETH.ZeroAddress.selector);
+        weEthInstance.mintFor(address(0), 1 ether);
+        vm.stopPrank();
+    }
+
+    //---------------------------------------------------------------------------------
+    //  depositETHToRecipient gating
+    //---------------------------------------------------------------------------------
+
+    function test_depositETHToRecipientRevertsForUnauthorisedCaller() public {
+        vm.deal(depositor, 1 ether);
+        vm.prank(depositor);
+        vm.expectRevert();
+        liquidityPoolInstance.depositETHToRecipient{value: 1 ether}(depositor, address(0));
+    }
+
+    /// @dev The adapter mints straight to the depositor now, so it should never be left
+    ///      holding weETH — not before a deposit, and not after one.
+    function test_adapterNeverRetainsWeETH() public {
+        assertEq(weEthInstance.balanceOf(address(depositAdapterInstance)), 0, "weETH held before deposit");
+
+        vm.prank(depositor);
+        depositAdapterInstance.depositETHForWeETH{value: 100 ether}(address(0));
+
+        assertEq(weEthInstance.balanceOf(address(depositAdapterInstance)), 0, "weETH held after deposit");
+    }
+}

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -756,6 +756,14 @@ contract TestSetup is Test, ContractCodeChecker, DepositDataGeneration {
         roleRegistryInstance.grantRole(_operatingMultisigRole, alice);
         roleRegistryInstance.grantRole(_operatingMultisigRole, admin);
         roleRegistryInstance.grantRole(_operatingMultisigRole, _operatingTimelockAddr);
+
+        // The DepositAdapter mints weETH directly for the ETH/WETH paths: it credits the
+        // eETH shares to weETH via LiquidityPool.depositETHToRecipient, then claims them
+        // with WeETH.mintFor. Both calls are role-gated, so grant the adapter both roles.
+        roleRegistryInstance.grantRole(
+            liquidityPoolInstance.LIQUIDITY_POOL_DEPOSIT_ADAPTER_ROLE(), address(depositAdapterInstance)
+        );
+        roleRegistryInstance.grantRole(weEthInstance.WEETH_MINTER_ROLE(), address(depositAdapterInstance));
         vm.stopPrank();
 
         // The freshly-upgraded LP introduces `minWithdrawAmount`/`maxWithdrawAmount`


### PR DESCRIPTION
## What this changes

ETH and WETH deposits now mint weETH directly instead of routing through `wrap`.

The adapter used to take the eETH shares itself, convert them to an eETH amount, and wrap that back into weETH. Both conversions floor, so the depositor received 1–2 wei less weETH than the shares that were minted for their deposit, and the difference piled up on the adapter as stranded eETH.

It now credits the shares straight to the weETH contract and mints against them:

```
before:  LiquidityPool.deposit  ->  shares to adapter
         amountForShare(shares)                          <- floor
         weETH.wrap(amount)     ->  sharesForAmount(amount)   <- floor again
         weETH.transfer(user)

after:   LiquidityPool.depositETHToRecipient  ->  shares to weETH
         weETH.mintFor(user, shares)
```

stETH and wstETH deposits are unchanged. They go through `Liquifier.depositWithERC20`, which hardcodes its own caller as the eETH recipient, so redirecting those shares would mean changing the Liquifier too. Out of scope here.

## What is provably unchanged

Every rate function in the protocol reads only `getTotalPooledEther()` and `eETH.totalShares()`. Both move exactly as they did before — same `_deposit` body, same `_sharesForDepositAmount`, same `nonDecreasingRate` guard. The only difference is which address the shares land on.

Total eETH shares already grew by the full `share` amount before this change; the 1–2 wei never left the ledger, it just sat on the adapter. So:

| | Effect |
|---|---|
| `getTotalPooledEther()` | unchanged |
| `eETH.totalShares()` | unchanged |
| `sharesForAmount` / `amountForShare` / `amountPerShareCeil` | unchanged for every input |
| `weETH.getRate()` | unchanged |
| Existing eETH and weETH holders | zero wei of movement |
| Withdrawal queue, redemption manager, membership manager | not touched |
| Storage layout | not touched |

`testFuzz_directMintLeavesRateAndOtherHoldersUntouched` asserts all of this with `assertEq`, not tolerances, across deposits from 1 gwei to 100k ETH.

## What does change

**The depositor receives 1–2 wei more weETH.** This is the dust that previously stranded on the adapter, where it was recoverable by operations via `sweepDust`. It is not diluted from any other holder — no other balance moves. `testFuzz_directMintMatchesWrapPathWithinTwoWei` runs both paths from the same snapshot and bounds the difference at `[0, 2]`.

This wants an explicit decision rather than a silent merge. If the preference is byte-identical behaviour including the depositor's balance, the alternative is to reproduce both floors in `depositETHToRecipient` and mint the remainder to the adapter as before. That is achievable but adds an ordering dependency, since `mintShares` itself calls `amountForShare`. Say the word and it can go in that direction.

**The event trail is shorter.** The `LiquidityPool.Deposit` event is byte-for-byte what it was — it deliberately emits the caller rather than the recipient so indexers keyed on the DepositAdapter keep working. The token `Transfer` events do change:

| | Before | After |
|---|---|---|
| eETH | `Transfer(0 -> adapter)`, then `Transfer(adapter -> weETH)` | `Transfer(0 -> weETH)` |
| weETH | `Transfer(0 -> adapter)`, then `Transfer(adapter -> user)` | `Transfer(0 -> user)` |

Anything off-chain that identifies a user deposit by `weETH.Transfer(from = DepositAdapter)` will stop seeing it — subgraphs, points attribution, tax tooling, accounting jobs. Foundry cannot catch this. **The indexers need an audit before this ships.**

**`sweepDust` becomes vestigial for ETH and WETH.** Keep it: the stETH and wstETH paths still strand dust, and the balance accrued to date still needs recovering.

## Why `mintFor` cannot inflate supply

`WEETH_MINTER_ROLE` is not a licence to mint. `mintFor` routes through the same `_afterTokenTransfer` backing check as every other mint, which reverts unless `totalSupply <= eETH.shares(address(this))`. A role holder that calls `mintFor` without having credited the shares first reverts with `WeETHUnderbacked` — covered by `test_mintForRevertsWhenNotBacked`.

The role governs who may claim newly credited backing, not how much weETH may exist. Even a fully compromised DepositAdapter cannot mint weETH that no eETH share backs.

## Operations

Two roles must be granted to the DepositAdapter, or every ETH and WETH deposit reverts:

- `LIQUIDITY_POOL_DEPOSIT_ADAPTER_ROLE` on LiquidityPool
- `WEETH_MINTER_ROLE` on WeETH

Neither contract's constructor changed, so no deploy-script signature churn and no test-setup rewrites.

## Forward note for the rate-limiter branch

This targets `master`, where WeETH has no rate limiter. When the rate-limiting work lands, `mintFor` needs a deliberate decision on the global `WEETH_MINT_LIMIT_ID` bucket. `wrap` sets `_WRAP_CTX_SLOT` to skip it, and the comment on that slot names "a new mint authority" as exactly the case the bucket is meant to catch. Either choice is defensible; it should not be made by accident:

- skip the bucket, and today's behaviour is preserved but the circuit breaker no longer covers the main deposit route
- consume the bucket, and ETH deposits start draining a bucket they do not touch today, so it needs resizing

## Testing

`test/DepositAdapterDirectMint.t.sol`, 11 tests on a mainnet fork:

- rate, pooled ETH, total shares and third-party balances unchanged (fuzzed)
- backing invariant holds with equality (fuzzed)
- direct mint vs the retired wrap path from the same snapshot, bounded at 2 wei (fuzzed)
- deposit/unwrap round trip
- no dust accrues on the adapter
- `mintFor` rejects unbacked mints, unauthorised callers, and zero arguments
- `depositETHToRecipient` rejects unauthorised callers

Existing `DepositAdapterTest`, `WeETHTest`, `LiquidityPoolTest` and `EETHTest` all pass unchanged — 229 tests across the five suites.

Full suite: 1417 passed. The failures are environmental or pre-existing:

- three `liquid-tests` OP suites need `OP_RPC_URL`, which was not set locally
- `WithdrawalSolvencyInvariantTest` intermittently trips its own non-vacuity coverage gate ("no finalized request was ever claimed"), where the fuzzer does not drive a full request/finalize/claim lifecycle within its run budget. Measured over five random-seed runs per side: 5/5 pass with this change, 4/5 on clean `master`. Three fixed-seed runs pass on both sides. The suite seeds actors through `liquidityPool.deposit` directly and never touches the DepositAdapter, so this change is not in its code path. Worth fixing separately — the gate is flaky on `master` today.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790537354&installation_model_id=18424&pr_number=499&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F499&signature=4c5088ae5c86b08d70cad988edad97ca8f164fe61e8cc17ebbeba191b81b389c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New role-gated mint/deposit entry points on core LiquidityPool and WeETH change the main ETH/WETH deposit path and token event shape; supply inflation is mitigated by the existing backing invariant but mis-granted roles or off-chain indexers are operational risks.
> 
> **Overview**
> ETH and WETH deposits through **DepositAdapter** no longer take eETH on the adapter and **wrap** (double floor rounding). They call **`LiquidityPool.depositETHToRecipient`** to mint backing eETH shares to **weETH**, then **`WeETH.mintFor`** to credit weETH to the depositor—typically **1–2 wei more** than the old path, with no change to pool rate or other holders.
> 
> **LiquidityPool** adds **`LIQUIDITY_POOL_DEPOSIT_ADAPTER_ROLE`** and payable **`depositETHToRecipient`** (same `_deposit` accounting as **`deposit`**, recipient chosen by the role holder). **WeETH** adds **`WEETH_MINTER_ROLE`** and **`mintFor`**, still bounded by the existing **`_afterTokenTransfer`** backing check. **stETH/wstETH** paths still use **`_wrapAndReturn`**.
> 
> **Interfaces**, **TestSetup** role grants for the adapter, and **`test/DepositAdapterDirectMint.t.sol`** cover rate invariance, backing, and access control. **weETH/eETH `Transfer` topology changes** (mint goes adapter → user directly); indexers keyed on adapter-as-intermediate may need review. Production must grant both new roles to **DepositAdapter**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7af8a75fdfcbfa894b32bf1b0ebe16780649a5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->