### PR TITLE
chore: AVS deregistration script (167 calls, 119 operator/AVS pairs)

### DIFF
--- a/script/upgrades/avs-deregistration/AvsDeregistration.s.sol
+++ b/script/upgrades/avs-deregistration/AvsDeregistration.s.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+import {Deployed} from "@scripts/deploys/Deployed.s.sol";
+
+interface IAvsOperatorManager {
+    function adminForwardCall(uint256 id, address target, bytes4 selector, bytes calldata args) external;
+    function avsOperators(uint256 id) external view returns (address);
+    function nextAvsOperatorId() external view returns (uint256);
+}
+
+interface IAVSDirectory {
+    function avsOperatorStatus(address avs, address operator) external view returns (uint8);
+}
+
+/**
+ * @title AvsDeregistration
+ * @notice Deregisters ether.fi's AvsOperator proxies from their EigenLayer AVSs.
+ *
+ * Routing: direct calls from ETHERFI_OPERATING_ADMIN (4-of-7 Safe), no timelock.
+ * `adminForwardCall` is gated by OPERATION_MULTISIG_ROLE, which that Safe holds and the
+ * UPGRADE_TIMELOCK does not, so this cannot be batched with a timelock upgrade.
+ *
+ * All registrations are on the legacy AVSDirectory. `deregisterOperatorFromAVS` there is
+ * AVS-only, so each deregistration is driven operator-side through the AVS's own middleware
+ * and forwarded by the manager. Middleware and arguments differ per AVS, so the call list is
+ * enumerated and fork-verified offline and committed as avs-deregistration-calls.json.
+ *
+ * command:
+ * forge script script/upgrades/avs-deregistration/AvsDeregistration.s.sol:AvsDeregistration \
+ *   --fork-url $MAINNET_RPC_URL -vvvv
+ */
+contract AvsDeregistration is Script, Deployed {
+    IAvsOperatorManager constant manager = IAvsOperatorManager(ETHERFI_AVS_OPERATORS_MANAGER);
+    IAVSDirectory constant avsDirectory = IAVSDirectory(0x135DDa560e946695d6f155dACaFC6f1F25C1F5AF);
+    address constant MULTISEND_CALL_ONLY = 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D;
+
+    /// @dev per-Safe-tx gas ceiling; EIP-7825 caps a tx at 16,777,216
+    uint256 constant BATCH_GAS_CAP = 12_000_000;
+    /// @dev Safe execTransaction + MultiSend overhead charged per inner call
+    uint256 constant PER_CALL_OVERHEAD = 30_000;
+
+    struct Call {
+        uint256 operatorId;
+        address avs;
+        string avsName;
+        address target;
+        bytes4 selector;
+        bytes args;
+        /// @dev real anvil tx gas, measured in sequence. Batches are sized on this, not on
+        ///      gasleft() inside the script, which excludes intrinsic and calldata cost.
+        uint256 gasUsed;
+    }
+
+    Call[] internal calls;
+
+    function run() public {
+        _loadCalls();
+        console2.log("loaded calls:", calls.length);
+
+        _simulateAll();
+        _verifyAllDeregistered();
+        _logBatches();
+    }
+
+    function _loadCalls() internal {
+        string memory json = vm.readFile("script/upgrades/avs-deregistration/avs-deregistration-calls.json");
+        uint256 n = vm.parseJsonUint(json, ".blockNumber");
+        console2.log("enumerated at block:", n);
+
+        for (uint256 i = 0; ; i++) {
+            string memory p = string.concat(".calls[", vm.toString(i), "]");
+            if (!vm.keyExistsJson(json, p)) break;
+            calls.push(
+                Call({
+                    operatorId: vm.parseJsonUint(json, string.concat(p, ".operatorId")),
+                    avs: vm.parseJsonAddress(json, string.concat(p, ".avs")),
+                    avsName: vm.parseJsonString(json, string.concat(p, ".avsName")),
+                    target: vm.parseJsonAddress(json, string.concat(p, ".target")),
+                    selector: bytes4(vm.parseJsonBytes(json, string.concat(p, ".selector"))),
+                    args: vm.parseJsonBytes(json, string.concat(p, ".args")),
+                    gasUsed: vm.parseJsonUint(json, string.concat(p, ".gasUsed"))
+                })
+            );
+        }
+    }
+
+    /// @dev runs every call in order from the Operating Safe
+    function _simulateAll() internal {
+        for (uint256 i = 0; i < calls.length; i++) {
+            Call memory c = calls[i];
+            vm.prank(ETHERFI_OPERATING_ADMIN);
+            manager.adminForwardCall(c.operatorId, c.target, c.selector, c.args);
+        }
+        console2.log("all calls succeeded");
+    }
+
+    /// @dev every (operator, avs) pair touched must now read UNREGISTERED on the AVSDirectory
+    function _verifyAllDeregistered() internal view {
+        for (uint256 i = 0; i < calls.length; i++) {
+            address operator = manager.avsOperators(calls[i].operatorId);
+            uint8 status = avsDirectory.avsOperatorStatus(calls[i].avs, operator);
+            if (status != 0) {
+                console2.log("[STILL REGISTERED]", calls[i].avsName, calls[i].operatorId);
+                revert("operator still registered after deregistration");
+            }
+        }
+        console2.log("[OK] every touched pair reads UNREGISTERED on the AVSDirectory");
+    }
+
+    /// @dev greedy-packs the calls into Safe txs under the gas cap and logs each MultiSend payload
+    function _logBatches() internal view {
+        console2.log("");
+        console2.log("=== Safe txs (MultiSendCallOnly, operation = 1) ===");
+        console2.log("safe:      ", ETHERFI_OPERATING_ADMIN);
+        console2.log("to:        ", MULTISEND_CALL_ONLY);
+        console2.log("gas cap:   ", BATCH_GAS_CAP);
+        console2.log("");
+
+        uint256 start;
+        uint256 batch;
+        while (start < calls.length) {
+            uint256 acc;
+            uint256 end = start;
+            while (end < calls.length && acc + calls[end].gasUsed + PER_CALL_OVERHEAD <= BATCH_GAS_CAP) {
+                acc += calls[end].gasUsed + PER_CALL_OVERHEAD;
+                end++;
+            }
+            require(end > start, "single call exceeds the gas cap");
+
+            bytes memory packed;
+            for (uint256 i = start; i < end; i++) {
+                bytes memory inner =
+                    abi.encodeWithSelector(IAvsOperatorManager.adminForwardCall.selector,
+                        calls[i].operatorId, calls[i].target, calls[i].selector, calls[i].args);
+                packed = abi.encodePacked(
+                    packed, uint8(0), ETHERFI_AVS_OPERATORS_MANAGER, uint256(0), inner.length, inner
+                );
+            }
+
+            batch++;
+            console2.log("--- batch", batch);
+            console2.log("calls:   ", end - start);
+            console2.log("est gas: ", acc);
+            console2.log("multiSend(bytes) calldata:");
+            console2.logBytes(abi.encodeWithSignature("multiSend(bytes)", packed));
+            console2.log("");
+
+            start = end;
+        }
+        console2.log("total Safe txs:", batch);
+    }
+}

--- a/script/upgrades/avs-deregistration/VerifyAvsBatches.s.sol
+++ b/script/upgrades/avs-deregistration/VerifyAvsBatches.s.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+import {Deployed} from "@scripts/deploys/Deployed.s.sol";
+
+interface ISafe {
+    function nonce() external view returns (uint256);
+    function getOwners() external view returns (address[] memory);
+    function getThreshold() external view returns (uint256);
+    function approveHash(bytes32 hashToApprove) external;
+    function getTransactionHash(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    ) external view returns (bytes32);
+    function execTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes calldata signatures
+    ) external payable returns (bool);
+}
+
+interface IAvsOperatorManager {
+    function adminForwardCall(uint256 id, address target, bytes4 selector, bytes calldata args) external;
+    function avsOperators(uint256 id) external view returns (address);
+}
+
+interface IAVSDirectory {
+    function avsOperatorStatus(address avs, address operator) external view returns (uint8);
+}
+
+/**
+ * @title VerifyAvsBatches
+ * @notice Executes the AVS deregistration batches as the REAL Safe transactions:
+ *         execTransaction -> delegatecall MultiSendCallOnly -> N x adminForwardCall.
+ *
+ * Signatures are supplied through Safe's approved-hash type (v = 1), which needs no private key:
+ * threshold is forced to 1 via vm.store, then one owner calls approveHash.
+ *
+ * command:
+ * forge script script/upgrades/avs-deregistration/VerifyAvsBatches.s.sol:VerifyAvsBatches \
+ *   --fork-url $MAINNET_RPC_URL -vvv
+ */
+contract VerifyAvsBatches is Script, Deployed {
+    ISafe constant safe = ISafe(ETHERFI_OPERATING_ADMIN);
+    address constant MULTISEND_CALL_ONLY = 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D;
+    IAVSDirectory constant avsDirectory = IAVSDirectory(0x135DDa560e946695d6f155dACaFC6f1F25C1F5AF);
+
+    uint256 constant BATCH_GAS_CAP = 12_000_000;
+    uint256 constant PER_CALL_OVERHEAD = 30_000;
+    /// @dev Safe 1.3.0 storage: slot 4 holds the threshold
+    uint256 constant SAFE_THRESHOLD_SLOT = 4;
+
+    struct Call {
+        uint256 operatorId;
+        address avs;
+        address target;
+        bytes4 selector;
+        bytes args;
+        uint256 gasUsed;
+    }
+
+    Call[] internal calls;
+
+    function run() public {
+        _loadCalls();
+
+        address owner = safe.getOwners()[0];
+        vm.store(address(safe), bytes32(SAFE_THRESHOLD_SLOT), bytes32(uint256(1)));
+        require(safe.getThreshold() == 1, "threshold override failed");
+        vm.deal(owner, owner.balance + 100 ether);
+        console2.log("owner used for approved-hash signing:", owner);
+
+        uint256 batches;
+        uint256 start;
+        uint256 maxGas;
+
+        while (start < calls.length) {
+            (uint256 end, uint256 est) = _packFrom(start);
+            bytes memory multiSendData = _buildMultiSend(start, end);
+
+            uint256 n = safe.nonce();
+            bytes32 txHash = safe.getTransactionHash(
+                MULTISEND_CALL_ONLY, 0, multiSendData, 1, 0, 0, 0, address(0), address(0), n
+            );
+
+            vm.prank(owner);
+            safe.approveHash(txHash);
+
+            // approved-hash signature: r = owner, s = 0, v = 1
+            bytes memory sig = abi.encodePacked(bytes32(uint256(uint160(owner))), bytes32(0), uint8(1));
+
+            uint256 before = gasleft();
+            vm.prank(owner);
+            bool ok = safe.execTransaction(
+                MULTISEND_CALL_ONLY, 0, multiSendData, 1, 0, 0, 0, address(0), payable(address(0)), sig
+            );
+            uint256 spent = before - gasleft();
+            require(ok, "execTransaction returned false");
+
+            batches++;
+            if (spent > maxGas) maxGas = spent;
+            console2.log("--- batch", batches);
+            console2.log("nonce:      ", n);
+            console2.log("inner calls:", end - start);
+            console2.log("est gas:    ", est);
+            console2.log("exec gas:   ", spent);
+
+            start = end;
+        }
+
+        console2.log("");
+        console2.log("batches executed:", batches);
+        console2.log("max exec gas:    ", maxGas);
+        require(maxGas < BATCH_GAS_CAP, "a batch exceeded the 12M ceiling");
+
+        _verifyAllDeregistered();
+    }
+
+    function _packFrom(uint256 start) internal view returns (uint256 end, uint256 acc) {
+        end = start;
+        while (end < calls.length && acc + calls[end].gasUsed + PER_CALL_OVERHEAD <= BATCH_GAS_CAP) {
+            acc += calls[end].gasUsed + PER_CALL_OVERHEAD;
+            end++;
+        }
+        require(end > start, "single call exceeds the cap");
+    }
+
+    function _buildMultiSend(uint256 start, uint256 end) internal view returns (bytes memory) {
+        bytes memory packed;
+        for (uint256 i = start; i < end; i++) {
+            bytes memory inner = abi.encodeWithSelector(
+                IAvsOperatorManager.adminForwardCall.selector,
+                calls[i].operatorId, calls[i].target, calls[i].selector, calls[i].args
+            );
+            packed = abi.encodePacked(
+                packed, uint8(0), ETHERFI_AVS_OPERATORS_MANAGER, uint256(0), inner.length, inner
+            );
+        }
+        return abi.encodeWithSignature("multiSend(bytes)", packed);
+    }
+
+    function _verifyAllDeregistered() internal view {
+        uint256 still;
+        for (uint256 i = 0; i < calls.length; i++) {
+            address operator = IAvsOperatorManager(ETHERFI_AVS_OPERATORS_MANAGER).avsOperators(calls[i].operatorId);
+            if (avsDirectory.avsOperatorStatus(calls[i].avs, operator) != 0) {
+                console2.log("[STILL REGISTERED] operator", calls[i].operatorId, calls[i].avs);
+                still++;
+            }
+        }
+        require(still == 0, "some pairs are still registered");
+        console2.log("[OK] all pairs read UNREGISTERED after the real Safe txs");
+    }
+
+    function _loadCalls() internal {
+        string memory json = vm.readFile("script/upgrades/avs-deregistration/avs-deregistration-calls.json");
+        for (uint256 i = 0; ; i++) {
+            string memory p = string.concat(".calls[", vm.toString(i), "]");
+            if (!vm.keyExistsJson(json, p)) break;
+            calls.push(
+                Call({
+                    operatorId: vm.parseJsonUint(json, string.concat(p, ".operatorId")),
+                    avs: vm.parseJsonAddress(json, string.concat(p, ".avs")),
+                    target: vm.parseJsonAddress(json, string.concat(p, ".target")),
+                    selector: bytes4(vm.parseJsonBytes(json, string.concat(p, ".selector"))),
+                    args: vm.parseJsonBytes(json, string.concat(p, ".args")),
+                    gasUsed: vm.parseJsonUint(json, string.concat(p, ".gasUsed"))
+                })
+            );
+        }
+        console2.log("loaded calls:", calls.length);
+    }
+}

--- a/script/upgrades/avs-deregistration/avs-deregistration-calls.json
+++ b/script/upgrades/avs-deregistration/avs-deregistration-calls.json
@@ -1,0 +1,1720 @@
+{
+ "blockNumber": 25875000,
+ "note": "Enumerated and fork-verified at the pinned block. One row per adminForwardCall, in execution order. gasUsed is real anvil tx gas measured in sequence.",
+ "calls": [
+  {
+   "operatorId": 1,
+   "avs": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+   "avsName": "EigenDA",
+   "target": "0x0baac79acd45a023e19345c352d8a7a83c4e5656",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433521
+  },
+  {
+   "operatorId": 1,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x000000000000000000000000fb487f216ca24162119c0c6ae015d680d7569c2f",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 1,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 236502
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 178822
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 194318
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 1,
+   "avs": "0xef2a435e5ee44b2041100ef8cbc8ae035166606c",
+   "avsName": "Aligned Layer",
+   "target": "0xa8cc0749b4409c3c47012323e625aecba92f64b9",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433174
+  },
+  {
+   "operatorId": 1,
+   "avs": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "avsName": "Othentic AvsGovernance",
+   "target": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "selector": "0x0399f004",
+   "fnSig": "unregisterAsOperatorFromEigenLayer()",
+   "args": "0x",
+   "gasUsed": 99954
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x9fc952bdcbb7daca7d420fa55b942405b073a89d",
+   "avsName": "Brevis (BrevisEigen A)",
+   "target": "0x434621cfd8bcdbe8839a33c85ae2b2893a4d596c",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020001000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 605884
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x0328635ba5ff28476118595234b5b7236b906c0b",
+   "avsName": "Brevis (BrevisEigen B)",
+   "target": "0x8b83b9808de79d5eee97417bb14f82c41bccd6f0",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433535
+  },
+  {
+   "operatorId": 1,
+   "avs": "0x6201bc0a699e3b10f324204e6f8ecdd0983de227",
+   "avsName": "EthGas Vision",
+   "target": "0xff94c9859e4b15341c1ba3e80cf80044ca2c4e76",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 192587
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 2,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x0000000000000000000000004bd479a34450d0cb1f5ef16a877bee47e1e4cdb9",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 2,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 251724
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 229562
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 204466
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 2,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+   "avsName": "EigenDA",
+   "target": "0x0baac79acd45a023e19345c352d8a7a83c4e5656",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020001000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 674731
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x71a77037870169d47aad6c2c9360861a4c0df2bf",
+   "avsName": "AltLayer MACH (MachServiceManager B)",
+   "target": "0x561be1ab42170a19f31645f774e6e3862b2139aa",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 435741
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x6026b61bdd2252160691cb3f6005b6b72e0ec044",
+   "avsName": "AltLayer MACH (MachServiceManager C)",
+   "target": "0x6e32dd4169825337b54236b9355910b83e51e5a8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453412
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 3,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x000000000000000000000000dcae4faf7c7d0f4a78abe147244c6e9d60cfd202",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 213669
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 201655
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 171485
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 3,
+   "avs": "0xe5445838c475a2980e6a88054ff1514230b83aeb",
+   "avsName": "Automata MultiProver",
+   "target": "0x414696e4f7f06273973e89bfd3499e8666d63bd4",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 435638
+  },
+  {
+   "operatorId": 3,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 3,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 3,
+   "avs": "0xef2a435e5ee44b2041100ef8cbc8ae035166606c",
+   "avsName": "Aligned Layer",
+   "target": "0xa8cc0749b4409c3c47012323e625aecba92f64b9",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433174
+  },
+  {
+   "operatorId": 3,
+   "avs": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "avsName": "Othentic AvsGovernance",
+   "target": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "selector": "0x0399f004",
+   "fnSig": "unregisterAsOperatorFromEigenLayer()",
+   "args": "0x",
+   "gasUsed": 99954
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 4,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x000000000000000000000000ea50bb6735703422d2e053452f1f28bff17da51f",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 4,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 221280
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 221951
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 181633
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 4,
+   "avs": "0xef2a435e5ee44b2041100ef8cbc8ae035166606c",
+   "avsName": "Aligned Layer",
+   "target": "0xa8cc0749b4409c3c47012323e625aecba92f64b9",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433174
+  },
+  {
+   "operatorId": 4,
+   "avs": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "avsName": "Othentic AvsGovernance",
+   "target": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "selector": "0x0399f004",
+   "fnSig": "unregisterAsOperatorFromEigenLayer()",
+   "args": "0x",
+   "gasUsed": 99954
+  },
+  {
+   "operatorId": 4,
+   "avs": "0x6201bc0a699e3b10f324204e6f8ecdd0983de227",
+   "avsName": "EthGas Vision",
+   "target": "0xff94c9859e4b15341c1ba3e80cf80044ca2c4e76",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 192587
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+   "avsName": "EigenDA",
+   "target": "0x0baac79acd45a023e19345c352d8a7a83c4e5656",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433521
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 5,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 5,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x00000000000000000000000017c5f0cc30bd57b308b7f62600b415fd1335e1fe",
+   "gasUsed": 102301
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 216206
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 237173
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 196855
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 5,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 6,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 249187
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 216877
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 176559
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 6,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x000000000000000000000000e0156ef2905c2ea8b1f7571caee85fdf1657ab38",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 6,
+   "avs": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "avsName": "Othentic AvsGovernance",
+   "target": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "selector": "0x0399f004",
+   "fnSig": "unregisterAsOperatorFromEigenLayer()",
+   "args": "0x",
+   "gasUsed": 99954
+  },
+  {
+   "operatorId": 6,
+   "avs": "0xef2a435e5ee44b2041100ef8cbc8ae035166606c",
+   "avsName": "Aligned Layer",
+   "target": "0xa8cc0749b4409c3c47012323e625aecba92f64b9",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433174
+  },
+  {
+   "operatorId": 6,
+   "avs": "0x6201bc0a699e3b10f324204e6f8ecdd0983de227",
+   "avsName": "EthGas Vision",
+   "target": "0xff94c9859e4b15341c1ba3e80cf80044ca2c4e76",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 192587
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 216206
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 232373
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 171485
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 7,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 7,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x0000000000000000000000008e7e7176d3470c6c2efe71004f496a6ef422a56f",
+   "gasUsed": 102301
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 7,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+   "avsName": "EigenDA",
+   "target": "0x0baac79acd45a023e19345c352d8a7a83c4e5656",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433521
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 8,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x0000000000000000000000005b9b3cf0202a1a3dc8f527257b7e6002d23d8c85",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 208595
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 196581
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 199392
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 8,
+   "avs": "0xe5445838c475a2980e6a88054ff1514230b83aeb",
+   "avsName": "Automata MultiProver",
+   "target": "0x414696e4f7f06273973e89bfd3499e8666d63bd4",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 435638
+  },
+  {
+   "operatorId": 8,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 8,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 8,
+   "avs": "0xef2a435e5ee44b2041100ef8cbc8ae035166606c",
+   "avsName": "Aligned Layer",
+   "target": "0xa8cc0749b4409c3c47012323e625aecba92f64b9",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433174
+  },
+  {
+   "operatorId": 8,
+   "avs": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "avsName": "Othentic AvsGovernance",
+   "target": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "selector": "0x0399f004",
+   "fnSig": "unregisterAsOperatorFromEigenLayer()",
+   "args": "0x",
+   "gasUsed": 99954
+  },
+  {
+   "operatorId": 9,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x000000000000000000000000d972a58b6a582954e578455e4752b12f2c8fcdbc",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 9,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 216206
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 229562
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 191781
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 9,
+   "avs": "0x6201bc0a699e3b10f324204e6f8ecdd0983de227",
+   "avsName": "EthGas Vision",
+   "target": "0xff94c9859e4b15341c1ba3e80cf80044ca2c4e76",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 192587
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+   "avsName": "EigenDA",
+   "target": "0x0baac79acd45a023e19345c352d8a7a83c4e5656",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433521
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 223817
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 211803
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 179096
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 10,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 10,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x00000000000000000000000067943ae8e07bfc9f5c9a90d608f7923d9c21e051",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 10,
+   "avs": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "avsName": "Othentic AvsGovernance",
+   "target": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "selector": "0x0399f004",
+   "fnSig": "unregisterAsOperatorFromEigenLayer()",
+   "args": "0x",
+   "gasUsed": 99954
+  },
+  {
+   "operatorId": 10,
+   "avs": "0xef2a435e5ee44b2041100ef8cbc8ae035166606c",
+   "avsName": "Aligned Layer",
+   "target": "0xa8cc0749b4409c3c47012323e625aecba92f64b9",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433174
+  },
+  {
+   "operatorId": 10,
+   "avs": "0x6201bc0a699e3b10f324204e6f8ecdd0983de227",
+   "avsName": "EthGas Vision",
+   "target": "0xff94c9859e4b15341c1ba3e80cf80044ca2c4e76",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 192587
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+   "avsName": "EigenDA",
+   "target": "0x0baac79acd45a023e19345c352d8a7a83c4e5656",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433521
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 11,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x0000000000000000000000005d4b5ef127c545e5bf8e247f9fcd4e75a0a366b4",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 11,
+   "avs": "0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc",
+   "avsName": "Hyperlane",
+   "target": "0x272cf0bb70d3b4f79414e0823b426d2eafd48910",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 177083
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 226354
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 188970
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 204466
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 11,
+   "avs": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "avsName": "Othentic AvsGovernance",
+   "target": "0xb3e069fd6dda251acbde09eda547e0ab207016ee",
+   "selector": "0x0399f004",
+   "fnSig": "unregisterAsOperatorFromEigenLayer()",
+   "args": "0x",
+   "gasUsed": 99954
+  },
+  {
+   "operatorId": 11,
+   "avs": "0xef2a435e5ee44b2041100ef8cbc8ae035166606c",
+   "avsName": "Aligned Layer",
+   "target": "0xa8cc0749b4409c3c47012323e625aecba92f64b9",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433174
+  },
+  {
+   "operatorId": 11,
+   "avs": "0x6201bc0a699e3b10f324204e6f8ecdd0983de227",
+   "avsName": "EthGas Vision",
+   "target": "0xff94c9859e4b15341c1ba3e80cf80044ca2c4e76",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 192587
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+   "avsName": "EigenDA",
+   "target": "0x0baac79acd45a023e19345c352d8a7a83c4e5656",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010100000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 433533
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+   "avsName": "Lagrange zkMapReduce (ZKMR)",
+   "target": "0x8dcdcc50cc00fe898b037bf61ccf3bf9ba46f15c",
+   "selector": "0x857dc190",
+   "fnSig": "deregisterOperator()",
+   "args": "0x",
+   "gasUsed": 108837
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000000a",
+   "gasUsed": 195910
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x0000000000000000000000000000000000000000000000000000000000002105",
+   "gasUsed": 221951
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0x0512d04c",
+   "fnSig": "unsubscribe(uint32)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000a4b1",
+   "gasUsed": 184170
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "avsName": "Lagrange State Committee",
+   "target": "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa2",
+   "selector": "0xaff5edb1",
+   "fnSig": "deregister()",
+   "args": "0x",
+   "gasUsed": 144663
+  },
+  {
+   "operatorId": 12,
+   "avs": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "avsName": "WitnessChain",
+   "target": "0xd25c2c5802198cb8541987b73a8db4c9bcae5cc7",
+   "selector": "0xa364f4da",
+   "fnSig": "deregisterOperatorFromAVS(address)",
+   "args": "0x0000000000000000000000001abdcdd0ec2523dd2c66b8c7d1c734f743e98b4a",
+   "gasUsed": 102313
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x1f2c296448f692af840843d993ffc0546619dcdb",
+   "avsName": "AltLayer MACH (MachServiceManager A)",
+   "target": "0x118610d207a32f10f4f7c3a1fefac5b3327c2bad",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 453434
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0x389517e4",
+   "fnSig": "startDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 119421
+  },
+  {
+   "operatorId": 12,
+   "avs": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "avsName": "UniFi AVS (Puffer)",
+   "target": "0x2d86e90ed40a034c753931ee31b1bd5e1970113d",
+   "selector": "0xe3672163",
+   "fnSig": "finishDeregisterOperator()",
+   "args": "0x",
+   "gasUsed": 113245
+  },
+  {
+   "operatorId": 14,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 15,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  },
+  {
+   "operatorId": 16,
+   "avs": "0x23221c5bb90c7c57ecc1e75513e2e4257673f0ef",
+   "avsName": "eoracle",
+   "target": "0x757e6f572afd8e111bd913d35314b5472c051ca8",
+   "selector": "0xca4f2d97",
+   "fnSig": "deregisterOperator(bytes)",
+   "args": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+   "gasUsed": 437451
+  }
+ ],
+ "blocked": [
+  {
+   "operatorId": 3,
+   "operatorAddr": "0xdcae4faf7c7d0f4a78abe147244c6e9d60cfd202",
+   "avs": "0xacb91045b8bba06f9026e1a30855b6c4a1c5bac6",
+   "avsName": "bare ServiceManager (aggregator 0x38f6001e)",
+   "reason": "onlyOwner (owner 0x38f6001e8ac11240f903cba56aff72a1425ae371). Its StakeRegistry 0x006124ae only exposes deregisterOperator(bytes32,bytes) onlyRegistryCoordinator. No operator-initiated path exists."
+  },
+  {
+   "operatorId": 4,
+   "operatorAddr": "0xea50bb6735703422d2e053452f1f28bff17da51f",
+   "avs": "0x1de75eaab2df55d467494a172652579e6fa4540e",
+   "avsName": "ARPA Network",
+   "reason": "NodeRegistry.nodeQuit() uses msg.sender as the node. The AvsOperator proxy is only the ARPA asset account; the node is a separate EOA. NodeRegistry.getNode(avsOperator) is empty, so nodeQuit() from the AvsOperator reverts NodeNotRegistered(). The ARPA node EOA for this operator is 0x961cAA85468805456DcaC0305C8a8FE009206e37; that key must call nodeQuit()."
+  },
+  {
+   "operatorId": 4,
+   "operatorAddr": "0xea50bb6735703422d2e053452f1f28bff17da51f",
+   "avs": "0xacb91045b8bba06f9026e1a30855b6c4a1c5bac6",
+   "avsName": "bare ServiceManager (aggregator 0x38f6001e)",
+   "reason": "onlyOwner (owner 0x38f6001e8ac11240f903cba56aff72a1425ae371). Its StakeRegistry 0x006124ae only exposes deregisterOperator(bytes32,bytes) onlyRegistryCoordinator. No operator-initiated path exists."
+  },
+  {
+   "operatorId": 8,
+   "operatorAddr": "0x5b9b3cf0202a1a3dc8f527257b7e6002d23d8c85",
+   "avs": "0xacb91045b8bba06f9026e1a30855b6c4a1c5bac6",
+   "avsName": "bare ServiceManager (aggregator 0x38f6001e)",
+   "reason": "onlyOwner (owner 0x38f6001e8ac11240f903cba56aff72a1425ae371). Its StakeRegistry 0x006124ae only exposes deregisterOperator(bytes32,bytes) onlyRegistryCoordinator. No operator-initiated path exists."
+  },
+  {
+   "operatorId": 10,
+   "operatorAddr": "0x67943ae8e07bfc9f5c9a90d608f7923d9c21e051",
+   "avs": "0xacb91045b8bba06f9026e1a30855b6c4a1c5bac6",
+   "avsName": "bare ServiceManager (aggregator 0x38f6001e)",
+   "reason": "onlyOwner (owner 0x38f6001e8ac11240f903cba56aff72a1425ae371). Its StakeRegistry 0x006124ae only exposes deregisterOperator(bytes32,bytes) onlyRegistryCoordinator. No operator-initiated path exists."
+  },
+  {
+   "operatorId": 11,
+   "operatorAddr": "0x5d4b5ef127c545e5bf8e247f9fcd4e75a0a366b4",
+   "avs": "0x1de75eaab2df55d467494a172652579e6fa4540e",
+   "avsName": "ARPA Network",
+   "reason": "NodeRegistry.nodeQuit() uses msg.sender as the node. The AvsOperator proxy is only the ARPA asset account; the node is a separate EOA. NodeRegistry.getNode(avsOperator) is empty, so nodeQuit() from the AvsOperator reverts NodeNotRegistered(). The ARPA node EOA for this operator is 0x13f24BECF6Ba32a84bc98FE7d516Af74753937E3; that key must call nodeQuit()."
+  }
+ ]
+}


### PR DESCRIPTION
Deregisters ether.fi's `AvsOperator` proxies from their EigenLayer AVSs. Branches off `master`; independent of #485 / #500.

Governance proposal: [3CP-secure#664](https://github.com/etherfi-protocol/3CP-secure/pull/664).

## Scope

**167 `adminForwardCall` operations covering 119 (operator, AVS) pairs — 15 operators, 16 AVSs.** Not "14 AVSs": the 14 refers to registered operator proxies, and there are 15 with live registrations.

All registrations are on the **legacy AVSDirectory** (`0x135DDa56`); `AllocationManager.getRegisteredSets` is empty for every operator, so there is no operator-set path to unwind.

`AVSDirectory.deregisterOperatorFromAVS` requires `msg.sender == the AVS`, so ether.fi cannot call it. Each deregistration is driven operator-side through that AVS's own middleware and forwarded by `AvsOperatorManager.adminForwardCall`. The middleware and arguments are **not uniform**, so the list is enumerated and fork-verified offline and committed as `avs-deregistration-calls.json`.

## Non-standard AVSs

| AVS | Target | Operator-initiated call |
|---|---|---|
| WitnessChain | self | `deregisterOperatorFromAVS(address)` |
| Hyperlane | ECDSAStakeRegistry | `deregisterOperator()` |
| Lagrange zkMR | ZKMRStakeRegistry | `deregisterOperator()` |
| EthGas Vision | ECDSAStakeRegistry | `deregisterOperator()` |
| Lagrange State Committee | self | `unsubscribe(10)`, `unsubscribe(8453)`, `unsubscribe(42161)`, then `deregister()` |
| Othentic AvsGovernance | self | `unregisterAsOperatorFromEigenLayer()` |
| UniFi AVS | self | `startDeregisterOperator()` + `finishDeregisterOperator()` |

Lagrange State Committee is why the call count exceeds the pair count: `deregister()` reverts with "operator is not able to deregister" until `subscribedChainCount == 0`, and all 12 operators are subscribed to 3 chains. UniFi's delay is currently 0, so start and finish fit one batch; if the AVS raises it, they must be split across blocks.

## Blocked — 6 pairs need someone else to act

| Operators | AVS | Why |
|---|---|---|
| 3, 4, 8, 10 | bare `ServiceManager 0xacb91045` | Only `deregisterOperatorFromAVS(address)` behind `onlyOwner`; the StakeRegistry is `onlyRegistryCoordinator`. No operator path — the AVS team must eject. |
| 4, 11 | ARPA Network | `NodeRegistry.nodeQuit()` keys on `msg.sender`. The AvsOperator is only ARPA's asset account; the node EOAs `0x961cAA85…` (op4) and `0x13f24BEC…` (op11) must call it. |

These are excluded from the batches. Closing them needs coordination outside this repo.

## Verification

`forge script script/upgrades/avs-deregistration/AvsDeregistration.s.sol:AvsDeregistration --fork-url $MAINNET_RPC_URL` — all 167 calls succeed and all 119 pairs read `avsOperatorStatus == 0` afterwards.

Tenderly VNET pinned to the enumeration block: **167/167 mined, 0 failures**.

Batching is on real anvil tx gas carried in the data file, not `gasleft()` inside the script — `gasleft()` excludes intrinsic and calldata cost and under-counts by ~2x, which would have produced 3 oversized batches instead of 4 safe ones.

| Safe tx | Calls | Est. gas |
|---|---|---|
| 1 | 40 | 11,839,972 |
| 2 | 49 | 11,949,605 |
| 3 | 47 | 11,876,295 |
| 4 | 31 | 8,818,515 |

All under the 12M ceiling. The script's MultiSend payloads were cross-checked byte-for-byte against an independent encoder.

## Caveat

The call list is **state-sensitive** — quorum bitmaps and registration status change as operators and AVSs act. Re-run the script immediately before signing and confirm 167/167 still pass. A VNET forked at `latest` rather than a pinned block produced spurious failures, so pin the block when simulating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> No production contract changes, but committed calldata drives a large privileged mainnet multisig operation; stale state or a wrong/missing call could leave operators partially registered or waste Safe nonces.
> 
> **Overview**
> Adds **mainnet upgrade tooling** to deregister ether.fi `AvsOperator` proxies from legacy EigenLayer AVSs via the Operating Safe (`ETHERFI_OPERATING_ADMIN`) and `AvsOperatorManager.adminForwardCall`, without timelock batching.
> 
> **`avs-deregistration-calls.json`** pins **167** fork-verified calls (block `25875000`) with per-call gas measurements, covering **119** operator/AVS pairs across heterogeneous AVS middleware. A **`blocked`** section documents **6** pairs that cannot be cleared through `adminForwardCall` (bare ServiceManager / ARPA `nodeQuit`).
> 
> **`AvsDeregistration.s.sol`** loads the manifest, simulates every call as the Operating Safe, asserts `AVSDirectory.avsOperatorStatus == 0` for each touched pair, and **greedy-packs** calls into Safe **MultiSendCallOnly** batches under a **12M** gas cap (using measured tx gas + per-call overhead).
> 
> **`VerifyAvsBatches.s.sol`** re-runs the same packing on a fork using the **real** Safe path (`execTransaction` → delegatecall MultiSend → inner `adminForwardCall`), with threshold forced to 1 and approved-hash signatures for fork testing, then re-checks directory status and batch gas against the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6585248c97777a39b5b51d9a6732a3e92e73e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->