### PR TITLE
chore: deploy + upgrade scripts for non-EigenPod withdrawal credentials

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -3,6 +3,12 @@ PRIVATE_KEY=
 ETHERSCAN_API_KEY=
 HOODI_PRIVATE_KEY=
 
+# Fork RPCs the test suite needs. `forge test` fails in setUp() without them:
+#   OP_RPC_URL     -> test/liquid-tests/LiquidRefer{Btc,Eth,UsdPermit}.t.sol OP variants
+#   SCROLL_RPC_URL -> Scroll-side sync-pool tests
+OP_RPC_URL=
+SCROLL_RPC_URL=
+
 # TENDERLY
 TENDERLY_ACCESS_KEY=
 TENDERLY_TEST_RPC=

--- a/script/deploys/Deployed.s.sol
+++ b/script/deploys/Deployed.s.sol
@@ -54,6 +54,9 @@ contract Deployed {
     address public constant EARLY_ADOPTER_POOL = 0x7623e9DC0DA6FF821ddb9EbABA794054E078f8c4;
     address public constant CUMULATIVE_MERKLE_REWARDS_DISTRIBUTOR = 0x9A8c5046a290664Bf42D065d33512fe403484534;
     address public constant TREASURY = 0x0c83EAe1FE72c390A02E426572854931EefF93BA;
+    // Retired Treasury (src/archive/Treasury.sol). Ownable, owned by UPGRADE_TIMELOCK.
+    // Still holds ETH; drained to the LiquidityPool via withdraw(uint256,address).
+    address public constant TREASURY_LEGACY = 0x6329004E903B7F420245E7aF3f355186f2432466;
     address public constant WITHDRAW_REQUEST_NFT_BUYBACK_SAFE = 0x2f5301a3D59388c509C65f8698f521377D41Fd0F; // buyback wallet
 
     // role registry & multi-sig

--- a/script/deploys/Deployed.s.sol
+++ b/script/deploys/Deployed.s.sol
@@ -54,9 +54,6 @@ contract Deployed {
     address public constant EARLY_ADOPTER_POOL = 0x7623e9DC0DA6FF821ddb9EbABA794054E078f8c4;
     address public constant CUMULATIVE_MERKLE_REWARDS_DISTRIBUTOR = 0x9A8c5046a290664Bf42D065d33512fe403484534;
     address public constant TREASURY = 0x0c83EAe1FE72c390A02E426572854931EefF93BA;
-    // Retired Treasury (src/archive/Treasury.sol). Ownable, owned by UPGRADE_TIMELOCK.
-    // Still holds ETH; drained to the LiquidityPool via withdraw(uint256,address).
-    address public constant TREASURY_LEGACY = 0x6329004E903B7F420245E7aF3f355186f2432466;
     address public constant WITHDRAW_REQUEST_NFT_BUYBACK_SAFE = 0x2f5301a3D59388c509C65f8698f521377D41Fd0F; // buyback wallet
 
     // role registry & multi-sig

--- a/script/upgrades/non-eigenpod-creds/OracleReportCycle.s.sol
+++ b/script/upgrades/non-eigenpod-creds/OracleReportCycle.s.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {EtherFiAdmin} from "@etherfi/oracle/EtherFiAdmin.sol";
+import {EtherFiOracle} from "@etherfi/oracle/EtherFiOracle.sol";
+import {IEtherFiOracle} from "@etherfi/oracle/interfaces/IEtherFiOracle.sol";
+import {LiquidityPool} from "@etherfi/core/LiquidityPool.sol";
+import {IWithdrawRequestNFT} from "@etherfi/withdrawals/interfaces/IWithdrawRequestNFT.sol";
+import {StakingManager} from "@etherfi/staking/StakingManager.sol";
+import {DeployNonEigenPodCreds} from "./deploy.s.sol";
+
+/**
+ * @title OracleReportCycle
+ * @notice Drives a full oracle report cycle against the UPGRADED EtherFiAdmin.
+ *
+ * Verifying the upgrade lands (impl pointer, immutables) does not prove the oracle still works.
+ * EtherFiAdmin is the oracle entry point, so this applies the upgrade and then runs a real cycle:
+ * submit -> consensus -> executeTasks, asserting the rebase applies exactly and the report cursors
+ * advance.
+ *
+ * Applies the upgrade directly from the timelock rather than through the governance batch, so it
+ * stays valid regardless of what else that batch carries.
+ *
+ * command:
+ * forge script script/upgrades/non-eigenpod-creds/OracleReportCycle.s.sol:OracleReportCycle \
+ *   --fork-url $MAINNET_RPC_URL -vv
+ */
+contract OracleReportCycle is DeployNonEigenPodCreds {
+    EtherFiOracle constant oracle = EtherFiOracle(ETHERFI_ORACLE);
+    EtherFiAdmin constant etherFiAdmin = EtherFiAdmin(ETHERFI_ADMIN);
+    LiquidityPool constant liquidityPool = LiquidityPool(payable(LIQUIDITY_POOL));
+
+    /// @dev ~4.8% APR on a 2.14M ETH TVL over one 1280-slot period, inside the 10% cap and the
+    ///      25 bps per-report positive rebase cap
+    int128 constant ACCRUED_REWARDS = 50 ether;
+
+    function run() public override {
+        _deployAll();
+        _applyUpgrade();
+        _runReportCycle();
+    }
+
+    /// @dev repoints the three UUPS proxies and the node beacon straight from the upgrade timelock
+    function _applyUpgrade() internal {
+        vm.startPrank(UPGRADE_TIMELOCK);
+        UUPSUpgradeable(ETHERFI_NODES_MANAGER).upgradeTo(etherFiNodesManagerImpl);
+        UUPSUpgradeable(STAKING_MANAGER).upgradeTo(stakingManagerImpl);
+        UUPSUpgradeable(ETHERFI_ADMIN).upgradeTo(etherFiAdminImpl);
+        StakingManager(STAKING_MANAGER).upgradeEtherFiNode(etherFiNodeImpl);
+        vm.stopPrank();
+
+        require(getImplementation(ETHERFI_ADMIN) == etherFiAdminImpl, "EtherFiAdmin not upgraded");
+        console2.log("[OK] upgrade applied. EtherFiAdmin impl:", etherFiAdminImpl);
+    }
+
+    function _runReportCycle() internal {
+        // The three live committee members, quorum 3. Pranking them exercises the real consensus
+        // path; the oracle config is left untouched. (Quorum cannot be lowered to 1 anyway:
+        // _checkQuorum requires numActiveCommitteeMembers < 2 * quorumSize.)
+        address[3] memory members = [
+            0x4293664628469891C4043780874bbFe4Dc6223E2,
+            0xc2f2a6308577eC02FF06221b087DBd5960792C9f,
+            0x9B705E518E1Ca057c216b1a64b37d6549a72f506
+        ];
+
+        IEtherFiOracle.OracleReport memory report;
+        report.consensusVersion = oracle.consensusVersion();
+        report.validatorsToApprove = new uint256[](0);
+        report.accruedRewards = ACCRUED_REWARDS;
+        // finalize nothing new: hold the cursor at its current value, zero amount. The report must
+        // never carry an id below withdrawRequestNft.lastFinalizedRequestId().
+        report.lastFinalizedWithdrawalRequestId =
+            IWithdrawRequestNFT(WITHDRAW_REQUEST_NFT).lastFinalizedRequestId();
+        report.finalizedWithdrawalAmount = 0;
+
+        // Roll forward until the window is finalized. Warping can also advance slotTo, so re-read
+        // the stamp each pass rather than computing a single jump.
+        bool ready;
+        for (uint256 i = 0; i < 40 && !ready; i++) {
+            (uint32 slotFrom, uint32 slotTo, uint32 blockFrom) = oracle.blockStampForNextReport();
+            report.refSlotFrom = slotFrom;
+            report.refSlotTo = slotTo;
+            report.refBlockFrom = blockFrom;
+            report.refBlockTo = uint32(block.number - 1);
+            try oracle.verifyReport(report) {
+                ready = true;
+            } catch {
+                vm.warp(block.timestamp + 32 * 12);
+                vm.roll(block.number + 32);
+            }
+        }
+        require(ready, "could not reach a finalized report window");
+        console2.log("report window: refSlotFrom", report.refSlotFrom, "refSlotTo", report.refSlotTo);
+
+        uint256 tvlBefore = liquidityPool.getTotalPooledEther();
+        uint256 rateBefore = liquidityPool.amountForShare(1 ether);
+
+        for (uint256 i = 0; i < members.length; i++) {
+            vm.prank(members[i]);
+            oracle.submitReport(report);
+        }
+        require(
+            oracle.isConsensusReached(oracle.generateReportHash(report)), "consensus not reached"
+        );
+        console2.log("[OK] report submitted by all 3 members, consensus reached");
+
+        uint256 wait = uint256(etherFiAdmin.postReportWaitTimeInSlots());
+        vm.warp(block.timestamp + (wait + 1) * 12);
+        vm.roll(block.number + wait + 1);
+
+        // executeTasks reverts with ReportValidationFailed(reason); surface it rather than a bare bool
+        if (!etherFiAdmin.canExecuteTasks(report)) {
+            try etherFiAdmin.executeTasks(report) {}
+            catch Error(string memory reason) {
+                console2.log("executeTasks rejected the report:", reason);
+                revert(reason);
+            } catch (bytes memory raw) {
+                if (raw.length >= 4 && bytes4(raw) == EtherFiAdmin.ReportValidationFailed.selector) {
+                    console2.log("report rejected:", abi.decode(_slice(raw), (string)));
+                }
+                revert("executeTasks reverted, see log above");
+            }
+        }
+
+        etherFiAdmin.executeTasks(report);
+
+        require(etherFiAdmin.lastHandledReportRefSlot() == report.refSlotTo, "refSlot cursor stuck");
+        require(etherFiAdmin.lastHandledReportRefBlock() == report.refBlockTo, "refBlock cursor stuck");
+
+        uint256 tvlAfter = liquidityPool.getTotalPooledEther();
+        require(
+            tvlAfter == tvlBefore + uint256(uint128(ACCRUED_REWARDS)), "rebase did not apply exactly"
+        );
+        require(liquidityPool.amountForShare(1 ether) > rateBefore, "eETH exchange rate did not rise");
+
+        console2.log("[OK] executeTasks succeeded on the upgraded EtherFiAdmin");
+        console2.log("     TVL before:", tvlBefore);
+        console2.log("     TVL after: ", tvlAfter);
+        console2.log("     rate before:", rateBefore);
+        console2.log("     rate after: ", liquidityPool.amountForShare(1 ether));
+    }
+
+    /// @dev strips the 4-byte selector so the ABI-encoded revert payload can be decoded
+    function _slice(bytes memory raw) internal pure returns (bytes memory out) {
+        out = new bytes(raw.length - 4);
+        for (uint256 i = 4; i < raw.length; i++) out[i - 4] = raw[i];
+    }
+}

--- a/script/upgrades/non-eigenpod-creds/deploy.s.sol
+++ b/script/upgrades/non-eigenpod-creds/deploy.s.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "forge-std/Script.sol";
+import {EtherFiNodesManager} from "@etherfi/staking/EtherFiNodesManager.sol";
+import {EtherFiNode} from "@etherfi/staking/EtherFiNode.sol";
+import {StakingManager} from "@etherfi/staking/StakingManager.sol";
+import {EtherFiAdmin} from "@etherfi/oracle/EtherFiAdmin.sol";
+import {IEtherFiAdmin} from "@etherfi/oracle/interfaces/IEtherFiAdmin.sol";
+import {Deployed} from "@scripts/deploys/Deployed.s.sol";
+import {Utils, ICreate2Factory} from "@scripts/utils/utils.sol";
+
+/**
+ * @title DeployNonEigenPodCreds
+ * @notice Deploys the four implementations changed by the non-EigenPod withdrawal credentials work (PR #485).
+ *
+ * EtherFiNodesManager  UUPS proxy  -> upgradeTo
+ * StakingManager       UUPS proxy  -> upgradeTo
+ * EtherFiAdmin         UUPS proxy  -> upgradeTo
+ * EtherFiNode          beacon impl -> StakingManager.upgradeEtherFiNode
+ *
+ * Constructor args are taken from the live deployments' immutables so the new implementations
+ * keep identical wiring. Deploys via CREATE2 so the addresses are known before the Safe txs
+ * are hashed.
+ *
+ * EtherFiNodesManager sits 98 bytes under the EIP-170 24,576-byte runtime limit, so it must be
+ * compiled with the repo's pinned settings (solc 0.8.27, optimizer_runs = 1500). Run
+ * `forge build --sizes` and confirm before broadcasting.
+ *
+ * command:
+ * forge script script/upgrades/non-eigenpod-creds/deploy.s.sol:DeployNonEigenPodCreds \
+ *   --fork-url $MAINNET_RPC_URL --verify --etherscan-api-key $ETHERSCAN_API_KEY
+ */
+contract DeployNonEigenPodCreds is Script, Deployed, Utils {
+    ICreate2Factory public constant factory = ICreate2Factory(0x356d1B83970CeF2018F2c9337cDdb67dff5AEF99);
+
+    /// @dev release commit for this upgrade; also the CREATE2 salt
+    bytes32 public constant commitHashSalt = bytes32(bytes20(hex"692d3f75d9b7cad14fda1e6922fd35db845fbc4f"));
+
+    // EtherFiAdmin numeric constructor args, read from the live proxy 0x0EF8fa47...
+    int256 public constant ADMIN_MAX_ACCEPTABLE_REBASE_APR_BPS = 1000;
+    uint256 public constant ADMIN_MAX_VALIDATOR_TASK_BATCH_SIZE = 100;
+    uint256 public constant ADMIN_STALE_ORACLE_REPORT_BLOCK_WINDOW = 100_800;
+    uint256 public constant ADMIN_MAX_FINALIZED_WITHDRAWAL_PER_DAY = 150_000 ether;
+    uint256 public constant ADMIN_MAX_VALIDATORS_TO_APPROVE_PER_DAY = 100;
+    uint256 public constant ADMIN_MAX_REQUESTS_TO_FINALIZE_PER_REPORT = 3500;
+
+    address public etherFiNodesManagerImpl;
+    address public etherFiNodeImpl;
+    address public stakingManagerImpl;
+    address public etherFiAdminImpl;
+
+    function run() public virtual {
+        console2.log("================================================");
+        console2.log("=== non-EigenPod withdrawal credentials deploy ==");
+        console2.log("================================================");
+        console2.log("");
+
+        vm.startBroadcast();
+        _deployAll();
+        vm.stopBroadcast();
+
+        console2.log("");
+        console2.log("=== Deployment summary ===");
+        console2.log("EtherFiNodesManager impl:", etherFiNodesManagerImpl);
+        console2.log("EtherFiNode impl:        ", etherFiNodeImpl);
+        console2.log("StakingManager impl:     ", stakingManagerImpl);
+        console2.log("EtherFiAdmin impl:       ", etherFiAdminImpl);
+        console2.log("");
+        console2.log("Paste these into transactions.s.sol before generating the Safe calldata.");
+    }
+
+    /// @notice CREATE2-deploys all four implementations. Idempotent: reuses any that already exist,
+    ///         so the transactions script can call it to stage a fork before the real broadcast.
+    function _deployAll() internal {
+        // EtherFiNodesManager implementation
+        {
+            bytes memory constructorArgs = abi.encode(STAKING_MANAGER, ROLE_REGISTRY, ETHERFI_RATE_LIMITER);
+            bytes memory bytecode = abi.encodePacked(type(EtherFiNodesManager).creationCode, constructorArgs);
+            etherFiNodesManagerImpl =
+                deploy("EtherFiNodesManager", constructorArgs, bytecode, commitHashSalt, true, factory);
+        }
+
+        // EtherFiNode implementation (beacon)
+        {
+            bytes memory constructorArgs =
+                abi.encode(LIQUIDITY_POOL, ETHERFI_NODES_MANAGER, EIGENLAYER_POD_MANAGER, EIGENLAYER_DELEGATION_MANAGER);
+            bytes memory bytecode = abi.encodePacked(type(EtherFiNode).creationCode, constructorArgs);
+            etherFiNodeImpl = deploy("EtherFiNode", constructorArgs, bytecode, commitHashSalt, true, factory);
+        }
+
+        // StakingManager implementation
+        {
+            bytes memory constructorArgs = abi.encode(
+                LIQUIDITY_POOL,
+                ETHERFI_NODES_MANAGER,
+                ETH2_DEPOSIT_CONTRACT,
+                AUCTION_MANAGER,
+                ETHERFI_NODE_BEACON,
+                ROLE_REGISTRY
+            );
+            bytes memory bytecode = abi.encodePacked(type(StakingManager).creationCode, constructorArgs);
+            stakingManagerImpl = deploy("StakingManager", constructorArgs, bytecode, commitHashSalt, true, factory);
+        }
+
+        // EtherFiAdmin implementation
+        {
+            bytes memory constructorArgs = abi.encode(
+                etherFiAdminConstructorAddresses(),
+                ADMIN_MAX_ACCEPTABLE_REBASE_APR_BPS,
+                ADMIN_MAX_VALIDATOR_TASK_BATCH_SIZE,
+                ADMIN_STALE_ORACLE_REPORT_BLOCK_WINDOW,
+                ADMIN_MAX_FINALIZED_WITHDRAWAL_PER_DAY,
+                ADMIN_MAX_VALIDATORS_TO_APPROVE_PER_DAY,
+                ADMIN_MAX_REQUESTS_TO_FINALIZE_PER_REPORT
+            );
+            bytes memory bytecode = abi.encodePacked(type(EtherFiAdmin).creationCode, constructorArgs);
+            // logging disabled: Utils.formatConstructorArgs cannot decode the ConstructorAddresses
+            // struct and reverts with "Unsupported static type".
+            etherFiAdminImpl = deploy("EtherFiAdmin", constructorArgs, bytecode, commitHashSalt, false, factory);
+        }
+    }
+
+    function etherFiAdminConstructorAddresses() internal pure returns (IEtherFiAdmin.ConstructorAddresses memory) {
+        return IEtherFiAdmin.ConstructorAddresses({
+            etherFiOracle: ETHERFI_ORACLE,
+            stakingManager: STAKING_MANAGER,
+            auctionManager: AUCTION_MANAGER,
+            etherFiNodesManager: ETHERFI_NODES_MANAGER,
+            liquidityPool: LIQUIDITY_POOL,
+            withdrawRequestNft: WITHDRAW_REQUEST_NFT,
+            roleRegistry: ROLE_REGISTRY,
+            priorityWithdrawalQueue: PRIORITY_WITHDRAWAL_QUEUE
+        });
+    }
+}

--- a/script/upgrades/non-eigenpod-creds/transactions.s.sol
+++ b/script/upgrades/non-eigenpod-creds/transactions.s.sol
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {EtherFiTimelock} from "@etherfi/governance/EtherFiTimelock.sol";
+import {EtherFiNodesManager} from "@etherfi/staking/EtherFiNodesManager.sol";
+import {EtherFiNode} from "@etherfi/staking/EtherFiNode.sol";
+import {StakingManager} from "@etherfi/staking/StakingManager.sol";
+import {Treasury} from "@etherfi/archive/Treasury.sol";
+import {ContractCodeChecker} from "@scripts/ContractCodeChecker.sol";
+import {DeployNonEigenPodCreds} from "./deploy.s.sol";
+
+/**
+ * @title NonEigenPodCredsTransactions
+ * @notice Builds and fork-verifies the governance transactions for the non-EigenPod withdrawal
+ *         credentials release (PR #485), plus two pieces of adjacent cleanup.
+ *
+ * Two independent routings, because the roles sit on different actors:
+ *
+ *  1. UPGRADE_TIMELOCK batch (10-day delay), proposed by ETHERFI_UPGRADE_ADMIN (6-of-N Safe):
+ *       - EtherFiNodesManager.upgradeTo
+ *       - StakingManager.upgradeTo
+ *       - EtherFiAdmin.upgradeTo
+ *       - StakingManager.upgradeEtherFiNode  (beacon; onlyUpgradeTimelock)
+ *       - Treasury(legacy).withdraw          (Ownable; owner == UPGRADE_TIMELOCK)
+ *     -> run()
+ *
+ *  2. Direct calls from ETHERFI_OPERATING_ADMIN (4-of-7 Safe), no timelock:
+ *       - AvsOperatorManager.adminForwardCall, deregistering ether.fi's AvsOperator proxies from
+ *         their EigenLayer AVSs. Gated by OPERATION_MULTISIG_ROLE, which the UPGRADE_TIMELOCK does
+ *         NOT hold, so this cannot ride in the batch above.
+ *     -> deregisterAvsOperators()
+ *
+ * command:
+ * forge script script/upgrades/non-eigenpod-creds/transactions.s.sol:NonEigenPodCredsTransactions \
+ *   --fork-url $MAINNET_RPC_URL -vvvv
+ */
+contract NonEigenPodCredsTransactions is DeployNonEigenPodCreds {
+    // ---------------------------------------------------------------------------------
+    // Expected CREATE2 addresses for commitHashSalt. These are what the Safe calldata
+    // encodes, so a mismatch against a fresh _deployAll() must halt the script.
+    // ---------------------------------------------------------------------------------
+    address constant EXPECTED_ETHERFI_NODES_MANAGER_IMPL = 0x020016Fa077515451975712595EB3e984907ad3b;
+    address constant EXPECTED_ETHERFI_NODE_IMPL = 0x73Df4a005332525fB0A0B2cf067352a9b706f233;
+    address constant EXPECTED_STAKING_MANAGER_IMPL = 0x6515B41BDcf83BE5543B88591BC0bC34d844c9c2;
+    address constant EXPECTED_ETHERFI_ADMIN_IMPL = 0x841fA691AA6E30E97c817608F90111701a3D0Ac8;
+
+    EtherFiTimelock constant upgradeTimelock = EtherFiTimelock(payable(UPGRADE_TIMELOCK));
+
+    /// @dev UPGRADE_TIMELOCK.getMinDelay() read on-chain: 864000 == 10 days
+    uint256 constant TIMELOCK_MIN_DELAY = 864_000;
+
+    /// @dev TREASURY_LEGACY balance. Only the timelock can withdraw, so the balance can only grow
+    ///      and a fixed amount can never over-withdraw. Re-check before generating Safe hashes.
+    uint256 constant TREASURY_LEGACY_SWEEP_AMOUNT = 9_712_223_546_514_004_611;
+
+    ContractCodeChecker public contractCodeChecker;
+
+    uint256 internal lpBalanceBefore;
+
+    function run() public override {
+        // Stage the fork: CREATE2-deploy the four implementations if they are not on-chain yet, so
+        // this simulates cleanly both before and after the real broadcast. Idempotent.
+        _deployAll();
+        _requireImplsMatchExpected();
+
+        contractCodeChecker = new ContractCodeChecker();
+
+        (address[] memory targets, uint256[] memory values, bytes[] memory data) = _buildUpgradeBatch();
+        bytes32 salt = _timelockSalt(targets, data);
+
+        _logUpgradeBatch(targets, values, data, salt);
+
+        lpBalanceBefore = LIQUIDITY_POOL.balance;
+
+        vm.startPrank(ETHERFI_UPGRADE_ADMIN);
+        upgradeTimelock.scheduleBatch(targets, values, data, bytes32(0), salt, TIMELOCK_MIN_DELAY);
+        vm.warp(block.timestamp + TIMELOCK_MIN_DELAY + 1);
+        upgradeTimelock.executeBatch(targets, values, data, bytes32(0), salt);
+        vm.stopPrank();
+
+        console2.log("Upgrade batch executed on fork");
+        console2.log("================================================");
+        console2.log("");
+
+        verifyDeployedBytecode();
+        verifyUpgrades();
+        verifyTreasurySweep();
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Leg 1 - UPGRADE_TIMELOCK batch
+    // ---------------------------------------------------------------------------------
+
+    function _buildUpgradeBatch()
+        internal
+        pure
+        returns (address[] memory targets, uint256[] memory values, bytes[] memory data)
+    {
+        targets = new address[](5);
+        data = new bytes[](5);
+        values = new uint256[](5);
+
+        // EtherFiNodesManager implementation
+        targets[0] = ETHERFI_NODES_MANAGER;
+        data[0] = abi.encodeWithSelector(UUPSUpgradeable.upgradeTo.selector, EXPECTED_ETHERFI_NODES_MANAGER_IMPL);
+
+        // StakingManager implementation
+        targets[1] = STAKING_MANAGER;
+        data[1] = abi.encodeWithSelector(UUPSUpgradeable.upgradeTo.selector, EXPECTED_STAKING_MANAGER_IMPL);
+
+        // EtherFiAdmin implementation
+        targets[2] = ETHERFI_ADMIN;
+        data[2] = abi.encodeWithSelector(UUPSUpgradeable.upgradeTo.selector, EXPECTED_ETHERFI_ADMIN_IMPL);
+
+        // EtherFiNode beacon implementation. Ordered after the StakingManager upgrade so the beacon
+        // is repointed by the manager build that ships with it.
+        targets[3] = STAKING_MANAGER;
+        data[3] = abi.encodeWithSelector(StakingManager.upgradeEtherFiNode.selector, EXPECTED_ETHERFI_NODE_IMPL);
+
+        // Drain the retired Treasury into the LiquidityPool
+        targets[4] = TREASURY_LEGACY;
+        data[4] = abi.encodeWithSelector(Treasury.withdraw.selector, TREASURY_LEGACY_SWEEP_AMOUNT, LIQUIDITY_POOL);
+    }
+
+    /// @dev Fixed, not block-derived: the Safe tx hashes signers reproduce must be stable across
+    ///      runs. The timelock only needs the salt to be unique against pending operations.
+    bytes32 constant TIMELOCK_SALT = keccak256("etherfi.non-eigenpod-creds.pr485");
+
+    function _timelockSalt(address[] memory, bytes[] memory) internal pure returns (bytes32) {
+        return TIMELOCK_SALT;
+    }
+
+    function logUpgradeBatchCalldata() public view {
+        (address[] memory targets, uint256[] memory values, bytes[] memory data) = _buildUpgradeBatch();
+        _logUpgradeBatch(targets, values, data, _timelockSalt(targets, data));
+    }
+
+    function _logUpgradeBatch(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory data,
+        bytes32 salt
+    ) internal view {
+        console2.log("=== UPGRADE_TIMELOCK batch ===");
+        console2.log("timelock:      ", UPGRADE_TIMELOCK);
+        console2.log("proposer Safe: ", ETHERFI_UPGRADE_ADMIN);
+        console2.log("minDelay:      ", TIMELOCK_MIN_DELAY);
+        console2.log("salt:");
+        console2.logBytes32(salt);
+        console2.log("");
+
+        for (uint256 i = 0; i < targets.length; i++) {
+            console2.log("--- call", i);
+            console2.log("target:", targets[i]);
+            console2.log("value: ", values[i]);
+            console2.log("data:");
+            console2.logBytes(data[i]);
+        }
+        console2.log("");
+
+        console2.log("Schedule calldata (Safe tx 1 -> UPGRADE_TIMELOCK):");
+        console2.logBytes(
+            abi.encodeWithSelector(
+                upgradeTimelock.scheduleBatch.selector, targets, values, data, bytes32(0), salt, TIMELOCK_MIN_DELAY
+            )
+        );
+        console2.log("");
+
+        console2.log("Execute calldata (Safe tx 2 -> UPGRADE_TIMELOCK, after 10 days):");
+        console2.logBytes(
+            abi.encodeWithSelector(upgradeTimelock.executeBatch.selector, targets, values, data, bytes32(0), salt)
+        );
+        console2.log("================================================");
+        console2.log("");
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Verification
+    // ---------------------------------------------------------------------------------
+
+    function verifyDeployedBytecode() public {
+        EtherFiNodesManager freshEtherFiNodesManager =
+            new EtherFiNodesManager(STAKING_MANAGER, ROLE_REGISTRY, ETHERFI_RATE_LIMITER);
+        contractCodeChecker.verifyContractByteCodeMatch(
+            EXPECTED_ETHERFI_NODES_MANAGER_IMPL, address(freshEtherFiNodesManager)
+        );
+
+        EtherFiNode freshEtherFiNode = new EtherFiNode(
+            LIQUIDITY_POOL, ETHERFI_NODES_MANAGER, EIGENLAYER_POD_MANAGER, EIGENLAYER_DELEGATION_MANAGER
+        );
+        contractCodeChecker.verifyContractByteCodeMatch(EXPECTED_ETHERFI_NODE_IMPL, address(freshEtherFiNode));
+
+        StakingManager freshStakingManager = new StakingManager(
+            LIQUIDITY_POOL,
+            ETHERFI_NODES_MANAGER,
+            ETH2_DEPOSIT_CONTRACT,
+            AUCTION_MANAGER,
+            ETHERFI_NODE_BEACON,
+            ROLE_REGISTRY
+        );
+        contractCodeChecker.verifyContractByteCodeMatch(EXPECTED_STAKING_MANAGER_IMPL, address(freshStakingManager));
+
+        console2.log("[OK] deployed bytecode matches this commit");
+    }
+
+    function verifyUpgrades() public view {
+        require(
+            getImplementation(ETHERFI_NODES_MANAGER) == EXPECTED_ETHERFI_NODES_MANAGER_IMPL, "ENM impl mismatch"
+        );
+        require(getImplementation(STAKING_MANAGER) == EXPECTED_STAKING_MANAGER_IMPL, "StakingManager impl mismatch");
+        require(getImplementation(ETHERFI_ADMIN) == EXPECTED_ETHERFI_ADMIN_IMPL, "EtherFiAdmin impl mismatch");
+        require(
+            StakingManager(STAKING_MANAGER).etherFiNodeBeacon().implementation() == EXPECTED_ETHERFI_NODE_IMPL,
+            "EtherFiNode beacon impl mismatch"
+        );
+
+        // The release's new surface must be present in the live implementation, and the dropped
+        // uint256-id overloads must be gone. Off-chain callers still on the id form break here
+        // rather than in production.
+        require(
+            _implHasSelector(
+                EXPECTED_ETHERFI_NODES_MANAGER_IMPL, EtherFiNodesManager.withdrawalCredentialTarget.selector
+            ),
+            "ENM missing withdrawalCredentialTarget"
+        );
+        require(
+            _implHasSelector(EXPECTED_ETHERFI_NODES_MANAGER_IMPL, EtherFiNodesManager.disablePod.selector),
+            "ENM missing disablePod"
+        );
+        require(
+            !_implHasSelector(EXPECTED_ETHERFI_NODES_MANAGER_IMPL, bytes4(keccak256("sweepFunds(uint256)"))),
+            "ENM still exposes the legacy sweepFunds(uint256) overload"
+        );
+
+        console2.log("[OK] all four implementations live");
+    }
+
+    function verifyTreasurySweep() public view {
+        require(TREASURY_LEGACY.balance == 0, "legacy treasury not drained");
+        require(
+            LIQUIDITY_POOL.balance == lpBalanceBefore + TREASURY_LEGACY_SWEEP_AMOUNT,
+            "liquidity pool did not receive the sweep"
+        );
+        console2.log("[OK] legacy treasury drained into the liquidity pool:", TREASURY_LEGACY_SWEEP_AMOUNT);
+    }
+
+    /// @dev scans an implementation's runtime code for a 4-byte selector constant
+    function _implHasSelector(address impl, bytes4 selector) internal view returns (bool) {
+        bytes memory code = impl.code;
+        if (code.length < 4) return false;
+        for (uint256 i = 0; i <= code.length - 4; i++) {
+            if (
+                code[i] == selector[0] && code[i + 1] == selector[1] && code[i + 2] == selector[2]
+                    && code[i + 3] == selector[3]
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _requireImplsMatchExpected() internal view {
+        require(etherFiNodesManagerImpl == EXPECTED_ETHERFI_NODES_MANAGER_IMPL, "ENM impl address drifted");
+        require(etherFiNodeImpl == EXPECTED_ETHERFI_NODE_IMPL, "EtherFiNode impl address drifted");
+        require(stakingManagerImpl == EXPECTED_STAKING_MANAGER_IMPL, "StakingManager impl address drifted");
+        require(etherFiAdminImpl == EXPECTED_ETHERFI_ADMIN_IMPL, "EtherFiAdmin impl address drifted");
+        console2.log("[OK] CREATE2 addresses match the constants encoded in the Safe calldata");
+    }
+}

--- a/script/upgrades/non-eigenpod-creds/transactions.s.sol
+++ b/script/upgrades/non-eigenpod-creds/transactions.s.sol
@@ -3,96 +3,111 @@ pragma solidity ^0.8.27;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";
+import {StdStorage, stdStorage} from "forge-std/StdStorage.sol";
 import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {EtherFiTimelock} from "@etherfi/governance/EtherFiTimelock.sol";
+import {RoleRegistry} from "@etherfi/governance/RoleRegistry.sol";
+import {EtherFiRateLimiter} from "@etherfi/governance/rate-limiting/EtherFiRateLimiter.sol";
 import {EtherFiNodesManager} from "@etherfi/staking/EtherFiNodesManager.sol";
 import {EtherFiNode} from "@etherfi/staking/EtherFiNode.sol";
+import {IEtherFiNode} from "@etherfi/staking/interfaces/IEtherFiNode.sol";
 import {StakingManager} from "@etherfi/staking/StakingManager.sol";
+import {IStakingManager} from "@etherfi/staking/interfaces/IStakingManager.sol";
+import {LiquidityPool} from "@etherfi/core/LiquidityPool.sol";
+import {IAuctionManager} from "@etherfi/staking/interfaces/IAuctionManager.sol";
+import {NodeOperatorManager} from "@etherfi/staking/NodeOperatorManager.sol";
+import {IEigenPodTypes} from "@etherfi/interfaces/eigenlayer-interfaces/IEigenPod.sol";
+import {depositDataRootGenerator} from "@etherfi/staking/libraries/DepositDataRootGenerator.sol";
 import {Treasury} from "@etherfi/archive/Treasury.sol";
 import {ContractCodeChecker} from "@scripts/ContractCodeChecker.sol";
 import {DeployNonEigenPodCreds} from "./deploy.s.sol";
 
 /**
  * @title NonEigenPodCredsTransactions
- * @notice Builds and fork-verifies the governance transactions for the non-EigenPod withdrawal
- *         credentials release (PR #485), plus two pieces of adjacent cleanup.
+ * @notice Governance transactions for the non-EigenPod withdrawal credentials release (PR #485),
+ *         plus a drain of the retired Treasury into the LiquidityPool.
  *
- * Two independent routings, because the roles sit on different actors:
+ * One UPGRADE_TIMELOCK batch (10-day delay) proposed by ETHERFI_UPGRADE_ADMIN:
+ *   0 EtherFiNodesManager.upgradeTo
+ *   1 StakingManager.upgradeTo
+ *   2 EtherFiAdmin.upgradeTo
+ *   3 StakingManager.upgradeEtherFiNode   (beacon; onlyUpgradeTimelock)
+ *   4 Treasury(retired).withdraw          (Ownable; owner == UPGRADE_TIMELOCK)
  *
- *  1. UPGRADE_TIMELOCK batch (10-day delay), proposed by ETHERFI_UPGRADE_ADMIN (6-of-N Safe):
- *       - EtherFiNodesManager.upgradeTo
- *       - StakingManager.upgradeTo
- *       - EtherFiAdmin.upgradeTo
- *       - StakingManager.upgradeEtherFiNode  (beacon; onlyUpgradeTimelock)
- *       - Treasury(legacy).withdraw          (Ownable; owner == UPGRADE_TIMELOCK)
- *     -> run()
+ * run() snapshots immutables, schedules, warps, executes, re-checks immutables, then exercises
+ * the upgraded contracts on the fork: a pod-less validator spin-up, an EL-triggered exit request,
+ * and the classic EigenLayer queue/complete withdrawal path.
  *
- *  2. Direct calls from ETHERFI_OPERATING_ADMIN (4-of-7 Safe), no timelock:
- *       - AvsOperatorManager.adminForwardCall, deregistering ether.fi's AvsOperator proxies from
- *         their EigenLayer AVSs. Gated by OPERATION_MULTISIG_ROLE, which the UPGRADE_TIMELOCK does
- *         NOT hold, so this cannot ride in the batch above.
- *     -> deregisterAvsOperators()
+ * AVS deregistration is deliberately absent. adminForwardCall is gated by OPERATION_MULTISIG_ROLE
+ * on the Operating Safe, which the UPGRADE_TIMELOCK does not hold, so it cannot ride this batch.
  *
  * command:
  * forge script script/upgrades/non-eigenpod-creds/transactions.s.sol:NonEigenPodCredsTransactions \
  *   --fork-url $MAINNET_RPC_URL -vvvv
  */
 contract NonEigenPodCredsTransactions is DeployNonEigenPodCreds {
-    // ---------------------------------------------------------------------------------
-    // Expected CREATE2 addresses for commitHashSalt. These are what the Safe calldata
-    // encodes, so a mismatch against a fresh _deployAll() must halt the script.
-    // ---------------------------------------------------------------------------------
+    using stdStorage for StdStorage;
+
+    // Expected CREATE2 addresses for commitHashSalt; these are what the Safe calldata encodes.
     address constant EXPECTED_ETHERFI_NODES_MANAGER_IMPL = 0x020016Fa077515451975712595EB3e984907ad3b;
     address constant EXPECTED_ETHERFI_NODE_IMPL = 0x73Df4a005332525fB0A0B2cf067352a9b706f233;
     address constant EXPECTED_STAKING_MANAGER_IMPL = 0x6515B41BDcf83BE5543B88591BC0bC34d844c9c2;
     address constant EXPECTED_ETHERFI_ADMIN_IMPL = 0x841fA691AA6E30E97c817608F90111701a3D0Ac8;
 
-    EtherFiTimelock constant upgradeTimelock = EtherFiTimelock(payable(UPGRADE_TIMELOCK));
+    /// @dev retired Treasury, src/archive/Treasury.sol
+    address constant TREASURY_LEGACY = 0x6329004E903B7F420245E7aF3f355186f2432466;
+    /// @dev its balance; only the timelock can withdraw, so it can only grow. Re-check before hashing.
+    uint256 constant TREASURY_LEGACY_SWEEP_AMOUNT = 9_712_223_546_514_004_611;
 
-    /// @dev UPGRADE_TIMELOCK.getMinDelay() read on-chain: 864000 == 10 days
+    EtherFiTimelock constant upgradeTimelock = EtherFiTimelock(payable(UPGRADE_TIMELOCK));
+    RoleRegistry constant roleRegistry = RoleRegistry(ROLE_REGISTRY);
+    EtherFiNodesManager constant etherFiNodesManager = EtherFiNodesManager(payable(ETHERFI_NODES_MANAGER));
+    StakingManager constant stakingManager = StakingManager(STAKING_MANAGER);
+    LiquidityPool constant liquidityPool = LiquidityPool(payable(LIQUIDITY_POOL));
+
+    /// @dev UPGRADE_TIMELOCK.getMinDelay() on-chain
     uint256 constant TIMELOCK_MIN_DELAY = 864_000;
 
-    /// @dev TREASURY_LEGACY balance. Only the timelock can withdraw, so the balance can only grow
-    ///      and a fixed amount can never over-withdraw. Re-check before generating Safe hashes.
-    uint256 constant TREASURY_LEGACY_SWEEP_AMOUNT = 9_712_223_546_514_004_611;
+    /// @dev fixed, not block-derived, so the Safe tx hashes stay reproducible
+    bytes32 constant TIMELOCK_SALT = keccak256("etherfi.non-eigenpod-creds.pr485");
 
     ContractCodeChecker public contractCodeChecker;
 
     uint256 internal lpBalanceBefore;
+    ImmutableSnapshot internal preEnm;
+    ImmutableSnapshot internal preStakingManager;
+    ImmutableSnapshot internal preEtherFiAdmin;
 
     function run() public override {
-        // Stage the fork: CREATE2-deploy the four implementations if they are not on-chain yet, so
-        // this simulates cleanly both before and after the real broadcast. Idempotent.
         _deployAll();
         _requireImplsMatchExpected();
-
         contractCodeChecker = new ContractCodeChecker();
 
-        (address[] memory targets, uint256[] memory values, bytes[] memory data) = _buildUpgradeBatch();
-        bytes32 salt = _timelockSalt(targets, data);
+        _snapshotImmutables();
 
-        _logUpgradeBatch(targets, values, data, salt);
+        (address[] memory targets, uint256[] memory values, bytes[] memory data) = _buildUpgradeBatch();
+        _logUpgradeBatch(targets, values, data, TIMELOCK_SALT);
 
         lpBalanceBefore = LIQUIDITY_POOL.balance;
 
         vm.startPrank(ETHERFI_UPGRADE_ADMIN);
-        upgradeTimelock.scheduleBatch(targets, values, data, bytes32(0), salt, TIMELOCK_MIN_DELAY);
+        upgradeTimelock.scheduleBatch(targets, values, data, bytes32(0), TIMELOCK_SALT, TIMELOCK_MIN_DELAY);
         vm.warp(block.timestamp + TIMELOCK_MIN_DELAY + 1);
-        upgradeTimelock.executeBatch(targets, values, data, bytes32(0), salt);
+        upgradeTimelock.executeBatch(targets, values, data, bytes32(0), TIMELOCK_SALT);
         vm.stopPrank();
 
-        console2.log("Upgrade batch executed on fork");
-        console2.log("================================================");
+        console2.log("upgrade batch executed on fork");
         console2.log("");
 
         verifyDeployedBytecode();
         verifyUpgrades();
+        verifyImmutablesPreserved();
         verifyTreasurySweep();
+
+        forkTests();
     }
 
-    // ---------------------------------------------------------------------------------
-    // Leg 1 - UPGRADE_TIMELOCK batch
-    // ---------------------------------------------------------------------------------
+    // ------------------------------------------------------------------ batch
 
     function _buildUpgradeBatch()
         internal
@@ -103,39 +118,26 @@ contract NonEigenPodCredsTransactions is DeployNonEigenPodCreds {
         data = new bytes[](5);
         values = new uint256[](5);
 
-        // EtherFiNodesManager implementation
         targets[0] = ETHERFI_NODES_MANAGER;
         data[0] = abi.encodeWithSelector(UUPSUpgradeable.upgradeTo.selector, EXPECTED_ETHERFI_NODES_MANAGER_IMPL);
 
-        // StakingManager implementation
         targets[1] = STAKING_MANAGER;
         data[1] = abi.encodeWithSelector(UUPSUpgradeable.upgradeTo.selector, EXPECTED_STAKING_MANAGER_IMPL);
 
-        // EtherFiAdmin implementation
         targets[2] = ETHERFI_ADMIN;
         data[2] = abi.encodeWithSelector(UUPSUpgradeable.upgradeTo.selector, EXPECTED_ETHERFI_ADMIN_IMPL);
 
-        // EtherFiNode beacon implementation. Ordered after the StakingManager upgrade so the beacon
-        // is repointed by the manager build that ships with it.
+        // after call 1 so the beacon is repointed by the StakingManager build shipping with it
         targets[3] = STAKING_MANAGER;
         data[3] = abi.encodeWithSelector(StakingManager.upgradeEtherFiNode.selector, EXPECTED_ETHERFI_NODE_IMPL);
 
-        // Drain the retired Treasury into the LiquidityPool
         targets[4] = TREASURY_LEGACY;
         data[4] = abi.encodeWithSelector(Treasury.withdraw.selector, TREASURY_LEGACY_SWEEP_AMOUNT, LIQUIDITY_POOL);
     }
 
-    /// @dev Fixed, not block-derived: the Safe tx hashes signers reproduce must be stable across
-    ///      runs. The timelock only needs the salt to be unique against pending operations.
-    bytes32 constant TIMELOCK_SALT = keccak256("etherfi.non-eigenpod-creds.pr485");
-
-    function _timelockSalt(address[] memory, bytes[] memory) internal pure returns (bytes32) {
-        return TIMELOCK_SALT;
-    }
-
     function logUpgradeBatchCalldata() public view {
-        (address[] memory targets, uint256[] memory values, bytes[] memory data) = _buildUpgradeBatch();
-        _logUpgradeBatch(targets, values, data, _timelockSalt(targets, data));
+        (address[] memory t, uint256[] memory v, bytes[] memory d) = _buildUpgradeBatch();
+        _logUpgradeBatch(t, v, d, TIMELOCK_SALT);
     }
 
     function _logUpgradeBatch(
@@ -145,55 +147,106 @@ contract NonEigenPodCredsTransactions is DeployNonEigenPodCreds {
         bytes32 salt
     ) internal view {
         console2.log("=== UPGRADE_TIMELOCK batch ===");
-        console2.log("timelock:      ", UPGRADE_TIMELOCK);
-        console2.log("proposer Safe: ", ETHERFI_UPGRADE_ADMIN);
-        console2.log("minDelay:      ", TIMELOCK_MIN_DELAY);
+        console2.log("timelock:     ", UPGRADE_TIMELOCK);
+        console2.log("proposer Safe:", ETHERFI_UPGRADE_ADMIN);
+        console2.log("minDelay:     ", TIMELOCK_MIN_DELAY);
         console2.log("salt:");
         console2.logBytes32(salt);
-        console2.log("");
 
         for (uint256 i = 0; i < targets.length; i++) {
             console2.log("--- call", i);
             console2.log("target:", targets[i]);
-            console2.log("value: ", values[i]);
             console2.log("data:");
             console2.logBytes(data[i]);
         }
-        console2.log("");
 
-        console2.log("Schedule calldata (Safe tx 1 -> UPGRADE_TIMELOCK):");
+        console2.log("Schedule calldata:");
         console2.logBytes(
             abi.encodeWithSelector(
                 upgradeTimelock.scheduleBatch.selector, targets, values, data, bytes32(0), salt, TIMELOCK_MIN_DELAY
             )
         );
-        console2.log("");
-
-        console2.log("Execute calldata (Safe tx 2 -> UPGRADE_TIMELOCK, after 10 days):");
+        console2.log("Execute calldata:");
         console2.logBytes(
             abi.encodeWithSelector(upgradeTimelock.executeBatch.selector, targets, values, data, bytes32(0), salt)
         );
-        console2.log("================================================");
         console2.log("");
     }
 
-    // ---------------------------------------------------------------------------------
-    // Verification
-    // ---------------------------------------------------------------------------------
+    // ------------------------------------------------------- immutable checks
+
+    function _enmImmutableSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](3);
+        s[0] = bytes4(keccak256("stakingManager()"));
+        s[1] = bytes4(keccak256("roleRegistry()"));
+        s[2] = bytes4(keccak256("rateLimiter()"));
+    }
+
+    function _stakingManagerImmutableSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](6);
+        s[0] = bytes4(keccak256("liquidityPool()"));
+        s[1] = bytes4(keccak256("etherFiNodesManager()"));
+        s[2] = bytes4(keccak256("depositContractEth2()"));
+        s[3] = bytes4(keccak256("auctionManager()"));
+        s[4] = bytes4(keccak256("etherFiNodeBeacon()"));
+        s[5] = bytes4(keccak256("roleRegistry()"));
+    }
+
+    function _etherFiAdminImmutableSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](14);
+        s[0] = bytes4(keccak256("etherFiOracle()"));
+        s[1] = bytes4(keccak256("stakingManager()"));
+        s[2] = bytes4(keccak256("auctionManager()"));
+        s[3] = bytes4(keccak256("etherFiNodesManager()"));
+        s[4] = bytes4(keccak256("liquidityPool()"));
+        s[5] = bytes4(keccak256("withdrawRequestNft()"));
+        s[6] = bytes4(keccak256("priorityWithdrawalQueue()"));
+        s[7] = bytes4(keccak256("roleRegistry()"));
+        s[8] = bytes4(keccak256("maxAcceptableRebaseAprInBps()"));
+        s[9] = bytes4(keccak256("maxValidatorTaskBatchSize()"));
+        s[10] = bytes4(keccak256("maxNumberOfRequestsToFinalizePerReport()"));
+        s[11] = bytes4(keccak256("maxAcceptableFinalizedWithdrawalAmountPerDay()"));
+        s[12] = bytes4(keccak256("maxAcceptableNumValidatorsToApprovePerDay()"));
+        s[13] = bytes4(keccak256("staleOracleReportBlockWindow()"));
+    }
+
+    function _snapshotImmutables() internal {
+        preEnm = takeImmutableSnapshot(ETHERFI_NODES_MANAGER, _enmImmutableSelectors());
+        preStakingManager = takeImmutableSnapshot(STAKING_MANAGER, _stakingManagerImmutableSelectors());
+        preEtherFiAdmin = takeImmutableSnapshot(ETHERFI_ADMIN, _etherFiAdminImmutableSelectors());
+        console2.log("[OK] pre-upgrade immutables snapshotted");
+    }
+
+    function verifyImmutablesPreserved() public view {
+        verifyImmutablesUnchanged(
+            preEnm, takeImmutableSnapshot(ETHERFI_NODES_MANAGER, _enmImmutableSelectors()), "EtherFiNodesManager"
+        );
+        verifyImmutablesUnchanged(
+            preStakingManager,
+            takeImmutableSnapshot(STAKING_MANAGER, _stakingManagerImmutableSelectors()),
+            "StakingManager"
+        );
+        verifyImmutablesUnchanged(
+            preEtherFiAdmin, takeImmutableSnapshot(ETHERFI_ADMIN, _etherFiAdminImmutableSelectors()), "EtherFiAdmin"
+        );
+
+        verifyNotReinitializable(ETHERFI_NODES_MANAGER, "EtherFiNodesManager");
+        verifyNotReinitializable(STAKING_MANAGER, "StakingManager");
+        verifyNotReinitializable(ETHERFI_ADMIN, "EtherFiAdmin");
+    }
+
+    // ------------------------------------------------------------ upgrade checks
 
     function verifyDeployedBytecode() public {
-        EtherFiNodesManager freshEtherFiNodesManager =
-            new EtherFiNodesManager(STAKING_MANAGER, ROLE_REGISTRY, ETHERFI_RATE_LIMITER);
-        contractCodeChecker.verifyContractByteCodeMatch(
-            EXPECTED_ETHERFI_NODES_MANAGER_IMPL, address(freshEtherFiNodesManager)
-        );
+        EtherFiNodesManager freshEnm = new EtherFiNodesManager(STAKING_MANAGER, ROLE_REGISTRY, ETHERFI_RATE_LIMITER);
+        contractCodeChecker.verifyContractByteCodeMatch(EXPECTED_ETHERFI_NODES_MANAGER_IMPL, address(freshEnm));
 
-        EtherFiNode freshEtherFiNode = new EtherFiNode(
+        EtherFiNode freshNode = new EtherFiNode(
             LIQUIDITY_POOL, ETHERFI_NODES_MANAGER, EIGENLAYER_POD_MANAGER, EIGENLAYER_DELEGATION_MANAGER
         );
-        contractCodeChecker.verifyContractByteCodeMatch(EXPECTED_ETHERFI_NODE_IMPL, address(freshEtherFiNode));
+        contractCodeChecker.verifyContractByteCodeMatch(EXPECTED_ETHERFI_NODE_IMPL, address(freshNode));
 
-        StakingManager freshStakingManager = new StakingManager(
+        StakingManager freshSm = new StakingManager(
             LIQUIDITY_POOL,
             ETHERFI_NODES_MANAGER,
             ETH2_DEPOSIT_CONTRACT,
@@ -201,40 +254,19 @@ contract NonEigenPodCredsTransactions is DeployNonEigenPodCreds {
             ETHERFI_NODE_BEACON,
             ROLE_REGISTRY
         );
-        contractCodeChecker.verifyContractByteCodeMatch(EXPECTED_STAKING_MANAGER_IMPL, address(freshStakingManager));
+        contractCodeChecker.verifyContractByteCodeMatch(EXPECTED_STAKING_MANAGER_IMPL, address(freshSm));
 
         console2.log("[OK] deployed bytecode matches this commit");
     }
 
     function verifyUpgrades() public view {
-        require(
-            getImplementation(ETHERFI_NODES_MANAGER) == EXPECTED_ETHERFI_NODES_MANAGER_IMPL, "ENM impl mismatch"
-        );
+        require(getImplementation(ETHERFI_NODES_MANAGER) == EXPECTED_ETHERFI_NODES_MANAGER_IMPL, "ENM impl mismatch");
         require(getImplementation(STAKING_MANAGER) == EXPECTED_STAKING_MANAGER_IMPL, "StakingManager impl mismatch");
         require(getImplementation(ETHERFI_ADMIN) == EXPECTED_ETHERFI_ADMIN_IMPL, "EtherFiAdmin impl mismatch");
         require(
-            StakingManager(STAKING_MANAGER).etherFiNodeBeacon().implementation() == EXPECTED_ETHERFI_NODE_IMPL,
+            stakingManager.etherFiNodeBeacon().implementation() == EXPECTED_ETHERFI_NODE_IMPL,
             "EtherFiNode beacon impl mismatch"
         );
-
-        // The release's new surface must be present in the live implementation, and the dropped
-        // uint256-id overloads must be gone. Off-chain callers still on the id form break here
-        // rather than in production.
-        require(
-            _implHasSelector(
-                EXPECTED_ETHERFI_NODES_MANAGER_IMPL, EtherFiNodesManager.withdrawalCredentialTarget.selector
-            ),
-            "ENM missing withdrawalCredentialTarget"
-        );
-        require(
-            _implHasSelector(EXPECTED_ETHERFI_NODES_MANAGER_IMPL, EtherFiNodesManager.disablePod.selector),
-            "ENM missing disablePod"
-        );
-        require(
-            !_implHasSelector(EXPECTED_ETHERFI_NODES_MANAGER_IMPL, bytes4(keccak256("sweepFunds(uint256)"))),
-            "ENM still exposes the legacy sweepFunds(uint256) overload"
-        );
-
         console2.log("[OK] all four implementations live");
     }
 
@@ -244,29 +276,165 @@ contract NonEigenPodCredsTransactions is DeployNonEigenPodCreds {
             LIQUIDITY_POOL.balance == lpBalanceBefore + TREASURY_LEGACY_SWEEP_AMOUNT,
             "liquidity pool did not receive the sweep"
         );
-        console2.log("[OK] legacy treasury drained into the liquidity pool:", TREASURY_LEGACY_SWEEP_AMOUNT);
+        console2.log("[OK] treasury drained into the liquidity pool:", TREASURY_LEGACY_SWEEP_AMOUNT);
     }
 
-    /// @dev scans an implementation's runtime code for a 4-byte selector constant
-    function _implHasSelector(address impl, bytes4 selector) internal view returns (bool) {
-        bytes memory code = impl.code;
-        if (code.length < 4) return false;
-        for (uint256 i = 0; i <= code.length - 4; i++) {
-            if (
-                code[i] == selector[0] && code[i + 1] == selector[1] && code[i + 2] == selector[2]
-                    && code[i + 3] == selector[3]
-            ) {
-                return true;
-            }
-        }
-        return false;
+    // ---------------------------------------------------------------- fork tests
+
+    function forkTests() public {
+        _grantForkTestRoles();
+        (address node, bytes memory pubkey) = forkTestSpinUpPodlessValidator();
+        forkTestElTriggeredExit(node, pubkey);
+        forkTestEigenLayerWithdrawal();
     }
+
+    /// @dev granted outside the timelock batch so the proposal's calldata is unaffected
+    function _grantForkTestRoles() internal {
+        vm.startPrank(UPGRADE_TIMELOCK);
+        roleRegistry.grantRole(roleRegistry.EXECUTOR_OPERATIONS_ROLE(), ADMIN_EOA);
+        roleRegistry.grantRole(roleRegistry.ORACLE_OPERATIONS_ROLE(), ADMIN_EOA);
+        roleRegistry.grantRole(roleRegistry.HOUSEKEEPING_OPERATIONS_ROLE(), ADMIN_EOA);
+        vm.stopPrank();
+    }
+
+    /// @notice pod-less validator: withdrawal credentials point at the node, not an EigenPod
+    function forkTestSpinUpPodlessValidator() public returns (address, bytes memory) {
+        address spawner = makeAddr("forkTestSpawner");
+        address operator = makeAddr("forkTestOperator");
+
+        vm.deal(LIQUIDITY_POOL, LIQUIDITY_POOL.balance + 10_000 ether);
+
+        vm.prank(OPERATING_TIMELOCK);
+        liquidityPool.registerValidatorSpawner(spawner);
+
+        vm.prank(ETHERFI_OPERATING_ADMIN);
+        NodeOperatorManager(NODE_OPERATOR_MANAGER).addToWhitelist(operator);
+        vm.prank(operator);
+        NodeOperatorManager(NODE_OPERATOR_MANAGER).registerNodeOperator("test_ipfs_hash", 1000);
+
+        vm.deal(operator, 1 ether);
+        vm.prank(operator);
+        uint256[] memory bidIds = IAuctionManager(AUCTION_MANAGER).createBid{value: 0.1 ether}(1, 0.1 ether);
+
+        vm.prank(ADMIN_EOA);
+        address node = stakingManager.instantiateEtherFiNode(false);
+        require(etherFiNodesManager.withdrawalCredentialTarget(node) == node, "pod-less target must be the node");
+
+        bytes memory creds = abi.encodePacked(bytes1(0x02), bytes11(0x0), node);
+        bytes memory pubkey = new bytes(48);
+        bytes memory sig = new bytes(96);
+        for (uint256 i = 0; i < 48; i++) pubkey[i] = 0xab;
+        for (uint256 i = 0; i < 96; i++) sig[i] = 0xcd;
+
+        IStakingManager.DepositData[] memory dd = new IStakingManager.DepositData[](1);
+        dd[0] = IStakingManager.DepositData({
+            publicKey: pubkey,
+            signature: sig,
+            depositDataRoot: depositDataRootGenerator.generateDepositDataRoot(pubkey, sig, creds, 1 ether),
+            ipfsHashForEncryptedValidatorKey: "test_ipfs_hash"
+        });
+
+        vm.prank(spawner);
+        liquidityPool.batchRegister(dd, bidIds, node);
+        vm.prank(ADMIN_EOA);
+        liquidityPool.batchCreateBeaconValidators(dd, bidIds, node);
+
+        // top-up root is built over 31 ETH, not 32
+        IStakingManager.DepositData[] memory dd31 = new IStakingManager.DepositData[](1);
+        dd31[0] = dd[0];
+        dd31[0].depositDataRoot = depositDataRootGenerator.generateDepositDataRoot(pubkey, sig, creds, 31 ether);
+        vm.prank(ADMIN_EOA);
+        liquidityPool.confirmAndFundBeaconValidators(dd31, 32 ether);
+
+        console2.log("[OK] pod-less validator spun up on node", node);
+        return (node, pubkey);
+    }
+
+    /// @notice EL-triggered full exit on a pod-less node: straight to the EIP-7002 predeploy, no
+    ///         EigenPod involved. Uses the node just spun up, so the validator is linked in our own
+    ///         pubkey map, which is what the pod-less branch checks instead of pod membership.
+    function forkTestElTriggeredExit(address node, bytes memory pubkey) public {
+        require(etherFiNodesManager.getEigenPod(node) == address(0), "expected a pod-less node");
+
+        _ensureExitCapacity();
+
+        IEigenPodTypes.WithdrawalRequest[] memory reqs = new IEigenPodTypes.WithdrawalRequest[](1);
+        reqs[0] = IEigenPodTypes.WithdrawalRequest({pubkey: pubkey, amountGwei: 0}); // 0 == full exit
+
+        uint256 fee = IEtherFiNode(node).getWithdrawalRequestFee();
+        vm.deal(ADMIN_EOA, ADMIN_EOA.balance + fee + 1 ether);
+        vm.prank(ADMIN_EOA);
+        etherFiNodesManager.requestExecutionLayerTriggeredWithdrawal{value: fee}(reqs);
+
+        console2.log("[OK] EL-triggered exit requested for node", node);
+        console2.log("     fee paid:", fee);
+    }
+
+    /// @notice classic EigenLayer queue -> delay -> complete, proceeds land in the LiquidityPool
+    function forkTestEigenLayerWithdrawal() public {
+        bytes memory pubkey =
+            hex"8f9c0aab19ee7586d3d470f132842396af606947a0589382483308fdffdaf544078c3be24210677a9c471ce70b3b4c2c";
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 10270;
+        bytes[] memory pubkeys = new bytes[](1);
+        pubkeys[0] = pubkey;
+        vm.prank(ETHERFI_OPERATING_ADMIN);
+        etherFiNodesManager.linkLegacyValidatorIds(ids, pubkeys);
+
+        address node = address(etherFiNodesManager.etherFiNodeFromPubkeyHash(
+            etherFiNodesManager.calculateValidatorPubkeyHash(pubkey)
+        ));
+        address pod = etherFiNodesManager.getEigenPod(node);
+        require(pod != address(0), "fixture node has no EigenPod");
+
+        // slot 52 is withdrawableRestakedExecutionLayerGwei; both pokes must precede the queue
+        vm.store(pod, bytes32(uint256(52)), bytes32(uint256(10_000 ether / 1 gwei)));
+        vm.deal(pod, 10_000 ether);
+        stdstore.target(EIGENLAYER_POD_MANAGER).sig("podOwnerDepositShares(address)").with_key(node)
+            .checked_write_int(int256(10_000 ether));
+
+        _ensureUnrestakingCapacity();
+
+        uint256 lpBefore = LIQUIDITY_POOL.balance;
+        vm.prank(ADMIN_EOA);
+        etherFiNodesManager.queueETHWithdrawal(node, 1 ether);
+
+        vm.roll(block.number + 100_800 + 1);
+
+        vm.prank(ADMIN_EOA);
+        etherFiNodesManager.completeQueuedETHWithdrawals(node, true);
+
+        require(LIQUIDITY_POOL.balance > lpBefore, "liquidity pool received no withdrawal proceeds");
+        console2.log("[OK] EigenLayer withdrawal completed. LP delta:", LIQUIDITY_POOL.balance - lpBefore);
+    }
+
+    // -------------------------------------------------------------- rate limits
+
+    function _ensureExitCapacity() internal {
+        _topUpLimit(etherFiNodesManager.EXIT_REQUEST_LIMIT_ID());
+    }
+
+    function _ensureUnrestakingCapacity() internal {
+        _topUpLimit(etherFiNodesManager.UNRESTAKING_LIMIT_ID());
+    }
+
+    /// @dev limits are denominated in gwei; the limiter and its consumers already exist on mainnet
+    function _topUpLimit(bytes32 limitId) internal {
+        EtherFiRateLimiter limiter = EtherFiRateLimiter(payable(ETHERFI_RATE_LIMITER));
+        uint64 capacity = 20_000_000 * 1e9;
+        vm.startPrank(OPERATING_TIMELOCK);
+        limiter.setCapacity(limitId, capacity);
+        limiter.setRemaining(limitId, capacity);
+        vm.stopPrank();
+    }
+
+    // ---------------------------------------------------------------- internals
 
     function _requireImplsMatchExpected() internal view {
         require(etherFiNodesManagerImpl == EXPECTED_ETHERFI_NODES_MANAGER_IMPL, "ENM impl address drifted");
         require(etherFiNodeImpl == EXPECTED_ETHERFI_NODE_IMPL, "EtherFiNode impl address drifted");
         require(stakingManagerImpl == EXPECTED_STAKING_MANAGER_IMPL, "StakingManager impl address drifted");
         require(etherFiAdminImpl == EXPECTED_ETHERFI_ADMIN_IMPL, "EtherFiAdmin impl address drifted");
-        console2.log("[OK] CREATE2 addresses match the constants encoded in the Safe calldata");
+        console2.log("[OK] CREATE2 addresses match the Safe calldata");
     }
 }

--- a/test/EtherFiRedemptionManager.t.sol
+++ b/test/EtherFiRedemptionManager.t.sol
@@ -881,9 +881,22 @@ contract EtherFiRedemptionManagerTest is TestSetup {
         liquidityPoolInstance.deposit{value: 10 ether}();
         address lidoToken = address(etherFiRestakerInstance.lido()); // external call; fetch before expectRevert
         eETHInstance.approve(address(etherFiRedemptionManagerInstance), 1 ether);
+        vm.stopPrank();
+
+        // The watermark only blocks the redeem while it exceeds the restaker's stETH balance.
+        // That balance is a live mainnet position and its share of TVL drifts (it has since
+        // grown past the 20_00 bps set above), so derive the blocking bps from current state
+        // rather than assuming a fixed percentage still clears it.
+        uint256 stEthLiquidity = stEth.balanceOf(address(etherFiRestakerInstance));
+        uint256 blockingBps = (stEthLiquidity * 10_000) / liquidityPoolInstance.getTotalPooledEther() + 1;
+        assertLe(blockingBps, etherFiRedemptionManagerInstance.maxLowWatermarkInBpsOfTvl());
+        vm.prank(op_admin);
+        etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(uint16(blockingBps), lidoToken);
+
+        vm.prank(user);
         vm.expectRevert(EtherFiRedemptionManager.ExceededRedeemable.selector);
         etherFiRedemptionManagerInstance.redeemEEth(1 ether, user, lidoToken);
-        vm.stopPrank();
+
         vm.startPrank(op_admin);
         etherFiRedemptionManagerInstance.setLowWatermarkInBpsOfTvl(0, lidoToken);
         vm.stopPrank();

--- a/test/integration-tests/Validator-Flows.t.sol
+++ b/test/integration-tests/Validator-Flows.t.sol
@@ -102,23 +102,31 @@ contract ValidatorFlowsIntegrationTest is TestSetup, Deployed {
             vm.store(address(etherFiAdminInstance), bytes32(uint256(209)), bytes32(val));
         }
 
-        // Step B: unconditionally reset operator submissions by removing and re-adding each one.
-        // addCommitteeMember() resets CommitteeMemberState to
-        // (registered=true, enabled=true, lastReportRefSlot=0, numReports=0), clearing any stale
-        // submission from mainnet without adding new committee members.
-        address oracleOwner = roleRegistryInstance.owner();
-        // Each add/remove now requires a _quorumSize that satisfies the strict-majority
-        // invariant for the resulting numActive. Compute a fresh value at each step
-        // so this works regardless of mainnet's current quorum.
-        vm.startPrank(oracleOwner);
-        uint32 active = etherFiOracleInstance.numActiveCommitteeMembers();
-        uint32 quorumAfterRemove = active > 1 ? (active - 1) / 2 + 1 : 1;
-        uint32 quorumAfterAdd = active / 2 + 1;
-        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_1, quorumAfterRemove);
-        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_1, quorumAfterAdd);
-        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_2, quorumAfterRemove);
-        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_2, quorumAfterAdd);
-        vm.stopPrank();
+        // Step B: make AVS_OPERATOR_1 and AVS_OPERATOR_2 the two signers that reach quorum.
+        // Mainnet's committee composition drifts: both operators have since been rotated off,
+        // so removeCommitteeMember reverts NotRegistered, and re-adding them leaves the
+        // strict-majority quorum above the two signers these tests prank as. Write the
+        // committee state directly so the setup does not depend on who is registered today.
+        _forceCommitteeMember(AVS_OPERATOR_1);
+        _forceCommitteeMember(AVS_OPERATOR_2);
+        _forceQuorumSize(2);
+    }
+
+    /// @dev Marks `_member` as a registered, enabled committee member with no prior submission.
+    ///      EtherFiOracle slot 251 holds `committeeMemberStates`; each entry packs
+    ///      registered (byte 0) + enabled (byte 1) + lastReportRefSlot + numReports.
+    function _forceCommitteeMember(address _member) internal {
+        bytes32 slot = keccak256(abi.encode(_member, uint256(251)));
+        vm.store(address(etherFiOracleInstance), slot, bytes32(uint256(0x0101)));
+    }
+
+    /// @dev Overwrites `quorumSize` (slot 253, offset 4) directly. setQuorumSize() would reject
+    ///      any value that breaks the strict-majority invariant against the live member count.
+    function _forceQuorumSize(uint32 _quorumSize) internal {
+        uint256 packed = uint256(vm.load(address(etherFiOracleInstance), bytes32(uint256(253))));
+        packed &= ~(uint256(type(uint32).max) << 32);
+        packed |= uint256(_quorumSize) << 32;
+        vm.store(address(etherFiOracleInstance), bytes32(uint256(253)), bytes32(packed));
     }
 
     function _toArray(IStakingManager.DepositData memory d) internal pure returns (IStakingManager.DepositData[] memory arr) {

--- a/test/integration-tests/Withdraw.t.sol
+++ b/test/integration-tests/Withdraw.t.sol
@@ -81,28 +81,31 @@ contract WithdrawIntegrationTest is TestSetup, Deployed {
             vm.store(address(etherFiAdminInstance), bytes32(uint256(209)), bytes32(val));
         }
 
-        // Step B: unconditionally reset operator submissions by removing and re-adding each one.
-        // addCommitteeMember() resets CommitteeMemberState to
-        // (registered=true, enabled=true, lastReportRefSlot=0, numReports=0), clearing any stale
-        // submission from mainnet without adding new committee members.
-        address oracleOwner = roleRegistryInstance.owner();
-        // add/removeCommitteeMember now route through OPERATION_TIMELOCK_ROLE.
-        bytes32 opTimelockRole = roleRegistryInstance.OPERATION_TIMELOCK_ROLE();
-        address rrOwner = roleRegistryInstance.owner();
-        vm.prank(rrOwner);
-        roleRegistryInstance.grantRole(opTimelockRole, oracleOwner);
-        vm.startPrank(oracleOwner);
-        // Each add/remove now requires a _quorumSize that satisfies the strict-majority
-        // invariant for the resulting numActive. Compute fresh values so this works
-        // regardless of mainnet's current quorum.
-        uint32 active = etherFiOracleInstance.numActiveCommitteeMembers();
-        uint32 quorumAfterRemove = active > 1 ? (active - 1) / 2 + 1 : 1;
-        uint32 quorumAfterAdd = active / 2 + 1;
-        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_1, quorumAfterRemove);
-        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_1, quorumAfterAdd);
-        etherFiOracleInstance.removeCommitteeMember(AVS_OPERATOR_2, quorumAfterRemove);
-        etherFiOracleInstance.addCommitteeMember(AVS_OPERATOR_2, quorumAfterAdd);
-        vm.stopPrank();
+        // Step B: make AVS_OPERATOR_1 and AVS_OPERATOR_2 the two signers that reach quorum.
+        // Mainnet's committee composition drifts: both operators have since been rotated off,
+        // so removeCommitteeMember reverts NotRegistered, and re-adding them leaves the
+        // strict-majority quorum above the two signers these tests prank as. Write the
+        // committee state directly so the setup does not depend on who is registered today.
+        _forceCommitteeMember(AVS_OPERATOR_1);
+        _forceCommitteeMember(AVS_OPERATOR_2);
+        _forceQuorumSize(2);
+    }
+
+    /// @dev Marks `_member` as a registered, enabled committee member with no prior submission.
+    ///      EtherFiOracle slot 251 holds `committeeMemberStates`; each entry packs
+    ///      registered (byte 0) + enabled (byte 1) + lastReportRefSlot + numReports.
+    function _forceCommitteeMember(address _member) internal {
+        bytes32 slot = keccak256(abi.encode(_member, uint256(251)));
+        vm.store(address(etherFiOracleInstance), slot, bytes32(uint256(0x0101)));
+    }
+
+    /// @dev Overwrites `quorumSize` (slot 253, offset 4) directly. setQuorumSize() would reject
+    ///      any value that breaks the strict-majority invariant against the live member count.
+    function _forceQuorumSize(uint32 _quorumSize) internal {
+        uint256 packed = uint256(vm.load(address(etherFiOracleInstance), bytes32(uint256(253))));
+        packed &= ~(uint256(type(uint32).max) << 32);
+        packed |= uint256(_quorumSize) << 32;
+        vm.store(address(etherFiOracleInstance), bytes32(uint256(253)), bytes32(packed));
     }
 
     /// @dev Mirrors EtherFiAdmin._validateReport's sum-of-requests sanity check.


### PR DESCRIPTION
Deploy and upgrade scripts for the non-EigenPod withdrawal credentials release. Branches off #485.

Governance proposal: [3CP-secure#662](https://github.com/etherfi-protocol/3CP-secure/pull/662).

## What's here

`script/upgrades/non-eigenpod-creds/deploy.s.sol` — CREATE2-deploys the four implementations PR #485 changes:

| Contract | Upgrade path | Runtime size |
|---|---|---|
| EtherFiNodesManager | UUPS `upgradeTo` | 24,478 / 24,576 |
| StakingManager | UUPS `upgradeTo` | 14,939 |
| EtherFiAdmin | UUPS `upgradeTo` | 19,643 |
| EtherFiNode | beacon, via `StakingManager.upgradeEtherFiNode` | 12,156 |

Constructor args are read off the live deployments' immutables rather than copied from an older script — the existing `reaudit-fixes` deploy passes five args to `EtherFiNode`, which now takes four.

`script/upgrades/non-eigenpod-creds/transactions.s.sol` — builds the UPGRADE_TIMELOCK batch (5 calls: the four upgrades plus `Treasury.withdraw`), prints the schedule/execute calldata, then fork-simulates schedule → +10 days → execute and asserts the end state.

`script/deploys/Deployed.s.sol` — adds `TREASURY_LEGACY` for the retired Treasury at `0x6329004E`.

## Notable findings while building this

- **The retired Treasury needs no upgrade.** `0x6329004E` is not a proxy; it's plain OZ `Ownable` (`src/archive/Treasury.sol`) with `owner() == UPGRADE_TIMELOCK` and an existing `withdraw(uint256,address)`. 9.712223546514004611 ETH.
- **The timelock salt is pinned**, not `keccak256(..., block.number)` as in `CrossPodApproval`. A block-derived salt changes the calldata every run, which makes the Safe tx hashes signers reproduce unstable.
- **`UPGRADE_TIMELOCK.getMinDelay()` is 864000 (10 days).** `CrossPodApproval/transactions.s.sol` still hardcodes 259200, which is stale.
- **StakingManager links `depositDataRootGenerator`** (already on mainnet at `0xa98F0A109dDC86c4A1dB974256d106C4B237171A`). Its address is baked into the creation code, so reproducing the CREATE2 address requires linking against it. Verified the impl address is sender-independent.
- **`forge build --sizes` exits non-zero on master**, from two test-only invariant handlers (`FrozenRateWithdrawalHandler` 28,107 and `ProtocolInvariantsHandler` 29,310). Neither is deployed, but it means the EIP-170 gate can't be used in CI as-is — worth a follow-up given EtherFiNodesManager has 98 bytes of headroom.
- **AVS deregistration is a separate routing.** `AvsOperatorManager.adminForwardCall` is gated by `OPERATION_MULTISIG_ROLE`, held by the Operating Safe `0x2aCA71` and not by UPGRADE_TIMELOCK, so it cannot ride in the upgrade batch. It also isn't 14 AVSs — it's 14 registered operator proxies across 18 AVSs on the legacy AVSDirectory. A `deregisterAvsOperators()` function is being added here in a follow-up commit.

## Verification

Local fork (`--fork-url $MAINNET_RPC_URL`): CREATE2 addresses match the constants in the calldata, deployed bytecode matches a fresh compile (`ContractCodeChecker`), all four implementation slots repoint, ENM gains `withdrawalCredentialTarget`/`disablePod` and drops `sweepFunds(uint256)`, Treasury drains to 0 and the LiquidityPool is credited exactly. All assertions pass.

Tenderly VNET `5de0fdbf-8001-437d-9a88-4cf2b26d2d23`: impls deployed to their predicted addresses at the expected runtime sizes, then the two real Safe txs — schedule 84,006 gas, execute 175,193 gas, both far under the EIP-7825 cap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production contract changes in the diff—only deployment scripts and fork tests; operational risk is mis-encoded governance calldata if constants drift from CREATE2 deploys.
> 
> **Overview**
> Adds **Forge upgrade tooling** for the non-EigenPod withdrawal-credentials release (PR #485): CREATE2 deployment of four implementations (`EtherFiNodesManager`, `StakingManager`, `EtherFiAdmin`, `EtherFiNode`), a **UPGRADE_TIMELOCK** batch builder that upgrades those proxies/beacon and sweeps the legacy Treasury into the LiquidityPool, plus fork simulation (schedule → 10-day delay → execute) with bytecode, immutables, and post-upgrade smoke tests (pod-less validator, EL exit, EigenLayer withdrawal).
> 
> **`OracleReportCycle.s.sol`** applies the same upgrades directly from the timelock on a fork and runs a full oracle path (three live committee members → consensus → `executeTasks`), asserting TVL/rebase and cursor advancement on upgraded `EtherFiAdmin`.
> 
> Documents **`OP_RPC_URL`** and **`SCROLL_RPC_URL`** in `.example.env` for fork-dependent tests.
> 
> **Test hardening** for drifting mainnet fork state: integration tests force oracle committee/quorum via storage instead of add/remove members; redemption low-watermark test derives blocking bps from live restaker stETH vs TVL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ae80100b5812455cfdc1b94d65bd41e97b4858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/smart-contracts/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790770673&installation_model_id=18424&pr_number=500&repository=etherfi-protocol%2Fsmart-contracts&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fsmart-contracts%2Fpull%2F500&signature=ff34ccd1f600f021fe06414ee392e494d590e8f981710a1511fbcc9d41d7f5e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->